### PR TITLE
fix: use BTreeMap for Params for consistent benchmark output

### DIFF
--- a/bencher/src/params.rs
+++ b/bencher/src/params.rs
@@ -1,6 +1,6 @@
 //! Benchmark parameter collection.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use timeseries::Label;
 
@@ -11,14 +11,14 @@ use timeseries::Label;
 /// to/from `Vec<Label>` for use with the metrics system.
 #[derive(Debug, Clone, Default)]
 pub struct Params {
-    inner: HashMap<String, String>,
+    inner: BTreeMap<String, String>,
 }
 
 impl Params {
     /// Create an empty Params collection.
     pub fn new() -> Self {
         Self {
-            inner: HashMap::new(),
+            inner: BTreeMap::new(),
         }
     }
 


### PR DESCRIPTION
## Summary

What does this PR do?

Use BTreeMap instead of Hashmap for Params to ensure benchmark output parameters are displayed in consistent order across all parameter sets for readability

## Test Plan

How was this tested?

Ran cargo run --bin log-bench and verified params appear in consistent order across all benchmark runs.

## Checklist

- [ ] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
