### PR TITLE
add initial limited support for attribute filtering to vector db

### DIFF
--- a/vector/bench/src/recall.rs
+++ b/vector/bench/src/recall.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use bencher::{Bench, Benchmark, Params, Summary};
 use common::StorageRuntime;
 use common::storage::factory::{FoyerCache, FoyerCacheOptions};
-use vector::{Config, DistanceMetric, SearchResult, Vector, VectorDb, VectorDbRead};
+use vector::{Config, DistanceMetric, Query, SearchResult, Vector, VectorDb, VectorDbRead};
 
 const DEFAULT_NUM_QUERIES: usize = 100;
 
@@ -590,7 +590,8 @@ impl Benchmark for RecallBenchmark {
         let mut cold_latencies_us = Vec::with_capacity(queries.len());
         for query in queries.iter() {
             let t = std::time::Instant::now();
-            let _ = db.search_with_nprobe(query, k, dataset.nprobe).await?;
+            let q = Query::new(query.clone()).with_limit(k);
+            let _ = db.search_with_nprobe(&q, dataset.nprobe).await?;
             let elapsed_us = t.elapsed().as_secs_f64() * 1_000_000.0;
             query_latency.record(elapsed_us);
             cold_latencies_us.push(elapsed_us);
@@ -607,7 +608,8 @@ impl Benchmark for RecallBenchmark {
         let mut latencies_us = Vec::with_capacity(queries.len());
         for (i, query) in queries.iter().enumerate() {
             let t = std::time::Instant::now();
-            let results = db.search_with_nprobe(query, k, dataset.nprobe).await?;
+            let q = Query::new(query.clone()).with_limit(k);
+            let results = db.search_with_nprobe(&q, dataset.nprobe).await?;
             let elapsed_us = t.elapsed().as_secs_f64() * 1_000_000.0;
             query_latency.record(elapsed_us);
             latencies_us.push(elapsed_us);

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -19,13 +19,14 @@ use crate::flusher::VectorDbFlusher;
 use crate::hnsw::{CentroidGraph, build_centroid_graph};
 use crate::lire::rebalancer::{IndexRebalancer, IndexRebalancerOpts};
 use crate::model::{
-    AttributeValue, Config, SearchResult, VECTOR_FIELD_NAME, Vector, attributes_to_map,
+    AttributeValue, Config, Query, SearchResult, VECTOR_FIELD_NAME, Vector, attributes_to_map,
 };
 use crate::query_engine::{QueryEngine, QueryEngineOptions};
 use crate::serde::centroid_chunk::CentroidEntry;
 use crate::serde::key::SeqBlockKey;
 use crate::storage::VectorDbStorageReadExt;
 use crate::storage::merge_operator::VectorDbMergeOperator;
+use async_trait::async_trait;
 use common::SequenceAllocator;
 use common::coordinator::{Durability, WriteCoordinator, WriteCoordinatorConfig};
 use common::storage::factory::create_storage;
@@ -40,6 +41,7 @@ pub(crate) const WRITE_CHANNEL: &str = "write";
 pub(crate) const REBALANCE_CHANNEL: &str = "rebalance";
 
 /// Trait for querying the vector db
+#[async_trait]
 pub trait VectorDbRead {
     /// Search for k-nearest neighbors to a query vector.
     ///
@@ -50,8 +52,7 @@ pub trait VectorDbRead {
     /// 4. Score candidates and return top-k
     ///
     /// # Arguments
-    /// * `query` - Query vector
-    /// * `k` - Number of nearest neighbors to return
+    /// * `query` - search query
     ///
     /// # Returns
     /// Vector of SearchResults sorted by similarity (best first)
@@ -60,18 +61,9 @@ pub trait VectorDbRead {
     /// Returns an error if:
     /// - Query dimensions don't match collection dimensions
     /// - Storage read fails
-    fn search(
-        &self,
-        query: &[f32],
-        k: usize,
-    ) -> impl std::future::Future<Output = Result<Vec<SearchResult>>> + Send;
+    async fn search(&self, query: &Query) -> Result<Vec<SearchResult>>;
 
-    fn search_with_nprobe(
-        &self,
-        query: &[f32],
-        k: usize,
-        nprobe: usize,
-    ) -> impl std::future::Future<Output = Result<Vec<SearchResult>>> + Send;
+    async fn search_with_nprobe(&self, query: &Query, nprobe: usize) -> Result<Vec<SearchResult>>;
 
     /// Retrieve a vector record by its external ID.
     ///
@@ -85,7 +77,7 @@ pub trait VectorDbRead {
     /// # Returns
     ///
     /// `Some(VectorRecord)` if found, `None` if not found or deleted.
-    fn get(&self, id: &str) -> impl std::future::Future<Output = Result<Option<Vector>>> + Send;
+    async fn get(&self, id: &str) -> Result<Option<Vector>>;
 }
 
 /// Vector database for storing and querying embedding vectors.
@@ -222,6 +214,7 @@ impl VectorDb {
                 rebalance_backpressure_resume_threshold: config
                     .rebalance_backpressure_resume_threshold,
                 split_threshold_vectors: config.split_threshold_vectors,
+                indexed_fields: VectorDbDeltaOpts::indexed_fields_from(&config.metadata_fields),
             },
             dictionary: Arc::clone(&dictionary),
             centroid_graph: Arc::clone(&centroid_graph),
@@ -662,34 +655,23 @@ impl VectorDb {
     }
 
     /// Search using brute-force centroid lookup (for diagnostics).
-    /// Compares all centroids to the query to find the true nearest ones,
-    /// bypassing HNSW entirely.
     pub async fn search_exact_nprobe(
         &self,
-        query: &[f32],
-        k: usize,
+        query: &Query,
         nprobe: usize,
     ) -> Result<Vec<SearchResult>> {
-        self.query_engine()
-            .search_exact_nprobe(query, k, nprobe)
-            .await
+        self.query_engine().search_exact_nprobe(query, nprobe).await
     }
 }
 
+#[async_trait]
 impl VectorDbRead for VectorDb {
-    async fn search(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {
-        self.query_engine().search(query, k).await
+    async fn search(&self, query: &Query) -> Result<Vec<SearchResult>> {
+        self.query_engine().search(query).await
     }
 
-    async fn search_with_nprobe(
-        &self,
-        query: &[f32],
-        k: usize,
-        nprobe: usize,
-    ) -> Result<Vec<SearchResult>> {
-        self.query_engine()
-            .search_with_nprobe(query, k, nprobe)
-            .await
+    async fn search_with_nprobe(&self, query: &Query, nprobe: usize) -> Result<Vec<SearchResult>> {
+        self.query_engine().search_with_nprobe(query, nprobe).await
     }
 
     async fn get(&self, id: &str) -> Result<Option<Vector>> {
@@ -889,7 +871,10 @@ mod tests {
             .unwrap();
 
         // then - should be able to search (dictionary and centroids loaded from storage)
-        let results = db2.search(&[1.0, 0.0, 0.0], 10).await.unwrap();
+        let results = db2
+            .search(&Query::new(vec![1.0, 0.0, 0.0]).with_limit(10))
+            .await
+            .unwrap();
         assert!(!results.is_empty());
     }
 
@@ -929,7 +914,10 @@ mod tests {
 
         // Reopen from durable state — data should be visible
         let db2 = VectorDb::open(config).await.unwrap();
-        let results = db2.search(&[1.0, 0.0, 0.0], 10).await.unwrap();
+        let results = db2
+            .search(&Query::new(vec![1.0, 0.0, 0.0]).with_limit(10))
+            .await
+            .unwrap();
         assert!(
             !results.is_empty(),
             "expected data to be durable after flush, but search returned no results"
@@ -937,6 +925,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::needless_return)]
     async fn close_without_explicit_flush_guarantees_durability() {
         use common::storage::config::{
             LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig,
@@ -970,7 +959,10 @@ mod tests {
 
         // Reopen and verify the vector survived
         let db2 = VectorDb::open(config).await.unwrap();
-        let results = db2.search(&[1.0, 0.0, 0.0], 1).await.unwrap();
+        let results = db2
+            .search(&Query::new(vec![1.0, 0.0, 0.0]).with_limit(1))
+            .await
+            .unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].external_id, "vec-1");
     }

--- a/vector/src/delta.rs
+++ b/vector/src/delta.rs
@@ -24,7 +24,8 @@ use std::sync::{Arc, OnceLock};
 use crate::hnsw::CentroidGraph;
 use crate::lire::commands::RebalanceCommand;
 use crate::lire::rebalancer::IndexRebalancer;
-use crate::model::AttributeValue;
+use crate::model::{AttributeValue, MetadataFieldSpec, VECTOR_FIELD_NAME};
+use crate::serde::FieldValue;
 use crate::serde::posting_list::PostingUpdate;
 use crate::storage::record;
 use common::SequenceAllocator;
@@ -32,6 +33,7 @@ use common::coordinator::{Delta, PauseHandle};
 use common::storage::RecordOp;
 use dashmap::DashMap;
 use roaring::RoaringTreemap;
+use std::collections::HashSet;
 use tracing::debug;
 // ============================================================================
 // WriteCoordinator Integration Types
@@ -65,6 +67,19 @@ pub(crate) struct VectorDbDeltaOpts {
     pub(crate) max_pending_and_running_rebalance_tasks: usize,
     pub(crate) split_threshold_vectors: usize,
     pub(crate) rebalance_backpressure_resume_threshold: usize,
+    /// Names of indexed metadata fields (for maintaining the inverted index).
+    pub(crate) indexed_fields: HashSet<String>,
+}
+
+impl VectorDbDeltaOpts {
+    /// Build the set of indexed field names from metadata field specs.
+    pub(crate) fn indexed_fields_from(specs: &[MetadataFieldSpec]) -> HashSet<String> {
+        specs
+            .iter()
+            .filter(|s| s.indexed)
+            .map(|s| s.name.clone())
+            .collect()
+    }
 }
 
 /// Image containing shared state for the delta.
@@ -179,6 +194,13 @@ impl Delta for VectorDbWriteDelta {
             ops.push(record::merge_centroid_stats(*centroid_id, count));
         }
 
+        // Finalize metadata inverted index merges
+        for (encoded_key, vector_ids) in &view.metadata_index_updates {
+            if let Ok(op) = record::merge_metadata_index_bitmap(encoded_key.clone(), vector_ids) {
+                ops.push(op);
+            }
+        }
+
         // Finalize deleted vectors merge
         if !view.deleted_centroids.is_empty() {
             let op = record::merge_deleted_vectors(view.deleted_centroids.clone())
@@ -257,6 +279,18 @@ impl VectorDbWriteDelta {
                 &write.attributes,
             ));
 
+            // Accumulate metadata inverted index postings for indexed attributes
+            for (attr_name, attr_value) in &write.attributes {
+                if attr_name == VECTOR_FIELD_NAME {
+                    continue;
+                }
+                if !self.ctx.opts.indexed_fields.contains(attr_name) {
+                    continue;
+                }
+                let field_value: FieldValue = attr_value.clone().into();
+                view.add_to_metadata_index(attr_name.clone(), field_value, new_internal_id);
+            }
+
             // Accumulate posting list update
             view.add_to_posting(centroid_id, new_internal_id, write.values);
             self.ctx.rebalancer.update_counts(&[(centroid_id, 1)])
@@ -272,6 +306,9 @@ impl VectorDbWriteDelta {
 pub(crate) struct VectorDbDeltaView {
     pub(crate) posting_updates: HashMap<u64, Vec<PostingUpdate>>,
     pub(crate) deleted_centroids: RoaringTreemap,
+    /// Accumulated metadata index postings: encoded key → set of vector IDs.
+    /// Built into merge ops during freeze().
+    pub(crate) metadata_index_updates: HashMap<bytes::Bytes, RoaringTreemap>,
 }
 
 impl VectorDbDeltaView {
@@ -279,6 +316,7 @@ impl VectorDbDeltaView {
         Self {
             posting_updates: HashMap::new(),
             deleted_centroids: RoaringTreemap::new(),
+            metadata_index_updates: HashMap::new(),
         }
     }
 
@@ -287,6 +325,20 @@ impl VectorDbDeltaView {
             .entry(centroid_id)
             .or_default()
             .push(PostingUpdate::append(vector_id, vector));
+    }
+
+    pub(crate) fn add_to_metadata_index(
+        &mut self,
+        field_name: String,
+        field_value: FieldValue,
+        vector_id: u64,
+    ) {
+        let key = crate::serde::key::MetadataIndexKey::new(field_name, field_value).encode();
+        #[allow(clippy::unwrap_or_default)]
+        self.metadata_index_updates
+            .entry(key)
+            .or_insert_with(RoaringTreemap::new)
+            .insert(vector_id);
     }
 
     pub(crate) fn delete_from_posting(&mut self, centroid_id: u64, vector_id: u64) {
@@ -379,6 +431,7 @@ mod tests {
                 max_pending_and_running_rebalance_tasks: usize::MAX,
                 split_threshold_vectors: usize::MAX,
                 rebalance_backpressure_resume_threshold: 0,
+                indexed_fields: HashSet::new(),
             },
             dictionary: Arc::new(DashMap::new()),
             centroid_graph,
@@ -711,6 +764,7 @@ mod tests {
                 max_pending_and_running_rebalance_tasks: usize::MAX,
                 split_threshold_vectors: usize::MAX,
                 rebalance_backpressure_resume_threshold: 0,
+                indexed_fields: HashSet::new(),
             },
             dictionary: Arc::new(DashMap::new()),
             centroid_graph,
@@ -833,6 +887,168 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_emit_metadata_index_merge_ops_for_indexed_fields() {
+        // given - context with "category" as an indexed field
+        let storage: Arc<dyn common::Storage> = Arc::new(InMemoryStorage::new());
+        let key = Bytes::from_static(&[0x01, 0x02]);
+        let id_allocator = SequenceAllocator::load(storage.as_ref(), key)
+            .await
+            .unwrap();
+        let centroid_graph: Arc<dyn CentroidGraph> =
+            Arc::new(MockCentroidGraph::new(vec![(1, vec![0.0; 3])]));
+        let rebalancer = IndexRebalancer::new(
+            IndexRebalancerOpts {
+                dimensions: 3,
+                distance_metric: DistanceMetric::L2,
+                split_search_neighbourhood: 4,
+                split_threshold_vectors: 10_000,
+                merge_threshold_vectors: 0,
+                max_rebalance_tasks: 0,
+            },
+            centroid_graph.clone(),
+            HashMap::new(),
+            Arc::new(std::sync::OnceLock::new()),
+        );
+
+        let ctx = VectorDbDeltaContext {
+            opts: VectorDbDeltaOpts {
+                dimensions: 3,
+                chunk_target: 4096,
+                max_pending_and_running_rebalance_tasks: usize::MAX,
+                split_threshold_vectors: usize::MAX,
+                rebalance_backpressure_resume_threshold: 0,
+                indexed_fields: HashSet::from(["category".to_string()]),
+            },
+            dictionary: Arc::new(DashMap::new()),
+            centroid_graph,
+            id_allocator,
+            current_chunk_id: 0,
+            current_chunk_count: 0,
+            rebalancer,
+            pause_handle: Arc::new(OnceLock::new()),
+        };
+        let mut delta = VectorDbWriteDelta::init(ctx);
+
+        let writes = vec![
+            VectorWrite {
+                external_id: "vec-1".to_string(),
+                values: vec![1.0, 0.0, 0.0],
+                attributes: vec![
+                    (
+                        "vector".to_string(),
+                        AttributeValue::Vector(vec![1.0, 0.0, 0.0]),
+                    ),
+                    (
+                        "category".to_string(),
+                        AttributeValue::String("shoes".to_string()),
+                    ),
+                ],
+            },
+            VectorWrite {
+                external_id: "vec-2".to_string(),
+                values: vec![0.0, 1.0, 0.0],
+                attributes: vec![
+                    (
+                        "vector".to_string(),
+                        AttributeValue::Vector(vec![0.0, 1.0, 0.0]),
+                    ),
+                    (
+                        "category".to_string(),
+                        AttributeValue::String("shoes".to_string()),
+                    ),
+                ],
+            },
+            VectorWrite {
+                external_id: "vec-3".to_string(),
+                values: vec![0.0, 0.0, 1.0],
+                attributes: vec![
+                    (
+                        "vector".to_string(),
+                        AttributeValue::Vector(vec![0.0, 0.0, 1.0]),
+                    ),
+                    (
+                        "category".to_string(),
+                        AttributeValue::String("boots".to_string()),
+                    ),
+                ],
+            },
+        ];
+
+        // when
+        delta.apply(VectorDbWrite::Write(writes)).unwrap();
+        let (frozen, _view, _ctx) = delta.freeze();
+
+        // then - should have metadata index merge ops
+        let metadata_prefix = crate::serde::RecordType::MetadataIndex.prefix();
+        let mut prefix_buf = bytes::BytesMut::with_capacity(2);
+        metadata_prefix.write_to(&mut prefix_buf);
+        let prefix = prefix_buf.freeze();
+
+        let metadata_merges: Vec<_> = frozen
+            .ops
+            .iter()
+            .filter(|op| is_merge_with_key_prefix(op, &prefix))
+            .collect();
+
+        // Should have exactly 2 merge ops: one for (category, "shoes") and one for (category, "boots")
+        assert_eq!(
+            metadata_merges.len(),
+            2,
+            "should have 2 metadata index merge ops (one per unique field/value pair)"
+        );
+
+        // Decode the bitmaps and verify: "shoes" should have 2 vector IDs, "boots" should have 1
+        let mut bitmap_sizes: Vec<u64> = metadata_merges
+            .iter()
+            .map(|op| {
+                let RecordOp::Merge(record) = op else {
+                    panic!("expected merge op");
+                };
+                let bitmap = crate::serde::metadata_index::MetadataIndexValue::decode_from_bytes(
+                    &record.record.value,
+                )
+                .unwrap();
+                bitmap.len()
+            })
+            .collect();
+        bitmap_sizes.sort();
+        assert_eq!(
+            bitmap_sizes,
+            vec![1, 2],
+            "should have bitmaps with 1 and 2 entries"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_not_emit_metadata_index_ops_for_non_indexed_fields() {
+        // given - context with NO indexed fields
+        let ctx = create_test_context(1).await;
+        let mut delta = VectorDbWriteDelta::init(ctx);
+
+        let write = create_vector_write("vec-1", vec![1.0, 2.0, 3.0]);
+
+        // when
+        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        let (frozen, _view, _ctx) = delta.freeze();
+
+        // then - should have NO metadata index merge ops
+        let metadata_prefix = crate::serde::RecordType::MetadataIndex.prefix();
+        let mut prefix_buf = bytes::BytesMut::with_capacity(2);
+        metadata_prefix.write_to(&mut prefix_buf);
+        let prefix = prefix_buf.freeze();
+
+        let metadata_merges = frozen
+            .ops
+            .iter()
+            .filter(|op| is_merge_with_key_prefix(op, &prefix))
+            .count();
+        assert_eq!(
+            metadata_merges, 0,
+            "should have no metadata index ops when no fields are indexed"
+        );
+    }
+
+    #[tokio::test]
     async fn should_update_centroid_counts_per_centroid() {
         // given - create a mock that routes vectors to different centroids
         struct MultiCentroidGraph;
@@ -893,6 +1109,7 @@ mod tests {
                 max_pending_and_running_rebalance_tasks: usize::MAX,
                 split_threshold_vectors: usize::MAX,
                 rebalance_backpressure_resume_threshold: 0,
+                indexed_fields: HashSet::new(),
             },
             dictionary: Arc::new(DashMap::new()),
             centroid_graph,

--- a/vector/src/lib.rs
+++ b/vector/src/lib.rs
@@ -52,7 +52,7 @@ pub(crate) mod test_utils;
 pub use db::{VectorDb, VectorDbRead};
 pub use error::{Error, Result};
 pub use model::{
-    Attribute, AttributeValue, Config, DistanceMetric, FieldType, MetadataFieldSpec, SearchResult,
-    Vector, VectorBuilder,
+    Attribute, AttributeValue, Config, DistanceMetric, FieldType, Filter, MetadataFieldSpec, Query,
+    ReaderConfig, SearchResult, Vector, VectorBuilder,
 };
 pub use reader::VectorDbReader;

--- a/vector/src/lire/rebalancer.rs
+++ b/vector/src/lire/rebalancer.rs
@@ -1007,6 +1007,7 @@ mod tests {
                     max_pending_and_running_rebalance_tasks: usize::MAX,
                     split_threshold_vectors: usize::MAX / 2,
                     rebalance_backpressure_resume_threshold: 0,
+                    indexed_fields: std::collections::HashSet::new(),
                 },
                 dictionary: Arc::new(DashMap::new()),
                 centroid_graph: centroid_graph.clone(),

--- a/vector/src/model.rs
+++ b/vector/src/model.rs
@@ -328,6 +328,93 @@ pub struct SearchResult {
     pub attributes: HashMap<String, AttributeValue>,
 }
 
+/// Query specification for vector search.
+///
+/// Constructed using the builder pattern:
+///
+/// ```ignore
+/// let query = Query::new(embedding)
+///     .with_limit(10)
+///     .with_filter(Filter::eq("category", "shoes"));
+/// ```
+#[derive(Debug, Clone)]
+pub struct Query {
+    /// Query vector (required).
+    pub vector: Vec<f32>,
+    /// Maximum number of results to return (default: 10).
+    pub limit: usize,
+    /// Optional metadata filter.
+    pub filter: Option<Filter>,
+}
+
+impl Query {
+    /// Creates a new query with the given vector.
+    pub fn new(vector: Vec<f32>) -> Self {
+        Self {
+            vector,
+            limit: 10,
+            filter: None,
+        }
+    }
+
+    /// Sets the maximum number of results to return.
+    pub fn with_limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    /// Sets the metadata filter.
+    pub fn with_filter(mut self, filter: Filter) -> Self {
+        self.filter = Some(filter);
+        self
+    }
+}
+
+/// Metadata filter for search queries.
+///
+/// Filters are composed using simple predicates and logical operators.
+/// All filters are evaluated against the metadata inverted indexes.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Filter {
+    /// Field equals value.
+    Eq(String, AttributeValue),
+    /// Field not equals value.
+    Neq(String, AttributeValue),
+    /// Field is in set of values.
+    In(String, Vec<AttributeValue>),
+    /// All filters must match (logical AND).
+    And(Vec<Filter>),
+    /// Any filter must match (logical OR).
+    Or(Vec<Filter>),
+}
+
+impl Filter {
+    /// Creates an equality filter.
+    pub fn eq(field: impl Into<String>, value: impl Into<AttributeValue>) -> Self {
+        Filter::Eq(field.into(), value.into())
+    }
+
+    /// Creates a not-equals filter.
+    pub fn neq(field: impl Into<String>, value: impl Into<AttributeValue>) -> Self {
+        Filter::Neq(field.into(), value.into())
+    }
+
+    /// Creates an in-set filter.
+    pub fn in_set(field: impl Into<String>, values: Vec<AttributeValue>) -> Self {
+        Filter::In(field.into(), values)
+    }
+
+    /// Combines filters with logical AND.
+    pub fn and(filters: Vec<Filter>) -> Self {
+        Filter::And(filters)
+    }
+
+    /// Combines filters with logical OR.
+    pub fn or(filters: Vec<Filter>) -> Self {
+        Filter::Or(filters)
+    }
+}
+
 /// Helper to build a metadata map from attributes.
 pub(crate) fn attributes_to_map(attributes: &[Attribute]) -> HashMap<String, AttributeValue> {
     attributes

--- a/vector/src/query_engine.rs
+++ b/vector/src/query_engine.rs
@@ -1,11 +1,12 @@
 use crate::error::{Error, Result};
 use crate::hnsw::CentroidGraph;
-use crate::model::{AttributeValue, SearchResult};
+use crate::model::{AttributeValue, Filter, Query, SearchResult};
 use crate::serde::collection_meta::DistanceMetric;
 use crate::serde::posting_list::PostingList;
 use crate::storage::VectorDbStorageReadExt;
 use crate::{Attribute, Vector, distance};
 use common::storage::StorageRead;
+use roaring::RoaringTreemap;
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::sync::Arc;
@@ -78,33 +79,33 @@ impl QueryEngine {
         }))
     }
 
-    pub(crate) async fn search(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {
-        let nprobe = k.clamp(10, 100);
-        self.search_with_nprobe(query, k, nprobe).await
+    pub(crate) async fn search(&self, query: &Query) -> Result<Vec<SearchResult>> {
+        let nprobe = query.limit.clamp(10, 100);
+        self.search_with_nprobe(query, nprobe).await
     }
 
     pub(crate) async fn search_exact_nprobe(
         &self,
-        query: &[f32],
-        k: usize,
+        query: &Query,
         nprobe: usize,
     ) -> Result<Vec<SearchResult>> {
-        if query.len() != self.options.dimensions as usize {
+        if query.vector.len() != self.options.dimensions as usize {
             return Err(Error::InvalidInput(format!(
                 "Query dimension mismatch: expected {}, got {}",
                 self.options.dimensions,
-                query.len()
+                query.vector.len()
             )));
         }
 
         // Brute-force: compute distance from query to every centroid
         let num_centroids = self.centroid_graph.len();
-        let all_centroid_ids = self.centroid_graph.search(query, num_centroids);
+        let all_centroid_ids = self.centroid_graph.search(&query.vector, num_centroids);
         let mut scored: Vec<(u64, distance::VectorDistance)> = all_centroid_ids
             .iter()
             .filter_map(|&cid| {
                 let cv = self.centroid_graph.get_centroid_vector(cid)?;
-                let d = distance::compute_distance(query, &cv, self.options.distance_metric);
+                let d =
+                    distance::compute_distance(&query.vector, &cv, self.options.distance_metric);
                 Some((cid, d))
             })
             .collect();
@@ -115,33 +116,38 @@ impl QueryEngine {
             return Ok(Vec::new());
         }
 
-        let centroid_ids = self.prune_centroids(&centroid_ids, query);
+        let centroid_ids = self.prune_centroids(&centroid_ids, &query.vector);
 
-        let sorted_lists = self.load_and_score(&centroid_ids, query).await?;
+        let mut sorted_lists = self.load_and_score(&centroid_ids, &query.vector).await?;
         if sorted_lists.is_empty() {
             return Ok(Vec::new());
         }
-        self.resolve_top_k(sorted_lists, k).await
+
+        // Apply metadata filter
+        if let Some(filter) = &query.filter {
+            Self::apply_filter(&mut sorted_lists, filter, self.storage.as_ref()).await?;
+        }
+
+        self.resolve_top_k(sorted_lists, query.limit).await
     }
 
     pub(crate) async fn search_with_nprobe(
         &self,
-        query: &[f32],
-        k: usize,
+        query: &Query,
         nprobe: usize,
     ) -> Result<Vec<SearchResult>> {
         // 1. Validate query dimensions
-        if query.len() != self.options.dimensions as usize {
+        if query.vector.len() != self.options.dimensions as usize {
             return Err(Error::InvalidInput(format!(
                 "Query dimension mismatch: expected {}, got {}",
                 self.options.dimensions,
-                query.len()
+                query.vector.len()
             )));
         }
 
         // 2. Search HNSW for nearest centroids
         let num_centroids = nprobe;
-        let centroid_ids = self.centroid_graph.search(query, num_centroids);
+        let centroid_ids = self.centroid_graph.search(&query.vector, num_centroids);
         debug!(
             "searched for {} centroids, found: {}",
             num_centroids,
@@ -154,23 +160,28 @@ impl QueryEngine {
 
         // 3. Dynamic pruning: skip posting lists whose centroids are far from query
         let original_ncentroids = centroid_ids.len();
-        let centroid_ids = self.prune_centroids(&centroid_ids, query);
+        let centroid_ids = self.prune_centroids(&centroid_ids, &query.vector);
         debug!(
             "query: {:?}, before pruning: {} centroids, after dynamic pruning: {} centroids",
-            query,
+            query.vector,
             original_ncentroids,
             centroid_ids.len()
         );
 
         // 4. Load posting lists and score candidates
-        let sorted_lists = self.load_and_score(&centroid_ids, query).await?;
+        let mut sorted_lists = self.load_and_score(&centroid_ids, &query.vector).await?;
 
         if sorted_lists.is_empty() {
             return Ok(Vec::new());
         }
 
-        // 5. K-way merge and resolve top-k forward index lookups
-        self.resolve_top_k(sorted_lists, k).await
+        // 5. Apply metadata filter (if provided)
+        if let Some(filter) = &query.filter {
+            Self::apply_filter(&mut sorted_lists, filter, self.storage.as_ref()).await?;
+        }
+
+        // 6. K-way merge and resolve top-k forward index lookups
+        self.resolve_top_k(sorted_lists, query.limit).await
     }
 
     /// Apply query-aware dynamic pruning
@@ -341,6 +352,91 @@ impl QueryEngine {
 
         Ok(results)
     }
+
+    /// Apply a metadata filter to scored candidate lists.
+    ///
+    /// Collects all candidate IDs into a bitmap, evaluates the filter against
+    /// the inverted index, then retains only candidates that pass the filter.
+    async fn apply_filter(
+        sorted_lists: &mut [Vec<ScoredCandidate>],
+        filter: &Filter,
+        storage: &dyn StorageRead,
+    ) -> Result<()> {
+        // Collect all candidate internal IDs
+        let mut candidates = RoaringTreemap::new();
+        for list in sorted_lists.iter() {
+            for candidate in list {
+                candidates.insert(candidate.internal_id);
+            }
+        }
+
+        // Evaluate filter to get allowed IDs
+        let allowed = Self::evaluate_filter(filter, &candidates, storage).await?;
+
+        // Filter each list
+        for list in sorted_lists.iter_mut() {
+            list.retain(|c| allowed.contains(c.internal_id));
+        }
+
+        Ok(())
+    }
+
+    /// Recursively evaluate a filter against the metadata inverted index.
+    ///
+    /// Returns a bitmap of vector IDs that match the filter.
+    /// For Neq, the `candidates` bitmap is used as the universe for complement.
+    fn evaluate_filter<'a>(
+        filter: &'a Filter,
+        candidates: &'a RoaringTreemap,
+        storage: &'a dyn StorageRead,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<RoaringTreemap>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            match filter {
+                Filter::Eq(field, value) => {
+                    let field_value: crate::serde::FieldValue = value.clone().into();
+                    let bitmap = storage.get_metadata_index(field, field_value).await?;
+                    Ok(bitmap.vector_ids)
+                }
+                Filter::Neq(field, value) => {
+                    let field_value: crate::serde::FieldValue = value.clone().into();
+                    let bitmap = storage.get_metadata_index(field, field_value).await?;
+                    let mut result = candidates.clone();
+                    result -= &bitmap.vector_ids;
+                    Ok(result)
+                }
+                Filter::In(field, values) => {
+                    let mut result = RoaringTreemap::new();
+                    for value in values {
+                        let field_value: crate::serde::FieldValue = value.clone().into();
+                        let bitmap = storage.get_metadata_index(field, field_value).await?;
+                        result |= &bitmap.vector_ids;
+                    }
+                    Ok(result)
+                }
+                Filter::And(filters) => {
+                    if filters.is_empty() {
+                        return Ok(candidates.clone());
+                    }
+                    let mut result =
+                        Self::evaluate_filter(&filters[0], candidates, storage).await?;
+                    for f in &filters[1..] {
+                        let sub = Self::evaluate_filter(f, candidates, storage).await?;
+                        result &= &sub;
+                    }
+                    Ok(result)
+                }
+                Filter::Or(filters) => {
+                    let mut result = RoaringTreemap::new();
+                    for f in filters {
+                        let sub = Self::evaluate_filter(f, candidates, storage).await?;
+                        result |= &sub;
+                    }
+                    Ok(result)
+                }
+            }
+        })
+    }
 }
 
 struct ScoredCandidate {
@@ -375,7 +471,7 @@ impl Ord for MergeEntry {
 mod tests {
     use crate::AttributeValue;
     use crate::db::{VectorDb, VectorDbRead};
-    use crate::model::{Config, VECTOR_FIELD_NAME, Vector};
+    use crate::model::{Config, Query, VECTOR_FIELD_NAME, Vector};
     use crate::serde::collection_meta::DistanceMetric;
     use common::{StorageConfig, StorageRuntime};
 
@@ -512,8 +608,8 @@ mod tests {
         db.flush().await.unwrap();
 
         // when - search for vector similar to cluster 0
-        let query = vec![1.0; 128];
-        let results = db.query_engine().search(&query, 10).await.unwrap();
+        let q = Query::new(vec![1.0; 128]).with_limit(10);
+        let results = db.query_engine().search(&q).await.unwrap();
 
         // then - should find vectors from cluster 0
         assert_eq!(results.len(), 10);
@@ -552,7 +648,7 @@ mod tests {
         // when - search
         let results = db
             .query_engine()
-            .search(&[1.0, 0.0, 0.0], 10)
+            .search(&Query::new(vec![1.0, 0.0, 0.0]).with_limit(10))
             .await
             .unwrap();
 
@@ -586,7 +682,11 @@ mod tests {
         db.flush().await.unwrap();
 
         // when - search for vectors near origin
-        let results = db.query_engine().search(&[0.0, 0.0, 0.0], 3).await.unwrap();
+        let results = db
+            .query_engine()
+            .search(&Query::new(vec![0.0, 0.0, 0.0]).with_limit(3))
+            .await
+            .unwrap();
 
         // then - should be sorted by L2 distance (lower = better)
         assert_eq!(results.len(), 3);
@@ -610,7 +710,10 @@ mod tests {
         let db = VectorDb::open(config).await.unwrap();
 
         // when - query with wrong dimensions
-        let result = db.query_engine().search(&[1.0, 2.0], 10).await;
+        let result = db
+            .query_engine()
+            .search(&Query::new(vec![1.0, 2.0]).with_limit(10))
+            .await;
 
         // then - should fail
         assert!(result.is_err());
@@ -631,7 +734,7 @@ mod tests {
         // when
         let results = db
             .query_engine()
-            .search(&[1.0, 0.0, 0.0], 10)
+            .search(&Query::new(vec![1.0, 0.0, 0.0]).with_limit(10))
             .await
             .unwrap();
 
@@ -652,11 +755,217 @@ mod tests {
         db.flush().await.unwrap();
 
         // when - search for k=5
-        let results = db.query_engine().search(&[1.0, 0.0], 5).await.unwrap();
+        let results = db
+            .query_engine()
+            .search(&Query::new(vec![1.0, 0.0]).with_limit(5))
+            .await
+            .unwrap();
 
         // then
         assert_eq!(results.len(), 5);
     }
+
+    // --- Filter tests ---
+
+    use crate::model::{Filter, MetadataFieldSpec};
+    use crate::serde::FieldType;
+
+    fn create_filterable_config() -> Config {
+        Config {
+            storage: StorageConfig::InMemory,
+            dimensions: 3,
+            distance_metric: DistanceMetric::L2,
+            metadata_fields: vec![
+                MetadataFieldSpec::new("category", FieldType::String, true),
+                MetadataFieldSpec::new("price", FieldType::Int64, true),
+                MetadataFieldSpec::new("active", FieldType::Bool, true),
+            ],
+            ..Default::default()
+        }
+    }
+
+    async fn setup_filterable_db() -> VectorDb {
+        let config = create_filterable_config();
+        let db = VectorDb::open(config).await.unwrap();
+
+        let vectors = vec![
+            Vector::builder("shoes-1", vec![1.0, 0.0, 0.0])
+                .attribute("category", "shoes")
+                .attribute("price", 50i64)
+                .attribute("active", true)
+                .build(),
+            Vector::builder("shoes-2", vec![0.9, 0.1, 0.0])
+                .attribute("category", "shoes")
+                .attribute("price", 100i64)
+                .attribute("active", false)
+                .build(),
+            Vector::builder("boots-1", vec![0.0, 1.0, 0.0])
+                .attribute("category", "boots")
+                .attribute("price", 150i64)
+                .attribute("active", true)
+                .build(),
+            Vector::builder("hats-1", vec![0.0, 0.0, 1.0])
+                .attribute("category", "hats")
+                .attribute("price", 25i64)
+                .attribute("active", true)
+                .build(),
+        ];
+        db.write(vectors).await.unwrap();
+        db.flush().await.unwrap();
+        db
+    }
+
+    /// Collect result IDs into a sorted Vec for deterministic comparison.
+    fn result_ids(results: &[crate::model::SearchResult]) -> Vec<String> {
+        let mut ids: Vec<String> = results.iter().map(|r| r.external_id.clone()).collect();
+        ids.sort();
+        ids
+    }
+
+    #[tokio::test]
+    async fn should_filter_with_eq() {
+        let db = setup_filterable_db().await;
+
+        let q = Query::new(vec![1.0, 0.0, 0.0])
+            .with_limit(10)
+            .with_filter(Filter::eq("category", "shoes"));
+        let results = db.search(&q).await.unwrap();
+
+        assert_eq!(result_ids(&results), vec!["shoes-1", "shoes-2"]);
+    }
+
+    #[tokio::test]
+    async fn should_filter_with_neq() {
+        let db = setup_filterable_db().await;
+
+        let q = Query::new(vec![1.0, 0.0, 0.0])
+            .with_limit(10)
+            .with_filter(Filter::neq("category", "shoes"));
+        let results = db.search(&q).await.unwrap();
+
+        assert_eq!(result_ids(&results), vec!["boots-1", "hats-1"]);
+    }
+
+    #[tokio::test]
+    async fn should_filter_with_in() {
+        let db = setup_filterable_db().await;
+
+        let q = Query::new(vec![1.0, 0.0, 0.0])
+            .with_limit(10)
+            .with_filter(Filter::in_set(
+                "category",
+                vec!["shoes".into(), "boots".into()],
+            ));
+        let results = db.search(&q).await.unwrap();
+
+        assert_eq!(result_ids(&results), vec!["boots-1", "shoes-1", "shoes-2"]);
+    }
+
+    #[tokio::test]
+    async fn should_filter_with_and() {
+        let db = setup_filterable_db().await;
+
+        // category=shoes AND active=true -> only shoes-1
+        let q = Query::new(vec![1.0, 0.0, 0.0])
+            .with_limit(10)
+            .with_filter(Filter::and(vec![
+                Filter::eq("category", "shoes"),
+                Filter::eq("active", true),
+            ]));
+        let results = db.search(&q).await.unwrap();
+
+        assert_eq!(result_ids(&results), vec!["shoes-1"]);
+    }
+
+    #[tokio::test]
+    async fn should_filter_with_or() {
+        let db = setup_filterable_db().await;
+
+        // category=hats OR category=boots -> boots-1 and hats-1
+        let q = Query::new(vec![1.0, 0.0, 0.0])
+            .with_limit(10)
+            .with_filter(Filter::or(vec![
+                Filter::eq("category", "hats"),
+                Filter::eq("category", "boots"),
+            ]));
+        let results = db.search(&q).await.unwrap();
+
+        assert_eq!(result_ids(&results), vec!["boots-1", "hats-1"]);
+    }
+
+    #[tokio::test]
+    async fn should_filter_with_int_eq() {
+        let db = setup_filterable_db().await;
+
+        let q = Query::new(vec![1.0, 0.0, 0.0])
+            .with_limit(10)
+            .with_filter(Filter::eq("price", 50i64));
+        let results = db.search(&q).await.unwrap();
+
+        assert_eq!(result_ids(&results), vec!["shoes-1"]);
+    }
+
+    #[tokio::test]
+    async fn should_return_empty_when_filter_matches_nothing() {
+        let db = setup_filterable_db().await;
+
+        let q = Query::new(vec![1.0, 0.0, 0.0])
+            .with_limit(10)
+            .with_filter(Filter::eq("category", "sandals"));
+        let results = db.search(&q).await.unwrap();
+
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn should_search_without_filter() {
+        let db = setup_filterable_db().await;
+
+        // No filter - should return all 4 vectors
+        let q = Query::new(vec![1.0, 0.0, 0.0]).with_limit(10);
+        let results = db.search(&q).await.unwrap();
+
+        assert_eq!(
+            result_ids(&results),
+            vec!["boots-1", "hats-1", "shoes-1", "shoes-2"]
+        );
+    }
+
+    #[tokio::test]
+    async fn should_filter_with_nested_and_or() {
+        let db = setup_filterable_db().await;
+
+        // (category=shoes AND active=true) OR category=hats -> shoes-1 and hats-1
+        let q = Query::new(vec![1.0, 0.0, 0.0])
+            .with_limit(10)
+            .with_filter(Filter::or(vec![
+                Filter::and(vec![
+                    Filter::eq("category", "shoes"),
+                    Filter::eq("active", true),
+                ]),
+                Filter::eq("category", "hats"),
+            ]));
+        let results = db.search(&q).await.unwrap();
+
+        assert_eq!(result_ids(&results), vec!["hats-1", "shoes-1"]);
+    }
+
+    #[tokio::test]
+    async fn should_respect_limit_with_filter() {
+        let db = setup_filterable_db().await;
+
+        // Filter matches 3 results but limit is 1
+        let q = Query::new(vec![1.0, 0.0, 0.0])
+            .with_limit(1)
+            .with_filter(Filter::neq("category", "hats"));
+        let results = db.search(&q).await.unwrap();
+
+        assert_eq!(results.len(), 1);
+        // Closest to [1,0,0] among shoes-1, shoes-2, boots-1 is shoes-1
+        assert_eq!(results[0].external_id, "shoes-1");
+    }
+
+    // --- Search tests ---
 
     #[tokio::test]
     async fn should_search_across_multiple_centroids() {
@@ -679,7 +988,11 @@ mod tests {
         db.flush().await.unwrap();
 
         // when - search in between centroids 1 and 2
-        let results = db.query_engine().search(&[0.7, 0.7], 10).await.unwrap();
+        let results = db
+            .query_engine()
+            .search(&Query::new(vec![0.7, 0.7]).with_limit(10))
+            .await
+            .unwrap();
 
         // then - should find vectors from multiple centroids
         assert!(!results.is_empty());

--- a/vector/src/reader.rs
+++ b/vector/src/reader.rs
@@ -9,11 +9,12 @@ use crate::Vector;
 use crate::db::VectorDbRead;
 use crate::error::{Error, Result};
 use crate::hnsw::{CentroidGraph, build_centroid_graph};
-use crate::model::{ReaderConfig, SearchResult};
+use crate::model::{Query, ReaderConfig, SearchResult};
 use crate::query_engine::{QueryEngine, QueryEngineOptions};
 use crate::serde::centroid_chunk::CentroidEntry;
 use crate::storage::VectorDbStorageReadExt;
 use crate::storage::merge_operator::VectorDbMergeOperator;
+use async_trait::async_trait;
 use common::StorageSemantics;
 use common::storage::factory::{StorageReaderRuntime, create_storage_read};
 use std::sync::Arc;
@@ -83,32 +84,16 @@ impl VectorDbReader {
         let query_engine = QueryEngine::new(options, centroid_graph, storage);
         Ok(Self { query_engine })
     }
-
-    /// Search using brute-force centroid lookup (for diagnostics).
-    pub async fn search_exact_nprobe(
-        &self,
-        query: &[f32],
-        k: usize,
-        nprobe: usize,
-    ) -> Result<Vec<SearchResult>> {
-        self.query_engine
-            .search_exact_nprobe(query, k, nprobe)
-            .await
-    }
 }
 
+#[async_trait]
 impl VectorDbRead for VectorDbReader {
-    async fn search(&self, query: &[f32], k: usize) -> Result<Vec<SearchResult>> {
-        self.query_engine.search(query, k).await
+    async fn search(&self, query: &Query) -> Result<Vec<SearchResult>> {
+        self.query_engine.search(query).await
     }
 
-    async fn search_with_nprobe(
-        &self,
-        query: &[f32],
-        k: usize,
-        nprobe: usize,
-    ) -> Result<Vec<SearchResult>> {
-        self.query_engine.search_with_nprobe(query, k, nprobe).await
+    async fn search_with_nprobe(&self, query: &Query, nprobe: usize) -> Result<Vec<SearchResult>> {
+        self.query_engine.search_with_nprobe(query, nprobe).await
     }
 
     async fn get(&self, id: &str) -> Result<Option<Vector>> {
@@ -120,7 +105,7 @@ impl VectorDbRead for VectorDbReader {
 mod tests {
     use crate::VectorDb;
     use crate::db::VectorDbRead;
-    use crate::model::{Config, ReaderConfig, Vector};
+    use crate::model::{Config, Query, ReaderConfig, Vector};
     use crate::reader::VectorDbReader;
     use crate::serde::collection_meta::DistanceMetric;
     use common::StorageConfig;
@@ -174,7 +159,10 @@ mod tests {
             metadata_fields: vec![],
         };
         let reader = VectorDbReader::open(reader_config).await.unwrap();
-        let results = reader.search(&[1.0, 0.0, 0.0], 2).await.unwrap();
+        let results = reader
+            .search(&Query::new(vec![1.0, 0.0, 0.0]).with_limit(2))
+            .await
+            .unwrap();
 
         // then - closest vector should be vec-1
         assert_eq!(results.len(), 2);

--- a/vector/src/storage/merge_operator.rs
+++ b/vector/src/storage/merge_operator.rs
@@ -90,7 +90,6 @@ impl common::storage::MergeOperator for VectorDbMergeOperator {
 /// Used for:
 /// - Deletions: Union deleted vector IDs
 /// - MetadataIndex: Union vector IDs matching a metadata filter
-#[allow(dead_code)]
 fn merge_roaring_treemap(existing: Bytes, new_value: Bytes) -> Result<Bytes, EncodingError> {
     // Deserialize both bitmaps
     let existing_bitmap = RoaringTreemap::deserialize_from(Cursor::new(existing.as_ref()))

--- a/vector/src/storage/mod.rs
+++ b/vector/src/storage/mod.rs
@@ -8,9 +8,10 @@ use crate::serde::centroid_chunk::CentroidChunkValue;
 use crate::serde::centroid_stats::CentroidStatsValue;
 use crate::serde::deletions::DeletionsValue;
 use crate::serde::key::{
-    CentroidChunkKey, CentroidStatsKey, DeletionsKey, IdDictionaryKey, PostingListKey,
-    VectorDataKey,
+    CentroidChunkKey, CentroidStatsKey, DeletionsKey, IdDictionaryKey, MetadataIndexKey,
+    PostingListKey, VectorDataKey,
 };
+use crate::serde::metadata_index::MetadataIndexValue;
 use crate::serde::posting_list::PostingListValue;
 use crate::serde::vector_data::VectorDataValue;
 
@@ -174,6 +175,27 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
         }
 
         Ok(stats)
+    }
+
+    /// Load a metadata index entry for a specific field/value pair.
+    ///
+    /// Returns a bitmap of vector IDs that have the given value for the field.
+    /// Returns an empty bitmap if no entry exists.
+    #[allow(dead_code)]
+    async fn get_metadata_index(
+        &self,
+        field: &str,
+        value: crate::serde::FieldValue,
+    ) -> Result<MetadataIndexValue> {
+        let key = MetadataIndexKey::new(field, value).encode();
+        let record = self.get(key).await?;
+        match record {
+            Some(record) => {
+                let value = MetadataIndexValue::decode_from_bytes(&record.value)?;
+                Ok(value)
+            }
+            None => Ok(MetadataIndexValue::new()),
+        }
     }
 
     /// Scan all centroid chunks to load centroids.

--- a/vector/src/storage/record.rs
+++ b/vector/src/storage/record.rs
@@ -18,6 +18,7 @@ use crate::serde::key::{
     CentroidChunkKey, CentroidStatsKey, DeletionsKey, IdDictionaryKey, PostingListKey,
     VectorDataKey,
 };
+use crate::serde::metadata_index::MetadataIndexValue;
 use crate::serde::posting_list::{PostingListValue, PostingUpdate};
 use crate::serde::vector_data::{Field, VectorDataValue};
 
@@ -97,6 +98,22 @@ pub fn merge_centroid_stats(centroid_id: u64, delta: i32) -> RecordOp {
     let key = CentroidStatsKey::new(centroid_id).encode();
     let value = CentroidStatsValue::new(delta).encode_to_bytes();
     RecordOp::Merge(Record::new(key, value).into())
+}
+
+/// Create a RecordOp to merge a batch of vector IDs into a metadata index entry.
+///
+/// The metadata index maps (field_name, field_value) → set of vector IDs.
+/// The merge operator unions RoaringTreemap bitmaps, so this adds all the
+/// vector IDs to the existing set for that field/value pair.
+///
+/// `encoded_key` is the pre-encoded MetadataIndexKey bytes.
+pub fn merge_metadata_index_bitmap(
+    encoded_key: bytes::Bytes,
+    vector_ids: &RoaringTreemap,
+) -> Result<RecordOp> {
+    let bitmap = MetadataIndexValue::from_treemap(vector_ids.clone());
+    let encoded = bitmap.encode_to_bytes()?;
+    Ok(RecordOp::Merge(Record::new(encoded_key, encoded).into()))
 }
 
 /// Create a RecordOp to merge new centroid entries into an existing centroid chunk.

--- a/vector/src/view_reader.rs
+++ b/vector/src/view_reader.rs
@@ -61,6 +61,7 @@ mod tests {
         VectorDbDeltaView {
             posting_updates,
             deleted_centroids: RoaringTreemap::new(),
+            metadata_index_updates: HashMap::new(),
         }
     }
 
@@ -131,6 +132,7 @@ mod tests {
             current: Arc::new(std::sync::RwLock::new(VectorDbDeltaView {
                 posting_updates: HashMap::new(),
                 deleted_centroids: RoaringTreemap::new(),
+                metadata_index_updates: HashMap::new(),
             })),
             frozen: vec![EpochStamped {
                 val: frozen_view,
@@ -170,6 +172,7 @@ mod tests {
             current: Arc::new(std::sync::RwLock::new(VectorDbDeltaView {
                 posting_updates: HashMap::new(),
                 deleted_centroids: RoaringTreemap::new(),
+                metadata_index_updates: HashMap::new(),
             })),
             frozen: vec![],
             snapshot,
@@ -284,6 +287,7 @@ mod tests {
             current: Arc::new(std::sync::RwLock::new(VectorDbDeltaView {
                 posting_updates: HashMap::new(),
                 deleted_centroids: RoaringTreemap::new(),
+                metadata_index_updates: HashMap::new(),
             })),
             frozen: vec![EpochStamped {
                 val: frozen_view,
@@ -398,6 +402,7 @@ mod tests {
             current: Arc::new(std::sync::RwLock::new(VectorDbDeltaView {
                 posting_updates: HashMap::new(),
                 deleted_centroids: RoaringTreemap::new(),
+                metadata_index_updates: HashMap::new(),
             })),
             frozen: vec![
                 EpochStamped {

--- a/vector/tests/sift1m.rs
+++ b/vector/tests/sift1m.rs
@@ -4,7 +4,7 @@ use std::io::{BufReader, Read};
 use std::path::Path;
 use std::process::Command;
 use tracing_subscriber::EnvFilter;
-use vector::{Config, DistanceMetric, Vector, VectorDb, VectorDbRead};
+use vector::{Config, DistanceMetric, Query, Vector, VectorDb, VectorDbRead};
 
 fn init_tracing() {
     let _ = tracing_subscriber::fmt()
@@ -136,13 +136,14 @@ async fn sift1m_recall() {
     let mut hnsw_recall = 0.0;
     let mut exact_recall = 0.0;
     for (i, query) in queries.iter().enumerate() {
+        let q = Query::new(query.clone()).with_limit(k);
         let hnsw_results = db
-            .search_with_nprobe(query, k, nprobe)
+            .search_with_nprobe(&q, nprobe)
             .await
             .expect("search failed");
         hnsw_recall += recall_at_k(&hnsw_results, &ground_truth[i], k);
         let exact_results = db
-            .search_exact_nprobe(query, k, nprobe)
+            .search_exact_nprobe(&q, nprobe)
             .await
             .expect("exact search failed");
         exact_recall += recall_at_k(&exact_results, &ground_truth[i], k);
@@ -237,14 +238,15 @@ async fn sift100k_recall() {
         if (i + 1) % 10 == 0 {
             info!("query {}", i);
         }
+        let q = Query::new(query.clone()).with_limit(k);
         let hnsw_results = db
-            .search_with_nprobe(query, k, nprobe)
+            .search_with_nprobe(&q, nprobe)
             .await
             .expect("search failed");
         hnsw_recall += recall_at_k(&hnsw_results, &ground_truth[i], k);
         if exact {
             let exact_results = db
-                .search_exact_nprobe(query, k, nprobe)
+                .search_exact_nprobe(&q, nprobe)
                 .await
                 .expect("exact search failed");
             exact_recall += recall_at_k(&exact_results, &ground_truth[i], k);


### PR DESCRIPTION
## Summary

- Introduce Query struct from RFC-00003 with support for a subset of filters. Specifically we support eq, neq, in, and, or.
- change the db query interfaces to use Query struct rather than just a vector.
- during ingest, write inverted index posting updates to delta
- at query time, evaluate filters on the postings returned from nearby centroids.

## Test Plan

unit tests added

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
