### PR TITLE
Change default logging level from error to info for Timeseries

### DIFF
--- a/timeseries/src/main.rs
+++ b/timeseries/src/main.rs
@@ -32,7 +32,9 @@ async fn main() {
     // Initialize tracing with configurable log level via RUST_LOG environment variable
     // Default to "info" if RUST_LOG is not set
     tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
         .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE) // Only exit events with timing
         .with_target(true)
         .with_line_number(true)


### PR DESCRIPTION
## Summary

Changes tracing_subscriber construction to correctly set default logging level when `RUST_LOG` is not set

## Related Issues
https://github.com/opendata-oss/opendata/issues/191

# Fixes 
- Instead of just passing `EnvFilter::from_default_env()` to `env_filter` for the tracing subscriber construction which sets the the logging severity level to ERROR by default, use `try_from_default_env()` and default to info when `RUST_LOG` is not set

## Test Plan
Run the binary to see if INFO logs show up.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
