### PR TITLE
[timseries] Fix failing test and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,4 @@ jobs:
         run: cargo build --all-targets
 
       - name: Run tests
-        run: cargo test --all
+        run: cargo test --all --all-features

--- a/timeseries/src/promql/remote_write.rs
+++ b/timeseries/src/promql/remote_write.rs
@@ -67,6 +67,7 @@ pub fn convert_write_request(request: WriteRequest) -> Vec<Series> {
     request
         .timeseries
         .into_iter()
+        .filter(|ts| !ts.samples.is_empty())
         .map(|ts| {
             let labels: Vec<Label> = ts
                 .labels


### PR DESCRIPTION
This test fails. We didn't catch it in CI because it depends on the "remote-write" feature.