### PR TITLE
support creating slatedb with block cache

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -11,7 +11,9 @@ pub use clock::Clock;
 pub use sequence::{DEFAULT_BLOCK_SIZE, SequenceAllocator, SequenceError, SequenceResult};
 pub use serde::seq_block::SeqBlock;
 pub use storage::config::StorageConfig;
-pub use storage::factory::{StorageRuntime, StorageSemantics, create_storage, create_storage_read};
+pub use storage::factory::{
+    StorageReaderRuntime, StorageRuntime, StorageSemantics, create_storage, create_storage_read,
+};
 pub use storage::loader::{LoadMetadata, LoadResult, LoadSpec, Loadable, Loader};
 pub use storage::{
     MergeRecordOp, PutRecordOp, Record, Storage, StorageError, StorageIterator, StorageRead,

--- a/keyvalue/src/reader.rs
+++ b/keyvalue/src/reader.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bytes::Bytes;
 use common::storage::factory::create_storage_read;
-use common::{StorageRead, StorageSemantics};
+use common::{StorageRead, StorageReaderRuntime, StorageSemantics};
 
 use crate::config::Config;
 use crate::error::Result;
@@ -42,6 +42,7 @@ impl KeyValueDbReader {
     pub async fn open(config: Config) -> Result<Self> {
         let storage: Arc<dyn StorageRead> = create_storage_read(
             &config.storage,
+            StorageReaderRuntime::new(),
             StorageSemantics::new(),
             slatedb::config::DbReaderOptions::default(),
         )


### PR DESCRIPTION
## Summary

Adds support for creating slatedb with a block cache by adding the cache as a `StorageRuntime` property. We use the runtime rather than config to specify the cache because this allows for multiple dbs to share the block cache. Individual dbs can define their own config for the block cache, or we can allow creating per-db block caches via common config in a follow-up.

Also adds a StorageReaderRuntime for passing runtime options to readers.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
