### PR TITLE
prepare for crates.io publishing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,12 +309,12 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
- "common",
  "humantime-serde",
  "metrics",
  "metrics-util",
+ "opendata-common",
+ "opendata-timeseries",
  "serde",
- "timeseries",
  "tokio",
  "toml 0.8.23",
 ]
@@ -554,24 +554,6 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
-
-[[package]]
-name = "common"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "bytes",
- "criterion",
- "futures",
- "proptest",
- "serde",
- "serde_yaml",
- "slatedb",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
-]
 
 [[package]]
 name = "concurrent-queue"
@@ -1064,7 +1046,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
- "log 0.4.29",
+ "log",
  "once_cell",
  "rand 0.8.5",
 ]
@@ -1075,7 +1057,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5666e8ca4ec174d896fb742789c29b1bea9319dcfd623c41bececc0a60c4939d"
 dependencies = [
- "log 0.4.29",
+ "log",
  "once_cell",
  "rand 0.8.5",
 ]
@@ -1685,7 +1667,7 @@ dependencies = [
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
- "log 0.4.29",
+ "log",
  "wasm-bindgen",
  "windows-core 0.62.2",
 ]
@@ -1925,17 +1907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyvalue"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "bytes",
- "common",
- "slatedb",
- "tokio",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1990,31 +1961,6 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "axum",
- "base64 0.22.1",
- "bytes",
- "clap",
- "common",
- "prometheus-client",
- "proptest",
- "prost",
- "reqwest",
- "serde",
- "serde_json",
- "serde_with",
- "slatedb",
- "tempfile",
- "tokio",
- "tower",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
@@ -2027,7 +1973,7 @@ dependencies = [
  "async-trait",
  "bencher",
  "bytes",
- "log 0.1.0",
+ "opendata-log",
  "tokio",
 ]
 
@@ -2435,6 +2381,116 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "opendata-common"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "criterion",
+ "futures",
+ "proptest",
+ "serde",
+ "serde_yaml",
+ "slatedb",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "opendata-keyvalue"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "opendata-common",
+ "slatedb",
+ "tokio",
+]
+
+[[package]]
+name = "opendata-log"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "clap",
+ "opendata-common",
+ "prometheus-client",
+ "proptest",
+ "prost",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "slatedb",
+ "tempfile",
+ "tokio",
+ "tower",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opendata-timeseries"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "axum",
+ "blake3",
+ "bytes",
+ "chrono",
+ "clap",
+ "config",
+ "dashmap",
+ "fail",
+ "moka",
+ "opendata-common",
+ "prometheus-client",
+ "promql-parser",
+ "prost",
+ "regex",
+ "regex-syntax",
+ "reqwest",
+ "roaring 0.7.0",
+ "rstest",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "slatedb",
+ "snap",
+ "thiserror 2.0.17",
+ "tokio",
+ "tower",
+ "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
+ "tsz",
+ "uuid",
+]
+
+[[package]]
+name = "opendata-vector"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "dashmap",
+ "fail",
+ "futures",
+ "opendata-common",
+ "rand 0.8.5",
+ "roaring 0.10.12",
+ "rstest",
+ "tokio",
+ "usearch",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -3129,7 +3185,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "js-sys",
- "log 0.4.29",
+ "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3621,8 +3677,9 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slatedb"
-version = "0.10.0"
-source = "git+https://github.com/slatedb/slatedb.git?branch=main#d0e0f46761c4708fabcdbf937d46085d393344b2"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588e9ae32019696205a05e54e4456486e8d11b69c72662739be853736833b3dd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3641,7 +3698,7 @@ dependencies = [
  "flatbuffers",
  "foyer",
  "futures",
- "log 0.4.29",
+ "log",
  "object_store",
  "once_cell",
  "ouroboros",
@@ -3651,8 +3708,6 @@ dependencies = [
  "serde",
  "serde_json",
  "siphasher",
- "slatedb-common",
- "slatedb-txn-obj",
  "sysinfo",
  "thiserror 1.0.69",
  "thread_local",
@@ -3663,30 +3718,6 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
-]
-
-[[package]]
-name = "slatedb-common"
-version = "0.10.0"
-source = "git+https://github.com/slatedb/slatedb.git?branch=main#d0e0f46761c4708fabcdbf937d46085d393344b2"
-dependencies = [
- "chrono",
- "tokio",
-]
-
-[[package]]
-name = "slatedb-txn-obj"
-version = "0.10.0"
-source = "git+https://github.com/slatedb/slatedb.git?branch=main#d0e0f46761c4708fabcdbf937d46085d393344b2"
-dependencies = [
- "async-trait",
- "bytes",
- "chrono",
- "futures",
- "log 0.4.29",
- "object_store",
- "slatedb-common",
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3929,51 +3960,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "timeseries"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "axum",
- "blake3",
- "bytes",
- "chrono",
- "clap",
- "common",
- "config",
- "dashmap",
- "fail",
- "moka",
- "prometheus-client",
- "promql-parser",
- "prost",
- "regex",
- "regex-syntax",
- "reqwest",
- "roaring 0.7.0",
- "rstest",
- "serde",
- "serde_json",
- "serde_yaml",
- "slatedb",
- "snap",
- "thiserror 2.0.17",
- "tokio",
- "tower",
- "tower-http 0.5.2",
- "tracing",
- "tracing-subscriber",
- "tsz",
- "uuid",
-]
-
-[[package]]
 name = "timeseries-bench"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "bencher",
- "timeseries",
+ "opendata-timeseries",
  "tokio",
 ]
 
@@ -4222,7 +4215,7 @@ version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
- "log 0.4.29",
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4255,7 +4248,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log 0.4.29",
+ "log",
  "once_cell",
  "tracing-core",
 ]
@@ -4432,32 +4425,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vector"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "common",
- "dashmap",
- "fail",
- "futures",
- "rand 0.8.5",
- "roaring 0.10.12",
- "rstest",
- "tokio",
- "usearch",
-]
-
-[[package]]
 name = "vector-bench"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "bencher",
+ "opendata-vector",
  "tokio",
- "vector",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ fail = "0.5"
 futures = { version = "0.3", features = ["std"] }
 moka = { version = "0.12", features = ["future"] }
 bencher = { path = "./bencher" }
-common = { path = "./common" }
+common = { path = "./common", package = "opendata-common", version = "0.1.0" }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 roaring = "0.10"
 rstest = "0.19"
@@ -38,7 +38,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3", features = ["base64"] }
 serde_yaml = "0.9"
-slatedb = { git = "https://github.com/slatedb/slatedb.git", branch = "main" }
+slatedb = "0.10.1"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full"] }
 tokio-util = "0.7"

--- a/bencher/Cargo.toml
+++ b/bencher/Cargo.toml
@@ -2,11 +2,12 @@
 name = "bencher"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 async-trait.workspace = true
 common.workspace = true
-timeseries = { path = "../timeseries" }
+timeseries = { path = "../timeseries", package = "opendata-timeseries" }
 tokio.workspace = true
 anyhow.workspace = true
 serde.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,7 +1,17 @@
 [package]
-name = "common"
+name = "opendata-common"
 version.workspace = true
 edition.workspace = true
+description = "Shared storage foundation for OpenData databases"
+license = "MIT"
+repository = "https://github.com/opendata-oss/opendata"
+readme = "README.md"
+keywords = ["database", "storage", "slatedb"]
+categories = ["database"]
+
+[lib]
+name = "common"
+path = "src/lib.rs"
 
 [dependencies]
 slatedb.workspace = true

--- a/common/README.md
+++ b/common/README.md
@@ -1,0 +1,10 @@
+# opendata-common
+
+Shared storage foundation for [OpenData](https://github.com/opendata-oss/opendata) databases.
+
+Provides common storage abstractions, configuration, and utilities used by
+`opendata-log`, `opendata-timeseries`, and `opendata-vector`.
+
+## License
+
+MIT

--- a/keyvalue/Cargo.toml
+++ b/keyvalue/Cargo.toml
@@ -1,9 +1,16 @@
 [package]
-name = "keyvalue"
+name = "opendata-keyvalue"
 version.workspace = true
 edition.workspace = true
+description = "Key-value database built on SlateDB"
+license = "MIT"
+repository = "https://github.com/opendata-oss/opendata"
+readme = "README.md"
+keywords = ["database", "key-value", "slatedb"]
+categories = ["database"]
 
 [lib]
+name = "keyvalue"
 path = "src/lib.rs"
 
 [dependencies]

--- a/keyvalue/README.md
+++ b/keyvalue/README.md
@@ -1,0 +1,8 @@
+# opendata-keyvalue
+
+Key-value database built on [SlateDB](https://github.com/slatedb/slatedb) for
+[OpenData](https://github.com/opendata-oss/opendata).
+
+## License
+
+MIT

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -1,13 +1,20 @@
 [package]
-name = "log"
+name = "opendata-log"
 version.workspace = true
 edition.workspace = true
+description = "Key-oriented log database built on SlateDB"
+license = "MIT"
+repository = "https://github.com/opendata-oss/opendata"
+readme = "README.md"
+keywords = ["database", "log", "streaming", "slatedb"]
+categories = ["database"]
 
 [lib]
+name = "log"
 path = "src/lib.rs"
 
 [[bin]]
-name = "log"
+name = "opendata-log"
 path = "src/main.rs"
 required-features = ["http-server"]
 

--- a/log/bench/Cargo.toml
+++ b/log/bench/Cargo.toml
@@ -2,11 +2,12 @@
 name = "log-bench"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 bencher.workspace = true
 bytes.workspace = true
-log = { path = ".." }
+log = { path = "..", package = "opendata-log" }
 anyhow.workspace = true
 async-trait.workspace = true
 tokio.workspace = true

--- a/log/src/server/config.rs
+++ b/log/src/server/config.rs
@@ -10,7 +10,7 @@ use crate::Config;
 
 /// CLI arguments for the log server.
 #[derive(Debug, Parser)]
-#[command(name = "log")]
+#[command(name = "opendata-log")]
 #[command(about = "OpenData Log HTTP Server")]
 pub struct CliArgs {
     /// HTTP server port.

--- a/timeseries/Cargo.toml
+++ b/timeseries/Cargo.toml
@@ -1,13 +1,20 @@
 [package]
-name = "timeseries"
+name = "opendata-timeseries"
 version.workspace = true
 edition.workspace = true
+description = "Prometheus-compatible time series database built on SlateDB"
+license = "MIT"
+repository = "https://github.com/opendata-oss/opendata"
+readme = "README.md"
+keywords = ["database", "timeseries", "prometheus", "metrics"]
+categories = ["database"]
 
 [lib]
+name = "timeseries"
 path = "src/lib.rs"
 
 [[bin]]
-name = "timeseries"
+name = "opendata-timeseries"
 path = "src/main.rs"
 
 [features]

--- a/timeseries/bench/Cargo.toml
+++ b/timeseries/bench/Cargo.toml
@@ -2,10 +2,11 @@
 name = "timeseries-bench"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 bencher.workspace = true
-timeseries = { path = ".." }
+timeseries = { path = "..", package = "opendata-timeseries" }
 anyhow.workspace = true
 async-trait.workspace = true
 tokio.workspace = true

--- a/vector/Cargo.toml
+++ b/vector/Cargo.toml
@@ -1,7 +1,17 @@
 [package]
-name = "vector"
+name = "opendata-vector"
 version.workspace = true
 edition.workspace = true
+description = "Vector similarity search database built on SlateDB"
+license = "MIT"
+repository = "https://github.com/opendata-oss/opendata"
+readme = "README.md"
+keywords = ["database", "vector", "similarity-search", "embeddings"]
+categories = ["database"]
+
+[lib]
+name = "vector"
+path = "src/lib.rs"
 
 [dependencies]
 anyhow.workspace = true

--- a/vector/bench/Cargo.toml
+++ b/vector/bench/Cargo.toml
@@ -2,10 +2,11 @@
 name = "vector-bench"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 bencher.workspace = true
-vector = { path = ".." }
+vector = { path = "..", package = "opendata-vector" }
 anyhow.workspace = true
 async-trait.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
- this commit renames the crates appropriately since things like `log` and `vector` are already taken on `crates.io`. 
- it also pins slatedb to `0.10.1` since crates.io doesn't allow you to publish pointing to a github link.
- it adds a basic readme to common since it's necessary for publishing

This is in preparation for stubbing out the docs site.