### PR TITLE
add a request-level cache to the evaluator

### DIFF
--- a/timeseries/src/tsdb.rs
+++ b/timeseries/src/tsdb.rs
@@ -566,7 +566,7 @@ mod tests {
         assert_eq!(tsdb.query_cache.entry_count(), 2);
 
         // Use the evaluator to run 4 separate instant queries, one per bucket
-        let evaluator = Evaluator::new(&reader);
+        let mut evaluator = Evaluator::new(&reader);
         let query = r#"http_requests"#;
         let lookback = Duration::from_secs(1000);
 
@@ -662,7 +662,7 @@ mod tests {
 
         // when: Execute a PromQL query that filters by a="c"
         let reader = tsdb.query_reader(3000, 8000).await.unwrap();
-        let evaluator = Evaluator::new(&reader);
+        let mut evaluator = Evaluator::new(&reader);
         // Query for foo{a="c"} at time 8000 seconds (in bucket 2)
         let query = r#"foo{a="c"}"#;
         let query_time = UNIX_EPOCH + Duration::from_secs(8000);


### PR DESCRIPTION
## Summary

This patch adds a request-level cache to the evaluator. When running query_range, the db iterates over each evaluation instant and re-executes query evaluation. Most of the time, it's repeating the same work since all evaluations within a time bucket read the same indexes and series rows from slatedb. This patch adds CachedQueryReader, which stores the results of these reads and uses them for future reads. Each new request creates its own CachedQueryReader when it creates the evaluator.

## Test Plan

- unit test
- ran perf benchmarks. Perf improved from ~30 timeseries/second to 180 timeseries/second

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
