### PR TITLE
[timeseries] Implement merge_batch

### DIFF
--- a/timeseries/src/serde/timeseries.rs
+++ b/timeseries/src/serde/timeseries.rs
@@ -210,86 +210,73 @@ impl TimeSeriesValue {
     }
 }
 
-/// Merges two compressed time series byte values into a single compressed value.
+/// Merges a batch of compressed time series byte values into a single compressed value.
 ///
-/// This function performs an efficient sorted merge of two Gorilla-compressed time series
+/// This function performs an efficient sorted merge of Gorilla-compressed time series
 /// without fully deserializing them into memory. Samples are merged in timestamp order,
-/// with duplicates resolved by keeping the value from `other` (last write wins).
+/// with duplicates resolved by keeping the value from the newest operand (last write wins).
 ///
 /// This is designed for use in merge operators during compaction.
 ///
 /// # Arguments
 ///
-/// * `base` - The base compressed time series value
-/// * `other` - The time series value to merge into the base
+/// * `existing` - The existing compressed time series value (if any)
+/// * `operands` - A slice of compressed time series operands, ordered oldest to newest
 ///
 /// # Returns
 ///
 /// A new compressed `Bytes` value containing the merged series
-pub(crate) fn merge_time_series(base: Bytes, other: Bytes) -> Result<Bytes, EncodingError> {
-    // Handle empty cases
-    if base.is_empty() {
-        return Ok(other);
+pub(crate) fn merge_batch_time_series(
+    existing: Option<Bytes>,
+    operands: &[Bytes],
+) -> Result<Bytes, EncodingError> {
+    let mut sources: Vec<&Bytes> = Vec::new();
+    if let Some(ref existing) = existing
+        && !existing.is_empty()
+    {
+        sources.push(existing);
     }
-    if other.is_empty() {
-        return Ok(base);
-    }
-
-    // Create iterators for both series
-    let mut base_iter =
-        TimeSeriesIterator::new(base.as_ref()).expect("Base series should not be empty");
-    let mut other_iter =
-        TimeSeriesIterator::new(other.as_ref()).expect("Other series should not be empty");
-
-    // Get first sample from each iterator to determine the earliest timestamp
-    let mut base_sample = base_iter.next().transpose()?;
-    let mut other_sample = other_iter.next().transpose()?;
-
-    let start_time = match (&base_sample, &other_sample) {
-        (Some(bs), Some(os)) => bs.timestamp_ms.min(os.timestamp_ms),
-        (Some(bs), None) => bs.timestamp_ms,
-        (None, Some(os)) => os.timestamp_ms,
-        (None, None) => {
-            // Both iterators returned None immediately - treat as empty
-            return Ok(Bytes::new());
+    for operand in operands {
+        if !operand.is_empty() {
+            sources.push(operand);
         }
-    };
+    }
 
-    // Create encoder for output
+    // Handle edge cases
+    if sources.is_empty() {
+        return Ok(Bytes::new());
+    }
+    if sources.len() == 1 {
+        return Ok(sources[0].clone());
+    }
+
+    // Decode all sources into (priority, timestamp, value) triples.
+    // Priority is the source index: higher index = newer = wins on tie.
+    let mut samples: Vec<(usize, i64, f64)> = Vec::new();
+    for (priority, source) in sources.iter().enumerate() {
+        let iter = TimeSeriesIterator::new(source.as_ref()).expect("Series should not be empty");
+        for result in iter {
+            let sample = result?;
+            samples.push((priority, sample.timestamp_ms, sample.value));
+        }
+    }
+    // If all iterators returned None immediately, treat as empty.
+    if samples.is_empty() {
+        return Ok(Bytes::new());
+    }
+
+    // Sort by timestamp ascending, then by priority descending (newest first)
+    samples.sort_by(|a, b| a.1.cmp(&b.1).then(b.0.cmp(&a.0)));
+    // Dedup by timestamp, keeping the first (highest priority) entry (last write wins)
+    samples.dedup_by(|a, b| a.1 == b.1);
+
+    // Encode the merged result
     let writer = BufferedWriter::new();
-    let mut encoder = StdEncoder::new(start_time as u64, writer);
+    let start_time = samples[0].1 as u64;
+    let mut encoder = StdEncoder::new(start_time, writer);
 
-    // Sorted merge with deduplication (keeping 'other' value on timestamp collision)
-    while base_sample.is_some() || other_sample.is_some() {
-        match (&base_sample, &other_sample) {
-            (Some(bs), Some(os)) => {
-                if bs.timestamp_ms < os.timestamp_ms {
-                    // Take from base
-                    encoder.encode(DataPoint::new(bs.timestamp_ms as u64, bs.value));
-                    base_sample = base_iter.next().transpose()?;
-                } else if bs.timestamp_ms > os.timestamp_ms {
-                    // Take from other
-                    encoder.encode(DataPoint::new(os.timestamp_ms as u64, os.value));
-                    other_sample = other_iter.next().transpose()?;
-                } else {
-                    // Equal timestamps: take from other (last write wins)
-                    encoder.encode(DataPoint::new(os.timestamp_ms as u64, os.value));
-                    base_sample = base_iter.next().transpose()?;
-                    other_sample = other_iter.next().transpose()?;
-                }
-            }
-            (Some(bs), None) => {
-                // Only base remaining
-                encoder.encode(DataPoint::new(bs.timestamp_ms as u64, bs.value));
-                base_sample = base_iter.next().transpose()?;
-            }
-            (None, Some(os)) => {
-                // Only other remaining
-                encoder.encode(DataPoint::new(os.timestamp_ms as u64, os.value));
-                other_sample = other_iter.next().transpose()?;
-            }
-            (None, None) => break,
-        }
+    for &(_, timestamp, value) in &samples {
+        encoder.encode(DataPoint::new(timestamp as u64, value));
     }
 
     // Close encoder to get compressed data
@@ -438,7 +425,7 @@ mod tests {
         let other_bytes = other.encode().unwrap();
 
         // when: merge the series
-        let merged_bytes = merge_time_series(base_bytes, other_bytes).unwrap();
+        let merged_bytes = merge_batch_time_series(Some(base_bytes), &[other_bytes]).unwrap();
         let merged = TimeSeriesValue::decode(merged_bytes.as_ref()).unwrap();
 
         // then: should have 4 points with duplicates resolved (last write wins)
@@ -493,7 +480,7 @@ mod tests {
         let other_bytes = other.encode().unwrap();
 
         // when: merge the series
-        let merged_bytes = merge_time_series(base_bytes, other_bytes).unwrap();
+        let merged_bytes = merge_batch_time_series(Some(base_bytes), &[other_bytes]).unwrap();
         let merged = TimeSeriesValue::decode(merged_bytes.as_ref()).unwrap();
 
         // then: should have all 6 points in sorted order
@@ -504,5 +491,234 @@ mod tests {
         assert_eq!(merged.points[3].timestamp_ms, 4000);
         assert_eq!(merged.points[4].timestamp_ms, 5000);
         assert_eq!(merged.points[5].timestamp_ms, 6000);
+    }
+
+    #[test]
+    fn should_batch_merge_return_empty_when_no_existing_and_no_operands() {
+        // given - nothing
+
+        // when
+        let merged = merge_batch_time_series(None, &[]).unwrap();
+
+        // then
+        assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn should_batch_merge_return_existing_when_no_operands() {
+        // given
+        let existing = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 1000,
+                    value: 10.0,
+                },
+                Sample {
+                    timestamp_ms: 2000,
+                    value: 20.0,
+                },
+            ],
+        };
+        let existing_bytes = existing.encode().unwrap();
+
+        // when
+        let merged = merge_batch_time_series(Some(existing_bytes.clone()), &[]).unwrap();
+
+        // then
+        assert_eq!(merged, existing_bytes);
+    }
+
+    #[test]
+    fn should_batch_merge_return_operand_when_no_existing_and_single_operand() {
+        // given
+        let op = TimeSeriesValue {
+            points: vec![Sample {
+                timestamp_ms: 1000,
+                value: 10.0,
+            }],
+        };
+        let op_bytes = op.encode().unwrap();
+
+        // when
+        let merged = merge_batch_time_series(None, std::slice::from_ref(&op_bytes)).unwrap();
+
+        // then
+        assert_eq!(merged, op_bytes);
+    }
+
+    #[test]
+    fn should_batch_merge_skip_empty_operands() {
+        // given
+        let existing = TimeSeriesValue {
+            points: vec![Sample {
+                timestamp_ms: 1000,
+                value: 10.0,
+            }],
+        };
+        let existing_bytes = existing.encode().unwrap();
+
+        // when
+        let merged =
+            merge_batch_time_series(Some(existing_bytes.clone()), &[Bytes::new(), Bytes::new()])
+                .unwrap();
+
+        // then - only existing remains, single source passthrough
+        assert_eq!(merged, existing_bytes);
+    }
+
+    #[test]
+    fn should_batch_merge_return_empty_when_all_sources_empty() {
+        // given - empty existing and empty operands
+
+        // when
+        let merged =
+            merge_batch_time_series(Some(Bytes::new()), &[Bytes::new(), Bytes::new()]).unwrap();
+
+        // then
+        assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn should_batch_merge_multiple_operands_with_last_write_wins() {
+        // given: three operands where later ones override earlier timestamps
+        let op0 = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 1000,
+                    value: 10.0,
+                },
+                Sample {
+                    timestamp_ms: 2000,
+                    value: 20.0,
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+        let op1 = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 2000,
+                    value: 200.0,
+                },
+                Sample {
+                    timestamp_ms: 3000,
+                    value: 30.0,
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+        let op2 = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 3000,
+                    value: 300.0,
+                },
+                Sample {
+                    timestamp_ms: 4000,
+                    value: 40.0,
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+
+        // when - no existing value
+        let merged = merge_batch_time_series(None, &[op0, op1, op2]).unwrap();
+        let decoded = TimeSeriesValue::decode(merged.as_ref()).unwrap();
+
+        // then - timestamp 2000 takes op1's value, timestamp 3000 takes op2's value
+        let expected = vec![
+            Sample {
+                timestamp_ms: 1000,
+                value: 10.0,
+            },
+            Sample {
+                timestamp_ms: 2000,
+                value: 200.0,
+            },
+            Sample {
+                timestamp_ms: 3000,
+                value: 300.0,
+            },
+            Sample {
+                timestamp_ms: 4000,
+                value: 40.0,
+            },
+        ];
+        assert_eq!(decoded.points, expected);
+    }
+
+    #[test]
+    fn should_batch_merge_existing_with_multiple_operands() {
+        // given
+        let existing = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 1000,
+                    value: 1.0,
+                },
+                Sample {
+                    timestamp_ms: 2000,
+                    value: 2.0,
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+        let op0 = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 2000,
+                    value: 20.0,
+                },
+                Sample {
+                    timestamp_ms: 3000,
+                    value: 30.0,
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+        let op1 = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 3000,
+                    value: 300.0,
+                },
+                Sample {
+                    timestamp_ms: 4000,
+                    value: 40.0,
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+
+        // when
+        let merged = merge_batch_time_series(Some(existing), &[op0, op1]).unwrap();
+        let decoded = TimeSeriesValue::decode(merged.as_ref()).unwrap();
+
+        // then - existing ts=2000 overridden by op0, op0 ts=3000 overridden by op1
+        let expected = vec![
+            Sample {
+                timestamp_ms: 1000,
+                value: 1.0,
+            },
+            Sample {
+                timestamp_ms: 2000,
+                value: 20.0,
+            },
+            Sample {
+                timestamp_ms: 3000,
+                value: 300.0,
+            },
+            Sample {
+                timestamp_ms: 4000,
+                value: 40.0,
+            },
+        ];
+        assert_eq!(decoded.points, expected);
     }
 }

--- a/timeseries/src/storage/merge_operator.rs
+++ b/timeseries/src/storage/merge_operator.rs
@@ -3,8 +3,9 @@ use bytes::Bytes;
 use crate::model::RecordTag;
 use crate::serde::bucket_list::BucketListValue;
 use crate::serde::inverted_index::InvertedIndexValue;
-use crate::serde::timeseries::merge_time_series;
+use crate::serde::timeseries::merge_batch_time_series;
 use crate::serde::{EncodingError, RecordType, record_type_from_tag};
+use common::storage::default_merge_batch;
 
 /// Merge operator for OpenTSDB that handles merging of different record types.
 ///
@@ -14,11 +15,10 @@ pub(crate) struct OpenTsdbMergeOperator;
 
 impl common::storage::MergeOperator for OpenTsdbMergeOperator {
     fn merge(&self, key: &Bytes, existing_value: Option<Bytes>, new_value: Bytes) -> Bytes {
-        // If no existing value, just return the new value
-        let Some(existing) = existing_value else {
-            return new_value;
-        };
+        self.merge_batch(key, existing_value, &[new_value])
+    }
 
+    fn merge_batch(&self, key: &Bytes, existing_value: Option<Bytes>, operands: &[Bytes]) -> Bytes {
         // Decode record type from key
         if key.len() < 2 {
             panic!("Invalid key: key length is less than 2 bytes");
@@ -31,53 +31,70 @@ impl common::storage::MergeOperator for OpenTsdbMergeOperator {
             record_type_from_tag(record_tag).expect("Failed to get record type from record tag");
 
         match record_type {
-            RecordType::InvertedIndex => {
-                merge_inverted_index(existing, new_value).expect("Failed to merge inverted index")
-            }
-            RecordType::TimeSeries => {
-                merge_time_series(existing, new_value).expect("Failed to merge time series")
-            }
-            RecordType::BucketList => {
-                merge_bucket_list(existing, new_value).expect("Failed to merge bucket list")
-            }
+            RecordType::InvertedIndex => merge_batch_inverted_index(existing_value, operands)
+                .expect("Failed to batch merge inverted index"),
+            RecordType::TimeSeries => merge_batch_time_series(existing_value, operands)
+                .expect("Failed to batch merge time series"),
+            RecordType::BucketList => merge_batch_bucket_list(existing_value, operands)
+                .expect("Failed to batch merge bucket list"),
             _ => {
-                // For other record types (SeriesDictionary, ForwardIndex), just use new value
+                // For other record types (SeriesDictionary, ForwardIndex), just use new value for each pairwise merge.
                 // These should use Put, not Merge, but handle gracefully
-                new_value
+                default_merge_batch(key, existing_value, operands, |_k, _e, v| v)
             }
         }
     }
 }
 
-/// Merge inverted index posting lists by unioning RoaringBitmaps.
-fn merge_inverted_index(existing: Bytes, new_value: Bytes) -> Result<Bytes, EncodingError> {
-    let existing_bitmap = InvertedIndexValue::decode(existing.as_ref())?.postings;
-    let new_bitmap = InvertedIndexValue::decode(new_value.as_ref())?.postings;
+/// Batch merge inverted index posting lists by unioning all RoaringBitmaps at once.
+///
+/// Decodes every bitmap once and unions them into a single result, avoiding
+/// repeated serialize/deserialize cycles of the default pairwise merge.
+fn merge_batch_inverted_index(
+    existing: Option<Bytes>,
+    operands: &[Bytes],
+) -> Result<Bytes, EncodingError> {
+    let mut merged = if let Some(existing) = existing {
+        InvertedIndexValue::decode(existing.as_ref())?.postings
+    } else {
+        roaring::RoaringBitmap::new()
+    };
 
-    let merged = existing_bitmap | new_bitmap;
+    for operand in operands {
+        let bitmap = InvertedIndexValue::decode(operand.as_ref())?.postings;
+        merged |= bitmap;
+    }
+
     (InvertedIndexValue { postings: merged }).encode()
 }
 
-/// Merge bucket lists by taking the union of buckets and sorting.
-/// Used by the merge operator to handle concurrent updates to the BucketsList.
-fn merge_bucket_list(existing: Bytes, new_value: Bytes) -> Result<Bytes, EncodingError> {
-    let mut base_buckets = BucketListValue::decode(existing.as_ref())?.buckets;
-    let other_buckets = BucketListValue::decode(new_value.as_ref())?.buckets;
+/// Batch merge bucket lists by collecting all unique buckets and sorting once.
+///
+/// Decodes every bucket list once, collects unique buckets, and produces a single
+/// sorted result, avoiding repeated decode/encode cycles.
+fn merge_batch_bucket_list(
+    existing: Option<Bytes>,
+    operands: &[Bytes],
+) -> Result<Bytes, EncodingError> {
+    let mut buckets = if let Some(existing) = existing {
+        BucketListValue::decode(existing.as_ref())?.buckets
+    } else {
+        Vec::new()
+    };
 
-    // Add buckets from other that aren't in base
-    for bucket in other_buckets {
-        if !base_buckets.contains(&bucket) {
-            base_buckets.push(bucket);
+    for operand in operands {
+        let other_buckets = BucketListValue::decode(operand.as_ref())?.buckets;
+        for bucket in other_buckets {
+            if !buckets.contains(&bucket) {
+                buckets.push(bucket);
+            }
         }
     }
 
     // Sort by start time
-    base_buckets.sort_by_key(|b| b.1);
+    buckets.sort_by_key(|b| b.1);
 
-    Ok(BucketListValue {
-        buckets: base_buckets,
-    }
-    .encode())
+    Ok(BucketListValue { buckets }.encode())
 }
 
 #[cfg(test)]
@@ -187,7 +204,7 @@ mod tests {
         .unwrap();
 
         // when
-        let merged = merge_inverted_index(existing_value, new_value).unwrap();
+        let merged = merge_batch_inverted_index(Some(existing_value), &[new_value]).unwrap();
         let decoded = InvertedIndexValue::decode(merged.as_ref()).unwrap();
 
         // then
@@ -257,7 +274,7 @@ mod tests {
         .encode();
 
         // when
-        let merged = merge_bucket_list(existing_value, new_value).unwrap();
+        let merged = merge_batch_bucket_list(Some(existing_value), &[new_value]).unwrap();
         let decoded = BucketListValue::decode(merged.as_ref()).unwrap();
 
         // then
@@ -329,7 +346,7 @@ mod tests {
         let new_value = TimeSeriesValue { points: new_points }.encode().unwrap();
 
         // when
-        let merged = merge_time_series(existing_value, new_value).unwrap();
+        let merged = merge_batch_time_series(Some(existing_value), &[new_value]).unwrap();
         let decoded = TimeSeriesValue::decode(merged.as_ref()).unwrap();
 
         // then
@@ -471,13 +488,21 @@ mod tests {
         // given
         let operator = OpenTsdbMergeOperator;
         let key = create_inverted_index_key();
-        let new_value = Bytes::from(b"new_value".to_vec());
+        let mut bm = RoaringBitmap::new();
+        bm.insert(1);
+        bm.insert(2);
+        let new_value = InvertedIndexValue {
+            postings: bm.clone(),
+        }
+        .encode()
+        .unwrap();
 
         // when
-        let result = operator.merge(&key, None, new_value.clone());
+        let result = operator.merge(&key, None, new_value);
 
         // then
-        assert_eq!(result, new_value);
+        let decoded = InvertedIndexValue::decode(result.as_ref()).unwrap();
+        assert_eq!(decoded.postings, bm);
     }
 
     #[test]
@@ -493,5 +518,401 @@ mod tests {
 
         // then - should return new_value without merging
         assert_eq!(result, new_value);
+    }
+
+    #[test]
+    fn should_batch_merge_inverted_index() {
+        // given
+        let op0 = InvertedIndexValue {
+            postings: {
+                let mut bm = RoaringBitmap::new();
+                bm.insert(1);
+                bm.insert(2);
+                bm
+            },
+        }
+        .encode()
+        .unwrap();
+        let op1 = InvertedIndexValue {
+            postings: {
+                let mut bm = RoaringBitmap::new();
+                bm.insert(2);
+                bm.insert(3);
+                bm
+            },
+        }
+        .encode()
+        .unwrap();
+        let op2 = InvertedIndexValue {
+            postings: {
+                let mut bm = RoaringBitmap::new();
+                bm.insert(4);
+                bm.insert(5);
+                bm
+            },
+        }
+        .encode()
+        .unwrap();
+
+        // when - no existing value
+        let merged =
+            merge_batch_inverted_index(None, &[op0.clone(), op1.clone(), op2.clone()]).unwrap();
+        let decoded = InvertedIndexValue::decode(merged.as_ref()).unwrap();
+
+        // then - union of all bitmaps
+        let mut expected = RoaringBitmap::new();
+        for id in [1, 2, 3, 4, 5] {
+            expected.insert(id);
+        }
+        assert_eq!(decoded.postings, expected);
+    }
+
+    #[test]
+    fn should_batch_merge_inverted_index_with_existing() {
+        // given
+        let existing = InvertedIndexValue {
+            postings: {
+                let mut bm = RoaringBitmap::new();
+                bm.insert(10);
+                bm
+            },
+        }
+        .encode()
+        .unwrap();
+        let op0 = InvertedIndexValue {
+            postings: {
+                let mut bm = RoaringBitmap::new();
+                bm.insert(1);
+                bm.insert(10);
+                bm
+            },
+        }
+        .encode()
+        .unwrap();
+
+        // when
+        let merged = merge_batch_inverted_index(Some(existing), &[op0]).unwrap();
+        let decoded = InvertedIndexValue::decode(merged.as_ref()).unwrap();
+
+        // then
+        let mut expected = RoaringBitmap::new();
+        for id in [1, 10] {
+            expected.insert(id);
+        }
+        assert_eq!(decoded.postings, expected);
+    }
+
+    #[test]
+    fn should_batch_merge_bucket_list() {
+        // given
+        let op0 = BucketListValue {
+            buckets: vec![(1, 100), (2, 200)],
+        }
+        .encode();
+        let op1 = BucketListValue {
+            buckets: vec![(2, 200), (3, 300)],
+        }
+        .encode();
+        let op2 = BucketListValue {
+            buckets: vec![(4, 400)],
+        }
+        .encode();
+
+        // when - no existing value
+        let merged = merge_batch_bucket_list(None, &[op0, op1, op2]).unwrap();
+        let decoded = BucketListValue::decode(merged.as_ref()).unwrap();
+
+        // then - unique buckets sorted by start time
+        assert_eq!(
+            decoded.buckets,
+            vec![(1, 100), (2, 200), (3, 300), (4, 400)]
+        );
+    }
+
+    #[test]
+    fn should_batch_merge_bucket_list_with_existing() {
+        // given
+        let existing = BucketListValue {
+            buckets: vec![(1, 100)],
+        }
+        .encode();
+        let op0 = BucketListValue {
+            buckets: vec![(2, 200)],
+        }
+        .encode();
+        let op1 = BucketListValue {
+            buckets: vec![(1, 100), (3, 300)],
+        }
+        .encode();
+
+        // when
+        let merged = merge_batch_bucket_list(Some(existing), &[op0, op1]).unwrap();
+        let decoded = BucketListValue::decode(merged.as_ref()).unwrap();
+
+        // then
+        assert_eq!(decoded.buckets, vec![(1, 100), (2, 200), (3, 300)]);
+    }
+
+    #[test]
+    fn should_batch_merge_time_series() {
+        // given
+        let op0 = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 1000,
+                    value: 10.0,
+                },
+                Sample {
+                    timestamp_ms: 2000,
+                    value: 20.0,
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+        let op1 = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 2000,
+                    value: 200.0,
+                },
+                Sample {
+                    timestamp_ms: 3000,
+                    value: 30.0,
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+        let op2 = TimeSeriesValue {
+            points: vec![Sample {
+                timestamp_ms: 4000,
+                value: 40.0,
+            }],
+        }
+        .encode()
+        .unwrap();
+
+        // when - no existing value
+        let merged =
+            crate::serde::timeseries::merge_batch_time_series(None, &[op0, op1, op2]).unwrap();
+        let decoded = TimeSeriesValue::decode(merged.as_ref()).unwrap();
+
+        // then - merged with last write wins on timestamp 2000
+        let expected = vec![
+            Sample {
+                timestamp_ms: 1000,
+                value: 10.0,
+            },
+            Sample {
+                timestamp_ms: 2000,
+                value: 200.0,
+            },
+            Sample {
+                timestamp_ms: 3000,
+                value: 30.0,
+            },
+            Sample {
+                timestamp_ms: 4000,
+                value: 40.0,
+            },
+        ];
+        assert_eq!(decoded.points, expected);
+    }
+
+    #[test]
+    fn should_batch_merge_time_series_with_existing() {
+        // given
+        let existing = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 1000,
+                    value: 1.0,
+                },
+                Sample {
+                    timestamp_ms: 3000,
+                    value: 3.0,
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+        let op0 = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 2000,
+                    value: 2.0,
+                },
+                Sample {
+                    timestamp_ms: 3000,
+                    value: 300.0,
+                },
+            ],
+        }
+        .encode()
+        .unwrap();
+
+        // when
+        let merged =
+            crate::serde::timeseries::merge_batch_time_series(Some(existing), &[op0]).unwrap();
+        let decoded = TimeSeriesValue::decode(merged.as_ref()).unwrap();
+
+        // then - timestamp 3000 takes operand value (newer)
+        let expected = vec![
+            Sample {
+                timestamp_ms: 1000,
+                value: 1.0,
+            },
+            Sample {
+                timestamp_ms: 2000,
+                value: 2.0,
+            },
+            Sample {
+                timestamp_ms: 3000,
+                value: 300.0,
+            },
+        ];
+        assert_eq!(decoded.points, expected);
+    }
+
+    #[rstest]
+    #[case(RecordType::InvertedIndex, create_inverted_index_key, "InvertedIndex")]
+    #[case(RecordType::TimeSeries, create_time_series_key, "TimeSeries")]
+    #[case(RecordType::BucketList, create_bucket_list_key, "BucketList")]
+    fn should_route_merge_batch_to_correct_function(
+        #[case] record_type: RecordType,
+        #[case] key_fn: fn() -> Bytes,
+        #[case] description: &str,
+    ) {
+        // given
+        let operator = OpenTsdbMergeOperator;
+        let key = key_fn();
+
+        let (existing_value, op0, op1) = match record_type {
+            RecordType::InvertedIndex => {
+                let existing = InvertedIndexValue {
+                    postings: {
+                        let mut bm = RoaringBitmap::new();
+                        bm.insert(1);
+                        bm
+                    },
+                }
+                .encode()
+                .unwrap();
+                let o0 = InvertedIndexValue {
+                    postings: {
+                        let mut bm = RoaringBitmap::new();
+                        bm.insert(2);
+                        bm
+                    },
+                }
+                .encode()
+                .unwrap();
+                let o1 = InvertedIndexValue {
+                    postings: {
+                        let mut bm = RoaringBitmap::new();
+                        bm.insert(3);
+                        bm
+                    },
+                }
+                .encode()
+                .unwrap();
+                (existing, o0, o1)
+            }
+            RecordType::TimeSeries => {
+                let existing = TimeSeriesValue {
+                    points: vec![Sample {
+                        timestamp_ms: 1000,
+                        value: 10.0,
+                    }],
+                }
+                .encode()
+                .unwrap();
+                let o0 = TimeSeriesValue {
+                    points: vec![Sample {
+                        timestamp_ms: 2000,
+                        value: 20.0,
+                    }],
+                }
+                .encode()
+                .unwrap();
+                let o1 = TimeSeriesValue {
+                    points: vec![Sample {
+                        timestamp_ms: 3000,
+                        value: 30.0,
+                    }],
+                }
+                .encode()
+                .unwrap();
+                (existing, o0, o1)
+            }
+            RecordType::BucketList => {
+                let existing = BucketListValue {
+                    buckets: vec![(1, 100)],
+                }
+                .encode();
+                let o0 = BucketListValue {
+                    buckets: vec![(2, 200)],
+                }
+                .encode();
+                let o1 = BucketListValue {
+                    buckets: vec![(3, 300)],
+                }
+                .encode();
+                (existing, o0, o1)
+            }
+            _ => unreachable!(),
+        };
+
+        // when
+        let merged = operator.merge_batch(&key, Some(existing_value), &[op0, op1]);
+
+        // then - verify all three sources were merged
+        match record_type {
+            RecordType::InvertedIndex => {
+                let decoded = InvertedIndexValue::decode(merged.as_ref()).unwrap();
+                assert_eq!(
+                    decoded.postings.len(),
+                    3,
+                    "{} batch merge should union all values",
+                    description
+                );
+            }
+            RecordType::TimeSeries => {
+                let decoded = TimeSeriesValue::decode(merged.as_ref()).unwrap();
+                assert_eq!(
+                    decoded.points.len(),
+                    3,
+                    "{} batch merge should combine all samples",
+                    description
+                );
+            }
+            RecordType::BucketList => {
+                let decoded = BucketListValue::decode(merged.as_ref()).unwrap();
+                assert_eq!(
+                    decoded.buckets.len(),
+                    3,
+                    "{} batch merge should union all buckets",
+                    description
+                );
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn should_merge_batch_return_new_value_for_other_record_types() {
+        // given
+        let operator = OpenTsdbMergeOperator;
+        let key = create_other_record_type_key();
+        let existing_value = Bytes::from(b"existing".to_vec());
+        let op0 = Bytes::from(b"op0".to_vec());
+        let op1 = Bytes::from(b"final".to_vec());
+
+        // when
+        let result = operator.merge_batch(&key, Some(existing_value), &[op0, op1.clone()]);
+
+        // then - falls back to pairwise merge; last operand wins for non-mergeable types
+        assert_eq!(result, op1);
     }
 }


### PR DESCRIPTION
## Summary

Implements `common::storage::MergeOperator::merge_batch()` for `OpenTsdbMergeOperator`.

I added some `merge_batch_` helper functions and modified the existing `merge_` helpers to call their new batch counterparts.

## Related Issues

Relates to #272. I have only tackled part of that issue.

## Test Plan

Added unit tests.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
