### PR TITLE
Specify common source/sink abstraction for write pipelines

### DIFF
--- a/rfcs/0006-write-pipeline.md
+++ b/rfcs/0006-write-pipeline.md
@@ -1,0 +1,163 @@
+# RFC 0006: Write Pipeline (Source/Sink)
+
+**Status**: Draft
+
+**Authors**:
+- [Jason Gustafson](https://github.com/hachikuji)
+
+## Summary
+
+This RFC proposes a shared write pipeline model for OpenData systems based on `Source` and `Sink` abstractions over a generic payload type `T`.
+The model supports direct writes and staged writes with intermediate `Sink`/`Source` pairs (for example, stateless ingest), while keeping protocol handling and storage concerns decoupled.
+
+## Motivation
+
+Multiple OpenData systems need the same end-to-end write pipeline shape:
+
+- A frontend component accepts writes from external protocols.
+- A terminal writer persists data into a database.
+- Optional intermediate stages provide durability, buffering, replay, or transport.
+
+Without a shared model, each database crate redefines naming, lifecycle, and acknowledgement semantics.
+That duplication makes cross-system ingest features harder to implement and reason about.
+
+## Goals
+
+- Define a reusable source/sink pipeline model for all OpenData systems.
+- Support push and pull source semantics with explicit acknowledgement.
+- Support intermediate composable stages that are both sink and source.
+- Keep payload type generic so each database provides its own serialization and domain model.
+
+## Non-Goals
+
+- Standardize one global record schema for all databases.
+- Define protocol-specific HTTP/gRPC request parsing.
+- Define datastore-specific idempotency logic in detail.
+
+## Design
+
+### Core Abstractions
+
+The pipeline is generic over payload `T`:
+
+- `Source<T>` emits payloads.
+- `Sink<T>` accepts payloads.
+- Intermediate stages may implement both (`Sink<T> + Source<T>`).
+
+Conceptual direct pipeline:
+
+```text
+Source<T> -> Sink<T>
+```
+
+Conceptual staged pipeline:
+
+```text
+Source<T> -> StageA(Sink<T> + Source<T>) -> StageB(Sink<T> + Source<T>) -> Sink<T>
+```
+
+### System Roles in OpenData
+
+This model characterizes OpenData components into three functional roles:
+
+- **End systems**: terminal systems that persist and serve domain data.
+  - Example: TimeSeries, Vector.
+- **Connecting systems**: intermediate pipeline stages that can accept and emit payloads.
+  - Example: Log, Stateless Ingest.
+- **Services/adapters**: boundary components that translate external protocols into pipeline payloads (and optionally expose read APIs).
+  - Example: HTTP remote-write and OTLP handlers for TimeSeries.
+
+These are roles, not strict product boundaries. A single deployed component may implement multiple roles.
+For example, a TimeSeries HTTP server can act as both a service adapter (ingest endpoints) and an end system (terminal sink).
+
+### Push and Pull Sources
+
+Sources come in two operational forms:
+
+- Push source: receives upstream input and immediately invokes a downstream sink.
+- Pull source: exposes batches for a downstream consumer to retrieve and acknowledge.
+
+Proposed traits:
+
+```rust
+#[async_trait]
+pub trait Sink<T>: Send + Sync {
+    async fn accept(&self, payload: T) -> Result<SinkAck>;
+}
+
+#[async_trait]
+pub trait PullSource<T>: Send + Sync {
+    async fn next_batch(&self) -> Result<Option<Batch<T>>>;
+    async fn ack(&self, batch: &Batch<T>) -> Result<()>;
+}
+```
+
+Push sources are typically adapters at protocol boundaries and can be represented as handlers that parse wire input and call `Sink<T>::accept`.
+
+### Acknowledgement Semantics
+
+`SinkAck` communicates acceptance level:
+
+- accepted in memory
+- durable in underlying storage
+
+The required level is protocol-specific and should be documented by each adapter.
+For durability-sensitive protocols, success responses SHOULD map to durable acknowledgement.
+
+### Stateless Ingest as Generic Sink/Source Stage
+
+Stateless ingest (see `ingest/rfcs/0001-stateless-ingest.md`) fits this model as a reusable intermediate stage:
+
+- `StatelessIngestSink<T>` accepts `T`, serializes it, and appends durable batches.
+- `StatelessIngestSource<T>` reads queued batches, deserializes to `T`, and emits downstream.
+
+This stage is generic in `T`; each database defines how `T` is serialized/deserialized.
+
+### Payload and Serialization
+
+This RFC does not mandate a single payload type for all systems.
+
+Each database chooses:
+
+- its pipeline payload type `T`,
+- its record/batch format for any intermediate storage stage,
+- compatibility/versioning strategy for that format.
+
+Examples:
+
+- TimeSeries may use `Vec<Series>`.
+- Log may use log entries/batches.
+- Vector may use vector write batches.
+
+### Mapping to Database Implementations
+
+Each database crate defines:
+
+- protocol adapters that produce `T`,
+- terminal sink that writes `T` to the database,
+- optional intermediate stages and codecs.
+
+Database-specific RFCs should reference this RFC and specify only system-specific bindings.
+
+## Alternatives
+
+### Per-database pipeline models
+
+Each database could define its own source/sink contracts.
+Rejected because this duplicates semantics and blocks shared ingest components.
+
+### Shared payload type across all databases
+
+A single canonical payload for all systems could be defined.
+Rejected because data models differ significantly and would require lossy or over-generalized abstractions.
+
+## Open Questions
+
+- Should `nack` be part of the pull-source contract in addition to timeout-based redelivery?
+- Should a shared `Batch` metadata schema (ids, trace fields) be standardized in `common`?
+
+## Updates
+
+| Date       | Description |
+|------------|-------------|
+| 2026-03-03 | Initial draft |

--- a/rfcs/0006-write-pipeline.md
+++ b/rfcs/0006-write-pipeline.md
@@ -42,7 +42,7 @@ The pipeline is generic over payload `T`:
 
 - `Source<T>` emits payloads.
 - `Sink<T>` accepts payloads.
-- Intermediate stages may implement both (`Sink<T> + Source<T>`).
+- Intermediate stages may implement both (`Sink<T> + Source<T>`, or `Sink<T> + Source<U>` when a stage transforms the payload type).
 
 Conceptual direct pipeline:
 
@@ -53,7 +53,7 @@ Source<T> -> Sink<T>
 Conceptual staged pipeline:
 
 ```text
-Source<T> -> StageA(Sink<T> + Source<T>) -> StageB(Sink<T> + Source<T>) -> Sink<T>
+Source<T> -> StageA(Sink<T> + Source<U>) -> StageB(Sink<U> + Source<V>) -> Sink<V>
 ```
 
 ### System Roles in OpenData
@@ -150,11 +150,6 @@ Rejected because this duplicates semantics and blocks shared ingest components.
 
 A single canonical payload for all systems could be defined.
 Rejected because data models differ significantly and would require lossy or over-generalized abstractions.
-
-## Open Questions
-
-- Should `nack` be part of the pull-source contract in addition to timeout-based redelivery?
-- Should a shared `Batch` metadata schema (ids, trace fields) be standardized in `common`?
 
 ## Updates
 

--- a/timeseries/rfcs/0004-service.md
+++ b/timeseries/rfcs/0004-service.md
@@ -74,52 +74,76 @@ The `otel` feature is usable without `http-server` — the builder can be used s
 
 The service uses Axum, listens on a single port (default 9090), and handles graceful shutdown (SIGINT/SIGTERM) with a TSDB flush.
 
-### Amendment: Protocol Adapters and Pluggable Ingest Sinks
+### Amendment: Source/Sink Pipeline Architecture
 
-To support both direct ingestion into `TimeSeriesDb` and ingestion through the stateless ingest module ([RFC 0001: Stateless Ingest](../../ingest/rfcs/0001-stateless-ingest.md)), the ingest path is split into two explicit layers:
+To support both direct ingestion into `TimeSeriesDb` and ingestion through the stateless ingest module ([RFC 0001: Stateless Ingest](../../ingest/rfcs/0001-stateless-ingest.md)), the write path is modeled as a pipeline over a normalized `Vec<Series>` payload.
 
-1. **Protocol adapters**: Parse transport/wire format into `Vec<Series>`.
-2. **Ingest sink**: Persist or forward normalized `Vec<Series>`.
+#### Core Model
 
-This keeps protocol-specific parsing logic independent from storage/write strategy and enables deployment-specific routing without duplicating endpoint logic.
+- **Source** emits `Vec<Series>`.
+- **Sink** accepts `Vec<Series>`.
+- **Sink/Source pair** implements both and acts as an intermediate stage.
 
-#### Protocol Adapters
+All write pipelines start from a source and end at a sink:
 
-The service defines protocol adapters for each ingest endpoint:
+- Direct: `HttpSource -> TsdbSink`
+- Buffered: `HttpSource -> StatelessIngest (sink/source pair) -> TsdbSink`
 
-| Endpoint | Adapter output |
+This isolates protocol parsing from delivery mechanics and lets us compose additional stages (for example LogDb) without changing endpoint logic.
+
+#### Push/Pull Semantics
+
+Sources come in two forms:
+
+- **Push source**: receives upstream writes and immediately pushes `Vec<Series>` to a downstream sink.
+  - HTTP endpoints are push sources.
+- **Pull source**: exposes batches for downstream consumers to fetch, then acknowledge.
+  - Collector-side stateless ingest is a pull source.
+
+Proposed contracts:
+
+```rust
+#[async_trait]
+pub trait Sink {
+    async fn accept(&self, series: Vec<Series>) -> Result<SinkAck>;
+}
+
+#[async_trait]
+pub trait PullSource {
+    async fn next_batch(&self) -> Result<Option<SeriesBatch>>;
+    async fn ack(&self, batch: &SeriesBatch) -> Result<()>;
+}
+```
+
+Push sources are endpoint handlers that parse protocol payloads and call `Sink::accept`.
+
+#### Protocol Sources
+
+The service defines push sources for ingest endpoints:
+
+| Endpoint | Source output |
 |---|---|
 | `POST /api/v1/write` (Prometheus Remote Write 1.0) | `Vec<Series>` |
 | `POST /v1/metrics` (OTLP/HTTP) | `Vec<Series>` via `OtelSeriesBuilder` |
 
-Both adapters perform format validation/decoding and produce the same normalized `Vec<Series>` model used by the write API.
+Both sources perform format validation/decoding and emit the same normalized series model.
 
-#### Ingest Sink Interface
+#### Sink and Sink/Source Implementations
 
-After protocol decoding, the handler delegates to a sink abstraction:
+- **TsdbSink**: terminal sink; writes to `TimeSeriesDb::write()` / `Tsdb::ingest_samples()`.
+- **StatelessIngestSink**: accepts `Vec<Series>`, serializes records, and writes durable batches through RFC 0001 `Ingestor`.
+- **StatelessIngestSource**: reads batches via RFC 0001 `Collector`, deserializes records, and emits `Vec<Series>` to downstream sinks.
 
-```rust
-#[async_trait]
-pub trait IngestSink {
-    async fn ingest(&self, series: Vec<Series>) -> Result<IngestResult>;
-}
-```
+The stateless ingest pair is a reusable intermediate stage, not a terminal writer.
 
-Implementations:
+#### Acknowledgement and Durability
 
-- **DirectTsdbSink**: calls `TimeSeriesDb::write()` / `Tsdb::ingest_samples()`.
-- **StatelessIngestSink**: encodes entries and calls RFC 0001 `Ingestor::ingest()`.
-
-`StatelessIngestSink` uses the ingest module as an opaque durable queue and leaves ordering, retries, and at-least-once behavior to RFC 0001 collector + acknowledgement flow.
-
-#### Acknowledgement Semantics
-
-For `StatelessIngestSink`, success responses from ingest endpoints SHOULD be returned only after entries are durable in object storage (i.e. `WriteWatcher::await_durable()` has completed).
+For `StatelessIngestSink`, ingest endpoints SHOULD return success only after durability in object storage (`WriteWatcher::await_durable()`).
 
 Rationale:
-- Aligns endpoint acknowledgement with durability, not in-memory acceptance.
-- Keeps retry behavior predictable for remote-write and OTLP clients.
-- Preserves at-least-once guarantees with collector-side idempotency.
+- Endpoint acknowledgement reflects durable acceptance, not in-memory buffering.
+- Retry behavior stays predictable for remote-write and OTLP clients.
+- Collector + `ack()` preserve at-least-once delivery semantics.
 
 #### Server Composition
 
@@ -130,11 +154,7 @@ The service can be composed into two server modes:
 | **Full server** | Query APIs + ingest APIs + health + metrics + UI |
 | **Write-only server** | Ingest APIs + health + metrics |
 
-Both modes reuse the same protocol adapters and sink abstraction. The difference is only route composition.
-
-This enables deployments such as:
-- zonal write-only ingest endpoints (remote-write and/or OTLP) using `StatelessIngestSink` for HA and cross-zone cost savings;
-- central full query+ingest endpoints using `DirectTsdbSink`.
+Both modes reuse the same source/sink contracts; only route composition changes.
 
 #### Endpoints
 
@@ -250,4 +270,4 @@ Each protocol could run its own server on a different port. This adds operationa
 |---|---|
 | 2026-02-24 | Initial draft (as RFC 0003: OTLP Metrics Ingest) |
 | 2026-02-25 | Restructured as TimeSeries Service RFC covering HTTP server, remote-write, and OTEL ingest |
-| 2026-03-03 | Amendment: protocol adapters + pluggable ingest sink to support direct TSDB and stateless ingest; added full vs write-only server composition |
+| 2026-03-03 | Amendment: source/sink pipeline model with push/pull semantics, stateless ingest sink/source pair, and full vs write-only server composition |

--- a/timeseries/rfcs/0004-service.md
+++ b/timeseries/rfcs/0004-service.md
@@ -74,6 +74,68 @@ The `otel` feature is usable without `http-server` — the builder can be used s
 
 The service uses Axum, listens on a single port (default 9090), and handles graceful shutdown (SIGINT/SIGTERM) with a TSDB flush.
 
+### Amendment: Protocol Adapters and Pluggable Ingest Sinks
+
+To support both direct ingestion into `TimeSeriesDb` and ingestion through the stateless ingest module ([RFC 0001: Stateless Ingest](../../ingest/rfcs/0001-stateless-ingest.md)), the ingest path is split into two explicit layers:
+
+1. **Protocol adapters**: Parse transport/wire format into `Vec<Series>`.
+2. **Ingest sink**: Persist or forward normalized `Vec<Series>`.
+
+This keeps protocol-specific parsing logic independent from storage/write strategy and enables deployment-specific routing without duplicating endpoint logic.
+
+#### Protocol Adapters
+
+The service defines protocol adapters for each ingest endpoint:
+
+| Endpoint | Adapter output |
+|---|---|
+| `POST /api/v1/write` (Prometheus Remote Write 1.0) | `Vec<Series>` |
+| `POST /v1/metrics` (OTLP/HTTP) | `Vec<Series>` via `OtelSeriesBuilder` |
+
+Both adapters perform format validation/decoding and produce the same normalized `Vec<Series>` model used by the write API.
+
+#### Ingest Sink Interface
+
+After protocol decoding, the handler delegates to a sink abstraction:
+
+```rust
+#[async_trait]
+pub trait IngestSink {
+    async fn ingest(&self, series: Vec<Series>) -> Result<IngestResult>;
+}
+```
+
+Implementations:
+
+- **DirectTsdbSink**: calls `TimeSeriesDb::write()` / `Tsdb::ingest_samples()`.
+- **StatelessIngestSink**: encodes entries and calls RFC 0001 `Ingestor::ingest()`.
+
+`StatelessIngestSink` uses the ingest module as an opaque durable queue and leaves ordering, retries, and at-least-once behavior to RFC 0001 collector + acknowledgement flow.
+
+#### Acknowledgement Semantics
+
+For `StatelessIngestSink`, success responses from ingest endpoints SHOULD be returned only after entries are durable in object storage (i.e. `WriteWatcher::await_durable()` has completed).
+
+Rationale:
+- Aligns endpoint acknowledgement with durability, not in-memory acceptance.
+- Keeps retry behavior predictable for remote-write and OTLP clients.
+- Preserves at-least-once guarantees with collector-side idempotency.
+
+#### Server Composition
+
+The service can be composed into two server modes:
+
+| Mode | Routes |
+|---|---|
+| **Full server** | Query APIs + ingest APIs + health + metrics + UI |
+| **Write-only server** | Ingest APIs + health + metrics |
+
+Both modes reuse the same protocol adapters and sink abstraction. The difference is only route composition.
+
+This enables deployments such as:
+- zonal write-only ingest endpoints (remote-write and/or OTLP) using `StatelessIngestSink` for HA and cross-zone cost savings;
+- central full query+ingest endpoints using `DirectTsdbSink`.
+
 #### Endpoints
 
 **PromQL query endpoints** (always available with `http-server`):
@@ -103,7 +165,7 @@ Each handler deserializes HTTP parameters, calls the corresponding `TimeSeriesDb
 | Encoding | Snappy-compressed protobuf `WriteRequest` |
 | Success | `204 No Content` |
 
-The handler decompresses, decodes the `WriteRequest` (a flat list of label/sample pairs), converts to `Vec<Series>`, and calls `tsdb.write()`.
+The handler decompresses, decodes the `WriteRequest` (a flat list of label/sample pairs), converts to `Vec<Series>`, and delegates to the configured ingest sink.
 
 **OTLP endpoint** (feature: `otel` + `http-server`):
 
@@ -113,7 +175,7 @@ The handler decompresses, decodes the `WriteRequest` (a flat list of label/sampl
 | Encoding | Protobuf `ExportMetricsServiceRequest` |
 | Success | `200 OK` with protobuf `ExportMetricsServiceResponse` |
 
-The handler decodes the request, calls `OtelSeriesBuilder::build()` to decompose OTEL metrics into `Vec<Series>`, and calls `tsdb.write()`.
+The handler decodes the request, calls `OtelSeriesBuilder::build()` to decompose OTEL metrics into `Vec<Series>`, and delegates to the configured ingest sink.
 
 ### OtelSeriesBuilder
 
@@ -188,3 +250,4 @@ Each protocol could run its own server on a different port. This adds operationa
 |---|---|
 | 2026-02-24 | Initial draft (as RFC 0003: OTLP Metrics Ingest) |
 | 2026-02-25 | Restructured as TimeSeries Service RFC covering HTTP server, remote-write, and OTEL ingest |
+| 2026-03-03 | Amendment: protocol adapters + pluggable ingest sink to support direct TSDB and stateless ingest; added full vs write-only server composition |

--- a/timeseries/rfcs/0004-service.md
+++ b/timeseries/rfcs/0004-service.md
@@ -74,87 +74,31 @@ The `otel` feature is usable without `http-server` — the builder can be used s
 
 The service uses Axum, listens on a single port (default 9090), and handles graceful shutdown (SIGINT/SIGTERM) with a TSDB flush.
 
-### Amendment: Source/Sink Pipeline Architecture
+### Amendment: TimeSeries Binding to Shared Write Pipeline
 
-To support both direct ingestion into `TimeSeriesDb` and ingestion through the stateless ingest module ([RFC 0001: Stateless Ingest](../../ingest/rfcs/0001-stateless-ingest.md)), the write path is modeled as a pipeline over a normalized `Vec<Series>` payload.
+TimeSeries adopts the cross-project write pipeline model defined in [RFC 0006: Write Pipeline (Source/Sink)](../../rfcs/0006-write-pipeline.md).
 
-#### Core Model
+For TimeSeries, the pipeline payload type is `Vec<Series>`.
 
-- **Source** emits `Vec<Series>`.
-- **Sink** accepts `Vec<Series>`.
-- **Sink/Source pair** implements both and acts as an intermediate stage.
+TimeSeries-specific bindings:
 
-All write pipelines start from a source and end at a sink:
+- **Push sources**:
+  - `POST /api/v1/write` (Prometheus Remote Write 1.0) decodes to `Vec<Series>`.
+  - `POST /v1/metrics` (OTLP/HTTP) uses `OtelSeriesBuilder` and emits `Vec<Series>`.
+- **Terminal sink**:
+  - `TsdbSink` writes to `TimeSeriesDb::write()` / `Tsdb::ingest_samples()`.
+- **Optional intermediate sink/source stage**:
+  - Stateless ingest (RFC 0001) can be inserted between protocol sources and `TsdbSink`.
+  - TimeSeries defines the record serialization for `Vec<Series>` used by this stage.
 
-- Direct: `HttpSource -> TsdbSink`
-- Buffered: `HttpSource -> StatelessIngest (sink/source pair) -> TsdbSink`
+Durability policy for the stateless ingest sink path: endpoint success SHOULD be returned only after object-store durability (`WriteWatcher::await_durable()`).
 
-This isolates protocol parsing from delivery mechanics and lets us compose additional stages (for example LogDb) without changing endpoint logic.
-
-#### Push/Pull Semantics
-
-Sources come in two forms:
-
-- **Push source**: receives upstream writes and immediately pushes `Vec<Series>` to a downstream sink.
-  - HTTP endpoints are push sources.
-- **Pull source**: exposes batches for downstream consumers to fetch, then acknowledge.
-  - Collector-side stateless ingest is a pull source.
-
-Proposed contracts:
-
-```rust
-#[async_trait]
-pub trait Sink {
-    async fn accept(&self, series: Vec<Series>) -> Result<SinkAck>;
-}
-
-#[async_trait]
-pub trait PullSource {
-    async fn next_batch(&self) -> Result<Option<SeriesBatch>>;
-    async fn ack(&self, batch: &SeriesBatch) -> Result<()>;
-}
-```
-
-Push sources are endpoint handlers that parse protocol payloads and call `Sink::accept`.
-
-#### Protocol Sources
-
-The service defines push sources for ingest endpoints:
-
-| Endpoint | Source output |
-|---|---|
-| `POST /api/v1/write` (Prometheus Remote Write 1.0) | `Vec<Series>` |
-| `POST /v1/metrics` (OTLP/HTTP) | `Vec<Series>` via `OtelSeriesBuilder` |
-
-Both sources perform format validation/decoding and emit the same normalized series model.
-
-#### Sink and Sink/Source Implementations
-
-- **TsdbSink**: terminal sink; writes to `TimeSeriesDb::write()` / `Tsdb::ingest_samples()`.
-- **StatelessIngestSink**: accepts `Vec<Series>`, serializes records, and writes durable batches through RFC 0001 `Ingestor`.
-- **StatelessIngestSource**: reads batches via RFC 0001 `Collector`, deserializes records, and emits `Vec<Series>` to downstream sinks.
-
-The stateless ingest pair is a reusable intermediate stage, not a terminal writer.
-
-#### Acknowledgement and Durability
-
-For `StatelessIngestSink`, ingest endpoints SHOULD return success only after durability in object storage (`WriteWatcher::await_durable()`).
-
-Rationale:
-- Endpoint acknowledgement reflects durable acceptance, not in-memory buffering.
-- Retry behavior stays predictable for remote-write and OTLP clients.
-- Collector + `ack()` preserve at-least-once delivery semantics.
-
-#### Server Composition
-
-The service can be composed into two server modes:
+Server composition remains:
 
 | Mode | Routes |
 |---|---|
 | **Full server** | Query APIs + ingest APIs + health + metrics + UI |
 | **Write-only server** | Ingest APIs + health + metrics |
-
-Both modes reuse the same source/sink contracts; only route composition changes.
 
 #### Endpoints
 
@@ -270,4 +214,4 @@ Each protocol could run its own server on a different port. This adds operationa
 |---|---|
 | 2026-02-24 | Initial draft (as RFC 0003: OTLP Metrics Ingest) |
 | 2026-02-25 | Restructured as TimeSeries Service RFC covering HTTP server, remote-write, and OTEL ingest |
-| 2026-03-03 | Amendment: source/sink pipeline model with push/pull semantics, stateless ingest sink/source pair, and full vs write-only server composition |
+| 2026-03-03 | Amendment: TimeSeries binding to shared source/sink pipeline model; generic pipeline semantics moved to RFC 0006 |


### PR DESCRIPTION
We should support stateless ingest to timeseries. This requires introducing a sink abstraction so that it is possible to write directly to TimeSeriesDb or through the stateless ingest layer. This patch proposes to separate ingest into protocol and sink layers to provide maximum flexibility.