### PR TITLE
some tweaks to the vector storage rfc

### DIFF
--- a/vector/rfcs/0001-storage.md
+++ b/vector/rfcs/0001-storage.md
@@ -755,7 +755,9 @@ Future RFCs will address:
 
 | Date       | Description                                                          |
 |------------|----------------------------------------------------------------------|
-| 2025-01-07 | Initial draft                                                        |
+| 2026-01-07 | Initial draft                                                        |
+| 2026-01-24 | Store full vectors in postings. Store all attributes in `VectorData` |
+|            | and drop `VectorMeta`                                                |
 
 ## References
 


### PR DESCRIPTION
makes a few changes to the vector storage design
- changes the value of the postings to include the vector ids, and to serialize it as a simple array.
- don't split the vector data and metadata.
- track the deletion vector in its own key rather than as centroid 0
- drop references to the workings of LIRE. This will be addressed in a future PR