### PR TITLE
support multiple write channels

### DIFF
--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -29,6 +29,8 @@ use crate::reader::{LogIterator, LogRead};
 use crate::segment::SegmentCache;
 use crate::storage::LogStorage;
 
+const WRITE_CHANNEL: &str = "write";
+
 /// The main log interface providing read and write operations.
 ///
 /// `LogDb` is the primary entry point for interacting with OpenData Log.
@@ -281,11 +283,12 @@ impl LogDb {
         let flusher = LogFlusher::new(log_storage.clone());
         let mut coordinator = WriteCoordinator::new(
             WriteCoordinatorConfig::default(),
+            vec![WRITE_CHANNEL.to_string()],
             context,
             log_storage.snapshot().await?,
             flusher,
         );
-        let handle = coordinator.handle();
+        let handle = coordinator.handle(WRITE_CHANNEL);
 
         let read_inner = Arc::new(RwLock::new(LogReadInner::new(
             log_storage_read,
@@ -430,11 +433,12 @@ impl LogDbBuilder {
         let snapshot = log_storage.snapshot().await?;
         let mut coordinator = WriteCoordinator::new(
             WriteCoordinatorConfig::default(),
+            vec![WRITE_CHANNEL.to_string()],
             context,
             snapshot,
             flusher,
         );
-        let handle = coordinator.handle();
+        let handle = coordinator.handle(WRITE_CHANNEL);
 
         let read_inner = Arc::new(RwLock::new(LogReadInner::new(
             log_storage_read,


### PR DESCRIPTION
## Summary

extend write coordinator to support consuming from multiple write channels. The channels are named, and the names are specified in the new fn. To get a handle, callers specify the channel name and receive a handle that interacts with that channel.

## Test Plan

Unit tests

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
