### PR TITLE
expand CentroidGraph trait with mutation and lookup

### DIFF
--- a/vector/src/delta.rs
+++ b/vector/src/delta.rs
@@ -253,6 +253,7 @@ mod tests {
     use super::*;
     use crate::hnsw::CentroidGraph;
     use crate::model::AttributeValue;
+    use crate::serde::centroid_chunk::CentroidEntry;
     use crate::serde::key::{
         CentroidStatsKey, DeletionsKey, IdDictionaryKey, PostingListKey, VectorDataKey,
     };
@@ -276,6 +277,22 @@ mod tests {
     impl CentroidGraph for MockCentroidGraph {
         fn search(&self, _query: &[f32], _k: usize) -> Vec<u64> {
             vec![self.centroid_id]
+        }
+
+        fn add_centroid(&self, _entry: &CentroidEntry) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn remove_centroid(&self, _centroid_id: u64) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn get_centroid_vector(&self, centroid_id: u64) -> Option<Vec<f32>> {
+            if centroid_id == self.centroid_id {
+                Some(vec![0.0; 3])
+            } else {
+                None
+            }
         }
 
         fn len(&self) -> usize {
@@ -592,6 +609,18 @@ mod tests {
                 }
             }
 
+            fn add_centroid(&self, _entry: &CentroidEntry) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            fn remove_centroid(&self, _centroid_id: u64) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            fn get_centroid_vector(&self, _centroid_id: u64) -> Option<Vec<f32>> {
+                None
+            }
+
             fn len(&self) -> usize {
                 3
             }
@@ -654,6 +683,18 @@ mod tests {
                 } else {
                     vec![3]
                 }
+            }
+
+            fn add_centroid(&self, _entry: &CentroidEntry) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            fn remove_centroid(&self, _centroid_id: u64) -> anyhow::Result<()> {
+                Ok(())
+            }
+
+            fn get_centroid_vector(&self, _centroid_id: u64) -> Option<Vec<f32>> {
+                None
             }
 
             fn len(&self) -> usize {

--- a/vector/src/hnsw/mod.rs
+++ b/vector/src/hnsw/mod.rs
@@ -28,6 +28,21 @@ pub trait CentroidGraph: Send + Sync {
     /// Vector of centroid_ids sorted by similarity (closest first)
     fn search(&self, query: &[f32], k: usize) -> Vec<u64>;
 
+    /// Add a centroid to the graph.
+    ///
+    /// Uses interior mutability since the graph is behind `Arc<dyn CentroidGraph>`.
+    fn add_centroid(&self, entry: &CentroidEntry) -> Result<()>;
+
+    /// Remove a centroid from the graph by its ID.
+    ///
+    /// Uses interior mutability since the graph is behind `Arc<dyn CentroidGraph>`.
+    fn remove_centroid(&self, centroid_id: u64) -> Result<()>;
+
+    /// Get the vector for a centroid by its ID.
+    ///
+    /// Returns `None` if the centroid is not in the graph.
+    fn get_centroid_vector(&self, centroid_id: u64) -> Option<Vec<f32>>;
+
     /// Returns the number of centroids in the graph.
     fn len(&self) -> usize;
 


### PR DESCRIPTION
## Summary

Add add_centroid, remove_centroid, get_centroid_vector to CentroidGraph trait. search returns Vec<u64> (from Vec<u32>).

UsearchCentroidGraph: interior mutability via RwLock<Inner>, HashMap-based key/centroid mappings, INITIAL_CAPACITY = 200_000 to avoid usearch deadlock near capacity limits. Tests for add, remove, get_centroid_vector.

## Test Plan

Unit tests

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
