### PR TITLE
kmeans clustering trait with SphericalKMeans

### DIFF
--- a/vector/Cargo.toml
+++ b/vector/Cargo.toml
@@ -27,6 +27,4 @@ rstest.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
-
-[dev-dependencies]
 rand = "0.8"


### PR DESCRIPTION
## Summary

Introduces a KMeans trait and a SphericalKMeans implementation for clustering vectors. This will be used by the split/merge rebalancer to partition posting lists when centroids grow too large. The choice of implementation depends on the distance metric. Euclidean distance (L2) uses basic kmeans. Cosine distance uses spherical kmeans

## Test Plan

unit tests, ran end-to-end test of lire (coming in later pr)

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
