### PR TITLE
RFC for log segmentation

### DIFF
--- a/log/rfcs/0002-logical-segmentation.md
+++ b/log/rfcs/0002-logical-segmentation.md
@@ -186,7 +186,7 @@ impl Log {
 ```
 
 This would enable use cases such as:
-- Creating checkpoint boundaries aligned with application logic
+- Creating segment boundaries aligned with application logic
 - Attaching metadata accumulated during writes (checksums, record counts, correlation IDs)
 - Aligning segments with external events (e.g., end of business day)
 


### PR DESCRIPTION
This patch adds a logical segmentation notion which is similar to the way that time buckets work in timeseries. Segments can be created based on time-based boundaries, such as hourly like with timeseries. The user can also seal a segment based on their own application logic. This provides a useful foundation for cross-key operations. For example, when reading from a range of keys, we can use the segment to position reads across all keys in the range. It could also be used as a basis for performing cross-key retention semantics (e.g. drop all segments older than one day). 