### PR TITLE
add split configuration fields to model

### DIFF
--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -635,6 +635,9 @@ mod tests {
             dimensions: 3,
             distance_metric: DistanceMetric::Cosine,
             flush_interval: Duration::from_secs(60),
+            split_threshold_vectors: 10_000,
+            split_search_neighbourhood: 8,
+            chunk_target: 4096,
             metadata_fields: vec![
                 MetadataFieldSpec::new("category", FieldType::String, true),
                 MetadataFieldSpec::new("price", FieldType::Int64, true),
@@ -786,6 +789,9 @@ mod tests {
             dimensions,
             distance_metric: DistanceMetric::Cosine,
             flush_interval: Duration::from_secs(60),
+            split_threshold_vectors: 10_000,
+            split_search_neighbourhood: 8,
+            chunk_target: 4096,
             metadata_fields: vec![],
         }
     }
@@ -907,6 +913,9 @@ mod tests {
             dimensions: 3,
             distance_metric: DistanceMetric::L2,
             flush_interval: Duration::from_secs(60),
+            split_threshold_vectors: 10_000,
+            split_search_neighbourhood: 8,
+            chunk_target: 4096,
             metadata_fields: vec![],
         };
         let db = VectorDb::open(config).await.unwrap();

--- a/vector/src/model.rs
+++ b/vector/src/model.rs
@@ -195,6 +195,15 @@ pub struct Config {
     /// How often to flush data to durable storage.
     pub flush_interval: Duration,
 
+    /// Number of vectors in a centroid's posting list that triggers a split.
+    pub split_threshold_vectors: u64,
+
+    /// Number of neighboring centroids to scan for reassignment candidates after a split.
+    pub split_search_neighbourhood: usize,
+
+    /// Target number of centroids per chunk.
+    pub chunk_target: u16,
+
     /// Metadata field schema.
     ///
     /// Defines the expected attribute names and types. Writes with unknown
@@ -210,6 +219,9 @@ impl Default for Config {
             dimensions: 0, // Must be set explicitly
             distance_metric: DistanceMetric::Cosine,
             flush_interval: Duration::from_secs(60),
+            split_threshold_vectors: 2_000,
+            split_search_neighbourhood: 8,
+            chunk_target: 4096,
             metadata_fields: Vec::new(),
         }
     }


### PR DESCRIPTION
## Summary

Add split_threshold_vectors (default 2000),
split_search_neighbourhood (default 8), and chunk_target (default 4096) to VectorDbConfig.

## Test Plan

unit tests

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
