### PR TITLE
[log] First implementation of log segments

### DIFF
--- a/log/src/config.rs
+++ b/log/src/config.rs
@@ -3,6 +3,8 @@
 //! This module defines the configuration and options structs that control
 //! the behavior of the log, including storage setup and operation parameters.
 
+use std::time::Duration;
+
 use common::StorageConfig;
 
 /// Configuration for opening a [`Log`](crate::Log).
@@ -18,6 +20,7 @@ use common::StorageConfig;
 ///
 /// let config = Config {
 ///     storage: StorageConfig::default(),
+///     segmentation: SegmentConfig::default(),
 /// };
 /// let log = Log::open(config).await?;
 /// ```
@@ -28,6 +31,41 @@ pub struct Config {
     /// Determines where and how log data is persisted. See [`StorageConfig`]
     /// for available options including in-memory and SlateDB backends.
     pub storage: StorageConfig,
+
+    /// Segmentation configuration.
+    ///
+    /// Controls how the log is partitioned into segments for efficient
+    /// time-based queries and retention management.
+    pub segmentation: SegmentConfig,
+}
+
+/// Configuration for log segmentation.
+///
+/// Segments partition the log into time-based chunks, enabling efficient
+/// range queries and retention management. See RFC 0002 for details.
+#[derive(Debug, Clone, Default)]
+pub struct SegmentConfig {
+    /// Interval for automatic segment sealing based on wall-clock time.
+    ///
+    /// When set, a new segment is created after the specified duration has
+    /// elapsed since the current segment was created. This enables time-based
+    /// partitioning for efficient queries and retention.
+    ///
+    /// When `None` (the default), automatic sealing is disabled and all
+    /// entries are written to segment 0 indefinitely.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use std::time::Duration;
+    /// use log::SegmentConfig;
+    ///
+    /// // Create a new segment every hour
+    /// let config = SegmentConfig {
+    ///     seal_interval: Some(Duration::from_secs(3600)),
+    /// };
+    /// ```
+    pub seal_interval: Option<Duration>,
 }
 
 /// Options for write operations.

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -46,11 +46,12 @@ mod error;
 mod log;
 mod model;
 mod reader;
+mod segment;
 mod sequence;
 mod serde;
 
-pub use config::{Config, CountOptions, ScanOptions, WriteOptions};
+pub use config::{Config, CountOptions, ScanOptions, SegmentConfig, WriteOptions};
 pub use error::{Error, Result};
-pub use log::{Log, LogIterator};
+pub use log::Log;
 pub use model::{LogEntry, Record};
-pub use reader::{LogRead, LogReader};
+pub use reader::{LogIterator, LogRead, LogReader};

--- a/log/src/segment.rs
+++ b/log/src/segment.rs
@@ -1,0 +1,967 @@
+#![allow(dead_code)]
+
+//! Log segment management.
+//!
+//! This module provides the [`LogSegment`] abstraction for logical partitioning
+//! of log data. Segments are sequential, non-overlapping ranges of sequence numbers
+//! that enable efficient seeking, retention management, and cross-key operations.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use common::{Record, Storage, StorageRead};
+use tokio::sync::RwLock;
+
+use crate::error::Result;
+use crate::serde::{SegmentId, SegmentMeta, SegmentMetaKey};
+
+/// Read-only operations for segments.
+#[async_trait]
+pub(crate) trait SegmentRead: Send + Sync {
+    /// Returns the underlying storage.
+    fn storage(&self) -> Arc<dyn StorageRead>;
+
+    /// Returns the latest segment, if any exist.
+    async fn latest(&self) -> Result<Option<LogSegment>>;
+
+    /// Returns all segments ordered by start sequence.
+    async fn all(&self) -> Result<Vec<LogSegment>>;
+
+    /// Finds segments covering the given sequence range.
+    async fn find_covering(&self, range: std::ops::Range<u64>) -> Result<Vec<LogSegment>>;
+}
+
+/// A logical segment of the log.
+///
+/// `LogSegment` is a first-class object representing a segment in the log.
+/// Segments group entries across all keys within a range of sequence numbers.
+///
+/// Currently tracks only ID and metadata, but designed to eventually hold
+/// additional state such as key listings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LogSegment {
+    id: SegmentId,
+    meta: SegmentMeta,
+}
+
+impl LogSegment {
+    /// Creates a new log segment.
+    pub(crate) fn new(id: SegmentId, meta: SegmentMeta) -> Self {
+        Self { id, meta }
+    }
+
+    /// Returns the segment's unique identifier.
+    pub fn id(&self) -> SegmentId {
+        self.id
+    }
+
+    /// Returns the segment's metadata.
+    pub fn meta(&self) -> &SegmentMeta {
+        &self.meta
+    }
+}
+
+/// In-memory cache of segments loaded from storage.
+///
+/// Used by both [`SegmentReader`] and [`SegmentStore`] to provide
+/// fast access to segment metadata without repeated storage reads.
+///
+/// Keyed by `start_seq` to optimize `find_covering` queries.
+struct SegmentCache {
+    /// Segments keyed by their starting sequence number.
+    segments: RwLock<BTreeMap<u64, LogSegment>>,
+}
+
+impl SegmentCache {
+    /// Creates a new cache by loading all segments from storage.
+    async fn open(storage: &dyn StorageRead) -> Result<Self> {
+        let range = SegmentMetaKey::scan_range(..);
+        let records = storage.scan(range).await?;
+
+        let mut segments = BTreeMap::new();
+        for record in records {
+            let key = SegmentMetaKey::deserialize(&record.key)?;
+            let meta = SegmentMeta::deserialize(&record.value)?;
+            let start_seq = meta.start_seq;
+            let segment = LogSegment::new(key.segment_id, meta);
+            segments.insert(start_seq, segment);
+        }
+
+        Ok(Self {
+            segments: RwLock::new(segments),
+        })
+    }
+
+    /// Creates an empty cache for testing.
+    #[cfg(test)]
+    fn new() -> Self {
+        Self {
+            segments: RwLock::new(BTreeMap::new()),
+        }
+    }
+
+    /// Returns the latest segment, if any exist.
+    async fn latest(&self) -> Option<LogSegment> {
+        let segments = self.segments.read().await;
+        segments.values().next_back().cloned()
+    }
+
+    /// Returns all segments ordered by start sequence.
+    async fn all(&self) -> Vec<LogSegment> {
+        let segments = self.segments.read().await;
+        segments.values().cloned().collect()
+    }
+
+    /// Finds segments covering the given sequence range.
+    async fn find_covering(&self, range: std::ops::Range<u64>) -> Vec<LogSegment> {
+        let segments = self.segments.read().await;
+
+        if range.start >= range.end {
+            return Vec::new();
+        }
+
+        // Find the first segment that could contain range.start.
+        // This is the segment with the largest start_seq <= range.start.
+        let mut result = Vec::new();
+        let mut iter = segments.range(..=range.start).rev();
+
+        if let Some((_, first_seg)) = iter.next() {
+            result.push(first_seg.clone());
+        }
+
+        // Add all segments starting within our query range
+        for (_, seg) in segments.range(range.start.saturating_add(1)..range.end) {
+            result.push(seg.clone());
+        }
+
+        result
+    }
+
+    /// Adds a segment to the cache.
+    async fn insert(&self, segment: LogSegment) {
+        let mut segments = self.segments.write().await;
+        segments.insert(segment.meta.start_seq, segment);
+    }
+
+    /// Refreshes the cache by loading segments from storage.
+    ///
+    /// If `after_segment_id` is `Some(id)`, only loads segments with id > `id` and appends them.
+    /// If `after_segment_id` is `None`, reloads all segments.
+    async fn refresh(
+        &self,
+        storage: &dyn StorageRead,
+        after_segment_id: Option<SegmentId>,
+    ) -> Result<()> {
+        let range = match after_segment_id {
+            Some(id) => SegmentMetaKey::scan_range(id.saturating_add(1)..),
+            None => SegmentMetaKey::scan_range(..),
+        };
+        let records = storage.scan(range).await?;
+
+        let mut segments = self.segments.write().await;
+        if after_segment_id.is_none() {
+            segments.clear();
+        }
+
+        for record in records {
+            let key = SegmentMetaKey::deserialize(&record.key)?;
+            let meta = SegmentMeta::deserialize(&record.value)?;
+            let start_seq = meta.start_seq;
+            let segment = LogSegment::new(key.segment_id, meta);
+            segments.insert(start_seq, segment);
+        }
+
+        Ok(())
+    }
+}
+
+/// Read-only access to segments.
+///
+/// `SegmentReader` provides read-only operations for discovering and
+/// loading segments from storage. Used by `LogReader` and other components
+/// that don't need write access.
+pub(crate) struct SegmentReader {
+    storage: Arc<dyn StorageRead>,
+    cache: SegmentCache,
+}
+
+impl SegmentReader {
+    /// Opens a segment reader, loading all segments into cache.
+    pub(crate) async fn open(storage: Arc<dyn StorageRead>) -> Result<Self> {
+        let cache = SegmentCache::open(&*storage).await?;
+        Ok(Self { storage, cache })
+    }
+
+    /// Creates a new segment reader for testing.
+    #[cfg(test)]
+    pub(crate) fn new(storage: Arc<dyn StorageRead>) -> Self {
+        Self {
+            storage,
+            cache: SegmentCache::new(),
+        }
+    }
+
+    /// Refreshes the segment cache by loading new segments from storage.
+    ///
+    /// Only scans for segments newer than the latest cached segment.
+    // TODO: Add periodic refresh to scan for new segments from storage.
+    pub(crate) async fn refresh(&self) -> Result<()> {
+        let after = self.cache.latest().await.map(|s| s.id);
+        self.cache.refresh(&*self.storage, after).await
+    }
+}
+
+#[async_trait]
+impl SegmentRead for SegmentReader {
+    fn storage(&self) -> Arc<dyn StorageRead> {
+        Arc::clone(&self.storage)
+    }
+
+    async fn latest(&self) -> Result<Option<LogSegment>> {
+        Ok(self.cache.latest().await)
+    }
+
+    async fn all(&self) -> Result<Vec<LogSegment>> {
+        Ok(self.cache.all().await)
+    }
+
+    async fn find_covering(&self, range: std::ops::Range<u64>) -> Result<Vec<LogSegment>> {
+        Ok(self.cache.find_covering(range).await)
+    }
+}
+
+/// Manages segment persistence and lifecycle.
+///
+/// `SegmentStore` handles creating new segments and tracking the active segment.
+/// For read-only access, use [`SegmentReader`].
+pub(crate) struct SegmentStore {
+    storage: Arc<dyn Storage>,
+    cache: SegmentCache,
+    config: crate::config::SegmentConfig,
+}
+
+impl SegmentStore {
+    /// Opens the segment store, loading all existing segments into cache.
+    pub(crate) async fn open(
+        storage: Arc<dyn Storage>,
+        config: crate::config::SegmentConfig,
+    ) -> Result<Self> {
+        let cache = SegmentCache::open(&*storage).await?;
+        Ok(Self {
+            storage,
+            cache,
+            config,
+        })
+    }
+
+    /// Creates a new segment store for testing.
+    #[cfg(test)]
+    pub(crate) fn new(storage: Arc<dyn Storage>) -> Self {
+        Self {
+            storage,
+            cache: SegmentCache::new(),
+            config: crate::config::SegmentConfig::default(),
+        }
+    }
+
+    /// Writes a new segment.
+    ///
+    /// The new segment ID is derived from the latest existing segment.
+    /// Returns the newly created segment.
+    pub(crate) async fn write(&self, meta: SegmentMeta) -> Result<LogSegment> {
+        let segment_id = match self.cache.latest().await {
+            Some(latest) => latest.id + 1,
+            None => 0,
+        };
+
+        let key = SegmentMetaKey::new(segment_id).serialize();
+        let value = meta.serialize();
+        self.storage.put(vec![Record::new(key, value)]).await?;
+
+        let segment = LogSegment::new(segment_id, meta);
+        self.cache.insert(segment.clone()).await;
+
+        Ok(segment)
+    }
+
+    /// Checks if the current segment should be rolled based on the seal interval.
+    ///
+    /// Returns `true` if:
+    /// - A seal interval is configured, AND
+    /// - Either no segment exists, OR the current segment has exceeded the seal interval
+    ///
+    /// The `current_time_ms` parameter is the current wall-clock time in milliseconds
+    /// since the Unix epoch.
+    pub(crate) async fn should_roll(&self, current_time_ms: i64) -> bool {
+        let Some(seal_interval) = self.config.seal_interval else {
+            return false;
+        };
+
+        let Some(latest) = self.cache.latest().await else {
+            // No segments exist yet
+            return true;
+        };
+
+        let seal_interval_ms = seal_interval.as_millis() as i64;
+        let segment_age_ms = current_time_ms - latest.meta().start_time_ms;
+        segment_age_ms >= seal_interval_ms
+    }
+
+    /// Forces creation of a new segment, sealing the current one.
+    ///
+    /// This unconditionally creates a new segment regardless of seal interval.
+    /// Used for testing and manual segment management.
+    ///
+    /// # Parameters
+    /// - `current_time_ms`: Current wall-clock time in milliseconds since Unix epoch
+    /// - `start_seq`: The starting sequence number for the new segment
+    ///
+    /// # Returns
+    /// The newly created segment.
+    pub(crate) async fn seal_current(
+        &self,
+        current_time_ms: i64,
+        start_seq: u64,
+    ) -> Result<LogSegment> {
+        self.write(SegmentMeta::new(start_seq, current_time_ms))
+            .await
+    }
+
+    /// Ensures a segment is available for writing, rolling if necessary.
+    ///
+    /// If no segment exists or the current segment has exceeded the seal interval,
+    /// a new segment is created. This method should be used when appending entries
+    /// to ensure writes go to the appropriate segment.
+    ///
+    /// # Parameters
+    /// - `current_time_ms`: Current wall-clock time in milliseconds since Unix epoch
+    /// - `start_seq`: The starting sequence number for a new segment if one is created
+    ///
+    /// # Returns
+    /// The segment that should receive new writes.
+    pub(crate) async fn ensure_latest(
+        &self,
+        current_time_ms: i64,
+        start_seq: u64,
+    ) -> Result<LogSegment> {
+        if self.should_roll(current_time_ms).await {
+            return self
+                .write(SegmentMeta::new(start_seq, current_time_ms))
+                .await;
+        }
+
+        // should_roll returned false. Either:
+        // 1. seal_interval is None - use latest or create first segment
+        // 2. seal_interval is Some but segment is young - use latest (which must exist)
+        match self.cache.latest().await {
+            Some(segment) => Ok(segment),
+            None => {
+                self.write(SegmentMeta::new(start_seq, current_time_ms))
+                    .await
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl SegmentRead for SegmentStore {
+    fn storage(&self) -> Arc<dyn StorageRead> {
+        Arc::clone(&self.storage) as Arc<dyn StorageRead>
+    }
+
+    async fn latest(&self) -> Result<Option<LogSegment>> {
+        Ok(self.cache.latest().await)
+    }
+
+    async fn all(&self) -> Result<Vec<LogSegment>> {
+        Ok(self.cache.all().await)
+    }
+
+    async fn find_covering(&self, range: std::ops::Range<u64>) -> Result<Vec<LogSegment>> {
+        Ok(self.cache.find_covering(range).await)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::SegmentConfig;
+    use common::storage::in_memory::InMemoryStorage;
+
+    #[tokio::test]
+    async fn should_return_none_when_no_segments_exist() {
+        // given
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage, Default::default())
+            .await
+            .unwrap();
+
+        // when
+        let latest = store.latest().await.unwrap();
+
+        // then
+        assert!(latest.is_none());
+    }
+
+    #[tokio::test]
+    async fn should_write_first_segment_with_id_zero() {
+        // given
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage, Default::default())
+            .await
+            .unwrap();
+        let meta = SegmentMeta::new(0, 1000);
+
+        // when
+        let segment = store.write(meta.clone()).await.unwrap();
+
+        // then
+        assert_eq!(segment.id(), 0);
+        assert_eq!(segment.meta(), &meta);
+    }
+
+    #[tokio::test]
+    async fn should_increment_segment_id_on_subsequent_writes() {
+        // given
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage, Default::default())
+            .await
+            .unwrap();
+
+        // when
+        let seg0 = store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        let seg1 = store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        let seg2 = store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+
+        // then
+        assert_eq!(seg0.id(), 0);
+        assert_eq!(seg1.id(), 1);
+        assert_eq!(seg2.id(), 2);
+    }
+
+    #[tokio::test]
+    async fn should_return_latest_segment() {
+        // given
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage, Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+
+        // when
+        let latest = store.latest().await.unwrap();
+
+        // then
+        assert_eq!(latest.unwrap().id(), 1);
+    }
+
+    #[tokio::test]
+    async fn should_scan_all_segments() {
+        // given
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage, Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+
+        // when
+        let segments = store.all().await.unwrap();
+
+        // then
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[0].id(), 0);
+        assert_eq!(segments[1].id(), 1);
+        assert_eq!(segments[2].id(), 2);
+    }
+
+    #[tokio::test]
+    async fn should_persist_segments_to_storage() {
+        // given
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+
+        // when - reopen from same storage
+        let store2 = SegmentStore::open(storage, Default::default())
+            .await
+            .unwrap();
+        let segments = store2.all().await.unwrap();
+
+        // then
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].id(), 0);
+        assert_eq!(segments[0].meta().start_seq, 0);
+        assert_eq!(segments[1].id(), 1);
+        assert_eq!(segments[1].meta().start_seq, 100);
+    }
+
+    #[tokio::test]
+    async fn should_load_segments_on_reader_open() {
+        // given
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+
+        // when
+        let reader = SegmentReader::open(storage).await.unwrap();
+        let segments = reader.all().await.unwrap();
+
+        // then
+        assert_eq!(segments.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn should_find_segments_by_seq_range_all() {
+        // given: segments at seq 0, 100, 200
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+
+        let reader = SegmentReader::open(storage).await.unwrap();
+
+        // when: query all sequences
+        let segments = reader.find_covering(0..u64::MAX).await.unwrap();
+
+        // then: all segments match
+        assert_eq!(segments.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn should_find_segments_by_seq_range_single() {
+        // given: segments at seq 0, 100, 200
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+
+        let reader = SegmentReader::open(storage).await.unwrap();
+
+        // when: query seq 50..60 (within first segment)
+        let segments = reader.find_covering(50..60).await.unwrap();
+
+        // then: only first segment matches
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].id(), 0);
+    }
+
+    #[tokio::test]
+    async fn should_find_segments_by_seq_range_spanning() {
+        // given: segments at seq 0, 100, 200
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+
+        let reader = SegmentReader::open(storage).await.unwrap();
+
+        // when: query seq 50..150 (spans first and second segment)
+        let segments = reader.find_covering(50..150).await.unwrap();
+
+        // then: first two segments match
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].id(), 0);
+        assert_eq!(segments[1].id(), 1);
+    }
+
+    #[tokio::test]
+    async fn should_find_segments_by_seq_range_unbounded_end() {
+        // given: segments at seq 0, 100, 200
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+
+        let reader = SegmentReader::open(storage).await.unwrap();
+
+        // when: query seq 150.. (from middle of second segment to end)
+        let segments = reader.find_covering(150..u64::MAX).await.unwrap();
+
+        // then: second and third segments match
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].id(), 1);
+        assert_eq!(segments[1].id(), 2);
+    }
+
+    #[tokio::test]
+    async fn should_find_no_segments_when_range_before_all() {
+        // given: segments starting at seq 100
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(100, 1000)).await.unwrap();
+
+        let reader = SegmentReader::open(storage).await.unwrap();
+
+        // when: query seq 0..50 (before any segment data)
+        let segments = reader.find_covering(0..50).await.unwrap();
+
+        // then: no segments match (segment starts at 100)
+        assert_eq!(segments.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn should_find_no_segments_when_storage_empty() {
+        // given: no segments
+        let storage = Arc::new(InMemoryStorage::new());
+        let reader = SegmentReader::open(storage).await.unwrap();
+
+        // when: query any range
+        let segments = reader.find_covering(0..u64::MAX).await.unwrap();
+
+        // then: no segments
+        assert_eq!(segments.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn should_find_last_segment_when_range_after_all() {
+        // given: segments at seq 0, 100, 200
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+
+        let reader = SegmentReader::open(storage).await.unwrap();
+
+        // when: query seq 500..600 (after all segment starts)
+        let segments = reader.find_covering(500..600).await.unwrap();
+
+        // then: last segment matches (it could contain seqs 200+)
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].id(), 2);
+    }
+
+    #[tokio::test]
+    async fn should_find_segment_when_query_starts_at_boundary() {
+        // given: segments at seq 0, 100, 200
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+
+        let reader = SegmentReader::open(storage).await.unwrap();
+
+        // when: query starting exactly at segment boundary
+        let segments = reader.find_covering(100..150).await.unwrap();
+
+        // then: only the segment starting at 100 matches
+        assert_eq!(segments.len(), 1);
+        assert_eq!(segments[0].id(), 1);
+    }
+
+    #[tokio::test]
+    async fn should_find_segments_with_unbounded_start() {
+        // given: segments at seq 0, 100, 200
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+
+        let reader = SegmentReader::open(storage).await.unwrap();
+
+        // when: query with unbounded start ..150
+        let segments = reader.find_covering(0..150).await.unwrap();
+
+        // then: first two segments match
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].id(), 0);
+        assert_eq!(segments[1].id(), 1);
+    }
+
+    #[tokio::test]
+    async fn should_find_covering_via_segment_store() {
+        // given: segments at seq 0, 100, 200
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage, Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+
+        // when: query via store (not reader)
+        let segments = store.find_covering(50..150).await.unwrap();
+
+        // then: first two segments match
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].id(), 0);
+        assert_eq!(segments[1].id(), 1);
+    }
+
+    #[tokio::test]
+    async fn should_roll_returns_false_when_no_seal_interval() {
+        // given: store without seal interval
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage, Default::default())
+            .await
+            .unwrap();
+
+        // when
+        let should_roll = store.should_roll(1000).await;
+
+        // then
+        assert!(!should_roll);
+    }
+
+    #[tokio::test]
+    async fn should_roll_returns_true_when_no_segments_exist() {
+        // given: store with seal interval but no segments
+        let storage = Arc::new(InMemoryStorage::new());
+        let config = SegmentConfig {
+            seal_interval: Some(std::time::Duration::from_secs(3600)),
+        };
+        let store = SegmentStore::open(storage, config).await.unwrap();
+
+        // when
+        let should_roll = store.should_roll(1000).await;
+
+        // then: should roll to create first segment
+        assert!(should_roll);
+    }
+
+    #[tokio::test]
+    async fn should_roll_returns_false_when_within_interval() {
+        // given: segment created at time 1000, seal interval 1 hour
+        let storage = Arc::new(InMemoryStorage::new());
+        let config = SegmentConfig {
+            seal_interval: Some(std::time::Duration::from_secs(3600)),
+        };
+        let store = SegmentStore::open(storage, config).await.unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+
+        // when: current time is 1000 + 30 minutes
+        let current_time_ms = 1000 + 30 * 60 * 1000;
+        let should_roll = store.should_roll(current_time_ms).await;
+
+        // then
+        assert!(!should_roll);
+    }
+
+    #[tokio::test]
+    async fn should_roll_returns_true_when_interval_exceeded() {
+        // given: segment created at time 1000, seal interval 1 hour
+        let storage = Arc::new(InMemoryStorage::new());
+        let config = SegmentConfig {
+            seal_interval: Some(std::time::Duration::from_secs(3600)),
+        };
+        let store = SegmentStore::open(storage, config).await.unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+
+        // when: current time is 1000 + 2 hours
+        let current_time_ms = 1000 + 2 * 60 * 60 * 1000;
+        let should_roll = store.should_roll(current_time_ms).await;
+
+        // then
+        assert!(should_roll);
+    }
+
+    #[tokio::test]
+    async fn should_roll_returns_true_when_exactly_at_interval() {
+        // given: segment created at time 1000, seal interval 1 hour
+        let storage = Arc::new(InMemoryStorage::new());
+        let config = SegmentConfig {
+            seal_interval: Some(std::time::Duration::from_secs(3600)),
+        };
+        let store = SegmentStore::open(storage, config).await.unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+
+        // when: current time is exactly at the interval boundary
+        let current_time_ms = 1000 + 60 * 60 * 1000;
+        let should_roll = store.should_roll(current_time_ms).await;
+
+        // then: at boundary should roll
+        assert!(should_roll);
+    }
+
+    #[tokio::test]
+    async fn ensure_latest_creates_first_segment_when_none_exist_without_seal_interval() {
+        // given: no segments, no seal interval
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage, Default::default())
+            .await
+            .unwrap();
+
+        // when
+        let segment = store.ensure_latest(1000, 0).await.unwrap();
+
+        // then: creates segment 0
+        assert_eq!(segment.id(), 0);
+        assert_eq!(segment.meta().start_seq, 0);
+        assert_eq!(segment.meta().start_time_ms, 1000);
+    }
+
+    #[tokio::test]
+    async fn ensure_latest_creates_first_segment_when_none_exist_with_seal_interval() {
+        // given: no segments, seal interval configured
+        let storage = Arc::new(InMemoryStorage::new());
+        let config = SegmentConfig {
+            seal_interval: Some(std::time::Duration::from_secs(3600)),
+        };
+        let store = SegmentStore::open(storage, config).await.unwrap();
+
+        // when
+        let segment = store.ensure_latest(1000, 0).await.unwrap();
+
+        // then: creates segment 0
+        assert_eq!(segment.id(), 0);
+        assert_eq!(segment.meta().start_seq, 0);
+        assert_eq!(segment.meta().start_time_ms, 1000);
+    }
+
+    #[tokio::test]
+    async fn ensure_latest_returns_existing_segment_when_within_interval() {
+        // given: segment at time 1000, seal interval 1 hour
+        let storage = Arc::new(InMemoryStorage::new());
+        let config = SegmentConfig {
+            seal_interval: Some(std::time::Duration::from_secs(3600)),
+        };
+        let store = SegmentStore::open(storage, config).await.unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+
+        // when: request at 30 minutes later
+        let current_time_ms = 1000 + 30 * 60 * 1000;
+        let segment = store.ensure_latest(current_time_ms, 100).await.unwrap();
+
+        // then: returns existing segment (not rolled)
+        assert_eq!(segment.id(), 0);
+        assert_eq!(segment.meta().start_seq, 0);
+    }
+
+    #[tokio::test]
+    async fn ensure_latest_rolls_to_new_segment_when_interval_exceeded() {
+        // given: segment at time 1000, seal interval 1 hour
+        let storage = Arc::new(InMemoryStorage::new());
+        let config = SegmentConfig {
+            seal_interval: Some(std::time::Duration::from_secs(3600)),
+        };
+        let store = SegmentStore::open(storage, config).await.unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+
+        // when: request at 2 hours later
+        let current_time_ms = 1000 + 2 * 60 * 60 * 1000;
+        let segment = store.ensure_latest(current_time_ms, 100).await.unwrap();
+
+        // then: creates new segment
+        assert_eq!(segment.id(), 1);
+        assert_eq!(segment.meta().start_seq, 100);
+        assert_eq!(segment.meta().start_time_ms, current_time_ms);
+    }
+
+    #[tokio::test]
+    async fn ensure_latest_returns_existing_segment_without_seal_interval() {
+        // given: segment exists, no seal interval
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage, Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+
+        // when: request at any time
+        let segment = store.ensure_latest(999999999, 100).await.unwrap();
+
+        // then: returns existing segment (never rolls without seal_interval)
+        assert_eq!(segment.id(), 0);
+        assert_eq!(segment.meta().start_seq, 0);
+    }
+
+    #[tokio::test]
+    async fn refresh_should_load_new_segments_after_id() {
+        // given: reader with segment 0 cached
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+
+        let reader = SegmentReader::open(storage.clone()).await.unwrap();
+        assert_eq!(reader.all().await.unwrap().len(), 1);
+
+        // when: new segments are written and reader refreshes
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+        store.write(SegmentMeta::new(200, 3000)).await.unwrap();
+        reader.refresh().await.unwrap();
+
+        // then: reader sees all three segments
+        let segments = reader.all().await.unwrap();
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[0].id(), 0);
+        assert_eq!(segments[1].id(), 1);
+        assert_eq!(segments[2].id(), 2);
+    }
+
+    #[tokio::test]
+    async fn refresh_should_load_all_when_cache_empty() {
+        // given: reader with empty cache, segments in storage
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+
+        let reader = SegmentReader::new(storage.clone());
+        assert_eq!(reader.all().await.unwrap().len(), 0);
+
+        // when: refresh with empty cache
+        reader.refresh().await.unwrap();
+
+        // then: all segments loaded
+        let segments = reader.all().await.unwrap();
+        assert_eq!(segments.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn refresh_should_be_idempotent_when_no_new_segments() {
+        // given: reader with all segments cached
+        let storage = Arc::new(InMemoryStorage::new());
+        let store = SegmentStore::open(storage.clone(), Default::default())
+            .await
+            .unwrap();
+        store.write(SegmentMeta::new(0, 1000)).await.unwrap();
+        store.write(SegmentMeta::new(100, 2000)).await.unwrap();
+
+        let reader = SegmentReader::open(storage).await.unwrap();
+        assert_eq!(reader.all().await.unwrap().len(), 2);
+
+        // when: refresh with no new segments
+        reader.refresh().await.unwrap();
+
+        // then: same segments, no duplicates
+        let segments = reader.all().await.unwrap();
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0].id(), 0);
+        assert_eq!(segments[1].id(), 1);
+    }
+}

--- a/log/src/serde.rs
+++ b/log/src/serde.rs
@@ -58,6 +58,8 @@ pub enum RecordType {
     LogEntry = 0x01,
     /// Block allocation record for sequence number tracking
     SeqBlock = 0x02,
+    /// Segment metadata record
+    SegmentMeta = 0x03,
 }
 
 impl RecordType {
@@ -71,6 +73,7 @@ impl RecordType {
         match id {
             0x01 => Ok(RecordType::LogEntry),
             0x02 => Ok(RecordType::SeqBlock),
+            0x03 => Ok(RecordType::SegmentMeta),
             _ => Err(Error::Encoding(format!(
                 "invalid record type: 0x{:02x}",
                 id
@@ -81,18 +84,19 @@ impl RecordType {
 
 /// Key for a log entry record.
 ///
-/// The key encodes the user key and sequence number in a format that
-/// preserves lexicographic ordering:
+/// The key serializes the segment ID, user key, and sequence number in a format
+/// that preserves lexicographic ordering:
 ///
 /// ```text
-/// | version (u8) | type (u8) | key (TerminatedBytes) | sequence (u64 BE) |
+/// | version (u8) | type (u8) | segment_id (u32 BE) | terminated_key | sequence (u64 BE) |
 /// ```
 ///
-/// This ensures that:
-/// - All entries for a given key are contiguous
-/// - Within a key, entries are ordered by sequence number
+/// The ordering (segment_id before key) ensures entries are grouped by segment,
+/// enabling efficient scans within a single segment.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LogEntryKey {
+    /// The segment this entry belongs to
+    pub segment_id: SegmentId,
     /// The user-provided key identifying the log stream
     pub key: Bytes,
     /// The sequence number assigned to this entry
@@ -100,26 +104,31 @@ pub struct LogEntryKey {
 }
 
 impl LogEntryKey {
-    /// Creates a new log entry key
-    pub fn new(key: Bytes, sequence: u64) -> Self {
-        Self { key, sequence }
+    /// Creates a new log entry key.
+    pub fn new(segment_id: SegmentId, key: Bytes, sequence: u64) -> Self {
+        Self {
+            segment_id,
+            key,
+            sequence,
+        }
     }
 
-    /// Encodes the key to bytes for storage
-    pub fn encode(&self) -> Bytes {
+    /// Serializes the key to bytes for storage.
+    pub fn serialize(&self) -> Bytes {
         let mut buf = BytesMut::new();
         buf.put_u8(KEY_VERSION);
         buf.put_u8(RecordType::LogEntry.id());
+        buf.put_u32(self.segment_id);
         terminated_bytes::serialize(&self.key, &mut buf);
         buf.put_u64(self.sequence);
         buf.freeze()
     }
 
-    /// Decodes a log entry key from bytes
-    pub fn decode(data: &[u8]) -> Result<Self, Error> {
-        if data.len() < 2 {
+    /// Deserializes a log entry key from bytes.
+    pub fn deserialize(data: &[u8]) -> Result<Self, Error> {
+        if data.len() < 6 {
             return Err(Error::Encoding(
-                "buffer too short for log entry key".to_string(),
+                "buffer too short for new log entry key".to_string(),
             ));
         }
 
@@ -138,7 +147,9 @@ impl LogEntryKey {
             )));
         }
 
-        let mut buf = &data[2..];
+        let segment_id = u32::from_be_bytes([data[2], data[3], data[4], data[5]]);
+
+        let mut buf = &data[6..];
         let key = terminated_bytes::deserialize(&mut buf)?;
 
         if buf.len() < 8 {
@@ -151,46 +162,33 @@ impl LogEntryKey {
             buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
         ]);
 
-        Ok(LogEntryKey { key, sequence })
+        Ok(LogEntryKey {
+            segment_id,
+            key,
+            sequence,
+        })
     }
 
-    /// Creates a prefix for scanning all entries of a given key.
-    ///
-    /// The prefix includes the version, type, and terminated key bytes,
-    /// allowing efficient range scans for a single key's log.
-    pub fn key_prefix(key: &[u8]) -> Bytes {
+    /// Creates a prefix for scanning all entries in a segment for a given key.
+    pub fn segment_key_prefix(segment_id: SegmentId, key: &[u8]) -> Bytes {
         let mut buf = BytesMut::new();
         buf.put_u8(KEY_VERSION);
         buf.put_u8(RecordType::LogEntry.id());
+        buf.put_u32(segment_id);
         terminated_bytes::serialize(key, &mut buf);
         buf.freeze()
     }
 
-    /// Creates a storage key range for scanning entries of a key within a sequence range.
+    /// Creates a storage key range for scanning entries within a segment.
     ///
-    /// Converts a user key and sequence number range into a [`BytesRange`] suitable
-    /// for storage scanning. The resulting range will match all log entries for the
-    /// specified key whose sequence numbers fall within the given bounds.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The user key identifying the log stream
-    /// * `seq_range` - The sequence number range to scan (supports all Rust range types)
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// // Scan sequences 10..20 for key "orders"
-    /// let range = LogEntryKey::scan_range(b"orders", 10..20);
-    ///
-    /// // Scan all sequences from 100 onwards
-    /// let range = LogEntryKey::scan_range(b"orders", 100..);
-    ///
-    /// // Scan all sequences
-    /// let range = LogEntryKey::scan_range(b"orders", ..);
-    /// ```
-    pub fn scan_range(key: &[u8], seq_range: impl RangeBounds<u64>) -> BytesRange {
-        let prefix = Self::key_prefix(key);
+    /// Returns a range that matches all entries for the given segment and key
+    /// whose sequence numbers fall within the specified bounds.
+    pub fn scan_range(
+        segment_id: SegmentId,
+        key: &[u8],
+        seq_range: impl RangeBounds<u64>,
+    ) -> BytesRange {
+        let prefix = Self::segment_key_prefix(segment_id, key);
 
         let start = match seq_range.start_bound() {
             Bound::Included(&seq) => {
@@ -244,12 +242,12 @@ pub struct LastSeqBlockKey;
 
 impl LastSeqBlockKey {
     /// Encodes the SeqBlock key
-    pub fn encode(&self) -> Bytes {
+    pub fn serialize(&self) -> Bytes {
         Bytes::from(vec![KEY_VERSION, RecordType::SeqBlock.id()])
     }
 
     /// Decodes and validates a SeqBlock key
-    pub fn decode(data: &[u8]) -> Result<Self, Error> {
+    pub fn deserialize(data: &[u8]) -> Result<Self, Error> {
         if data.len() < 2 {
             return Err(Error::Encoding(
                 "buffer too short for SeqBlock key".to_string(),
@@ -302,7 +300,7 @@ impl SeqBlock {
     }
 
     /// Encodes the value to bytes
-    pub fn encode(&self) -> Bytes {
+    pub fn serialize(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(16);
         buf.put_u64(self.base_sequence);
         buf.put_u64(self.block_size);
@@ -310,7 +308,7 @@ impl SeqBlock {
     }
 
     /// Decodes a SeqBlock value from bytes
-    pub fn decode(data: &[u8]) -> Result<Self, Error> {
+    pub fn deserialize(data: &[u8]) -> Result<Self, Error> {
         if data.len() < 16 {
             return Err(Error::Encoding(format!(
                 "buffer too short for SeqBlock value: need 16 bytes, got {}",
@@ -334,6 +332,134 @@ impl SeqBlock {
     /// Returns the next sequence number after this block
     pub fn next_base(&self) -> u64 {
         self.base_sequence + self.block_size
+    }
+}
+
+/// Segment identifier type.
+pub type SegmentId = u32;
+
+/// Key for a segment metadata record.
+///
+/// ```text
+/// | version (u8) | type (u8=0x03) | segment_id (u32 BE) |
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentMetaKey {
+    /// The segment identifier
+    pub segment_id: SegmentId,
+}
+
+impl SegmentMetaKey {
+    /// Creates a new segment metadata key
+    pub fn new(segment_id: SegmentId) -> Self {
+        Self { segment_id }
+    }
+
+    /// Encodes the key to bytes for storage
+    pub fn serialize(&self) -> Bytes {
+        let mut buf = BytesMut::with_capacity(6);
+        buf.put_u8(KEY_VERSION);
+        buf.put_u8(RecordType::SegmentMeta.id());
+        buf.put_u32(self.segment_id);
+        buf.freeze()
+    }
+
+    /// Decodes a segment metadata key from bytes
+    pub fn deserialize(data: &[u8]) -> Result<Self, Error> {
+        if data.len() < 6 {
+            return Err(Error::Encoding(
+                "buffer too short for SegmentMeta key".to_string(),
+            ));
+        }
+
+        if data[0] != KEY_VERSION {
+            return Err(Error::Encoding(format!(
+                "invalid key version: expected 0x{:02x}, got 0x{:02x}",
+                KEY_VERSION, data[0]
+            )));
+        }
+
+        let record_type = RecordType::from_id(data[1])?;
+        if record_type != RecordType::SegmentMeta {
+            return Err(Error::Encoding(format!(
+                "invalid record type: expected SegmentMeta, got {:?}",
+                record_type
+            )));
+        }
+
+        let segment_id = u32::from_be_bytes([data[2], data[3], data[4], data[5]]);
+
+        Ok(SegmentMetaKey { segment_id })
+    }
+
+    /// Creates a storage key range for scanning segment metadata within a segment ID range.
+    pub fn scan_range(range: impl RangeBounds<SegmentId>) -> BytesRange {
+        let start = match range.start_bound() {
+            Bound::Included(&id) => Bound::Included(SegmentMetaKey::new(id).serialize()),
+            Bound::Excluded(&id) => Bound::Excluded(SegmentMetaKey::new(id).serialize()),
+            Bound::Unbounded => Bound::Included(SegmentMetaKey::new(0).serialize()),
+        };
+
+        let end = match range.end_bound() {
+            Bound::Included(&id) => Bound::Included(SegmentMetaKey::new(id).serialize()),
+            Bound::Excluded(&id) => Bound::Excluded(SegmentMetaKey::new(id).serialize()),
+            Bound::Unbounded => Bound::Included(SegmentMetaKey::new(SegmentId::MAX).serialize()),
+        };
+
+        BytesRange::new(start, end)
+    }
+}
+
+/// Value for a segment metadata record.
+///
+/// ```text
+/// | start_seq (u64 BE) | start_time_ms (i64 BE) |
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SegmentMeta {
+    /// The first sequence number in this segment
+    pub start_seq: u64,
+    /// Wall-clock time when this segment was created (milliseconds since epoch)
+    pub start_time_ms: i64,
+}
+
+impl SegmentMeta {
+    /// Creates a new segment metadata value
+    pub fn new(start_seq: u64, start_time_ms: i64) -> Self {
+        Self {
+            start_seq,
+            start_time_ms,
+        }
+    }
+
+    /// Encodes the value to bytes
+    pub fn serialize(&self) -> Bytes {
+        let mut buf = BytesMut::with_capacity(16);
+        buf.put_u64(self.start_seq);
+        buf.put_i64(self.start_time_ms);
+        buf.freeze()
+    }
+
+    /// Decodes a segment metadata value from bytes
+    pub fn deserialize(data: &[u8]) -> Result<Self, Error> {
+        if data.len() < 16 {
+            return Err(Error::Encoding(format!(
+                "buffer too short for SegmentMeta value: need 16 bytes, got {}",
+                data.len()
+            )));
+        }
+
+        let start_seq = u64::from_be_bytes([
+            data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7],
+        ]);
+        let start_time_ms = i64::from_be_bytes([
+            data[8], data[9], data[10], data[11], data[12], data[13], data[14], data[15],
+        ]);
+
+        Ok(SegmentMeta {
+            start_seq,
+            start_time_ms,
+        })
     }
 }
 
@@ -367,129 +493,19 @@ mod tests {
     }
 
     #[test]
-    fn should_serialize_and_deserialize_log_entry_key() {
-        // given
-        let key = LogEntryKey::new(Bytes::from("orders"), 12345);
-
-        // when
-        let encoded = key.encode();
-        let decoded = LogEntryKey::decode(&encoded).unwrap();
-
-        // then
-        assert_eq!(decoded, key);
-    }
-
-    #[test]
-    fn should_serialize_and_deserialize_log_entry_key_with_special_bytes() {
-        // given - key containing all special bytes: terminator (0x00), escape (0x01), range end (0xFF)
-        let key = LogEntryKey::new(Bytes::from_static(&[0x61, 0x00, 0x01, 0xFF, 0x62]), 99999);
-
-        // when
-        let encoded = key.encode();
-        let decoded = LogEntryKey::decode(&encoded).unwrap();
-
-        // then
-        assert_eq!(decoded, key);
-    }
-
-    #[test]
-    fn should_serialize_log_entry_key_with_correct_structure() {
-        // given
-        let key = LogEntryKey::new(Bytes::from("test"), 256);
-
-        // when
-        let encoded = key.encode();
-
-        // then
-        assert_eq!(encoded[0], KEY_VERSION);
-        assert_eq!(encoded[1], RecordType::LogEntry.id());
-        // "test" + terminator = [t, e, s, t, 0x00]
-        // sequence 256 = 0x0000000000000100
-    }
-
-    #[test]
-    fn should_order_log_entries_by_key_then_sequence() {
-        // given
-        let entries = [
-            LogEntryKey::new(Bytes::from("a"), 2),
-            LogEntryKey::new(Bytes::from("a"), 1),
-            LogEntryKey::new(Bytes::from("b"), 1),
-            LogEntryKey::new(Bytes::from("a"), 3),
-        ];
-
-        // when
-        let mut encoded: Vec<Bytes> = entries.iter().map(|e| e.encode()).collect();
-        encoded.sort();
-
-        // then - should be ordered: a:1, a:2, a:3, b:1
-        let decoded: Vec<LogEntryKey> = encoded
-            .iter()
-            .map(|e| LogEntryKey::decode(e).unwrap())
-            .collect();
-
-        assert_eq!(decoded[0], LogEntryKey::new(Bytes::from("a"), 1));
-        assert_eq!(decoded[1], LogEntryKey::new(Bytes::from("a"), 2));
-        assert_eq!(decoded[2], LogEntryKey::new(Bytes::from("a"), 3));
-        assert_eq!(decoded[3], LogEntryKey::new(Bytes::from("b"), 1));
-    }
-
-    #[test]
-    fn should_generate_key_prefix_for_scanning() {
-        // given
-        let user_key = b"orders";
-        let entry1 = LogEntryKey::new(Bytes::from_static(user_key), 1);
-        let entry2 = LogEntryKey::new(Bytes::from_static(user_key), 100);
-        let other_entry = LogEntryKey::new(Bytes::from("other"), 1);
-
-        // when
-        let prefix = LogEntryKey::key_prefix(user_key);
-
-        // then
-        assert!(entry1.encode().starts_with(&prefix));
-        assert!(entry2.encode().starts_with(&prefix));
-        assert!(!other_entry.encode().starts_with(&prefix));
-    }
-
-    #[test]
-    fn should_fail_deserialize_log_entry_key_with_wrong_version() {
-        // given
-        let data = LogEntryKey::new(Bytes::from("test"), 1).encode();
-        let mut modified = data.to_vec();
-        modified[0] = 0x99; // wrong version
-
-        // when
-        let result = LogEntryKey::decode(&modified);
-
-        // then
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn should_fail_deserialize_log_entry_key_with_wrong_type() {
-        // given - SeqBlock type instead of LogEntry
-        let data = vec![KEY_VERSION, RecordType::SeqBlock.id()];
-
-        // when
-        let result = LogEntryKey::decode(&data);
-
-        // then
-        assert!(result.is_err());
-    }
-
-    #[test]
     fn should_serialize_and_deserialize_seq_block_key() {
         // given
         let key = LastSeqBlockKey;
 
         // when
-        let encoded = key.encode();
-        let decoded = LastSeqBlockKey::decode(&encoded).unwrap();
+        let serialized = key.serialize();
+        let deserialized = LastSeqBlockKey::deserialize(&serialized).unwrap();
 
         // then
-        assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 2);
-        assert_eq!(encoded[0], KEY_VERSION);
-        assert_eq!(encoded[1], RecordType::SeqBlock.id());
+        assert_eq!(deserialized, key);
+        assert_eq!(serialized.len(), 2);
+        assert_eq!(serialized[0], KEY_VERSION);
+        assert_eq!(serialized[1], RecordType::SeqBlock.id());
     }
 
     #[test]
@@ -498,7 +514,7 @@ mod tests {
         let data = vec![KEY_VERSION, RecordType::LogEntry.id()];
 
         // when
-        let result = LastSeqBlockKey::decode(&data);
+        let result = LastSeqBlockKey::deserialize(&data);
 
         // then
         assert!(result.is_err());
@@ -510,12 +526,12 @@ mod tests {
         let value = SeqBlock::new(1000, 100);
 
         // when
-        let encoded = value.encode();
-        let decoded = SeqBlock::decode(&encoded).unwrap();
+        let serialized = value.serialize();
+        let deserialized = SeqBlock::deserialize(&serialized).unwrap();
 
         // then
-        assert_eq!(decoded, value);
-        assert_eq!(encoded.len(), 16);
+        assert_eq!(deserialized, value);
+        assert_eq!(serialized.len(), 16);
     }
 
     #[test]
@@ -536,7 +552,7 @@ mod tests {
         let data = vec![0u8; 15]; // need 16 bytes
 
         // when
-        let result = SeqBlock::decode(&data);
+        let result = SeqBlock::deserialize(&data);
 
         // then
         assert!(result.is_err());
@@ -548,15 +564,102 @@ mod tests {
         let value = SeqBlock::new(0x0102030405060708, 0x1112131415161718);
 
         // when
-        let encoded = value.encode();
+        let serialized = value.serialize();
 
         // then
         assert_eq!(
-            encoded.as_ref(),
+            serialized.as_ref(),
             &[
                 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, // base_sequence
                 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, // block_size
             ]
         );
+    }
+
+    #[test]
+    fn should_serialize_and_deserialize_log_entry_key() {
+        // given
+        let key = LogEntryKey::new(42, Bytes::from("test_key"), 12345);
+
+        // when
+        let serialized = key.serialize();
+        let deserialized = LogEntryKey::deserialize(&serialized).unwrap();
+
+        // then
+        assert_eq!(deserialized.segment_id, 42);
+        assert_eq!(deserialized.key, Bytes::from("test_key"));
+        assert_eq!(deserialized.sequence, 12345);
+    }
+
+    #[test]
+    fn should_serialize_log_entry_key_with_correct_structure() {
+        // given
+        let key = LogEntryKey::new(1, Bytes::from("k"), 100);
+
+        // when
+        let serialized = key.serialize();
+
+        // then
+        // version (1) + type (1) + segment_id (4) + key "k" (1) + terminator (1) + sequence (8) = 16
+        assert_eq!(serialized[0], KEY_VERSION);
+        assert_eq!(serialized[1], RecordType::LogEntry.id());
+        // segment_id = 1 in big endian
+        assert_eq!(&serialized[2..6], &[0, 0, 0, 1]);
+        // key "k" + terminator
+        assert_eq!(serialized[6], b'k');
+        assert_eq!(serialized[7], 0x00); // terminator
+        // sequence = 100 in big endian
+        assert_eq!(&serialized[8..16], &[0, 0, 0, 0, 0, 0, 0, 100]);
+    }
+
+    #[test]
+    fn should_order_log_entries_by_segment_then_key_then_sequence() {
+        // given
+        let key1 = LogEntryKey::new(0, Bytes::from("a"), 1);
+        let key2 = LogEntryKey::new(0, Bytes::from("a"), 2);
+        let key3 = LogEntryKey::new(0, Bytes::from("b"), 1);
+        let key4 = LogEntryKey::new(1, Bytes::from("a"), 1);
+
+        // when
+        let s1 = key1.serialize();
+        let s2 = key2.serialize();
+        let s3 = key3.serialize();
+        let s4 = key4.serialize();
+
+        // then - segment_id ordering takes precedence
+        assert!(s1 < s2, "same segment/key, seq 1 < seq 2");
+        assert!(s2 < s3, "same segment, key 'a' < key 'b'");
+        assert!(s3 < s4, "segment 0 < segment 1");
+    }
+
+    #[test]
+    fn should_generate_segment_key_prefix() {
+        // given
+        let segment_id = 5;
+        let key = b"orders";
+
+        // when
+        let prefix = LogEntryKey::segment_key_prefix(segment_id, key);
+
+        // then
+        // version (1) + type (1) + segment_id (4) + key (6) + terminator (1) = 13
+        assert_eq!(prefix.len(), 13);
+        assert_eq!(prefix[0], KEY_VERSION);
+        assert_eq!(prefix[1], RecordType::LogEntry.id());
+        assert_eq!(&prefix[2..6], &[0, 0, 0, 5]); // segment_id
+        assert_eq!(&prefix[6..12], b"orders");
+        assert_eq!(prefix[12], 0x00); // terminator
+    }
+
+    #[test]
+    fn should_fail_deserialize_log_entry_key_too_short() {
+        // given
+        let data = vec![KEY_VERSION, RecordType::LogEntry.id(), 0, 0, 0]; // only 5 bytes
+
+        // when
+        let result = LogEntryKey::deserialize(&data);
+
+        // then
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
This patch implements [RFC 2](https://github.com/opendata-oss/opendata/blob/main/log/rfcs/0002-logical-segmentation.md). 