### PR TITLE
Add SlateDB Metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2400,6 +2400,7 @@ dependencies = [
  "bytes",
  "criterion",
  "futures",
+ "prometheus-client",
  "proptest",
  "serde",
  "serde_yaml",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -13,6 +13,10 @@ categories = ["database"]
 name = "common"
 path = "src/lib.rs"
 
+[features]
+default = []
+metrics = ["dep:prometheus-client"]
+
 [dependencies]
 slatedb.workspace = true
 bytes.workspace = true
@@ -23,6 +27,7 @@ tokio-util.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 serde.workspace = true
+prometheus-client = { version = "0.22", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -194,4 +194,12 @@ pub trait Storage: StorageRead {
     /// This method should be called before dropping the storage to ensure
     /// proper cleanup. For SlateDB, this releases the database fence.
     async fn close(&self) -> StorageResult<()>;
+
+    /// Registers storage engine metrics into the given Prometheus registry.
+    ///
+    /// The default implementation is a no-op. Storage backends that expose
+    /// internal metrics (e.g., SlateDB) override this to register gauges
+    /// that read live values on each scrape.
+    #[cfg(feature = "metrics")]
+    fn register_metrics(&self, _registry: &mut prometheus_client::registry::Registry) {}
 }

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["http-server"]
 
 [features]
 default = []
-http-server = ["dep:axum", "dep:tower", "dep:clap", "dep:prometheus-client"]
+http-server = ["dep:axum", "dep:tower", "dep:clap", "dep:prometheus-client", "common/metrics"]
 
 [dependencies]
 async-trait.workspace = true

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -112,6 +112,12 @@ impl LogDb {
         LogDbBuilder::new(config).build().await
     }
 
+    /// Registers storage engine metrics into the given Prometheus registry.
+    #[cfg(feature = "http-server")]
+    pub fn register_metrics(&self, registry: &mut prometheus_client::registry::Registry) {
+        self.storage.register_metrics(registry);
+    }
+
     /// Appends records to the log without blocking.
     ///
     /// Records are assigned sequence numbers in the order they appear in the

--- a/log/src/server/http.rs
+++ b/log/src/server/http.rs
@@ -30,8 +30,10 @@ impl LogServer {
 
     /// Run the HTTP server.
     pub async fn run(self) {
-        // Create metrics registry
-        let metrics = Arc::new(Metrics::new());
+        // Create metrics registry and register storage engine metrics
+        let mut metrics = Metrics::new();
+        self.log.register_metrics(metrics.registry_mut());
+        let metrics = Arc::new(metrics);
 
         // Create app state
         let state = AppState {

--- a/log/src/server/metrics.rs
+++ b/log/src/server/metrics.rs
@@ -159,6 +159,14 @@ impl Metrics {
         }
     }
 
+    /// Returns a mutable reference to the underlying Prometheus registry.
+    ///
+    /// Use this to register additional metrics (e.g. storage engine metrics)
+    /// before wrapping `Metrics` in an `Arc`.
+    pub fn registry_mut(&mut self) -> &mut Registry {
+        &mut self.registry
+    }
+
     /// Encode all metrics to Prometheus text format.
     pub fn encode(&self) -> String {
         let mut buffer = String::new();

--- a/log/src/storage.rs
+++ b/log/src/storage.rs
@@ -161,6 +161,12 @@ impl LogStorage {
         Self::new(Arc::new(InMemoryStorage::new()))
     }
 
+    /// Registers storage engine metrics into the given Prometheus registry.
+    #[cfg(feature = "http-server")]
+    pub(crate) fn register_metrics(&self, registry: &mut prometheus_client::registry::Registry) {
+        self.storage.register_metrics(registry);
+    }
+
     /// Returns a read-only view of this storage.
     pub(crate) fn as_read(&self) -> LogStorageRead {
         LogStorageRead::new(Arc::clone(&self.storage) as Arc<dyn StorageRead>)

--- a/log/tests/http_api_formats.rs
+++ b/log/tests/http_api_formats.rs
@@ -15,7 +15,7 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 use bytes::Bytes;
 use common::StorageConfig;
 use log::server::handlers::{
-    AppState, handle_append, handle_list_keys, handle_list_segments, handle_scan,
+    AppState, handle_append, handle_list_keys, handle_list_segments, handle_metrics, handle_scan,
 };
 use log::server::metrics::Metrics;
 use log::server::proto;
@@ -742,5 +742,138 @@ async fn test_scan_follow_at_poll_boundary_returns_empty() {
         elapsed < Duration::from_millis(200),
         "expected < 200ms but got {:?}",
         elapsed
+    );
+}
+
+// ============================================================================
+// SlateDB Metrics Tests
+// ============================================================================
+
+/// Setup a test app backed by SlateDB (in-memory object store) so that
+/// the StatRegistry is populated with real metrics.
+async fn setup_slatedb_test_app() -> Router {
+    use common::storage::config::{ObjectStoreConfig, SlateDbStorageConfig};
+
+    let config = Config {
+        storage: StorageConfig::SlateDb(SlateDbStorageConfig {
+            path: "test-metrics".to_string(),
+            object_store: ObjectStoreConfig::InMemory,
+            settings_path: None,
+        }),
+        ..Default::default()
+    };
+
+    let log = Arc::new(LogDb::open(config).await.expect("Failed to open log"));
+    let mut metrics = Metrics::new();
+    log.register_metrics(metrics.registry_mut());
+    let metrics = Arc::new(metrics);
+
+    let state = AppState {
+        log: log.clone(),
+        metrics,
+    };
+
+    Router::new()
+        .route("/api/v1/log/append", post(handle_append))
+        .route("/api/v1/log/scan", get(handle_scan))
+        .route("/metrics", get(handle_metrics))
+        .with_state(state)
+}
+
+#[tokio::test]
+async fn test_slatedb_metrics_appear_on_metrics_endpoint() {
+    let app = setup_slatedb_test_app().await;
+
+    // Hit /metrics before any writes — SlateDB stats should be registered
+    let request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+
+    // Verify SlateDB metrics are present (these are registered by the Db on startup)
+    assert!(
+        text.contains("slatedb_"),
+        "Expected slatedb_ prefixed metrics in output, got:\n{}",
+        &text[..text.len().min(500)]
+    );
+}
+
+/// Parse the value of a Prometheus metric line like "slatedb_db_write_ops 42".
+fn parse_metric_value(metrics_text: &str, metric_name: &str) -> i64 {
+    let line = metrics_text
+        .lines()
+        .find(|line| line.starts_with(&format!("{metric_name} ")))
+        .unwrap_or_else(|| panic!("{metric_name} metric line not found"));
+    line.split_whitespace()
+        .last()
+        .unwrap()
+        .parse()
+        .unwrap_or_else(|_| panic!("Failed to parse {metric_name} value"))
+}
+
+#[tokio::test]
+async fn test_slatedb_metrics_reflect_writes() {
+    let app = setup_slatedb_test_app().await;
+
+    // Capture baseline write_ops before append (startup may already increment it)
+    let baseline_request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let baseline_response = app.clone().oneshot(baseline_request).await.unwrap();
+    assert_eq!(baseline_response.status(), StatusCode::OK);
+    let baseline_body = axum::body::to_bytes(baseline_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let baseline_text = String::from_utf8(baseline_body.to_vec()).unwrap();
+    let baseline_write_ops = parse_metric_value(&baseline_text, "slatedb_db_write_ops");
+
+    // Append some data via the HTTP API
+    let key_b64 = STANDARD.encode("metrics-test-key");
+    let value_b64 = STANDARD.encode("metrics-test-value");
+    let append_body = format!(
+        r#"{{"records": [{{"key": "{}", "value": "{}"}}], "awaitDurable": true}}"#,
+        key_b64, value_b64
+    );
+
+    let append_request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/log/append")
+        .header(header::CONTENT_TYPE, "application/protobuf+json")
+        .body(Body::from(append_body))
+        .unwrap();
+    let append_response = app.clone().oneshot(append_request).await.unwrap();
+    assert_eq!(append_response.status(), StatusCode::OK);
+
+    // Check /metrics — write_ops should have increased from the append
+    let metrics_request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let metrics_response = app.oneshot(metrics_request).await.unwrap();
+    assert_eq!(metrics_response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(metrics_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let text = String::from_utf8(body.to_vec()).unwrap();
+    let write_ops_after = parse_metric_value(&text, "slatedb_db_write_ops");
+
+    assert!(
+        write_ops_after > baseline_write_ops,
+        "Expected write_ops to increase after append: baseline={}, after={}",
+        baseline_write_ops,
+        write_ops_after
     );
 }

--- a/timeseries/Cargo.toml
+++ b/timeseries/Cargo.toml
@@ -30,7 +30,7 @@ clap.workspace = true
 config.workspace = true
 dashmap.workspace = true
 moka.workspace = true
-common.workspace = true
+common = { workspace = true, features = ["metrics"] }
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/timeseries/src/main.rs
+++ b/timeseries/src/main.rs
@@ -76,7 +76,7 @@ async fn main() {
     tracing::info!("Storage created successfully");
 
     // Create Tsdb
-    let tsdb = Arc::new(Tsdb::new(storage));
+    let tsdb = Arc::new(Tsdb::new(storage.clone()));
 
     // Create server configuration
     let config = ServerConfig {
@@ -85,7 +85,7 @@ async fn main() {
     };
 
     // Create and run server
-    let server = PromqlServer::new(tsdb, config);
+    let server = PromqlServer::new(tsdb, config, storage);
 
     tracing::info!(
         "Starting timeseries Prometheus-compatible server on port {}...",

--- a/timeseries/src/promql/metrics.rs
+++ b/timeseries/src/promql/metrics.rs
@@ -166,6 +166,14 @@ impl Metrics {
         }
     }
 
+    /// Returns a mutable reference to the underlying Prometheus registry.
+    ///
+    /// Use this to register additional metrics (e.g. storage engine metrics)
+    /// before wrapping `Metrics` in an `Arc`.
+    pub fn registry_mut(&mut self) -> &mut Registry {
+        &mut self.registry
+    }
+
     /// Encode all metrics to Prometheus text format.
     pub fn encode(&self) -> String {
         let mut buffer = String::new();


### PR DESCRIPTION
## Summary

Collect SlateDB metrics and make them available in the `/metrics` api of `Log` and `Timeseries`. To achieve this, we create a Prometheus Gauge wrapper around SlateDB's `ReadableStat`, and register these wrapped gauges in the Prometheus registry of the Log and TimeSeries. Every scrape reads directly from SlateDB for its metrics. 

## Related Issues

Fixes https://github.com/opendata-oss/opendata/issues/193

## Test Plan

Apart from unit tests, added an integration test for the Log which checks that:

1. SlateDB metrics are returned in the /metrics response.
2. SlateDB Metrics are as expected after a write to the log.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
