### PR TITLE
add write backpressure for rebalancing

### DIFF
--- a/common/src/coordinator/mod.rs
+++ b/common/src/coordinator/mod.rs
@@ -636,11 +636,11 @@ pub struct PauseHandle {
 }
 
 impl PauseHandle {
-    fn pause(&self) {
+    pub fn pause(&self) {
         self.pause_tx.send_replace(true);
     }
 
-    fn unpause(&self) {
+    pub fn unpause(&self) {
         self.pause_tx.send_replace(false);
     }
 }

--- a/vector/src/lire/rebalancer.rs
+++ b/vector/src/lire/rebalancer.rs
@@ -946,6 +946,9 @@ mod tests {
                 opts: VectorDbDeltaOpts {
                     dimensions,
                     chunk_target,
+                    max_pending_and_running_rebalance_tasks: usize::MAX,
+                    split_threshold_vectors: usize::MAX / 2,
+                    rebalance_backpressure_resume_threshold: 0,
                 },
                 dictionary: Arc::new(DashMap::new()),
                 centroid_graph: centroid_graph.clone(),
@@ -953,6 +956,7 @@ mod tests {
                 current_chunk_id,
                 current_chunk_count,
                 rebalancer,
+                pause_handle: Arc::new(OnceLock::new()),
             };
 
             // 9. Create flusher and coordinator

--- a/vector/src/model.rs
+++ b/vector/src/model.rs
@@ -204,6 +204,17 @@ pub struct Config {
     /// Number of neighboring centroids to scan for reassignment candidates after a split.
     pub split_search_neighbourhood: usize,
 
+    /// The maximum number of centroids that require rebalancing before which backpressure
+    /// is applied by pausing ingestion of new vector writes.
+    pub max_pending_and_running_rebalance_tasks: usize,
+
+    /// After backpressure is applied, ingestion resumes after the total number of centroids
+    /// requiring rebalance drops below this value.
+    pub rebalance_backpressure_resume_threshold: usize,
+
+    /// The maximum number of rebalance tasks that the rebalancer will run concurrently.
+    pub max_rebalance_tasks: usize,
+
     /// Target number of centroids per chunk.
     pub chunk_target: u16,
 
@@ -225,6 +236,9 @@ impl Default for Config {
             split_threshold_vectors: 2_000,
             merge_threshold_vectors: 500,
             split_search_neighbourhood: 16,
+            max_pending_and_running_rebalance_tasks: 16,
+            rebalance_backpressure_resume_threshold: 8,
+            max_rebalance_tasks: 8,
             chunk_target: 4096,
             metadata_fields: Vec::new(),
         }


### PR DESCRIPTION
## Summary

When too many rebalance operations are in-flight or a centroid grows beyond 2x the split threshold, the write channel is paused to let the rebalancer catch up. Writes resume once in-flight ops drop below the resume threshold.

Backpressure is checked whenever the delta applies any write command. This includes whenever the delta writes new vectors, or applies a rebalance command.

## Test Plan

Tested using the end-to-end vectordb recall integration test

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
