### PR TITLE
Simplify promqltest after RFC 3

### DIFF
--- a/timeseries/src/promql/promqltest/assert.rs
+++ b/timeseries/src/promql/promqltest/assert.rs
@@ -1,5 +1,4 @@
-use crate::model::Labels;
-use crate::promql::promqltest::dsl::{EvalResult, ExpectedSample};
+use crate::model::RangeSample;
 
 /// Compare actual results against expected results
 ///
@@ -15,8 +14,8 @@ use crate::promql::promqltest::dsl::{EvalResult, ExpectedSample};
 /// The implementation achieves this by only checking labels that are present in the
 /// expected sample, not all labels from the actual result.
 pub(super) fn assert_results(
-    results: &[EvalResult],
-    expected: &[ExpectedSample],
+    results: &[RangeSample],
+    expected: &[RangeSample],
     test_name: &str,
     eval_num: usize,
     query: &str,
@@ -56,10 +55,12 @@ pub(super) fn assert_results(
             }
         }
 
-        if (result.value - exp.value).abs() > 1e-6 {
+        let exp_value = exp.samples[0].1;
+        let result_value = result.samples[0].1;
+        if (result_value - exp_value).abs() > 1e-6 {
             return Err(format!(
                 "{} eval #{} (query: {}): Value mismatch: expected {}, got {}",
-                test_name, eval_num, query, exp.value, result.value
+                test_name, eval_num, query, exp_value, result_value
             ));
         }
     }
@@ -70,7 +71,7 @@ pub(super) fn assert_results(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::Label;
+    use crate::model::{Label, Labels};
 
     fn labels_from(pairs: &[(&str, &str)]) -> Labels {
         let mut labels: Vec<Label> = pairs.iter().map(|(k, v)| Label::new(*k, *v)).collect();
@@ -78,17 +79,18 @@ mod tests {
         Labels::new(labels)
     }
 
+    fn range_sample(labels: Labels, value: f64) -> RangeSample {
+        RangeSample {
+            labels,
+            samples: vec![(0, value)],
+        }
+    }
+
     #[test]
     fn should_match_expected_results() {
         // given
-        let results = vec![EvalResult {
-            labels: labels_from(&[("job", "test")]),
-            value: 42.0,
-        }];
-        let expected = vec![ExpectedSample {
-            labels: labels_from(&[("job", "test")]),
-            value: 42.0,
-        }];
+        let results = vec![range_sample(labels_from(&[("job", "test")]), 42.0)];
+        let expected = vec![range_sample(labels_from(&[("job", "test")]), 42.0)];
 
         // when
         let result = assert_results(&results, &expected, "test", 1, "metric");
@@ -100,10 +102,7 @@ mod tests {
     #[test]
     fn should_reject_count_mismatch() {
         // given
-        let results = vec![EvalResult {
-            labels: Labels::empty(),
-            value: 42.0,
-        }];
+        let results = vec![range_sample(Labels::empty(), 42.0)];
         let expected = vec![];
 
         // when
@@ -117,14 +116,8 @@ mod tests {
     #[test]
     fn should_reject_mismatched_values() {
         // given
-        let results = vec![EvalResult {
-            labels: Labels::empty(),
-            value: 42.0,
-        }];
-        let expected = vec![ExpectedSample {
-            labels: Labels::empty(),
-            value: 99.0,
-        }];
+        let results = vec![range_sample(Labels::empty(), 42.0)];
+        let expected = vec![range_sample(Labels::empty(), 99.0)];
 
         // when
         let result = assert_results(&results, &expected, "test", 1, "metric");

--- a/timeseries/src/promql/promqltest/dsl.rs
+++ b/timeseries/src/promql/promqltest/dsl.rs
@@ -1,4 +1,4 @@
-use crate::model::{Label, Labels};
+use crate::model::{Label, Labels, RangeSample};
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -16,7 +16,7 @@ pub struct LoadCmd {
 pub struct EvalInstantCmd {
     pub time: SystemTime,
     pub query: String,
-    pub expected: Vec<ExpectedSample>,
+    pub expected: Vec<RangeSample>,
 }
 
 #[derive(Debug, Clone)]
@@ -45,23 +45,6 @@ pub enum Command {
 pub struct SeriesLoad {
     pub labels: HashMap<String, String>, // includes __name__
     pub values: Vec<(i64, f64)>,         // (step_index, value)
-}
-
-#[derive(Debug, Clone)]
-pub struct ExpectedSample {
-    pub labels: Labels,
-    pub value: f64,
-    // Future:
-    // #[cfg(feature = "histograms")]
-    // pub histogram: Option<Histogram>,
-    // #[cfg(feature = "range-vectors")]
-    // pub range_values: Option<Vec<(i64, f64)>>,
-}
-
-#[derive(Debug, Clone)]
-pub struct EvalResult {
-    pub labels: Labels,
-    pub value: f64,
 }
 
 // ============================================================================
@@ -394,7 +377,7 @@ fn parse_values(s: &str) -> Result<Vec<(i64, f64)>, String> {
     }
 }
 
-fn parse_expected(line: &str) -> Result<ExpectedSample, String> {
+fn parse_expected(line: &str) -> Result<RangeSample, String> {
     let mut chars = line.chars().peekable();
     let mut metric_part = String::new();
 
@@ -444,9 +427,9 @@ fn parse_expected(line: &str) -> Result<ExpectedSample, String> {
         labels.push(Label::metric_name(metric_name));
     }
     labels.sort();
-    Ok(ExpectedSample {
+    Ok(RangeSample {
         labels: Labels::new(labels),
-        value,
+        samples: vec![(0, value)],
     })
 }
 

--- a/timeseries/src/promql/promqltest/evaluator.rs
+++ b/timeseries/src/promql/promqltest/evaluator.rs
@@ -1,5 +1,4 @@
-use crate::model::{Labels, QueryOptions, QueryValue};
-use crate::promql::promqltest::dsl::EvalResult;
+use crate::model::{QueryOptions, RangeSample};
 use crate::tsdb::Tsdb;
 use std::time::SystemTime;
 
@@ -8,38 +7,9 @@ pub(super) async fn eval_instant(
     tsdb: &Tsdb,
     time: SystemTime,
     query: &str,
-) -> Result<Vec<EvalResult>, String> {
-    let result = tsdb
-        .eval_query(query, Some(time), &QueryOptions::default())
+) -> Result<Vec<RangeSample>, String> {
+    tsdb.eval_query(query, Some(time), &QueryOptions::default())
         .await
-        .map_err(|e| e.to_string())?;
-
-    match result {
-        QueryValue::Vector(samples) => {
-            let results = samples
-                .into_iter()
-                .map(|sample| EvalResult {
-                    labels: sample.labels,
-                    value: sample.value,
-                })
-                .collect();
-            Ok(results)
-        }
-        QueryValue::Scalar { value, .. } => Ok(vec![EvalResult {
-            labels: Labels::empty(),
-            value,
-        }]),
-        QueryValue::Matrix(range_samples) => {
-            let results = range_samples
-                .into_iter()
-                .flat_map(|rs| {
-                    rs.samples.into_iter().map(move |(_, val)| EvalResult {
-                        labels: rs.labels.clone(),
-                        value: val,
-                    })
-                })
-                .collect();
-            Ok(results)
-        }
-    }
+        .map_err(|e| e.to_string())
+        .map(|qv| qv.into_matrix())
 }

--- a/timeseries/src/promql/promqltest/runner.rs
+++ b/timeseries/src/promql/promqltest/runner.rs
@@ -167,7 +167,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].value, 2.0);
+        assert_eq!(result[0].samples[0].1, 2.0);
     }
 
     #[tokio::test]
@@ -189,7 +189,7 @@ mod tests {
 
         // then
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].value, 30.0);
+        assert_eq!(result[0].samples[0].1, 30.0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Addresses https://github.com/opendata-oss/opendata/issues/264. This is a minor followup after #260 . We can simplify promqltest using `QueryValue::into_matrix".