### PR TITLE
use inverted index to serve labels/label_values instead of forward

### DIFF
--- a/open-tsdb/src/minitsdb.rs
+++ b/open-tsdb/src/minitsdb.rs
@@ -50,6 +50,20 @@ impl<'a> QueryReader for MiniQueryReader<'a> {
         Ok(Box::new(inverted_index))
     }
 
+    async fn all_inverted_index(&self) -> Result<Box<dyn InvertedIndexLookup + Send + Sync + '_>> {
+        let inverted_index = self
+            .snapshot
+            .get_inverted_index(self.bucket.clone())
+            .await?;
+        Ok(Box::new(inverted_index))
+    }
+
+    async fn label_values(&self, label_name: &str) -> Result<Vec<String>> {
+        self.snapshot
+            .get_label_values(self.bucket, label_name)
+            .await
+    }
+
     async fn samples(
         &self,
         series_id: SeriesId,


### PR DESCRIPTION
## Summary

The original approach was embarrassingly bad... I can't believe I merged it that way! I had to change it from the Aion implementation because we don't have explicit dictionaries. 
                                                                                                                                 
  - Optimizes `labels()` and `label_values()` endpoints to use inverted index keys instead of iterating through forward index
  - Implements hybrid approach: forward index for filtered queries (match[]), inverted index for unfiltered queries
  - Adds `InvertedIndexKey::attribute_range()` for efficient storage scans by label name
  - Adds `QueryReader::label_values()` method that scans only keys matching the requested label

## Test plan

  - [x] Existing tests pass (322 tests)
  - [x] Added unit test for `attribute_range()` key matching
  - [x] Existing integration tests for `labels()` and `label_values()` endpoints cover both filtered and unfiltered cases

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
