### PR TITLE
read neighbour postings in parallel during split

### DIFF
--- a/vector/src/lire/rebalancer.rs
+++ b/vector/src/lire/rebalancer.rs
@@ -708,8 +708,7 @@ impl IndexRebalancerTask {
 
         // 4. Process each neighbour's postings to find reassignments
         for (neighbour_id, posting_result) in neighbour_ids.iter().zip(posting_results) {
-            let neighbour_postings: PostingList =
-                posting_result.map_err(|e| e.to_string())?;
+            let neighbour_postings: PostingList = posting_result.map_err(|e| e.to_string())?;
 
             for p in neighbour_postings.iter() {
                 // use the heuristic for neighbour vectors from the spfresh paper to cheaply


### PR DESCRIPTION
## Summary

When splitting a centroid the rebalancer searches its neighbours for vectors that need to be reassigned to preserve NPA. This patch does these reads concurrently to help speed up splits by doing the i/o concurrently.

## Test Plan

- all unit tests pass
- vector recall is preserved (e2e recall test passes)

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
