### PR TITLE
[tsdb] Handle standalone PromQL string literals without panic

### DIFF
--- a/timeseries/src/promql/evaluator.rs
+++ b/timeseries/src/promql/evaluator.rs
@@ -1020,8 +1020,8 @@ mod tests {
     use crate::query::test_utils::MockQueryReaderBuilder;
     use crate::test_utils::assertions::approx_eq;
     use promql_parser::label::{METRIC_NAME, Matchers};
-    use promql_parser::parser::value::ValueType;
     use promql_parser::parser::EvalStmt;
+    use promql_parser::parser::value::ValueType;
     use rstest::rstest;
 
     use std::time::{Duration, SystemTime, UNIX_EPOCH};


### PR DESCRIPTION
## Summary

This PR replaces a `todo!()` in the PromQL evaluator for `Expr::StringLiteral` with a structured evaluation error.

String literals are valid PromQL syntax but cannot be evaluated as standalone query results. Previously, attempting to evaluate such an expression would panic.

This change:
- Avoids a runtime panic
- Returns a clear, user-facing evaluation error
- Keeps scope minimal and evaluator-only

## Related Issues

Relates to #83

## Test Plan

- Added a regression test asserting that evaluating a standalone string literal returns an error
- Ran existing literal evaluation tests

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation not required
