### PR TITLE
add range vector selectors and rate fn

### DIFF
--- a/timeseries/src/promql/functions.rs
+++ b/timeseries/src/promql/functions.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::evaluator::{EvalResult, EvalSample};
+use super::evaluator::{EvalResult, EvalSample, EvalSamples};
 
 /// Trait for PromQL functions that operate on instant vectors
 pub(crate) trait PromQLFunction {
@@ -9,6 +9,17 @@ pub(crate) trait PromQLFunction {
     fn apply(
         &self,
         samples: Vec<EvalSample>,
+        eval_timestamp_ms: i64,
+    ) -> EvalResult<Vec<EvalSample>>;
+}
+
+/// Trait for PromQL functions that operate on range vectors (matrix selectors)
+pub(crate) trait RangeFunction {
+    /// Apply the function to range vector samples.
+    /// `eval_timestamp_ms` is the evaluation timestamp in milliseconds since UNIX epoch.
+    fn apply(
+        &self,
+        samples: Vec<EvalSamples>,
         eval_timestamp_ms: i64,
     ) -> EvalResult<Vec<EvalSample>>;
 }
@@ -34,11 +45,13 @@ impl PromQLFunction for UnaryFunction {
 /// Function registry that maps function names to their implementations
 pub(crate) struct FunctionRegistry {
     functions: HashMap<String, Box<dyn PromQLFunction>>,
+    range_functions: HashMap<String, Box<dyn RangeFunction>>,
 }
 
 impl FunctionRegistry {
     pub(crate) fn new() -> Self {
         let mut functions: HashMap<String, Box<dyn PromQLFunction>> = HashMap::new();
+        let mut range_functions: HashMap<String, Box<dyn RangeFunction>> = HashMap::new();
 
         // Mathematical functions
         functions.insert("abs".to_string(), Box::new(UnaryFunction { op: f64::abs }));
@@ -124,11 +137,21 @@ impl FunctionRegistry {
         functions.insert("absent".to_string(), Box::new(AbsentFunction));
         functions.insert("scalar".to_string(), Box::new(ScalarFunction));
 
-        Self { functions }
+        // Range vector functions
+        range_functions.insert("rate".to_string(), Box::new(RateFunction));
+
+        Self {
+            functions,
+            range_functions,
+        }
     }
 
     pub(crate) fn get(&self, name: &str) -> Option<&dyn PromQLFunction> {
         self.functions.get(name).map(|f| f.as_ref())
+    }
+
+    pub(crate) fn get_range_function(&self, name: &str) -> Option<&dyn RangeFunction> {
+        self.range_functions.get(name).map(|f| f.as_ref())
     }
 }
 
@@ -174,9 +197,54 @@ impl PromQLFunction for ScalarFunction {
     }
 }
 
+/// Rate function: calculates per-second rate of change for range vectors
+struct RateFunction;
+
+impl RangeFunction for RateFunction {
+    fn apply(
+        &self,
+        samples: Vec<EvalSamples>,
+        eval_timestamp_ms: i64,
+    ) -> EvalResult<Vec<EvalSample>> {
+        // TODO(rohan): handle counter resets
+        // TODO(rohan): implement extrapolation
+        let mut result = Vec::with_capacity(samples.len());
+
+        for sample_series in samples {
+            if sample_series.values.len() < 2 {
+                continue;
+            }
+
+            let first = &sample_series.values[0];
+            let last = &sample_series.values[sample_series.values.len() - 1];
+
+            let time_diff_seconds = (last.timestamp_ms - first.timestamp_ms) as f64 / 1000.0;
+
+            if time_diff_seconds <= 0.0 {
+                continue;
+            }
+
+            let value_diff = last.value - first.value;
+
+            let rate = value_diff / time_diff_seconds;
+
+            let rate = if rate < 0.0 { 0.0 } else { rate };
+
+            result.push(EvalSample {
+                timestamp_ms: eval_timestamp_ms,
+                value: rate,
+                labels: sample_series.labels,
+            });
+        }
+
+        Ok(result)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::Sample;
     use std::collections::HashMap;
 
     fn create_sample(value: f64) -> EvalSample {
@@ -237,6 +305,81 @@ mod tests {
         let result = func
             .apply(vec![create_sample(1.0), create_sample(2.0)], 1000)
             .unwrap();
+        assert!(result.is_empty());
+    }
+
+    fn create_eval_samples(
+        values: Vec<(i64, f64)>,
+        labels: HashMap<String, String>,
+    ) -> EvalSamples {
+        let values = values
+            .into_iter()
+            .map(|(t, v)| Sample::new(t, v))
+            .collect::<Vec<_>>();
+        EvalSamples { values, labels }
+    }
+
+    #[test]
+    fn should_apply_rate_function() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get_range_function("rate").unwrap();
+
+        let mut labels = HashMap::new();
+        labels.insert("job".to_string(), "test".to_string());
+
+        // Create sample series with increasing counter values
+        let samples = vec![create_eval_samples(
+            vec![
+                (1000, 100.0), // t=1s, value=100
+                (2000, 110.0), // t=2s, value=110
+                (3000, 125.0), // t=3s, value=125
+            ],
+            labels.clone(),
+        )];
+
+        let result = func.apply(samples, 3000).unwrap();
+
+        assert_eq!(result.len(), 1);
+        // Rate = (125 - 100) / (3000 - 1000) * 1000 = 25 / 2 = 12.5 per second
+        assert_eq!(result[0].value, 12.5);
+        assert_eq!(result[0].timestamp_ms, 3000);
+        assert_eq!(result[0].labels, labels);
+    }
+
+    #[test]
+    fn should_handle_counter_reset_in_rate() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get_range_function("rate").unwrap();
+
+        let labels = HashMap::new();
+
+        // Create sample series with counter reset (value goes down)
+        let samples = vec![create_eval_samples(
+            vec![
+                (1000, 100.0), // t=1s, value=100
+                (2000, 50.0),  // t=2s, value=50 (counter reset)
+            ],
+            labels,
+        )];
+
+        let result = func.apply(samples, 2000).unwrap();
+
+        assert_eq!(result.len(), 1);
+        // Rate should be 0 for negative differences (counter resets)
+        assert_eq!(result[0].value, 0.0);
+    }
+
+    #[test]
+    fn should_skip_series_with_insufficient_samples() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get_range_function("rate").unwrap();
+
+        // Create sample series with only one point
+        let samples = vec![create_eval_samples(vec![(1000, 100.0)], HashMap::new())];
+
+        let result = func.apply(samples, 1000).unwrap();
+
+        // Should return empty result for insufficient samples
         assert!(result.is_empty());
     }
 }

--- a/timeseries/src/promql/tsdb_router.rs
+++ b/timeseries/src/promql/tsdb_router.rs
@@ -187,6 +187,17 @@ impl PromqlRouter for Tsdb {
                     error_type: None,
                 }
             }
+            ExprResult::RangeVector(_) => {
+                let err = ErrorResponse::execution(
+                    "Range vectors not supported for instant queries".to_string(),
+                );
+                QueryResponse {
+                    status: err.status,
+                    data: None,
+                    error: Some(err.error),
+                    error_type: Some(err.error_type),
+                }
+            }
         }
     }
 
@@ -273,6 +284,17 @@ impl PromqlRouter for Tsdb {
                             let labels_key = vec![];
                             let values = series_map.entry(labels_key).or_default();
                             values.push((timestamp_secs, value.to_string()));
+                        }
+                        ExprResult::RangeVector(_) => {
+                            let err = ErrorResponse::execution(
+                                "Range vectors not supported in range query evaluation".to_string(),
+                            );
+                            return QueryRangeResponse {
+                                status: err.status,
+                                data: None,
+                                error: Some(err.error),
+                                error_type: Some(err.error_type),
+                            };
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Add support for range vector selectors in queries, and support a basic implementation of the rate fn over range vectors

required to support the grafana metrics explorer panel

## Test Plan

Unit tests
Tested plotting a graph on grafana

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
