### PR TITLE
misc storage changes we need for lire

### DIFF
--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -193,9 +193,9 @@ impl VectorDb {
             .scan_all_centroids(config.dimensions as usize)
             .await?;
 
-        if !existing_centroids.is_empty() {
+        if !existing_centroids.entries.is_empty() {
             // Use existing centroids from storage
-            let graph = build_centroid_graph(existing_centroids, config.distance_metric)?;
+            let graph = build_centroid_graph(existing_centroids.entries, config.distance_metric)?;
             return Ok(Arc::from(graph));
         }
 

--- a/vector/src/storage/record.rs
+++ b/vector/src/storage/record.rs
@@ -98,3 +98,15 @@ pub fn merge_centroid_stats(centroid_id: u64, delta: i32) -> RecordOp {
     let value = CentroidStatsValue::new(delta).encode_to_bytes();
     RecordOp::Merge(Record::new(key, value))
 }
+
+/// Create a RecordOp to merge new centroid entries into an existing centroid chunk.
+#[allow(dead_code)]
+pub fn merge_centroid_chunk(
+    chunk_id: u32,
+    entries: Vec<CentroidEntry>,
+    dimensions: usize,
+) -> RecordOp {
+    let key = CentroidChunkKey::new(chunk_id).encode();
+    let value = CentroidChunkValue::new(entries).encode_to_bytes(dimensions);
+    RecordOp::Merge(Record::new(key, value))
+}


### PR DESCRIPTION
## Summary

Changes the posting updates constructor to use last-write-wins for dedup instead of error on duplicates. This allows multiple reassignments in a single flush (e.g. if a vector is assigned and then reassigned by a split).

Add a new fn merge_decoded_posting_lists (priority k-way merge, earlier operand wins). This will be used for the read-applied-writes view so we can merge the in-memory posting lists. Split/merge need this to figure out the set of vectors that need to move around after a split/merge without blocking the split/merge on a flush after each step.

Adds a CentroidChunk merge operator which appends new centroid entries. This allows us to add centroids to chunks as they get created.

Adds CentroidScanResult struct that returns the last centroid chunk and its size along with all the centroids. We use this to initialize the delta with the current chunk metadata so it knows how to write new centroids.

## Test Plan

unit tests

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
