### PR TITLE
some perf fixes for ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1805,6 +1805,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,10 +3535,14 @@ version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = "1.0", features = ["full"] }
 tower = "0.5"
 tower-http = { version = "0.5", features = ["cors"] }
 tracing = "0.1"
-tracing-subscriber = "0.3"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = "1.14.0"
 prost = "0.13"
 snap = "1"

--- a/timeseries/src/main.rs
+++ b/timeseries/src/main.rs
@@ -27,8 +27,14 @@ use tsdb::Tsdb;
 
 #[tokio::main]
 async fn main() {
-    // Initialize tracing
-    tracing_subscriber::fmt::init();
+    // Initialize tracing with configurable log level via RUST_LOG environment variable
+    // Default to "info" if RUST_LOG is not set
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE) // Only exit events with timing
+        .with_target(true)
+        .with_line_number(true)
+        .init();
 
     // Parse CLI arguments
     let args = CliArgs::parse();

--- a/timeseries/src/promql/metrics.rs
+++ b/timeseries/src/promql/metrics.rs
@@ -61,6 +61,12 @@ pub struct Metrics {
 
     /// Counter of HTTP requests.
     pub http_requests_total: Family<HttpLabelsWithStatus, Counter>,
+
+    /// Counter of samples successfully ingested via remote write.
+    pub remote_write_samples_ingested: Counter,
+
+    /// Counter of samples that failed to ingest via remote write.
+    pub remote_write_samples_failed: Counter,
 }
 
 impl Default for Metrics {
@@ -98,11 +104,29 @@ impl Metrics {
             http_requests_total.clone(),
         );
 
+        // Remote write samples ingested counter
+        let remote_write_samples_ingested = Counter::default();
+        registry.register(
+            "remote_write_samples_ingested_total",
+            "Total number of samples successfully ingested via remote write",
+            remote_write_samples_ingested.clone(),
+        );
+
+        // Remote write samples failed counter
+        let remote_write_samples_failed = Counter::default();
+        registry.register(
+            "remote_write_samples_failed_total",
+            "Total number of samples that failed to ingest via remote write",
+            remote_write_samples_failed.clone(),
+        );
+
         Self {
             registry,
             scrape_samples_scraped,
             scrape_samples_failed,
             http_requests_total,
+            remote_write_samples_ingested,
+            remote_write_samples_failed,
         }
     }
 
@@ -128,6 +152,8 @@ mod tests {
         let encoded = metrics.encode();
         assert!(encoded.contains("# HELP scrape_samples_scraped"));
         assert!(encoded.contains("# HELP http_requests_total"));
+        assert!(encoded.contains("# HELP remote_write_samples_ingested_total"));
+        assert!(encoded.contains("# HELP remote_write_samples_failed_total"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds some perf fixes for ingestion
- apply all samples to a given bucket in-batch within a single request. Amortizes costs from applying individual deltas to the current bucket (previously we were creating a new delta, and entering the critical section on every sample)
- configure some read-ahead for scans to improve bucket loading times. Currently we just use a fixed 1MB read-ahead. This is perhaps not appropriate for some scan scenarios. We can do something smarter later. Takes load time from minutes to millis
- adds a metric for samples ingested over remote-write

## Test Plan

Tested with victoriametrics prometheus benchmark. After this patch (and an additional patch to add backpressure: #45), I was able to ingest ~150K samples/second on an r5.xlarge (4 cores)

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
