### PR TITLE
dont require delta to impl Default

### DIFF
--- a/common/src/coordinator/traits.rs
+++ b/common/src/coordinator/traits.rs
@@ -43,7 +43,7 @@ pub struct FlushEvent<D: Delta> {
 }
 
 /// A delta accumulates writes and can produce a snapshot image.
-pub trait Delta: Default + Sized + Send + Sync + 'static {
+pub trait Delta: Sized + Send + Sync + 'static {
     /// The Context is data owned only while the Delta is mutable. After
     /// freezing the delta the context is returned to the write coordinator
     type Context: Send + Sync + 'static;
@@ -52,7 +52,7 @@ pub trait Delta: Default + Sized + Send + Sync + 'static {
 
     /// Create a new delta initialized from a snapshot context.
     /// The delta takes ownership of the context while it is mutable.
-    fn init(&mut self, context: Self::Context);
+    fn init(context: Self::Context) -> Self;
 
     /// Apply a write to the delta.
     fn apply(&mut self, write: Self::Write) -> Result<(), String>;


### PR DESCRIPTION
## Summary

dont require delta to impl Default, and instead create deltas directly from context. In the coordinator, we wrap the delta in an Option so that when its frozen it can be first consumed to extract the frozen delta and context, then replaced with a new delta created from context.

## Checklist

- [x] Tests added/updated
- [ ] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
