### PR TITLE
[log] Expose read visibility as enum in c bindings

### DIFF
--- a/log/c/include/opendata_log.h
+++ b/log/c/include/opendata_log.h
@@ -9,6 +9,10 @@
 
 #define OPENDATA_LOG_STORAGE_SLATEDB 1
 
+#define OPENDATA_LOG_READ_VISIBILITY_MEMORY 0
+
+#define OPENDATA_LOG_READ_VISIBILITY_REMOTE 1
+
 #define OPENDATA_LOG_BOUND_UNBOUNDED 0
 
 #define OPENDATA_LOG_BOUND_INCLUDED 1
@@ -49,9 +53,11 @@ typedef struct opendata_log_config_t {
   const char *settings_path;
   int64_t seal_interval_ms;
   /**
-   * When true, reads only see data confirmed durable by the storage engine.
+   * Controls which data is visible to reads.
+   * Use `OPENDATA_LOG_READ_VISIBILITY_MEMORY` (default) to include in-memory data,
+   * or `OPENDATA_LOG_READ_VISIBILITY_REMOTE` to only see data confirmed durable.
    */
-  bool read_durable;
+  uint8_t read_visibility;
 } opendata_log_config_t;
 
 typedef struct opendata_log_seq_bound_t {

--- a/log/c/src/ffi.rs
+++ b/log/c/src/ffi.rs
@@ -56,6 +56,9 @@ pub struct opendata_log_result_t {
 pub const OPENDATA_LOG_STORAGE_IN_MEMORY: u8 = 0;
 pub const OPENDATA_LOG_STORAGE_SLATEDB: u8 = 1;
 
+pub const OPENDATA_LOG_READ_VISIBILITY_MEMORY: u8 = 0;
+pub const OPENDATA_LOG_READ_VISIBILITY_REMOTE: u8 = 1;
+
 #[repr(C)]
 pub struct opendata_log_config_t {
     pub storage_type: u8,
@@ -63,8 +66,10 @@ pub struct opendata_log_config_t {
     pub object_store: *const opendata_log_object_store_t,
     pub settings_path: *const c_char,
     pub seal_interval_ms: i64,
-    /// When true, reads only see data confirmed durable by the storage engine.
-    pub read_durable: bool,
+    /// Controls which data is visible to reads.
+    /// Use `OPENDATA_LOG_READ_VISIBILITY_MEMORY` (default) to include in-memory data,
+    /// or `OPENDATA_LOG_READ_VISIBILITY_REMOTE` to only see data confirmed durable.
+    pub read_visibility: u8,
 }
 
 #[repr(C)]
@@ -295,10 +300,15 @@ pub(crate) unsafe fn build_config(
     Ok(Config {
         storage,
         segmentation: SegmentConfig { seal_interval },
-        read_visibility: if config.read_durable {
-            ReadVisibility::Remote
-        } else {
-            ReadVisibility::Memory
+        read_visibility: match config.read_visibility {
+            OPENDATA_LOG_READ_VISIBILITY_REMOTE => ReadVisibility::Remote,
+            OPENDATA_LOG_READ_VISIBILITY_MEMORY => ReadVisibility::Memory,
+            other => {
+                return Err(error_result(
+                    opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+                    &format!("invalid read_visibility: {other}"),
+                ));
+            }
         },
     })
 }

--- a/log/c/tests/integration_test.rs
+++ b/log/c/tests/integration_test.rs
@@ -34,7 +34,7 @@ fn open_in_memory_log() -> *mut opendata_log_t {
         object_store: ptr::null(),
         settings_path: ptr::null(),
         seal_interval_ms: -1,
-        read_durable: false,
+        read_visibility: OPENDATA_LOG_READ_VISIBILITY_MEMORY,
     };
     let mut log: *mut opendata_log_t = ptr::null_mut();
     assert_ok(unsafe { opendata_log_open(&config, &mut log) });
@@ -114,7 +114,7 @@ fn open_rejects_null_out_pointer() {
         object_store: ptr::null(),
         settings_path: ptr::null(),
         seal_interval_ms: -1,
-        read_durable: false,
+        read_visibility: OPENDATA_LOG_READ_VISIBILITY_MEMORY,
     };
     assert_error(
         unsafe { opendata_log_open(&config, ptr::null_mut()) },
@@ -138,7 +138,7 @@ fn open_rejects_invalid_storage_type() {
         object_store: ptr::null(),
         settings_path: ptr::null(),
         seal_interval_ms: -1,
-        read_durable: false,
+        read_visibility: OPENDATA_LOG_READ_VISIBILITY_MEMORY,
     };
     let mut log: *mut opendata_log_t = ptr::null_mut();
     assert_error(
@@ -451,7 +451,7 @@ fn reader_open_and_close() {
         object_store: store,
         settings_path: ptr::null(),
         seal_interval_ms: -1,
-        read_durable: false,
+        read_visibility: OPENDATA_LOG_READ_VISIBILITY_MEMORY,
     };
     let mut log: *mut opendata_log_t = ptr::null_mut();
     assert_ok(unsafe { opendata_log_open(&writer_config, &mut log) });
@@ -490,7 +490,7 @@ fn reader_scan_returns_written_data() {
         object_store: store,
         settings_path: ptr::null(),
         seal_interval_ms: -1,
-        read_durable: false,
+        read_visibility: OPENDATA_LOG_READ_VISIBILITY_MEMORY,
     };
     let mut log: *mut opendata_log_t = ptr::null_mut();
     assert_ok(unsafe { opendata_log_open(&writer_config, &mut log) });
@@ -577,7 +577,7 @@ fn reader_list_keys() {
         object_store: store,
         settings_path: ptr::null(),
         seal_interval_ms: -1,
-        read_durable: false,
+        read_visibility: OPENDATA_LOG_READ_VISIBILITY_MEMORY,
     };
     let mut log: *mut opendata_log_t = ptr::null_mut();
     assert_ok(unsafe { opendata_log_open(&writer_config, &mut log) });
@@ -644,7 +644,7 @@ fn reader_list_segments() {
         object_store: store,
         settings_path: ptr::null(),
         seal_interval_ms: -1,
-        read_durable: false,
+        read_visibility: OPENDATA_LOG_READ_VISIBILITY_MEMORY,
     };
     let mut log: *mut opendata_log_t = ptr::null_mut();
     assert_ok(unsafe { opendata_log_open(&writer_config, &mut log) });
@@ -723,7 +723,7 @@ fn open_with_local_slatedb() {
         object_store: store,
         settings_path: ptr::null(),
         seal_interval_ms: -1,
-        read_durable: false,
+        read_visibility: OPENDATA_LOG_READ_VISIBILITY_MEMORY,
     };
     let mut log: *mut opendata_log_t = ptr::null_mut();
     assert_ok(unsafe { opendata_log_open(&config, &mut log) });


### PR DESCRIPTION
We changed `LogDb` to use a `ReadVisibility` enum instead of a `read_durable` boolean. This patch updates the c bindings similarly.