### PR TITLE
handle empty labels in selectors

### DIFF
--- a/timeseries/src/promql/evaluator.rs
+++ b/timeseries/src/promql/evaluator.rs
@@ -411,8 +411,9 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
                 let fut = self.evaluate_binary_expr(b, start, end, interval, lookback_delta);
                 Box::pin(fut)
             }
-            Expr::Paren(_p) => {
-                todo!()
+            Expr::Paren(p) => {
+                let fut = self.evaluate_expr(&p.expr, start, end, interval, lookback_delta);
+                Box::pin(fut)
             }
             Expr::Subquery(_q) => {
                 todo!()


### PR DESCRIPTION
## Summary

Handles empty labels in selectors as defined in the prometheus query spec. Required for loading the grafana metrics explorer panel

## Test Plan

- unit tests
- grafana quickstart

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
