### PR TITLE
remove OpenTsdbError in favor of TimeseriesError

### DIFF
--- a/timeseries/src/delta.rs
+++ b/timeseries/src/delta.rs
@@ -6,12 +6,13 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use dashmap::DashMap;
 
 use crate::{
+    error::TimeseriesError,
     index::{ForwardIndex, InvertedIndex},
     model::{
         MetricType, Sample, SampleWithLabels, SeriesFingerprint, SeriesId, SeriesSpec, TimeBucket,
     },
     series::Label,
-    util::{Fingerprint, OpenTsdbError, Result},
+    util::{Fingerprint, Result},
 };
 
 /// The delta chunk is the current in-memory segment of OpenTSDB representing
@@ -66,7 +67,7 @@ impl<'a> TsdbDeltaBuilder<'a> {
         let bucket_end_ms =
             (self.bucket.start as u64 + self.bucket.size_in_mins() as u64) * 60 * 1000;
         if sample.timestamp < bucket_start_ms || sample.timestamp >= bucket_end_ms {
-            return Err(OpenTsdbError::InvalidInput(format!(
+            return Err(TimeseriesError::InvalidInput(format!(
                 "Sample timestamp {} is outside bucket range [{}, {})",
                 sample.timestamp, bucket_start_ms, bucket_end_ms
             )));
@@ -743,7 +744,7 @@ mod tests {
         // then
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(matches!(err, OpenTsdbError::InvalidInput(_)));
+        assert!(matches!(err, TimeseriesError::InvalidInput(_)));
         assert!(err.to_string().contains("outside bucket range"));
     }
 
@@ -768,7 +769,7 @@ mod tests {
         // then
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(matches!(err, OpenTsdbError::InvalidInput(_)));
+        assert!(matches!(err, TimeseriesError::InvalidInput(_)));
         assert!(err.to_string().contains("outside bucket range"));
     }
 }

--- a/timeseries/src/head.rs
+++ b/timeseries/src/head.rs
@@ -7,7 +7,8 @@ use dashmap::DashMap;
 use opendata_common::Storage;
 use opendata_common::storage::StorageSnapshot;
 
-use crate::util::{OpenTsdbError, Result};
+use crate::error::TimeseriesError;
+use crate::util::Result;
 use crate::{
     delta::TsdbDelta,
     index::{ForwardIndex, InvertedIndex},
@@ -71,7 +72,7 @@ impl TsdbHead {
 
     pub fn merge(&self, delta: &TsdbDelta) -> Result<()> {
         if self.frozen.load(Ordering::SeqCst) {
-            return Err(OpenTsdbError::Internal("TsdbHead is frozen".to_string()));
+            return Err(TimeseriesError::Internal("TsdbHead is frozen".to_string()));
         }
 
         self.forward_index.merge(&delta.forward_index);
@@ -98,7 +99,7 @@ impl TsdbHead {
 
     pub async fn flush(&self, storage: Arc<dyn Storage>) -> Result<Arc<dyn StorageSnapshot>> {
         if !self.frozen.load(Ordering::SeqCst) {
-            return Err(OpenTsdbError::Internal(
+            return Err(TimeseriesError::Internal(
                 "Should only flush frozen TsdbHead".to_string(),
             ));
         }

--- a/timeseries/src/lib.rs
+++ b/timeseries/src/lib.rs
@@ -54,12 +54,12 @@ mod util;
 
 // Public API modules
 mod config;
-mod error;
+pub(crate) mod error;
 pub(crate) mod series;
 mod timeseries;
 
 // Public re-exports
 pub use config::{Config, WriteOptions};
-pub use error::{Error, Result};
+pub use error::{Result, TimeseriesError};
 pub use series::{Label, MetricType, Sample, Series, SeriesBuilder};
 pub use timeseries::TimeSeries;

--- a/timeseries/src/main.rs
+++ b/timeseries/src/main.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 mod delta;
+mod error;
 mod head;
 mod index;
 mod minitsdb;

--- a/timeseries/src/minitsdb.rs
+++ b/timeseries/src/minitsdb.rs
@@ -8,6 +8,7 @@ use opendata_common::{Storage, StorageRead};
 use tokio::sync::{Mutex, RwLock};
 
 use crate::delta::{TsdbDelta, TsdbDeltaBuilder};
+use crate::error::TimeseriesError;
 use crate::index::{ForwardIndexLookup, InvertedIndexLookup};
 use crate::model::{Sample, SampleWithLabels, SeriesFingerprint, SeriesId, TimeBucket};
 use crate::query::QueryReader;
@@ -15,7 +16,7 @@ use crate::serde::key::TimeSeriesKey;
 use crate::serde::timeseries::TimeSeriesIterator;
 use crate::series::Label;
 use crate::storage::{OpenTsdbStorageExt, OpenTsdbStorageReadExt};
-use crate::util::{OpenTsdbError, Result};
+use crate::util::Result;
 
 pub(crate) struct MiniQueryReader<'a> {
     bucket: &'a TimeBucket,
@@ -81,7 +82,7 @@ impl<'a> QueryReader for MiniQueryReader<'a> {
         match record {
             Some(record) => {
                 let iter = TimeSeriesIterator::new(record.value.as_ref()).ok_or_else(|| {
-                    OpenTsdbError::Internal("Invalid timeseries data in storage".into())
+                    TimeseriesError::Internal("Invalid timeseries data in storage".into())
                 })?;
 
                 let samples: Vec<Sample> = iter

--- a/timeseries/src/promql/config.rs
+++ b/timeseries/src/promql/config.rs
@@ -105,11 +105,11 @@ pub struct StaticConfig {
 /// Load Prometheus configuration from a YAML file.
 pub fn load_config<P: AsRef<Path>>(path: P) -> Result<PrometheusConfig> {
     let contents = std::fs::read_to_string(path.as_ref()).map_err(|e| {
-        crate::util::OpenTsdbError::InvalidInput(format!("Failed to read config file: {}", e))
+        crate::error::TimeseriesError::InvalidInput(format!("Failed to read config file: {}", e))
     })?;
 
     serde_yaml::from_str(&contents).map_err(|e| {
-        crate::util::OpenTsdbError::InvalidInput(format!("Failed to parse config file: {}", e))
+        crate::error::TimeseriesError::InvalidInput(format!("Failed to parse config file: {}", e))
     })
 }
 
@@ -141,7 +141,7 @@ pub fn parse_duration(s: &str) -> Result<Duration> {
         "h" => 3600.0,
         "d" => 86400.0,
         _ => {
-            return Err(crate::util::OpenTsdbError::InvalidInput(format!(
+            return Err(crate::error::TimeseriesError::InvalidInput(format!(
                 "Unknown duration unit: {}",
                 unit
             )));

--- a/timeseries/src/promql/evaluator.rs
+++ b/timeseries/src/promql/evaluator.rs
@@ -33,8 +33,8 @@ impl Display for EvaluationError {
 
 impl std::error::Error for EvaluationError {}
 
-impl From<crate::util::OpenTsdbError> for EvaluationError {
-    fn from(err: crate::util::OpenTsdbError) -> Self {
+impl From<crate::error::TimeseriesError> for EvaluationError {
+    fn from(err: crate::error::TimeseriesError) -> Self {
         EvaluationError::StorageError(err.to_string())
     }
 }

--- a/timeseries/src/promql/request.rs
+++ b/timeseries/src/promql/request.rs
@@ -2,7 +2,8 @@ use std::time::{Duration, SystemTime};
 
 use serde::Deserialize;
 
-use crate::util::{OpenTsdbError, parse_duration, parse_timestamp, parse_timestamp_to_seconds};
+use crate::error::TimeseriesError;
+use crate::util::{parse_duration, parse_timestamp, parse_timestamp_to_seconds};
 
 // =============================================================================
 // Domain Request Types (parsed, validated)
@@ -80,7 +81,7 @@ pub struct QueryParams {
 }
 
 impl TryFrom<QueryParams> for QueryRequest {
-    type Error = OpenTsdbError;
+    type Error = TimeseriesError;
 
     fn try_from(params: QueryParams) -> Result<Self, Self::Error> {
         Ok(QueryRequest {
@@ -102,7 +103,7 @@ pub struct QueryRangeParams {
 }
 
 impl TryFrom<QueryRangeParams> for QueryRangeRequest {
-    type Error = OpenTsdbError;
+    type Error = TimeseriesError;
 
     fn try_from(params: QueryRangeParams) -> Result<Self, Self::Error> {
         Ok(QueryRangeRequest {
@@ -126,7 +127,7 @@ pub struct SeriesParams {
 }
 
 impl TryFrom<SeriesParams> for SeriesRequest {
-    type Error = OpenTsdbError;
+    type Error = TimeseriesError;
 
     fn try_from(params: SeriesParams) -> Result<Self, Self::Error> {
         Ok(SeriesRequest {
@@ -155,7 +156,7 @@ pub struct LabelsParams {
 }
 
 impl TryFrom<LabelsParams> for LabelsRequest {
-    type Error = OpenTsdbError;
+    type Error = TimeseriesError;
 
     fn try_from(params: LabelsParams) -> Result<Self, Self::Error> {
         Ok(LabelsRequest {
@@ -189,7 +190,7 @@ pub struct LabelValuesParams {
 
 impl LabelValuesParams {
     /// Convert to LabelValuesRequest with the label name from the path
-    pub fn into_request(self, label_name: String) -> Result<LabelValuesRequest, OpenTsdbError> {
+    pub fn into_request(self, label_name: String) -> Result<LabelValuesRequest, TimeseriesError> {
         Ok(LabelValuesRequest {
             label_name,
             matches: if self.matches.is_empty() {

--- a/timeseries/src/promql/server.rs
+++ b/timeseries/src/promql/server.rs
@@ -23,8 +23,8 @@ use super::response::{
 };
 use super::router::PromqlRouter;
 use super::scraper::Scraper;
+use crate::error::TimeseriesError;
 use crate::tsdb::Tsdb;
-use crate::util::OpenTsdbError;
 
 /// Shared application state.
 #[derive(Clone)]
@@ -133,16 +133,16 @@ impl PromqlServer {
     }
 }
 
-/// Error response wrapper for converting OpenTsdbError to HTTP responses
-struct ApiError(OpenTsdbError);
+/// Error response wrapper for converting TimeseriesError to HTTP responses
+struct ApiError(TimeseriesError);
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let (status, error_type) = match &self.0 {
-            OpenTsdbError::InvalidInput(_) => (StatusCode::BAD_REQUEST, "bad_data"),
-            OpenTsdbError::Storage(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal"),
-            OpenTsdbError::Encoding(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal"),
-            OpenTsdbError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal"),
+            TimeseriesError::InvalidInput(_) => (StatusCode::BAD_REQUEST, "bad_data"),
+            TimeseriesError::Storage(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal"),
+            TimeseriesError::Encoding(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal"),
+            TimeseriesError::Internal(_) => (StatusCode::INTERNAL_SERVER_ERROR, "internal"),
         };
 
         let body = serde_json::json!({
@@ -155,8 +155,8 @@ impl IntoResponse for ApiError {
     }
 }
 
-impl From<OpenTsdbError> for ApiError {
-    fn from(err: OpenTsdbError) -> Self {
+impl From<TimeseriesError> for ApiError {
+    fn from(err: TimeseriesError) -> Self {
         ApiError(err)
     }
 }


### PR DESCRIPTION
## Summary

After #17 we now have two errors types for `timeseries` this consolidates the two and renames `Error` -> `TimseriesError` so it makes codesearch easier going forward

## Related Issues

N/A

## Test Plan

Ran existing tests

## Checklist

- [ ] Tests added/updated
- [ ] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
