### PR TITLE
[vector] Use conventional storage configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,7 +2275,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.12.1",
  "metrics",
  "ordered-float",
  "quanta",

--- a/vector/src/delta.rs
+++ b/vector/src/delta.rs
@@ -198,15 +198,12 @@ mod tests {
     use crate::model::{MetadataFieldSpec, Vector};
     use crate::serde::FieldType;
     use crate::serde::collection_meta::DistanceMetric;
-    use common::storage::in_memory::InMemoryStorage;
-    use std::sync::Arc;
+    use common::StorageConfig;
     use std::time::Duration;
 
     async fn create_test_builder() -> VectorDbDeltaBuilder<'static> {
-        let storage: Arc<dyn common::Storage> = Arc::new(InMemoryStorage::new());
-
         let config = Config {
-            storage: storage.clone(),
+            storage: StorageConfig::InMemory,
             dimensions: 3,
             distance_metric: DistanceMetric::Cosine,
             flush_interval: Duration::from_secs(60),

--- a/vector/src/model.rs
+++ b/vector/src/model.rs
@@ -5,10 +5,9 @@
 //! like dimension matching and metadata schema validation.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Duration;
 
-use common::Storage;
+use common::StorageConfig;
 
 // Re-export types from serde layer
 pub use crate::serde::FieldType;
@@ -157,10 +156,13 @@ impl From<bool> for AttributeValue {
 }
 
 /// Configuration for a VectorDb instance.
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct Config {
     /// Storage backend configuration.
-    pub storage: Arc<dyn Storage>,
+    ///
+    /// Determines where and how vector data is persisted. See [`StorageConfig`]
+    /// for available options including in-memory and SlateDB backends.
+    pub storage: StorageConfig,
 
     /// Vector dimensionality (immutable after creation).
     ///
@@ -185,7 +187,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            storage: Arc::new(common::storage::in_memory::InMemoryStorage::new()),
+            storage: StorageConfig::InMemory,
             dimensions: 0, // Must be set explicitly
             distance_metric: DistanceMetric::Cosine,
             flush_interval: Duration::from_secs(60),


### PR DESCRIPTION
This patch modifies `Vector::Config` to embed `StorageConfig` instead of `Storage`. This mirrors log and timeseries.