### PR TITLE
add manifesto signature markdown

### DIFF
--- a/MANIFESTO_SIGNERS.md
+++ b/MANIFESTO_SIGNERS.md
@@ -1,0 +1,6 @@
+This is a list of people who have signed the [OpenData Manifesto](https://www.opendata.dev/manifesto).
+To sign, open a pull request to add your name to the list.
+
+- [Almog Gavra](https://github.com/agavra)
+- [Apurva Metha](https://github.com/apurvam)
+- [Jason Gustafson](https://github.com/hachikuji)


### PR DESCRIPTION
We have an auto-generated list of manifesto signatories that includes every contributor to this repository. Since some people may want to sign the manifesto without having a clear idea of a contribution they can make, this gives people a place to make an easy contribution to show up in the list of signatories. 