### PR TITLE
Replace rug with dashu-float to reduce CI build times

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,12 +304,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "az"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
-
-[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -926,6 +920,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashu-base"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b80bf6b85aa68c58ffea2ddb040109943049ce3fbdf4385d0380aef08ef289"
+
+[[package]]
+name = "dashu-float"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85078445a8dbd2e1bd21f04a816f352db8d333643f0c9b78ca7c3d1df71063e7"
+dependencies = [
+ "dashu-base",
+ "dashu-int",
+ "num-modular",
+ "num-order",
+ "rustversion",
+ "static_assertions",
+]
+
+[[package]]
+name = "dashu-int"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee99d08031ca34a4d044efbbb21dff9b8c54bb9d8c82a189187c0651ffdb9fbf"
+dependencies = [
+ "cfg-if",
+ "dashu-base",
+ "num-modular",
+ "rustversion",
+ "static_assertions",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1458,16 +1485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gmp-mpfr-sys"
-version = "1.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60f8970a75c006bb2f8ae79c6768a116dd215fa8346a87aed99bf9d82ca43394"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1960,12 +1977,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
 name = "libredox"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2349,6 +2360,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-modular"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f"
+
+[[package]]
+name = "num-order"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537b596b97c40fcf8056d153049eb22f481c17ebce72a513ec9286e4986d1bb6"
+dependencies = [
+ "num-modular",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,6 +2533,7 @@ dependencies = [
  "clap",
  "config",
  "dashmap",
+ "dashu-float",
  "fail",
  "mime_guess",
  "moka",
@@ -2520,7 +2547,6 @@ dependencies = [
  "reqwest",
  "roaring 0.7.0",
  "rstest",
- "rug",
  "rust-embed",
  "serde",
  "serde_json",
@@ -3355,18 +3381,6 @@ dependencies = [
  "rustc_version",
  "syn 2.0.111",
  "unicode-ident",
-]
-
-[[package]]
-name = "rug"
-version = "1.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de190ec858987c79cad4da30e19e546139b3339331282832af004d0ea7829639"
-dependencies = [
- "az",
- "gmp-mpfr-sys",
- "libc",
- "libm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = "1.14.0"
 prost = "0.13"
 proptest = "1"
-rug = "1.28"
+dashu-float = "0.4"
 snap = "1"
 criterion = "0.5"

--- a/timeseries/Cargo.toml
+++ b/timeseries/Cargo.toml
@@ -64,7 +64,7 @@ snap = { workspace = true, optional = true }
 fail.workspace = true
 proptest.workspace = true
 rstest.workspace = true
-rug.workspace = true
+dashu-float.workspace = true
 
 [[test]]
 name = "http_server"

--- a/timeseries/src/promql/functions.rs
+++ b/timeseries/src/promql/functions.rs
@@ -942,8 +942,8 @@ mod tests {
     // Property-based tests using proptest
     mod proptests {
         use super::*;
+        use dashu_float::{FBig, round::mode::HalfEven};
         use proptest::prelude::*;
-        use rug::Float;
 
         /// Generate finite f64 values (no NaN, no infinity)
         fn finite_f64() -> impl Strategy<Value = f64> {
@@ -952,21 +952,20 @@ mod tests {
 
         /// Compute high-precision sum using arbitrary precision arithmetic (oracle)
         fn oracle_sum_high_precision(values: &[f64]) -> f64 {
-            // Use 256-bit precision (much higher than f64's 53 bits)
-            let mut sum = Float::with_val(256, 0.0);
+            let mut sum = FBig::<HalfEven>::ZERO.with_precision(256).value();
             for &val in values {
-                sum += Float::with_val(256, val);
+                sum += FBig::try_from(val).unwrap();
             }
-            sum.to_f64()
+            sum.to_f64().value()
         }
 
         /// Compute sum of absolute values for error bound
         fn sum_abs(values: &[f64]) -> f64 {
-            let mut sum = Float::with_val(256, 0.0);
+            let mut sum = FBig::<HalfEven>::ZERO.with_precision(256).value();
             for &val in values {
-                sum += Float::with_val(256, val.abs());
+                sum += FBig::try_from(val.abs()).unwrap();
             }
-            sum.to_f64()
+            sum.to_f64().value()
         }
 
         proptest! {


### PR DESCRIPTION
## Summary

Replaced rug (GMP-backed) with dashu-float (pure Rust) for arbitrary precision arithmetic in property tests. This eliminates the native dependency on GMP.

## Related Issues

Fixes #209 

## Test Plan

How was this tested?

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
