### PR TITLE
refactor(log): simplify proto Record 

### DIFF
--- a/log/src/server/response.rs
+++ b/log/src/server/response.rs
@@ -88,7 +88,7 @@ mod tests {
 
         // then
         assert_eq!(response.status, "success");
-        assert_eq!(response.key.as_ref().unwrap().value, Bytes::from("key"));
+        assert_eq!(*response.key.as_ref().unwrap(), Bytes::from("key"));
         assert_eq!(response.values.len(), 1);
     }
 
@@ -109,7 +109,7 @@ mod tests {
         // then
         // "test-key" -> "dGVzdC1rZXk=", "test-value" -> "dGVzdC12YWx1ZQ=="
         assert!(json.contains(r#""status":"success""#));
-        assert!(json.contains(r#""key":{"value":"dGVzdC1rZXk="}"#));
+        assert!(json.contains(r#""key":"dGVzdC1rZXk=""#));
         assert!(json.contains(r#""sequence":42"#));
         assert!(json.contains(r#""value":"dGVzdC12YWx1ZQ==""#));
         assert!(json.contains(r#""values":"#));
@@ -150,7 +150,7 @@ mod tests {
 
         // then
         // "events" -> "ZXZlbnRz", "orders" -> "b3JkZXJz"
-        assert!(json.contains(r#""keys":[{"value":"ZXZlbnRz"},{"value":"b3JkZXJz"}]"#));
+        assert!(json.contains(r#""keys":[{"key":"ZXZlbnRz"},{"key":"b3JkZXJz"}]"#));
     }
 
     #[test]

--- a/log/tests/http_api_formats.rs
+++ b/log/tests/http_api_formats.rs
@@ -59,7 +59,7 @@ async fn test_append_json_request_and_response() {
     let value_b64 = STANDARD.encode("test-value");
 
     let body = format!(
-        r#"{{"records": [{{"key": {{"value": "{}"}}, "value": "{}"}}], "awaitDurable": false}}"#,
+        r#"{{"records": [{{"key": "{}", "value": "{}"}}], "awaitDurable": false}}"#,
         key_b64, value_b64
     );
 
@@ -94,7 +94,7 @@ async fn test_append_multiple_records_json() {
     let value2_b64 = STANDARD.encode("value-2");
 
     let body = format!(
-        r#"{{"records": [{{"key": {{"value": "{}"}}, "value": "{}"}}, {{"key": {{"value": "{}"}}, "value": "{}"}}], "awaitDurable": false}}"#,
+        r#"{{"records": [{{"key": "{}", "value": "{}"}}, {{"key": "{}", "value": "{}"}}], "awaitDurable": false}}"#,
         key1_b64, value1_b64, key2_b64, value2_b64
     );
 
@@ -156,7 +156,7 @@ async fn test_scan_json_response() {
 
     assert_eq!(json["status"], "success");
 
-    let key_b64 = json["key"]["value"].as_str().unwrap();
+    let key_b64 = json["key"].as_str().unwrap();
     let key_decoded = STANDARD.decode(key_b64).unwrap();
     assert_eq!(key_decoded, b"events");
 
@@ -218,8 +218,8 @@ async fn test_list_keys_json_response() {
     assert_eq!(keys.len(), 2);
 
     // Keys are returned in lexicographic order: "events" before "orders"
-    let key1_decoded = STANDARD.decode(keys[0]["value"].as_str().unwrap()).unwrap();
-    let key2_decoded = STANDARD.decode(keys[1]["value"].as_str().unwrap()).unwrap();
+    let key1_decoded = STANDARD.decode(keys[0]["key"].as_str().unwrap()).unwrap();
+    let key2_decoded = STANDARD.decode(keys[1]["key"].as_str().unwrap()).unwrap();
     assert_eq!(key1_decoded, b"events");
     assert_eq!(key2_decoded, b"orders");
 }
@@ -298,10 +298,8 @@ async fn test_append_protobuf_request_and_response() {
 
     let proto_request = proto::AppendRequest {
         records: vec![proto::Record {
-            key: Some(proto::Key {
-                value: Bytes::from("proto-key"),
-            }),
-            value: Bytes::from("proto-value"),
+            key: Some(Bytes::from("proto-key")),
+            value: Some(Bytes::from("proto-value")),
         }],
         await_durable: false,
     };
@@ -339,10 +337,8 @@ async fn test_append_protobuf_request_json_response() {
 
     let proto_request = proto::AppendRequest {
         records: vec![proto::Record {
-            key: Some(proto::Key {
-                value: Bytes::from("mixed-key"),
-            }),
-            value: Bytes::from("mixed-value"),
+            key: Some(Bytes::from("mixed-key")),
+            value: Some(Bytes::from("mixed-value")),
         }],
         await_durable: false,
     };
@@ -408,7 +404,7 @@ async fn test_scan_protobuf_response() {
 
     assert_eq!(proto_response.status, "success");
     assert_eq!(
-        proto_response.key.as_ref().unwrap().value,
+        *proto_response.key.as_ref().unwrap(),
         Bytes::from("proto-events")
     );
     assert_eq!(proto_response.values.len(), 2);
@@ -458,8 +454,8 @@ async fn test_list_keys_protobuf_response() {
 
     assert_eq!(proto_response.status, "success");
     assert_eq!(proto_response.keys.len(), 2);
-    assert_eq!(proto_response.keys[0].value, Bytes::from("alpha"));
-    assert_eq!(proto_response.keys[1].value, Bytes::from("beta"));
+    assert_eq!(proto_response.keys[0].key, Bytes::from("alpha"));
+    assert_eq!(proto_response.keys[1].key, Bytes::from("beta"));
 }
 
 #[tokio::test]
@@ -543,7 +539,7 @@ async fn test_json_append_then_scan_roundtrip() {
     let value_b64 = STANDARD.encode("roundtrip-value");
 
     let append_body = format!(
-        r#"{{"records": [{{"key": {{"value": "{}"}}, "value": "{}"}}], "awaitDurable": true}}"#,
+        r#"{{"records": [{{"key": "{}", "value": "{}"}}], "awaitDurable": true}}"#,
         key_b64, value_b64
     );
 
@@ -589,10 +585,8 @@ async fn test_protobuf_append_then_scan_roundtrip() {
     // Append via protobuf
     let proto_request = proto::AppendRequest {
         records: vec![proto::Record {
-            key: Some(proto::Key {
-                value: Bytes::from("proto-roundtrip"),
-            }),
-            value: Bytes::from("proto-roundtrip-value"),
+            key: Some(Bytes::from("proto-roundtrip")),
+            value: Some(Bytes::from("proto-roundtrip-value")),
         }],
         await_durable: true,
     };


### PR DESCRIPTION
Remove the Key wrapper from Record and ScanResponse, using Option<bytes::Bytes> directly for both key and value fields. Key struct is now only used in KeysResponse. Rename Key.value to Key.key for clarity. Add validation that both key and value are required on append requests, returning 400 if either is missing.