### PR TITLE
[timeseries] Fix quickstart Docker file

### DIFF
--- a/timeseries/quickstart/Dockerfile.timeseries
+++ b/timeseries/quickstart/Dockerfile.timeseries
@@ -13,7 +13,7 @@ WORKDIR /app
 COPY . ./
 
 # Build the timeseries binary
-RUN cargo build --release -p timeseries
+RUN cargo build --release -p opendata-timeseries --features http-server
 
 # Runtime stage
 FROM debian:bookworm-slim
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /app
 
 # Copy the built binary
-COPY --from=builder /app/target/release/timeseries /app/timeseries
+COPY --from=builder /app/target/release/opendata-timeseries /app/timeseries
 
 # Create data directory
 RUN mkdir -p /app/data


### PR DESCRIPTION
## Summary

Fixes the Docker file for running the timeseries quickstart:
- package name fixed
- required features specified

## Related Issues

I didn't create an issue but can do so if required.

## Test Plan

I was able to run the quickstart locally.

## Checklist

- [ ] Tests added/updated
- [ ] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
