### PR TITLE
Add service framework rfc

### DIFF
--- a/rfcs/0003-service-layer.md
+++ b/rfcs/0003-service-layer.md
@@ -1057,6 +1057,8 @@ impl Catalog for LocalCatalog {
 
 #### S3Catalog (Multi-Shard)
 
+> **Note**: The catalog implementation sketched here is directional. There are many approaches. For instance the catalog could be stored in a special config-kv store that's backed by SlateDB itself, this could use a single-writer/many-readers pattern, with reader instances embedded alongside database writers and readers to quickly resolve key → shard → storage config. This architecture would scale well and is worth exploring in a follow-up RFC.
+
 For distributed deployments, the catalog is stored in S3 alongside the data:
 
 ```


### PR DESCRIPTION
##  Summary

  Adds RFC 0003: Service Layer, which defines a framework for consuming OpenData databases (Log, TSDB, Vector) in various deployment configurations—from fully embedded to fully service-oriented.

  The RFC covers:
  - Role Abstractions: Writer, Reader, and Compactor traits that decompose databases into composable pieces
  - Composition Patterns: Five deployment modes (Embedded, Embedded + Background Compactor, Single-Server, Scaled Readers, Serverless)
  - ServiceRuntime: Shared Axum-based HTTP infrastructure with health checks and metrics
  - Protocol Bindings: Per-database HTTP endpoints (Log, PromQL, Vector)
  - Catalog Abstraction: Foundation for future sharding support
  - Configuration Model: Builder pattern + TOML/YAML file support

##  Related Issues

  Relates to #47 

##  Test Plan

  RFC document only—no code changes. Reviewed for:
  - Consistency with existing RFC format (log/rfcs/0001-storage.md)
  - Alignment with current codebase patterns (Axum server in timeseries/src/promql/server.rs, storage traits in common/src/storage/)
  - Technical accuracy regarding SlateDB capabilities

##  Checklist

[] Tests added/updated
[] cargo fmt and cargo clippy pass
[] Documentation updated (if applicable)