### PR TITLE
test(promql): refactor promqltest framework and add upstream test coverage

### DIFF
--- a/timeseries/src/promql/promqltest/assert.rs
+++ b/timeseries/src/promql/promqltest/assert.rs
@@ -1,0 +1,138 @@
+use crate::promql::promqltest::dsl::{EvalResult, ExpectedSample};
+use std::collections::HashMap;
+
+/// Compare actual results against expected results
+///
+/// IMPORTANT: Metric name handling follows Prometheus promqltest semantics:
+/// - Prometheus represents the metric name as the __name__ label
+/// - If expected sample omits __name__ → we don't check it (allows flexible matching)
+/// - If expected sample includes __name__ → we verify it matches
+///
+/// This means test expectations can be written as:
+///   {job="test"} 42          # Matches any metric with job="test"
+///   {__name__="metric"} 42   # Must be exactly "metric"
+///
+/// The implementation achieves this by only checking labels that are present in the
+/// expected sample, not all labels from the actual result.
+pub(super) fn assert_results(
+    results: &[EvalResult],
+    expected: &[ExpectedSample],
+    test_name: &str,
+    eval_num: usize,
+    query: &str,
+) -> Result<(), String> {
+    if results.len() != expected.len() {
+        return Err(format!(
+            "{} eval #{} (query: {}): Expected {} samples, got {}",
+            test_name,
+            eval_num,
+            query,
+            expected.len(),
+            results.len()
+        ));
+    }
+
+    // Sort both sides deterministically - PromQL doesn't guarantee result ordering
+    let mut results_sorted = results.to_vec();
+    results_sorted.sort_by_key(|r| label_sort_key(&r.labels));
+
+    let mut expected_sorted = expected.to_vec();
+    expected_sorted.sort_by_key(|e| label_sort_key(&e.labels));
+
+    for (i, exp) in expected_sorted.iter().enumerate() {
+        let result = &results_sorted[i];
+
+        // Check all expected labels are present and match
+        for (k, v) in &exp.labels {
+            let actual = result.labels.get(k).ok_or(format!(
+                "{} eval #{} (query: {}): Missing label '{}'",
+                test_name, eval_num, query, k
+            ))?;
+            if actual != v {
+                return Err(format!(
+                    "{} eval #{} (query: {}): Label {} mismatch: expected '{}', got '{}'",
+                    test_name, eval_num, query, k, v, actual
+                ));
+            }
+        }
+
+        if (result.value - exp.value).abs() > 1e-6 {
+            return Err(format!(
+                "{} eval #{} (query: {}): Value mismatch: expected {}, got {}",
+                test_name, eval_num, query, exp.value, result.value
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn label_sort_key(labels: &HashMap<String, String>) -> String {
+    let mut keys: Vec<_> = labels.iter().collect();
+    keys.sort_by_key(|(k, _)| *k);
+    keys.iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_match_expected_results() {
+        // given
+        let results = vec![EvalResult {
+            labels: HashMap::from([("job".to_string(), "test".to_string())]),
+            value: 42.0,
+        }];
+        let expected = vec![ExpectedSample {
+            labels: HashMap::from([("job".to_string(), "test".to_string())]),
+            value: 42.0,
+        }];
+
+        // when
+        let result = assert_results(&results, &expected, "test", 1, "metric");
+
+        // then
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn should_reject_count_mismatch() {
+        // given
+        let results = vec![EvalResult {
+            labels: HashMap::new(),
+            value: 42.0,
+        }];
+        let expected = vec![];
+
+        // when
+        let result = assert_results(&results, &expected, "test", 1, "metric");
+
+        // then
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Expected 0 samples, got 1"));
+    }
+
+    #[test]
+    fn should_reject_mismatched_values() {
+        // given
+        let results = vec![EvalResult {
+            labels: HashMap::new(),
+            value: 42.0,
+        }];
+        let expected = vec![ExpectedSample {
+            labels: HashMap::new(),
+            value: 99.0,
+        }];
+
+        // when
+        let result = assert_results(&results, &expected, "test", 1, "metric");
+
+        // then
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Value mismatch"));
+    }
+}

--- a/timeseries/src/promql/promqltest/dsl.rs
+++ b/timeseries/src/promql/promqltest/dsl.rs
@@ -67,7 +67,7 @@ pub struct EvalResult {
 // Parser
 // ============================================================================
 
-pub struct Parser;
+struct Parser;
 
 impl Parser {
     /// Parse entire test file into commands

--- a/timeseries/src/promql/promqltest/evaluator.rs
+++ b/timeseries/src/promql/promqltest/evaluator.rs
@@ -1,0 +1,49 @@
+use crate::promql::promqltest::dsl::EvalResult;
+use crate::promql::request::QueryRequest;
+use crate::promql::router::PromqlRouter;
+use crate::tsdb::Tsdb;
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+/// Execute instant query and return structured results
+pub(super) async fn eval_instant(
+    tsdb: &Tsdb,
+    time: SystemTime,
+    query: &str,
+) -> Result<Vec<EvalResult>, String> {
+    let resp = tsdb
+        .query(QueryRequest {
+            query: query.to_string(),
+            time: Some(time),
+            timeout: None,
+        })
+        .await;
+
+    let data = resp.data.ok_or_else(|| {
+        format!(
+            "No data in response (query: {}, status: {:?}, error: {:?})",
+            query, resp.status, resp.error
+        )
+    })?;
+    let result = data.result.as_array().ok_or("Result is not a vector")?;
+
+    // Convert JSON to structured EvalResult
+    let mut results = Vec::new();
+    for sample in result {
+        let labels_obj = sample["metric"].as_object().ok_or("Missing metric")?;
+        let mut labels = HashMap::new();
+        for (k, v) in labels_obj {
+            labels.insert(k.clone(), v.as_str().unwrap_or("").to_string());
+        }
+
+        let value = sample["value"][1]
+            .as_str()
+            .ok_or("Missing value")?
+            .parse::<f64>()
+            .map_err(|e| format!("Invalid value: {}", e))?;
+
+        results.push(EvalResult { labels, value });
+    }
+
+    Ok(results)
+}

--- a/timeseries/src/promql/promqltest/loader.rs
+++ b/timeseries/src/promql/promqltest/loader.rs
@@ -1,0 +1,79 @@
+use crate::model::{Label, MetricType, Sample, Series, TimeBucket};
+use crate::promql::promqltest::dsl::SeriesLoad;
+use crate::tsdb::Tsdb;
+use std::time::UNIX_EPOCH;
+
+/// Load series data into TSDB
+pub(super) async fn load_series(
+    tsdb: &Tsdb,
+    interval: std::time::Duration,
+    series: &[SeriesLoad],
+) -> Result<(), String> {
+    for s in series {
+        // Collect all samples for this series
+        let mut samples = Vec::new();
+
+        for (step, value) in &s.values {
+            // Validate step index
+            if *step < 0 {
+                return Err(format!("Negative step index not allowed: {}", step));
+            }
+
+            // Safe timestamp calculation with overflow checking
+            let delta = interval
+                .checked_mul(*step as u32)
+                .ok_or_else(|| format!("Timestamp overflow for step {}", step))?;
+
+            let ts = UNIX_EPOCH + delta;
+            let ts_ms = ts
+                .duration_since(UNIX_EPOCH)
+                .map_err(|e| format!("Invalid timestamp: {}", e))?
+                .as_millis() as i64;
+
+            samples.push((ts_ms, *value));
+        }
+
+        // Sort by timestamp and deduplicate (keep last value per timestamp)
+        // This matches Prometheus promqltest semantics
+        samples.sort_by_key(|(ts, _)| *ts);
+        samples.dedup_by_key(|(ts, _)| *ts);
+
+        // Group by bucket and ingest
+        let mut bucket_samples: std::collections::HashMap<TimeBucket, Vec<Sample>> =
+            std::collections::HashMap::new();
+
+        for (ts_ms, value) in samples {
+            let ts = UNIX_EPOCH + std::time::Duration::from_millis(ts_ms as u64);
+            let bucket = TimeBucket::round_to_hour(ts).unwrap();
+            bucket_samples
+                .entry(bucket)
+                .or_default()
+                .push(Sample::new(ts_ms, value));
+        }
+
+        // Ingest each bucket
+        for (bucket, bucket_samples) in bucket_samples {
+            let labels: Vec<Label> = s
+                .labels
+                .iter()
+                .map(|(k, v)| Label {
+                    name: k.clone(),
+                    value: v.clone(),
+                })
+                .collect();
+
+            let series = Series {
+                labels,
+                metric_type: Some(MetricType::Gauge),
+                unit: None,
+                description: None,
+                samples: bucket_samples,
+            };
+
+            let mini = tsdb.get_or_create_for_ingest(bucket).await.unwrap();
+            mini.ingest(&series).await.unwrap();
+        }
+    }
+    tsdb.flush().await.unwrap();
+    Ok(())
+}

--- a/timeseries/src/promql/promqltest/mod.rs
+++ b/timeseries/src/promql/promqltest/mod.rs
@@ -1,4 +1,7 @@
-pub mod dsl;
+mod assert;
+mod dsl;
+mod evaluator;
+mod loader;
 pub mod runner;
 
 #[cfg(test)]

--- a/timeseries/src/promql/promqltest/testdata/at_modifier.test
+++ b/timeseries/src/promql/promqltest/testdata/at_modifier.test
@@ -62,44 +62,243 @@ eval instant at 10s metric @ 0 offset -50
   metric{job="1"} 5
   metric{job="2"} 10
 
-
-# Test @ modifier at epoch
-eval instant at 100s metric @ 0
-  metric{job="1"} 0
-  metric{job="2"} 0
-
-# Test @ modifier with future timestamp
-eval instant at 10s metric @ 200s
-  metric{job="1"} 20
-  metric{job="2"} 40
-
-# Test @ modifier with millisecond precision
-eval instant at 5000ms metric_ms @ 3000ms
-  metric_ms 3000
-
-# Test range selector with @ modifier
-eval instant at 100s rate(metric{job="1"}[30s] @ 50s)
-  {job="1"} 0.1
-
-# Test @ modifier with specific label selector
-eval instant at 50s metric{job="2"} @ 30s
-  metric{job="2"} 6
-
-# Test offset without @ modifier for comparison
-eval instant at 100s metric offset 50s
-  metric{job="1"} 5
-  metric{job="2"} 10
-
-# Test @ modifier at exact load boundary
-eval instant at 200s metric @ 100s
-  metric{job="1"} 10
-  metric{job="2"} 20
-
-# Start ignoring
+# ignoring unary operator (-)
 ignore
 
 eval instant at 10s -metric @ 100
   {job="1"} -10
   {job="2"} -20
 
+eval instant at 10s ---metric @ 100
+  {job="1"} -10
+  {job="2"} -20
+
 resume
+
+# Millisecond precision.
+eval instant at 100s metric_ms @ 1.234
+  metric_ms 1234
+
+# ignoring aggregator functions
+ignore
+
+# Range vector selectors.
+eval instant at 25s sum_over_time(metric{job="1"}[100s] @ 100)
+  {job="1"} 55
+
+eval instant at 25s sum_over_time(metric{job="1"}[100s] @ 100 offset 50s)
+  {job="1"} 15
+
+eval instant at 25s sum_over_time(metric{job="1"}[100s] offset 50s @ 100)
+  {job="1"} 15
+
+eval instant at 25s sum_over_time(metric{job="1"}[100] @ 100 offset 50)
+  {job="1"} 15
+
+eval instant at 25s sum_over_time(metric{job="1"}[100] offset 50s @ 100)
+  {job="1"} 15
+
+resume
+
+# Different timestamps.
+eval instant at 25s metric{job="1"} @ 50 + metric{job="1"} @ 100
+  {job="1"} 15
+
+# ignoring label_replace function
+ignore
+
+eval instant at 25s rate(metric{job="1"}[100s] @ 100) + label_replace(rate(metric{job="2"}[123s] @ 200), "job", "1", "", "")
+  {job="1"} 0.3
+  
+resume
+
+# ignoring aggregator functions
+ignore
+
+eval instant at 25s sum_over_time(metric{job="1"}[100s] @ 100) + label_replace(sum_over_time(metric{job="2"}[100s] @ 100), "job", "1", "", "")
+  {job="1"} 165
+
+eval instant at 25s sum_over_time(metric{job="1"}[100] @ 100) + label_replace(sum_over_time(metric{job="2"}[100] @ 100), "job", "1", "", "")
+  {job="1"} 165
+
+resume
+# ignoring sum_over_time aggregator functions
+ignore
+
+# Subqueries.
+
+# 10*(1+2+...+9) + 10.
+eval instant at 25s sum_over_time(metric{job="1"}[100s:1s] @ 100)
+  {job="1"} 460
+
+# 10*(1+2+...+7) + 8.
+eval instant at 25s sum_over_time(metric{job="1"}[100s:1s] @ 100 offset 20s)
+  {job="1"} 288
+
+# 10*(1+2+...+7) + 8.
+eval instant at 25s sum_over_time(metric{job="1"}[100s:1s] offset 20s @ 100)
+  {job="1"} 288
+
+# 10*(1+2+...+7) + 8.
+eval instant at 25s sum_over_time(metric{job="1"}[100:1] offset 20 @ 100)
+  {job="1"} 288
+
+# Subquery with different timestamps.
+
+# Since vector selector has timestamp, the result value does not depend on the timestamp of subqueries.
+# Inner most sum=1+2+...+10=55.
+# With [100s:25s] subquery, it's 55*4.
+eval instant at 100s sum_over_time(sum_over_time(metric{job="1"}[100s] @ 100)[100s:25s] @ 50)
+  {job="1"} 220
+
+# Nested subqueries with different timestamps on both.
+
+# Since vector selector has timestamp, the result value does not depend on the timestamp of subqueries.
+# Sum of innermost subquery is 220 as above. The outer subquery repeats it 3 times.
+eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[100s] @ 100)[100s:25s] @ 50)[3s:1s] @ 3000)
+  {job="1"} 660
+
+# Testing the inner subquery timestamp since vector selector does not have @.
+
+# Inner sum for subquery [100s:25s] @ 50 are
+#   at -50 nothing, at -25 nothing, at 0=0, at 25=2, at 50=5.
+# This sum of 7 is repeated 3 times by outer subquery.
+eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[10s])[100s:25s] @ 50)[3s:1s] @ 200)
+  {job="1"} 21
+
+# Inner sum for subquery [100s:25s] @ 200 are
+#   at 125=12, at 150=15, at 175=17, at 200=20.
+# This sum of 64 is repeated 3 times by outer subquery.
+eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[10s])[100s:25s] @ 200)[3s:1s] @ 50)
+  {job="1"} 192
+
+# Nested subqueries with timestamp only on outer subquery.
+# Outer most subquery:
+#   at 925=360
+#     inner subquery: at 905=90+89, at 915=91+90
+#   at 950=372
+#     inner subquery: at 930=93+92, at 940=94+93
+#   at 975=380
+#     inner subquery: at 955=95+94, at 965=96+95
+#   at 1000=392
+#     inner subquery: at 980=98+97, at 990=99+98
+eval instant at 0s sum_over_time(sum_over_time(sum_over_time(metric{job="1"}[20s])[20s:10s] offset 10s)[100s:25s] @ 1000)
+  {job="1"} 1504
+
+resume
+
+# ignoring minute function
+ignore
+# minute is counted on the value of the sample.
+eval instant at 10s minute(metric @ 1500)
+  {job="1"} 2
+  {job="2"} 5
+resume
+
+# ignoring timestamp function
+ignore
+# timestamp() takes the time of the sample and not the evaluation time.
+eval instant at 10m timestamp(metric{job="1"} @ 10)
+  {job="1"} 10
+
+# The result of inner timestamp() will have the timestamp as the
+# eval time, hence entire expression is not step invariant and depends on eval time.
+eval instant at 10m timestamp(timestamp(metric{job="1"} @ 10))
+  {job="1"} 600
+
+eval instant at 15m timestamp(timestamp(metric{job="1"} @ 10))
+  {job="1"} 900
+resume
+
+# ignoring sum_over_time aggregator functions
+ignore
+
+# Time functions inside a subquery.
+
+# minute is counted on the value of the sample.
+eval instant at 0s sum_over_time(minute(metric @ 1500)[100s:10s])
+  {job="1"} 20
+  {job="2"} 50
+
+# If nothing passed, minute() takes eval time.
+# Here the eval time is determined by the subquery.
+# [50m:1m] at 6000, i.e. 100m, is 50m to 100m.
+# sum=51+52+...+59+0+1+2+...+40.
+eval instant at 0s sum_over_time(minute()[50m:1m] @ 6000)
+  {} 1315
+
+# sum=46+47+...+59+0+1+2+...+35.
+eval instant at 0s sum_over_time(minute()[50m:1m] @ 6000 offset 5m)
+  {} 1365
+
+# time() is the eval time which is determined by subquery here.
+# 2901+...+3000 = (3000*3001 - 2899*2900)/2.
+eval instant at 0s sum_over_time(vector(time())[100s:1s] @ 3000)
+  {} 295050
+
+# 2301+...+2400 = (2400*2401 - 2299*2300)/2.
+eval instant at 0s sum_over_time(vector(time())[100s:1s] @ 3000 offset 600s)
+  {} 235050
+
+# timestamp() takes the time of the sample and not the evaluation time.
+eval instant at 0s sum_over_time(timestamp(metric{job="1"} @ 10)[100s:10s] @ 3000)
+  {job="1"} 100
+
+# The result of inner timestamp() will have the timestamp as the
+# eval time, hence entire expression is not step invariant and depends on eval time.
+# Here eval time is determined by the subquery.
+eval instant at 0s sum_over_time(timestamp(timestamp(metric{job="1"} @ 999))[10s:1s] @ 10)
+  {job="1"} 55
+
+resume
+
+clear
+
+# Tests for @ modifier with empty data.
+# Data only at 0s, 10s, 20s. Eval at timestamp with no data.
+load 10s
+  up 1 2 3
+
+# ignoring various functions (quantile_over_time, predict_linear, deriv, changes, resets, first_over_time, last_over_time)
+ignore
+
+# Functions that should return empty results when @ modifier points to timestamp with no data.
+# These were panicking before the fix.
+
+eval instant at 1111111s quantile_over_time(scalar(up) + 1, {__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s predict_linear({__name__="up"}[1h:1m] @ 1111111, 0.1)
+
+eval instant at 1111111s deriv({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s changes({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s resets({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s first_over_time({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s last_over_time({__name__="up"}[1h:1m] @ 1111111)
+resume
+
+# ignoring aggregate functions (avg_over_time, min_over_time, max_over_time, count_over_time, stddev_over_time, stdvar_over_time, mad_over_time)
+ignore
+
+eval instant at 1111111s sum_over_time({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s avg_over_time({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s min_over_time({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s max_over_time({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s count_over_time({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s stddev_over_time({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s stdvar_over_time({__name__="up"}[1h:1m] @ 1111111)
+
+eval instant at 1111111s mad_over_time({__name__="up"}[1h:1m] @ 1111111)
+
+resume
+
+clear

--- a/timeseries/src/promql/promqltest/testdata/selectors.test
+++ b/timeseries/src/promql/promqltest/testdata/selectors.test
@@ -20,23 +20,18 @@ eval instant at 18000s rate(http_requests_total[1m])
 	{job="api-server", instance="0", group="canary"} 8
 	{job="api-server", instance="1", group="canary"} 4
 
-eval instant at 8000s rate(http_requests_total{group="production"}[1m])
-	{job="api-server", instance="0", group="production"} 1
-	{job="api-server", instance="1", group="production"} 2
-
-eval instant at 18000s rate(http_requests_total{group="canary", instance="1"}[1m])
-	{job="api-server", instance="1", group="canary"} 4
-
-# Start ignoring
+# ignoring regex patterns (=~)
 ignore
-
 eval instant at 8000s rate(http_requests_total{group=~"pro.*"}[1m])
 	{job="api-server", instance="0", group="production"} 1
 	{job="api-server", instance="1", group="production"} 2
 
 eval instant at 18000s rate(http_requests_total{group=~".*ry", instance="1"}[1m])
 	{job="api-server", instance="1", group="canary"} 4
+resume
 
+# ignoring != matcher combined with offset
+ignore
 eval instant at 18000s rate(http_requests_total{instance!="3"}[1m] offset 10000s)
 	{job="api-server", instance="0", group="production"} 1
 	{job="api-server", instance="1", group="production"} 2
@@ -48,38 +43,194 @@ eval instant at 4000s rate(http_requests_total{instance!="3"}[1m] offset -4000s)
 	{job="api-server", instance="1", group="production"} 2
 	{job="api-server", instance="0", group="canary"} 3
 	{job="api-server", instance="1", group="canary"} 4
-
 resume
 
-# Additional tests for label matching and selectors
+# ignoring binary operation with offset
+ignore
+eval instant at 18000s rate(http_requests_total[40s]) - rate(http_requests_total[1m] offset 10000s)
+	{job="api-server", instance="0", group="production"} 2
+	{job="api-server", instance="1", group="production"} 1
+	{job="api-server", instance="0", group="canary"} 5
+	{job="api-server", instance="1", group="canary"} 0
+resume
 
-# Test single instance selector
-eval instant at 8000s rate(http_requests_total{instance="0"}[1m])
+# https://github.com/prometheus/prometheus/issues/3575
+eval instant at 0s http_requests_total{foo!="bar"}
+	http_requests_total{job="api-server", instance="0", group="production"} 0
+	http_requests_total{job="api-server", instance="1", group="production"} 0
+	http_requests_total{job="api-server", instance="0", group="canary"} 0
+	http_requests_total{job="api-server", instance="1", group="canary"} 0
+
+eval instant at 0s http_requests_total{foo!="bar", job="api-server"}
+	http_requests_total{job="api-server", instance="0", group="production"} 0
+	http_requests_total{job="api-server", instance="1", group="production"} 0
+	http_requests_total{job="api-server", instance="0", group="canary"} 0
+	http_requests_total{job="api-server", instance="1", group="canary"} 0
+
+# ignoring regex patterns (!~) and != matcher
+ignore
+eval instant at 0s http_requests_total{foo!~"bar", job="api-server"}
+	http_requests_total{job="api-server", instance="0", group="production"} 0
+	http_requests_total{job="api-server", instance="1", group="production"} 0
+	http_requests_total{job="api-server", instance="0", group="canary"} 0
+	http_requests_total{job="api-server", instance="1", group="canary"} 0
+
+eval instant at 0s http_requests_total{foo!~"bar", job="api-server", instance="1", x!="y", z="", group!=""}
+	http_requests_total{job="api-server", instance="1", group="production"} 0
+	http_requests_total{job="api-server", instance="1", group="canary"} 0
+
+# https://github.com/prometheus/prometheus/issues/7994
+eval instant at 8000s rate(http_requests_total{group=~"(?i:PRO).*"}[1m])
 	{job="api-server", instance="0", group="production"} 1
-	{job="api-server", instance="0", group="canary"} 3
+	{job="api-server", instance="1", group="production"} 2
 
-# Test job selector (all series have same job)
-eval instant at 8000s rate(http_requests_total{job="api-server"}[1m])
+eval instant at 8000s rate(http_requests_total{group=~".*?(?i:PRO).*"}[1m])
+	{job="api-server", instance="0", group="production"} 1
+	{job="api-server", instance="1", group="production"} 2
+
+eval instant at 8000s rate(http_requests_total{group=~".*(?i:DUC).*"}[1m])
+	{job="api-server", instance="0", group="production"} 1
+	{job="api-server", instance="1", group="production"} 2
+
+eval instant at 8000s rate(http_requests_total{group=~".*(?i:TION)"}[1m])
+	{job="api-server", instance="0", group="production"} 1
+	{job="api-server", instance="1", group="production"} 2
+
+eval instant at 8000s rate(http_requests_total{group=~".*(?i:TION).*?"}[1m])
+	{job="api-server", instance="0", group="production"} 1
+	{job="api-server", instance="1", group="production"} 2
+
+
+eval instant at 8000s rate(http_requests_total{group=~"((?i)PRO).*"}[1m])
+	{job="api-server", instance="0", group="production"} 1
+	{job="api-server", instance="1", group="production"} 2
+
+eval instant at 8000s rate(http_requests_total{group=~".*((?i)DUC).*"}[1m])
+	{job="api-server", instance="0", group="production"} 1
+	{job="api-server", instance="1", group="production"} 2
+
+eval instant at 8000s rate(http_requests_total{group=~".*((?i)TION)"}[1m])
+	{job="api-server", instance="0", group="production"} 1
+	{job="api-server", instance="1", group="production"} 2
+
+
+eval instant at 8000s rate(http_requests_total{group=~"(?i:PRODUCTION)"}[1m])
+	{job="api-server", instance="0", group="production"} 1
+	{job="api-server", instance="1", group="production"} 2
+
+eval instant at 8000s rate(http_requests_total{group=~".*(?i:C).*"}[1m])
 	{job="api-server", instance="0", group="production"} 1
 	{job="api-server", instance="1", group="production"} 2
 	{job="api-server", instance="0", group="canary"} 3
 	{job="api-server", instance="1", group="canary"} 4
+resume
 
-# Test multiple label selectors
-eval instant at 8000s rate(http_requests_total{job="api-server", group="production", instance="0"}[1m])
-	{job="api-server", instance="0", group="production"} 1
+clear
+load 1m
+    metric1{a="a"} 0+1x100
+    metric2{b="b"} 0+1x50
 
-# Test inequality selector
-eval instant at 8000s rate(http_requests_total{instance!="0"}[1m])
-	{job="api-server", instance="1", group="production"} 2
-	{job="api-server", instance="1", group="canary"} 4
+# ignoring or operator with offset
+ignore
+eval instant at 90m metric1 offset 15m or metric2 offset 45m
+    metric1{a="a"} 75
+    metric2{b="b"} 45
+resume
 
-# Test selector at different time point (before rate change at 10000s)
-eval instant at 9000s rate(http_requests_total{group="canary"}[1m])
-	{job="api-server", instance="0", group="canary"} 3
-	{job="api-server", instance="1", group="canary"} 4
+clear
 
-# Test with different range window
-eval instant at 8000s rate(http_requests_total{group="production"}[30s])
-	{job="api-server", instance="0", group="production"} 1
-	{job="api-server", instance="1", group="production"} 2
+load 5m
+	x{y="testvalue"} 0+10x10
+
+load 5m
+	cpu_count{instance="0", type="numa"}	0+30x10
+	cpu_count{instance="0", type="smp"} 	0+10x20
+	cpu_count{instance="1", type="smp"} 	0+20x10
+
+load 5m
+	label_grouping_test{a="aa", b="bb"}	0+10x10
+	label_grouping_test{a="a", b="abb"}	0+20x10
+
+load 5m
+	http_requests_total{job="api-server", instance="0", group="production"}	0+10x10
+	http_requests_total{job="api-server", instance="1", group="production"}	0+20x10
+	http_requests_total{job="api-server", instance="0", group="canary"}		0+30x10
+	http_requests_total{job="api-server", instance="1", group="canary"}		0+40x10
+	http_requests_total{job="app-server", instance="0", group="production"}	0+50x10
+	http_requests_total{job="app-server", instance="1", group="production"}	0+60x10
+	http_requests_total{job="app-server", instance="0", group="canary"}		0+70x10
+	http_requests_total{job="app-server", instance="1", group="canary"}		0+80x10
+
+# ignoring single-letter label names
+ignore
+# Single-letter label names and values.
+eval instant at 50m x{y="testvalue"}
+	x{y="testvalue"} 100
+resume
+
+# ignoring regex patterns (=~, !~) and != matcher
+ignore
+# Basic Regex
+eval instant at 50m {__name__=~".+"}
+	http_requests_total{group="canary", instance="0", job="api-server"} 300
+	http_requests_total{group="canary", instance="0", job="app-server"} 700
+	http_requests_total{group="canary", instance="1", job="api-server"} 400
+	http_requests_total{group="canary", instance="1", job="app-server"} 800
+	http_requests_total{group="production", instance="0", job="api-server"} 100
+	http_requests_total{group="production", instance="0", job="app-server"} 500
+	http_requests_total{group="production", instance="1", job="api-server"} 200
+	http_requests_total{group="production", instance="1", job="app-server"} 600
+	x{y="testvalue"} 100
+	label_grouping_test{a="a", b="abb"} 200
+	label_grouping_test{a="aa", b="bb"} 100
+	cpu_count{instance="1", type="smp"} 200
+	cpu_count{instance="0", type="smp"} 100
+	cpu_count{instance="0", type="numa"} 300
+
+eval instant at 50m {job=~".+-server", job!~"api-.+"}
+	http_requests_total{group="canary", instance="0", job="app-server"} 700
+	http_requests_total{group="canary", instance="1", job="app-server"} 800
+	http_requests_total{group="production", instance="0", job="app-server"} 500
+	http_requests_total{group="production", instance="1", job="app-server"} 600
+
+eval instant at 50m http_requests_total{group!="canary"}
+	http_requests_total{group="production", instance="1", job="app-server"} 600
+	http_requests_total{group="production", instance="0", job="app-server"} 500
+	http_requests_total{group="production", instance="1", job="api-server"} 200
+	http_requests_total{group="production", instance="0", job="api-server"} 100
+
+eval instant at 50m http_requests_total{job=~".+-server",group!="canary"}
+	http_requests_total{group="production", instance="1", job="app-server"} 600
+	http_requests_total{group="production", instance="0", job="app-server"} 500
+	http_requests_total{group="production", instance="1", job="api-server"} 200
+	http_requests_total{group="production", instance="0", job="api-server"} 100
+
+eval instant at 50m http_requests_total{job!~"api-.+",group!="canary"}
+	http_requests_total{group="production", instance="1", job="app-server"} 600
+	http_requests_total{group="production", instance="0", job="app-server"} 500
+
+eval instant at 50m http_requests_total{group="production",job=~"api-.+"}
+	http_requests_total{group="production", instance="0", job="api-server"} 100
+	http_requests_total{group="production", instance="1", job="api-server"} 200
+resume
+
+eval instant at 50m http_requests_total{group="production",job="api-server"} offset 5m
+	http_requests_total{group="production", instance="0", job="api-server"} 90
+	http_requests_total{group="production", instance="1", job="api-server"} 180
+
+clear
+
+
+# Matrix tests.
+load 1h
+	testmetric{aa="bb"} 1
+	testmetric{a="abb"} 2
+
+# ignoring single-letter label names
+ignore
+eval instant at 0h testmetric
+	testmetric{aa="bb"} 1
+	testmetric{a="abb"} 2
+resume
+
+clear


### PR DESCRIPTION
Refactored the promqltest framework into focused modules and added comprehensive test coverage from Prometheus upstream test suite.

Changes:
-Made dsl module and internal functions private. Only runner::run_test() remains public for generated tests.
- Refactored runner.rs by extracting loader, evaluator, and assertion logic into separate modules (loader.rs, evaluator.rs, assert.rs)
- Updated README.md with improved architecture documentation showing module responsibilities and execution flow
- Updated at_modifier.test from Prometheus upstream with ignore/resume blocks for unimplemented features
- Updated selectors.test from Prometheus upstream with ignore/resume blocks for unimplemented features

Test coverage:
- at_modifier.test: Tests @ modifier syntax with various scenarios
- Wrapped unimplemented: unary operator, subqueries, timestamp(),minute(), label_replace(), and aggregate functions
- selectors.test: Tests label selectors and matchers
- Wrapped unimplemented: full regex patterns (=~, !~), != with offset,binary operations, or operator, single-letter label names

## Related Issues

Fixes #184 

## Test Plan

How was this tested?

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
