### PR TITLE
switch seq allocation to use deferred writes

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,9 +8,7 @@ pub mod storage;
 
 pub use bytes::BytesRange;
 pub use clock::Clock;
-pub use sequence::{
-    DEFAULT_BLOCK_SIZE, SeqBlockStore, SequenceAllocator, SequenceError, SequenceResult,
-};
+pub use sequence::{DEFAULT_BLOCK_SIZE, SequenceAllocator, SequenceError, SequenceResult};
 pub use serde::seq_block::SeqBlock;
 pub use storage::config::StorageConfig;
 pub use storage::factory::{StorageRuntime, StorageSemantics, create_storage, create_storage_read};


### PR DESCRIPTION
## Summary

switches sequence allocation to a deferred writes model.
- SequenceAllocator now returns both a sequence number and optionally a record that needs to be written to storage to reserve the block if the seq num is in a new block
- Drops the SequenceBlockAllocator since the interaction with storage now happens outside

This allows sequence allocation to include sequence block puts in the deltas built up by write coordinator deltas

## Checklist

- [x] Tests added/updated
- [ ] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
