### PR TITLE
drop support for cosine distance metric

### DIFF
--- a/vector/bench/src/recall.rs
+++ b/vector/bench/src/recall.rs
@@ -120,6 +120,14 @@ fn read_bvecs(path: &Path, limit: Option<usize>) -> Vec<Vec<f32>> {
     vectors
 }
 
+/// L2-normalize a vector in place.
+fn normalize_vec(v: &mut [f32]) {
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        v.iter_mut().for_each(|x| *x /= norm);
+    }
+}
+
 // -- Recall / percentile helpers ----------------------------------------------
 
 fn recall_at_k(results: &[SearchResult], ground_truth: &[i32], k: usize) -> f64 {
@@ -179,13 +187,16 @@ struct Dataset {
     format: VecFormat,
     /// Maximum number of base vectors to ingest. `None` = all.
     max_vectors: Option<usize>,
+    /// Whether to L2-normalize vectors before ingestion and query.
+    /// Used for datasets that originally use cosine similarity.
+    normalize: bool,
 }
 
 impl Dataset {
-    /// Load base vectors, respecting `format` and `max_vectors`.
+    /// Load base vectors, respecting `format`, `max_vectors`, and `normalize`.
     fn load_base_vectors(&self, data_dir: &Path) -> Vec<Vec<f32>> {
         let path = data_dir.join(self.base_file);
-        match self.format {
+        let mut vecs = match self.format {
             VecFormat::Fvecs => {
                 let vecs = read_fvecs(&path);
                 match self.max_vectors {
@@ -194,26 +205,37 @@ impl Dataset {
                 }
             }
             VecFormat::Bvecs => read_bvecs(&path, self.max_vectors),
+        };
+        if self.normalize {
+            for v in &mut vecs {
+                normalize_vec(v);
+            }
         }
+        vecs
     }
 
-    /// Load query vectors, respecting `format`.
+    /// Load query vectors, respecting `format` and `normalize`.
     fn load_query_vectors(&self, data_dir: &Path) -> Vec<Vec<f32>> {
         let path = data_dir.join(self.query_file);
-        match self.format {
+        let mut vecs = match self.format {
             VecFormat::Fvecs => read_fvecs(&path)
                 .into_iter()
                 .take(self.num_queries)
                 .collect(),
             VecFormat::Bvecs => read_bvecs(&path, Some(self.num_queries)),
+        };
+        if self.normalize {
+            for v in &mut vecs {
+                normalize_vec(v);
+            }
         }
+        vecs
     }
 }
 
 fn distance_metric_to_str(m: DistanceMetric) -> &'static str {
     match m {
         DistanceMetric::L2 => "l2",
-        DistanceMetric::Cosine => "cosine",
         DistanceMetric::DotProduct => "dot_product",
     }
 }
@@ -221,7 +243,6 @@ fn distance_metric_to_str(m: DistanceMetric) -> &'static str {
 fn str_to_distance_metric(s: &str) -> DistanceMetric {
     match s {
         "l2" => DistanceMetric::L2,
-        "cosine" => DistanceMetric::Cosine,
         "dot_product" => DistanceMetric::DotProduct,
         _ => panic!("unknown distance metric: {}", s),
     }
@@ -322,6 +343,7 @@ impl From<Params> for Dataset {
                 .get("vector_config")
                 .map(|s| s.to_string())
                 .or_else(|| default.vector_config.clone()),
+            normalize: default.normalize,
         }
     }
 }
@@ -343,12 +365,13 @@ const SIFT1M: Dataset = Dataset {
     vector_config: None,
     format: VecFormat::Fvecs,
     max_vectors: None,
+    normalize: false,
 };
 
 const COHERE1M: Dataset = Dataset {
     name: "cohere1m",
     dimensions: 768,
-    distance_metric: DistanceMetric::Cosine,
+    distance_metric: DistanceMetric::L2,
     base_file: "cohere/cohere_base.fvecs",
     query_file: "cohere/cohere_query.fvecs",
     ground_truth_file: "cohere/cohere_groundtruth.ivecs",
@@ -362,6 +385,7 @@ const COHERE1M: Dataset = Dataset {
     vector_config: None,
     format: VecFormat::Fvecs,
     max_vectors: None,
+    normalize: true,
 };
 
 // BigANN / SIFT1B variants — all share the same base and query files but
@@ -384,6 +408,7 @@ const SIFT10M: Dataset = Dataset {
     vector_config: None,
     format: VecFormat::Bvecs,
     max_vectors: Some(10_000_000),
+    normalize: false,
 };
 
 const SIFT50M: Dataset = Dataset {
@@ -403,6 +428,7 @@ const SIFT50M: Dataset = Dataset {
     vector_config: None,
     format: VecFormat::Bvecs,
     max_vectors: Some(50_000_000),
+    normalize: false,
 };
 
 const SIFT100M: Dataset = Dataset {
@@ -422,6 +448,7 @@ const SIFT100M: Dataset = Dataset {
     vector_config: None,
     format: VecFormat::Bvecs,
     max_vectors: Some(100_000_000),
+    normalize: false,
 };
 
 const SIFT1B: Dataset = Dataset {
@@ -441,6 +468,7 @@ const SIFT1B: Dataset = Dataset {
     vector_config: None,
     format: VecFormat::Bvecs,
     max_vectors: None,
+    normalize: false,
 };
 
 const ALL_DATASETS: &[&Dataset] = &[&SIFT1M, &COHERE1M, &SIFT10M, &SIFT50M, &SIFT100M, &SIFT1B];

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -946,7 +946,7 @@ mod tests {
         Config {
             storage: StorageConfig::InMemory,
             dimensions: 3,
-            distance_metric: DistanceMetric::Cosine,
+            distance_metric: DistanceMetric::L2,
             flush_interval: Duration::from_secs(60),
             split_threshold_vectors: 10_000,
             merge_threshold_vectors: 200,
@@ -1097,7 +1097,7 @@ mod tests {
         Config {
             storage: StorageConfig::InMemory,
             dimensions,
-            distance_metric: DistanceMetric::Cosine,
+            distance_metric: DistanceMetric::L2,
             flush_interval: Duration::from_secs(60),
             split_threshold_vectors: 10_000,
             merge_threshold_vectors: 200,
@@ -1170,10 +1170,10 @@ mod tests {
             );
         }
 
-        // Verify results are sorted by score (cosine similarity, higher = better)
+        // Verify results are sorted by score (L2 distance, lower = better)
         for i in 1..results.len() {
             assert!(
-                results[i - 1].score >= results[i].score,
+                results[i - 1].score <= results[i].score,
                 "Results not sorted by score"
             );
         }
@@ -1483,7 +1483,7 @@ mod tests {
         let config = Config {
             storage: storage_config.clone(),
             dimensions: 3,
-            distance_metric: DistanceMetric::Cosine,
+            distance_metric: DistanceMetric::L2,
             ..Default::default()
         };
 

--- a/vector/src/distance.rs
+++ b/vector/src/distance.rs
@@ -28,7 +28,6 @@ pub(crate) fn compute_distance(a: &[f32], b: &[f32], metric: DistanceMetric) -> 
 
     let v = match metric {
         DistanceMetric::L2 => l2_distance(a, b),
-        DistanceMetric::Cosine => cosine_similarity(a, b),
         DistanceMetric::DotProduct => dot_product(a, b),
     };
     VectorDistance { score: v, metric }
@@ -39,7 +38,6 @@ pub(crate) fn compute_distance(a: &[f32], b: &[f32], metric: DistanceMetric) -> 
 pub(crate) fn raw_distance(a: &[f32], b: &[f32], metric: DistanceMetric) -> f32 {
     match metric {
         DistanceMetric::L2 => compute_distance(a, b, metric).score(),
-        DistanceMetric::Cosine => 1.0 - compute_distance(a, b, metric).score(),
         DistanceMetric::DotProduct => -compute_distance(a, b, metric).score(),
     }
 }
@@ -57,24 +55,6 @@ fn l2_distance(a: &[f32], b: &[f32]) -> f32 {
         .sqrt()
 }
 
-/// Compute cosine similarity between two vectors.
-///
-/// Formula: dot(a, b) / (||a|| * ||b||)
-///
-/// Higher scores indicate more similar vectors.
-/// Returns 0 if either vector has zero magnitude.
-fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|x| x.powi(2)).sum::<f32>().sqrt();
-
-    if norm_a == 0.0 || norm_b == 0.0 {
-        0.0
-    } else {
-        dot / (norm_a * norm_b)
-    }
-}
-
 /// Compute dot product between two vectors.
 ///
 /// Formula: sum(a[i] * b[i])
@@ -89,7 +69,7 @@ fn dot_product(a: &[f32], b: &[f32]) -> f32 {
 /// Ordering is defined so that `a < b` means `a` is **more similar** than `b`.
 /// This abstracts over the direction of each metric:
 /// - L2: lower raw value = more similar (natural order)
-/// - Cosine/DotProduct: higher raw value = more similar (reversed order)
+/// - DotProduct: higher raw value = more similar (reversed order)
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct VectorDistance {
     score: f32,
@@ -122,10 +102,8 @@ impl Ord for VectorDistance {
         match self.metric {
             // L2: lower value = more similar, so natural order
             DistanceMetric::L2 => self.score.total_cmp(&other.score),
-            // Cosine/DotProduct: higher value = more similar, so reverse order
-            DistanceMetric::Cosine | DistanceMetric::DotProduct => {
-                other.score.total_cmp(&self.score)
-            }
+            // DotProduct: higher value = more similar, so reverse order
+            DistanceMetric::DotProduct => other.score.total_cmp(&self.score),
         }
     }
 }
@@ -153,24 +131,6 @@ mod tests {
     }
 
     #[rstest]
-    #[case(vec![1.0, 0.0, 0.0], vec![1.0, 0.0, 0.0], 1.0, "identical vectors")]
-    #[case(vec![1.0, 0.0], vec![0.0, 1.0], 0.0, "orthogonal vectors")]
-    #[case(vec![1.0, 0.0], vec![-1.0, 0.0], -1.0, "opposite vectors")]
-    #[case(vec![1.0, 2.0], vec![0.0, 0.0], 0.0, "zero vector")]
-    fn should_compute_cosine_similarity(
-        #[case] a: Vec<f32>,
-        #[case] b: Vec<f32>,
-        #[case] expected: f32,
-        #[case] _desc: &str,
-    ) {
-        // when
-        let similarity = cosine_similarity(&a, &b);
-
-        // then
-        assert!((similarity - expected).abs() < 0.0001);
-    }
-
-    #[rstest]
     #[case(vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0], 32.0, "normal vectors")]
     #[case(vec![1.0, 0.0], vec![0.0, 1.0], 0.0, "orthogonal vectors")]
     fn should_compute_dot_product(
@@ -188,7 +148,6 @@ mod tests {
 
     #[rstest]
     #[case(DistanceMetric::L2, "L2")]
-    #[case(DistanceMetric::Cosine, "Cosine")]
     #[case(DistanceMetric::DotProduct, "DotProduct")]
     fn should_use_correct_metric(#[case] metric: DistanceMetric, #[case] _desc: &str) {
         // given
@@ -201,7 +160,6 @@ mod tests {
         // then - verify result matches direct function call
         let expected = match metric {
             DistanceMetric::L2 => l2_distance(&a, &b),
-            DistanceMetric::Cosine => cosine_similarity(&a, &b),
             DistanceMetric::DotProduct => dot_product(&a, &b),
         };
         assert_eq!(result.score(), expected);
@@ -232,16 +190,6 @@ mod tests {
         assert!(closer < farther);
         assert!(farther > closer);
         assert_ne!(closer, farther);
-    }
-
-    #[test]
-    fn should_order_cosine_by_higher_is_more_similar() {
-        // given
-        let more_similar = compute_distance(&[1.0, 0.0], &[1.0, 0.1], DistanceMetric::Cosine);
-        let less_similar = compute_distance(&[1.0, 0.0], &[0.0, 1.0], DistanceMetric::Cosine);
-
-        // then - higher cosine sim should be "less than" (more similar)
-        assert!(more_similar < less_similar);
     }
 
     #[test]
@@ -279,22 +227,5 @@ mod tests {
         assert_eq!(distances[0].score(), d_near.score());
         assert_eq!(distances[1].score(), d_mid.score());
         assert_eq!(distances[2].score(), d_far.score());
-    }
-
-    #[test]
-    fn should_sort_cosine_distances_most_similar_first() {
-        // given - three cosine distances
-        let d_high = compute_distance(&[1.0, 0.0], &[1.0, 0.0], DistanceMetric::Cosine); // sim=1.0
-        let d_mid = compute_distance(&[1.0, 0.0], &[1.0, 1.0], DistanceMetric::Cosine); // sim≈0.707
-        let d_low = compute_distance(&[1.0, 0.0], &[0.0, 1.0], DistanceMetric::Cosine); // sim=0.0
-        let mut distances = [d_low, d_high, d_mid];
-
-        // when
-        distances.sort();
-
-        // then - most similar (highest cosine) first
-        assert_eq!(distances[0].score(), d_high.score());
-        assert_eq!(distances[1].score(), d_mid.score());
-        assert_eq!(distances[2].score(), d_low.score());
     }
 }

--- a/vector/src/hnsw/usearch.rs
+++ b/vector/src/hnsw/usearch.rs
@@ -79,7 +79,6 @@ impl UsearchCentroidGraph {
         // Convert distance metric to usearch MetricKind
         let metric = match distance_metric {
             DistanceMetric::L2 => MetricKind::L2sq,
-            DistanceMetric::Cosine => MetricKind::Cos,
             DistanceMetric::DotProduct => MetricKind::IP,
         };
 
@@ -245,25 +244,6 @@ mod tests {
         // then
         assert_eq!(results.len(), 1);
         assert_eq!(results[0], 1);
-    }
-
-    #[test]
-    fn should_build_and_search_cosine_graph() {
-        // given - 3 centroids
-        let centroids = vec![
-            CentroidEntry::new(10, vec![1.0, 0.0]),
-            CentroidEntry::new(20, vec![0.0, 1.0]),
-            CentroidEntry::new(30, vec![1.0, 1.0]),
-        ];
-
-        // when
-        let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::Cosine).unwrap();
-        let query = vec![0.9, 0.1];
-        let results = graph.search(&query, 1);
-
-        // then
-        assert_eq!(results.len(), 1);
-        assert_eq!(results[0], 10);
     }
 
     #[test]

--- a/vector/src/lib.rs
+++ b/vector/src/lib.rs
@@ -12,7 +12,7 @@
 //! # async fn main() -> vector::Result<()> {
 //! let config = Config {
 //!     dimensions: 384,
-//!     distance_metric: DistanceMetric::Cosine,
+//!     distance_metric: DistanceMetric::L2,
 //!     flush_interval: Duration::from_secs(60),
 //!     ..Default::default()
 //! };

--- a/vector/src/lire/kmeans.rs
+++ b/vector/src/lire/kmeans.rs
@@ -11,21 +11,13 @@ pub(crate) trait Clustering {
 }
 
 /// K-means with L2-based initialization and arithmetic mean centroids.
-/// Suitable for L2 and DotProduct metrics.
 pub(crate) struct KMeansPP {
     metric: DistanceMetric,
 }
 
-/// Spherical k-means: cosine-aware initialization and L2-normalized centroids.
-/// Suitable for Cosine metric.
-pub(crate) struct SphericalKMeans;
-
 /// Create a clustering strategy appropriate for the given distance metric.
 pub(crate) fn for_metric(metric: DistanceMetric) -> Box<dyn Clustering + Send> {
-    match metric {
-        DistanceMetric::Cosine => Box::new(SphericalKMeans),
-        _ => Box::new(KMeansPP { metric }),
-    }
+    Box::new(KMeansPP { metric })
 }
 
 /// Compute the arithmetic mean vector of a set of vectors.
@@ -44,14 +36,6 @@ fn mean_vector(vectors: &[&[f32]], dimensions: usize) -> Vec<f32> {
         *val /= n;
     }
     mean
-}
-
-/// L2-normalize a vector in place.
-fn normalize(v: &mut [f32]) {
-    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if norm > 0.0 {
-        v.iter_mut().for_each(|x| *x /= norm);
-    }
 }
 
 /// Farthest-pair initialization using a given distance metric.
@@ -87,54 +71,6 @@ fn kmeans_pp_init_l2(vectors: &[(u64, &[f32])]) -> (usize, usize) {
                 .zip(vectors[idx_a].1.iter())
                 .map(|(a, b)| (a - b) * (a - b))
                 .sum()
-        })
-        .collect();
-    let total: f32 = distances.iter().sum();
-
-    let idx_b = if total > 0.0 {
-        let threshold = rng.gen_range(0.0..total);
-        let mut cumsum = 0.0;
-        let mut chosen = 0;
-        for (i, &d) in distances.iter().enumerate() {
-            cumsum += d;
-            if cumsum >= threshold {
-                chosen = i;
-                break;
-            }
-        }
-        chosen
-    } else if idx_a == 0 {
-        1
-    } else {
-        0
-    };
-
-    (idx_a, idx_b)
-}
-
-/// K-means++ initialization using cosine dissimilarity (1 - cosine_similarity).
-/// Picks first centroid randomly, then picks second with probability proportional
-/// to `1.0 - cosine_similarity` from the first.
-fn kmeans_pp_init_cosine(vectors: &[(u64, &[f32])]) -> (usize, usize) {
-    let mut rng = rand::thread_rng();
-    let idx_a = rng.gen_range(0..vectors.len());
-
-    let distances: Vec<f32> = vectors
-        .iter()
-        .map(|(_, v)| {
-            let dot: f32 = v
-                .iter()
-                .zip(vectors[idx_a].1.iter())
-                .map(|(a, b)| a * b)
-                .sum();
-            let norm_v: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
-            let norm_a: f32 = vectors[idx_a].1.iter().map(|x| x * x).sum::<f32>().sqrt();
-            let sim = if norm_v > 0.0 && norm_a > 0.0 {
-                dot / (norm_v * norm_a)
-            } else {
-                0.0
-            };
-            (1.0 - sim).max(0.0)
         })
         .collect();
     let total: f32 = distances.iter().sum();
@@ -218,11 +154,6 @@ fn kmeans_loop(
 /// Identity update — no post-processing after computing the mean.
 fn identity(_v: &mut [f32]) {}
 
-/// Normalize the centroid vector to unit length.
-fn normalize_centroid(v: &mut [f32]) {
-    normalize(v);
-}
-
 impl Clustering for KMeansPP {
     fn two_means(&self, vectors: &[(u64, &[f32])], dimensions: usize) -> (Vec<f32>, Vec<f32>) {
         assert!(vectors.len() >= 2, "two_means requires at least 2 vectors");
@@ -237,32 +168,6 @@ impl Clustering for KMeansPP {
         let mut c1 = vectors[idx_b].1.to_vec();
 
         kmeans_loop(vectors, dimensions, self.metric, &mut c0, &mut c1, identity);
-
-        (c0, c1)
-    }
-}
-
-impl Clustering for SphericalKMeans {
-    fn two_means(&self, vectors: &[(u64, &[f32])], dimensions: usize) -> (Vec<f32>, Vec<f32>) {
-        assert!(vectors.len() >= 2, "two_means requires at least 2 vectors");
-
-        let (idx_a, idx_b) = if vectors.len() <= 100 {
-            farthest_pair_init(vectors, DistanceMetric::Cosine)
-        } else {
-            kmeans_pp_init_cosine(vectors)
-        };
-
-        let mut c0 = vectors[idx_a].1.to_vec();
-        let mut c1 = vectors[idx_b].1.to_vec();
-
-        kmeans_loop(
-            vectors,
-            dimensions,
-            DistanceMetric::Cosine,
-            &mut c0,
-            &mut c1,
-            normalize_centroid,
-        );
 
         (c0, c1)
     }
@@ -317,54 +222,6 @@ mod tests {
             "centroids should match inputs: c0={:?}, c1={:?}",
             c0,
             c1
-        );
-    }
-
-    #[test]
-    fn should_work_with_cosine_metric() {
-        // given - vectors pointing in different directions
-        let vectors: Vec<(u64, Vec<f32>)> = vec![
-            (1, vec![1.0, 0.0, 0.0]),
-            (2, vec![0.9, 0.1, 0.0]),
-            (3, vec![0.0, 0.0, 1.0]),
-            (4, vec![0.0, 0.1, 0.9]),
-        ];
-        let refs: Vec<(u64, &[f32])> = vectors.iter().map(|(id, v)| (*id, v.as_slice())).collect();
-
-        // when
-        let clustering = for_metric(DistanceMetric::Cosine);
-        let (c0, c1) = clustering.two_means(&refs, 3);
-
-        // then - centroids should separate into two groups
-        assert_ne!(c0, c1, "centroids should be different");
-    }
-
-    #[test]
-    fn should_produce_normalized_centroids_for_spherical_kmeans() {
-        // given - vectors in different directions (not unit length)
-        let vectors: Vec<(u64, Vec<f32>)> = vec![
-            (1, vec![3.0, 0.0, 0.0]),
-            (2, vec![2.7, 0.3, 0.0]),
-            (3, vec![0.0, 0.0, 5.0]),
-            (4, vec![0.0, 0.5, 4.5]),
-        ];
-        let refs: Vec<(u64, &[f32])> = vectors.iter().map(|(id, v)| (*id, v.as_slice())).collect();
-
-        // when
-        let (c0, c1) = SphericalKMeans.two_means(&refs, 3);
-
-        // then - both centroids should be approximately unit length
-        let norm_c0: f32 = c0.iter().map(|x| x * x).sum::<f32>().sqrt();
-        let norm_c1: f32 = c1.iter().map(|x| x * x).sum::<f32>().sqrt();
-        assert!(
-            (norm_c0 - 1.0).abs() < 1e-5,
-            "c0 should be unit length, got norm {}",
-            norm_c0
-        );
-        assert!(
-            (norm_c1 - 1.0).abs() < 1e-5,
-            "c1 should be unit length, got norm {}",
-            norm_c1
         );
     }
 

--- a/vector/src/model.rs
+++ b/vector/src/model.rs
@@ -293,7 +293,6 @@ pub struct SearchResult {
     /// Similarity score (interpretation depends on distance metric)
     ///
     /// - L2: Lower scores = more similar
-    /// - Cosine: Higher scores = more similar (range: -1 to 1)
     /// - DotProduct: Higher scores = more similar
     pub score: f32,
     /// Attribute key-value pairs

--- a/vector/src/serde/collection_meta.rs
+++ b/vector/src/serde/collection_meta.rs
@@ -47,16 +47,13 @@ use bytes::{Bytes, BytesMut};
 /// The distance metric determines how vector similarity is computed during search.
 /// This is set at collection creation and cannot be changed afterward.
 ///
-/// - **L2**: Euclidean distance. Lower values = more similar. Best for normalized vectors.
-/// - **Cosine**: Cosine similarity. Higher values = more similar. Automatically normalizes.
-/// - **DotProduct**: Dot product. Higher values = more similar. Fastest but requires normalized vectors.
+/// - **L2**: Euclidean distance. Lower values = more similar.
+/// - **DotProduct**: Dot product. Higher values = more similar. Requires normalized vectors.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[repr(u8)]
 pub enum DistanceMetric {
     /// Euclidean (L2) distance: sqrt(sum((a\[i\] - b\[i\])²))
     L2 = 0,
-    /// Cosine similarity: dot(a, b) / (|a| * |b|)
-    Cosine = 1,
     /// Dot product: sum(a\[i\] * b\[i\])
     DotProduct = 2,
 }
@@ -65,7 +62,6 @@ impl DistanceMetric {
     pub fn from_byte(byte: u8) -> Result<Self, EncodingError> {
         match byte {
             0 => Ok(DistanceMetric::L2),
-            1 => Ok(DistanceMetric::Cosine),
             2 => Ok(DistanceMetric::DotProduct),
             _ => Err(EncodingError {
                 message: format!("Invalid distance metric: {}", byte),
@@ -148,7 +144,7 @@ impl Decode for MetadataFieldSpec {
 /// ┌────────────────────────────────────────────────────────────────┐
 /// │  schema_version:    u32                                        │
 /// │  dimensions:        u16                                        │
-/// │  distance_metric:   u8   (0=L2, 1=cosine, 2=dot_product)       │
+/// │  distance_metric:   u8   (0=L2, 2=dot_product)                  │
 /// │  chunk_target:      u16  (centroids per chunk, default 4096)   │
 /// │  metadata_fields:   Array<MetadataFieldSpec>                   │
 /// │                                                                │
@@ -263,7 +259,7 @@ mod tests {
         // given
         let value = CollectionMetaValue::new(
             1536,
-            DistanceMetric::Cosine,
+            DistanceMetric::DotProduct,
             4096,
             vec![
                 MetadataFieldSpec::new("category", FieldType::String, true),
@@ -299,7 +295,7 @@ mod tests {
         // given
         let value = CollectionMetaValue::new(
             1536,
-            DistanceMetric::Cosine,
+            DistanceMetric::DotProduct,
             4096,
             vec![
                 MetadataFieldSpec::new("category", FieldType::String, true),
@@ -324,7 +320,7 @@ mod tests {
         // given
         let value = CollectionMetaValue::new(
             1536,
-            DistanceMetric::Cosine,
+            DistanceMetric::DotProduct,
             4096,
             vec![
                 MetadataFieldSpec::new("category", FieldType::String, true),
@@ -342,11 +338,7 @@ mod tests {
 
     #[test]
     fn should_preserve_all_distance_metrics() {
-        for metric in [
-            DistanceMetric::L2,
-            DistanceMetric::Cosine,
-            DistanceMetric::DotProduct,
-        ] {
+        for metric in [DistanceMetric::L2, DistanceMetric::DotProduct] {
             // given
             let value = CollectionMetaValue::new(128, metric, 2048, vec![]);
 


### PR DESCRIPTION
## Summary

drops support for the cosine distance metric. Cosine distance handling typically works by normalizing vectors to the unit sphere and then using euclidean (l2) distance. This way we can use the same clustering and search heuristics. For now, users can normalize vectors before ingesting. The recall test does this for the cohere data set. In a later patch, we'll add back cosine distance and normalize when preparing vectors for insert

## Test Plan

- unit tests
- cohere recall benchmark

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
