### PR TITLE
support consistent snapshots of the centroid graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2658,6 +2658,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "usearch",
+ "uuid",
 ]
 
 [[package]]

--- a/common/src/coordinator/mod.rs
+++ b/common/src/coordinator/mod.rs
@@ -87,6 +87,24 @@ impl<D: Delta, F: Flusher<D>> WriteCoordinator<D, F> {
         initial_snapshot: Arc<dyn StorageSnapshot>,
         flusher: F,
     ) -> WriteCoordinator<D, F> {
+        Self::new_with_last_written_delta(
+            config,
+            channels,
+            initial_context,
+            initial_snapshot,
+            flusher,
+            None,
+        )
+    }
+
+    pub fn new_with_last_written_delta(
+        config: WriteCoordinatorConfig,
+        channels: Vec<impl ToString>,
+        initial_context: D::Context,
+        initial_snapshot: Arc<dyn StorageSnapshot>,
+        flusher: F,
+        initial_last_written_delta: Option<D::FrozenView>,
+    ) -> WriteCoordinator<D, F> {
         let (watermarks, watcher) = EpochWatermarks::new();
         let watermarks = Arc::new(watermarks);
 
@@ -114,6 +132,7 @@ impl<D: Delta, F: Flusher<D>> WriteCoordinator<D, F> {
             config,
             initial_context,
             initial_snapshot,
+            initial_last_written_delta,
             write_rxs,
             flush_tx,
             watermarks.clone(),
@@ -216,6 +235,7 @@ impl<D: Delta> WriteCoordinatorTask<D> {
         config: WriteCoordinatorConfig,
         initial_context: D::Context,
         initial_snapshot: Arc<dyn StorageSnapshot>,
+        initial_last_written_delta: Option<D::FrozenView>,
         write_rxs: Vec<PausableReceiver<D>>,
         flush_tx: mpsc::Sender<FlushEvent<D>>,
         watermarks: Arc<EpochWatermarks>,
@@ -228,7 +248,7 @@ impl<D: Delta> WriteCoordinatorTask<D> {
             current: delta.reader(),
             frozen: vec![],
             snapshot: initial_snapshot,
-            last_written_delta: None,
+            last_written_delta: initial_last_written_delta.map(|v| EpochStamped::new(v, 0..0)),
         };
         let initial_view = Arc::new(BroadcastedView::new(initial_view));
 
@@ -333,7 +353,7 @@ impl<D: Delta> WriteCoordinatorTask<D> {
         let write_epoch = self.epoch;
         self.epoch += 1;
 
-        let result = self.delta.apply(write);
+        let result = self.delta.apply(write, write_epoch);
         // Ignore error if receiver was dropped (fire-and-forget write)
         let _ = result_tx.send(
             result
@@ -739,7 +759,7 @@ mod tests {
             }
         }
 
-        fn apply(&mut self, write: Self::Write) -> Result<(), String> {
+        fn apply(&mut self, write: Self::Write, _epoch: u64) -> Result<(), String> {
             if let Some(error) = &self.context.error {
                 return Err(error.clone());
             }

--- a/common/src/coordinator/traits.rs
+++ b/common/src/coordinator/traits.rs
@@ -58,7 +58,9 @@ pub trait Delta: Sized + Send + Sync + 'static {
     fn init(context: Self::Context) -> Self;
 
     /// Apply a write to the delta and return a result for the caller.
-    fn apply(&mut self, write: Self::Write) -> Result<Self::ApplyResult, String>;
+    ///
+    /// The `epoch` is the write epoch assigned by the coordinator for this write.
+    fn apply(&mut self, write: Self::Write, epoch: u64) -> Result<Self::ApplyResult, String>;
 
     /// Estimate the size of the delta in bytes.
     fn estimate_size(&self) -> usize;

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -5,7 +5,6 @@ pub mod display;
 pub mod sequence;
 pub mod serde;
 pub mod storage;
-
 pub use bytes::BytesRange;
 pub use clock::Clock;
 pub use sequence::{DEFAULT_BLOCK_SIZE, SequenceAllocator, SequenceError, SequenceResult};

--- a/timeseries/src/delta.rs
+++ b/timeseries/src/delta.rs
@@ -141,7 +141,7 @@ impl Delta for TsdbWriteDelta {
         }
     }
 
-    fn apply(&mut self, write: Self::Write) -> Result<Self::ApplyResult, String> {
+    fn apply(&mut self, write: Self::Write, _epoch: u64) -> Result<Self::ApplyResult, String> {
         for series in &write {
             self.ingest(series)?;
         }
@@ -228,7 +228,7 @@ mod tests {
             create_test_series("http_requests", vec![("env", "prod")], create_test_sample());
 
         // when
-        delta.apply(vec![series]).unwrap();
+        delta.apply(vec![series], 0).unwrap();
 
         // then
         assert_eq!(delta.next_series_id, 1);
@@ -254,8 +254,8 @@ mod tests {
         let series2 = create_test_series("http_requests", vec![("env", "prod")], sample2);
 
         // when
-        delta.apply(vec![series1]).unwrap();
-        delta.apply(vec![series2]).unwrap();
+        delta.apply(vec![series1], 0).unwrap();
+        delta.apply(vec![series2], 0).unwrap();
 
         // then
         assert_eq!(delta.next_series_id, 1); // Only one series created
@@ -270,7 +270,7 @@ mod tests {
         let mut delta = TsdbWriteDelta::init(ctx);
         let series =
             create_test_series("http_requests", vec![("env", "prod")], create_test_sample());
-        delta.apply(vec![series]).unwrap();
+        delta.apply(vec![series], 0).unwrap();
 
         // when: freeze and create new delta
         let (frozen, _, new_ctx) = delta.freeze();
@@ -282,7 +282,7 @@ mod tests {
             value: 99.0,
         };
         let series2 = create_test_series("http_requests", vec![("env", "prod")], sample2);
-        delta2.apply(vec![series2]).unwrap();
+        delta2.apply(vec![series2], 0).unwrap();
 
         // then: should reuse series_id from frozen context
         assert_eq!(delta2.next_series_id, 1); // No new ID allocated
@@ -306,7 +306,7 @@ mod tests {
         let series = create_test_series("http_requests", vec![("env", "prod")], bad_sample);
 
         // when
-        let result = delta.apply(vec![series]);
+        let result = delta.apply(vec![series], 0);
 
         // then
         assert!(result.is_err());
@@ -326,7 +326,7 @@ mod tests {
                 value: i as f64,
             };
             let series = create_test_series("metric", vec![("k", "v")], sample);
-            delta.apply(vec![series]).unwrap();
+            delta.apply(vec![series], 0).unwrap();
         }
 
         // then
@@ -371,8 +371,8 @@ mod tests {
         );
 
         // when
-        delta.apply(vec![series1]).unwrap();
-        delta.apply(vec![series2]).unwrap();
+        delta.apply(vec![series1], 0).unwrap();
+        delta.apply(vec![series2], 0).unwrap();
 
         // then
         assert_eq!(delta.next_series_id, 2);
@@ -402,8 +402,8 @@ mod tests {
         );
 
         // when
-        delta.apply(vec![series1]).unwrap();
-        delta.apply(vec![series2]).unwrap();
+        delta.apply(vec![series1], 0).unwrap();
+        delta.apply(vec![series2], 0).unwrap();
 
         // then
         assert_eq!(delta.next_series_id, 1); // Same series_id reused
@@ -428,7 +428,7 @@ mod tests {
         });
 
         // when
-        delta.apply(vec![series]).unwrap();
+        delta.apply(vec![series], 0).unwrap();
 
         // then
         let series_spec = delta.forward_index.series.get(&0).unwrap();
@@ -457,7 +457,7 @@ mod tests {
         );
 
         // when
-        delta.apply(vec![series]).unwrap();
+        delta.apply(vec![series], 0).unwrap();
 
         // then: __name__ label + 3 explicit labels = 4
         assert_eq!(delta.inverted_index.postings.len(), 4);
@@ -481,7 +481,7 @@ mod tests {
         let series = create_test_series("metric", vec![], create_test_sample());
 
         // when
-        delta.apply(vec![series]).unwrap();
+        delta.apply(vec![series], 0).unwrap();
 
         // then
         assert_eq!(delta.next_series_id, 1);
@@ -505,7 +505,7 @@ mod tests {
         series.metric_type = Some(MetricType::Gauge);
 
         // when
-        delta.apply(vec![series]).unwrap();
+        delta.apply(vec![series], 0).unwrap();
 
         // then
         let series_spec = delta.forward_index.series.get(&0).unwrap();
@@ -535,7 +535,7 @@ mod tests {
             create_test_series("http_requests", vec![("env", "prod")], create_test_sample());
 
         // when
-        delta.apply(vec![series]).unwrap();
+        delta.apply(vec![series], 0).unwrap();
 
         // then
         assert_eq!(delta.next_series_id, 43); // No new ID allocated

--- a/timeseries/src/flusher.rs
+++ b/timeseries/src/flusher.rs
@@ -126,7 +126,7 @@ mod tests {
         let mut delta = TsdbWriteDelta::init(ctx);
         let series =
             create_test_series("http_requests", vec![("env", "prod")], create_test_sample());
-        delta.apply(vec![series]).unwrap();
+        delta.apply(vec![series], 0).unwrap();
         let (frozen, _, _) = delta.freeze();
 
         // when
@@ -177,7 +177,7 @@ mod tests {
         let mut delta = TsdbWriteDelta::init(ctx);
         let series =
             create_test_series("http_requests", vec![("env", "prod")], create_test_sample());
-        delta.apply(vec![series]).unwrap();
+        delta.apply(vec![series], 0).unwrap();
         let (frozen, _, _) = delta.freeze();
         frozen
     }
@@ -269,7 +269,7 @@ mod tests {
                 value: 99.0,
             },
         );
-        delta.apply(vec![series1, series2]).unwrap();
+        delta.apply(vec![series1, series2], 0).unwrap();
         let (frozen, _, _) = delta.freeze();
 
         // when

--- a/vector/Cargo.toml
+++ b/vector/Cargo.toml
@@ -30,6 +30,7 @@ serde_yaml.workspace = true
 slatedb.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
+uuid.workspace = true
 log = "0.4.29"
 rand = "0.8"
 

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -13,7 +13,8 @@
 
 use crate::VectorDbReader;
 use crate::delta::{
-    VectorDbDeltaContext, VectorDbDeltaOpts, VectorDbWrite, VectorDbWriteDelta, VectorWrite,
+    VectorDbDeltaContext, VectorDbDeltaOpts, VectorDbFrozenView, VectorDbWrite, VectorDbWriteDelta,
+    VectorWrite,
 };
 use crate::error::{Error, Result};
 use crate::flusher::VectorDbFlusher;
@@ -232,12 +233,14 @@ impl VectorDb {
             flush_interval: Duration::from_secs(5),
             flush_size_threshold: 64 * 1024 * 1024,
         };
-        let mut write_coordinator = WriteCoordinator::new(
+        let initial_frozen_view = Arc::new(VectorDbFrozenView::new(centroid_graph.snapshot()?));
+        let mut write_coordinator = WriteCoordinator::new_with_last_written_delta(
             coordinator_config,
             vec![WRITE_CHANNEL.to_string(), REBALANCE_CHANNEL.to_string()],
             ctx,
             snapshot.clone(),
             flusher,
+            Some(initial_frozen_view),
         );
         handle_tx
             .set(write_coordinator.handle(REBALANCE_CHANNEL))
@@ -646,13 +649,20 @@ impl VectorDb {
 
     /// Create a QueryEngine from the current snapshot for executing queries.
     pub(crate) fn query_engine(&self) -> QueryEngine {
-        let snapshot = self.write_coordinator.view().snapshot.clone();
+        let view = self.write_coordinator.view();
+        let centroid_graph = view
+            .last_written_delta
+            .as_ref()
+            .expect("last_written_delta should always be present")
+            .val
+            .centroid_graph
+            .clone();
         let options = QueryEngineOptions {
             dimensions: self.config.dimensions,
             distance_metric: self.config.distance_metric,
             query_pruning_factor: self.config.query_pruning_factor,
         };
-        QueryEngine::new(options, self.centroid_graph.clone(), snapshot)
+        QueryEngine::new(options, centroid_graph, view.snapshot.clone())
     }
 
     /// Search using brute-force centroid lookup (for diagnostics).

--- a/vector/src/delta.rs
+++ b/vector/src/delta.rs
@@ -21,7 +21,7 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock};
 
-use crate::hnsw::CentroidGraph;
+use crate::hnsw::{CentroidGraph, CentroidGraphRead};
 use crate::lire::commands::RebalanceCommand;
 use crate::lire::rebalancer::IndexRebalancer;
 use crate::model::{AttributeValue, MetadataFieldSpec, VECTOR_FIELD_NAME};
@@ -144,7 +144,7 @@ impl Delta for VectorDbWriteDelta {
     type Write = VectorDbWrite;
     type DeltaView = Arc<std::sync::RwLock<VectorDbDeltaView>>;
     type Frozen = VectorDbImmutableDelta;
-    type FrozenView = Arc<VectorDbDeltaView>;
+    type FrozenView = Arc<VectorDbFrozenView>;
     type ApplyResult = Arc<dyn Any + Send + Sync + 'static>;
 
     fn init(context: VectorDbDeltaContext) -> Self {
@@ -158,10 +158,11 @@ impl Delta for VectorDbWriteDelta {
     fn apply(
         &mut self,
         write: Self::Write,
+        epoch: u64,
     ) -> Result<Arc<dyn Any + Send + Sync + 'static>, String> {
         let result = match write {
             VectorDbWrite::Write(writes) => self.apply_write(writes),
-            VectorDbWrite::Rebalance(cmd) => self.apply_rebalance_cmd(cmd),
+            VectorDbWrite::Rebalance(cmd) => self.apply_rebalance_cmd(cmd, epoch),
         };
         self.toggle_rebalance_backpressure();
         result
@@ -183,7 +184,18 @@ impl Delta for VectorDbWriteDelta {
     fn freeze(self) -> (Self::Frozen, Self::FrozenView, Self::Context) {
         self.ctx.rebalancer.log_summary();
         let mut ops = self.ops;
-        let view = self.view.read().expect("lock poisoned").clone();
+        let delta_view = self.view.read().expect("lock poisoned").clone();
+        let centroid_graph = self
+            .ctx
+            .centroid_graph
+            .snapshot()
+            .expect("centroid graph snapshot should succeed");
+        let view = VectorDbFrozenView {
+            posting_updates: delta_view.posting_updates,
+            deleted_centroids: delta_view.deleted_centroids,
+            metadata_index_updates: delta_view.metadata_index_updates,
+            centroid_graph,
+        };
 
         // Finalize posting list merges and centroid stats deltas
         for (centroid_id, updates) in &view.posting_updates {
@@ -311,6 +323,26 @@ pub(crate) struct VectorDbDeltaView {
     pub(crate) metadata_index_updates: HashMap<bytes::Bytes, RoaringTreemap>,
 }
 
+/// Read-only view of a frozen delta, including a centroid graph snapshot.
+#[derive(Clone)]
+pub(crate) struct VectorDbFrozenView {
+    pub(crate) posting_updates: HashMap<u64, Vec<PostingUpdate>>,
+    pub(crate) deleted_centroids: RoaringTreemap,
+    pub(crate) metadata_index_updates: HashMap<bytes::Bytes, RoaringTreemap>,
+    pub(crate) centroid_graph: Arc<dyn CentroidGraphRead>,
+}
+
+impl VectorDbFrozenView {
+    pub(crate) fn new(centroid_graph: Arc<dyn CentroidGraphRead>) -> Self {
+        Self {
+            posting_updates: HashMap::new(),
+            deleted_centroids: RoaringTreemap::new(),
+            metadata_index_updates: HashMap::new(),
+            centroid_graph,
+        }
+    }
+}
+
 impl VectorDbDeltaView {
     fn new() -> Self {
         Self {
@@ -352,7 +384,7 @@ impl VectorDbDeltaView {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::hnsw::CentroidGraph;
+    use crate::hnsw::{CentroidGraph, CentroidGraphRead};
     use crate::lire::rebalancer::{IndexRebalancer, IndexRebalancerOpts};
     use crate::model::AttributeValue;
     use crate::serde::centroid_chunk::CentroidEntry;
@@ -376,17 +408,9 @@ mod tests {
         }
     }
 
-    impl CentroidGraph for MockCentroidGraph {
+    impl CentroidGraphRead for MockCentroidGraph {
         fn search(&self, _query: &[f32], _k: usize) -> Vec<u64> {
             self.centroids.iter().map(|(id, _)| *id).collect()
-        }
-
-        fn add_centroid(&self, _entry: &CentroidEntry) -> crate::error::Result<()> {
-            Ok(())
-        }
-
-        fn remove_centroid(&self, _centroid_id: u64) -> crate::error::Result<()> {
-            Ok(())
         }
 
         fn get_centroid_vector(&self, centroid_id: u64) -> Option<Vec<f32>> {
@@ -398,6 +422,20 @@ mod tests {
 
         fn len(&self) -> usize {
             self.centroids.len()
+        }
+    }
+
+    impl CentroidGraph for MockCentroidGraph {
+        fn add_centroid(&self, _entry: &CentroidEntry, _epoch: u64) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        fn remove_centroid(&self, _centroid_id: u64, _epoch: u64) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        fn snapshot(&self) -> crate::error::Result<Arc<dyn CentroidGraphRead>> {
+            Ok(Arc::new(MockCentroidGraph::new(self.centroids.clone())))
         }
     }
 
@@ -483,7 +521,7 @@ mod tests {
         let write = create_vector_write("vec-1", vec![1.0, 2.0, 3.0]);
 
         // when
-        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        delta.apply(VectorDbWrite::Write(vec![write]), 0).unwrap();
         let (frozen, _view, _ctx) = delta.freeze();
 
         // then - should have ops for ID dictionary put and vector data put
@@ -515,7 +553,7 @@ mod tests {
         let write = create_vector_write("vec-1", vec![1.0, 2.0, 3.0]);
 
         // when
-        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        delta.apply(VectorDbWrite::Write(vec![write]), 0).unwrap();
         let (frozen, _view, _ctx) = delta.freeze();
 
         // then - should have a merge op for the posting list of centroid 42
@@ -541,7 +579,7 @@ mod tests {
         let write = create_vector_write("vec-1", vec![1.0, 2.0, 3.0]);
 
         // when
-        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        delta.apply(VectorDbWrite::Write(vec![write]), 0).unwrap();
 
         // then - dictionary should be updated in memory
         assert!(dictionary.contains_key("vec-1"));
@@ -555,12 +593,12 @@ mod tests {
         let ctx = create_test_context(1).await;
         let mut delta = VectorDbWriteDelta::init(ctx);
         let write = create_vector_write("vec-1", vec![1.0, 2.0, 3.0]);
-        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        delta.apply(VectorDbWrite::Write(vec![write]), 0).unwrap();
         let write = create_vector_write("vec-1", vec![4.0, 5.0, 6.0]);
         let first_id = *delta.ctx.dictionary.get("vec-1").unwrap();
 
         // when:
-        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        delta.apply(VectorDbWrite::Write(vec![write]), 0).unwrap();
         let (frozen, _view, ctx) = delta.freeze();
 
         // then - should have put for new ID dictionary entry only
@@ -599,7 +637,7 @@ mod tests {
         let write = create_vector_write("vec-1", vec![4.0, 5.0, 6.0]);
 
         // when
-        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        delta.apply(VectorDbWrite::Write(vec![write]), 0).unwrap();
         let (frozen, _view, _ctx) = delta.freeze();
 
         // then - should have posting list merge for the new vector
@@ -620,12 +658,12 @@ mod tests {
         let ctx = create_test_context(1).await;
         let mut delta = VectorDbWriteDelta::init(ctx);
         let write = create_vector_write("vec-1", vec![4.0, 5.0, 6.0]);
-        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        delta.apply(VectorDbWrite::Write(vec![write]), 0).unwrap();
         let old_internal_id = *delta.ctx.dictionary.get("vec-1").unwrap();
 
         // when
         let write = create_vector_write("vec-1", vec![4.0, 5.0, 6.0]);
-        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        delta.apply(VectorDbWrite::Write(vec![write]), 0).unwrap();
         let (frozen, _view, _ctx) = delta.freeze();
 
         // then - should have delete op for old vector data
@@ -650,7 +688,7 @@ mod tests {
         ];
 
         // when
-        delta.apply(VectorDbWrite::Write(writes)).unwrap();
+        delta.apply(VectorDbWrite::Write(writes), 0).unwrap();
         let (frozen, _view, ctx) = delta.freeze();
 
         // then - should have 3 vectors in dictionary
@@ -690,7 +728,7 @@ mod tests {
         ];
 
         // when
-        delta.apply(VectorDbWrite::Write(writes)).unwrap();
+        delta.apply(VectorDbWrite::Write(writes), 0).unwrap();
 
         // then - internal IDs should be sequential starting from 0
         let id1 = *dictionary.get("vec-1").unwrap();
@@ -707,7 +745,7 @@ mod tests {
         // given - create a mock that returns different centroids based on query
         struct MultiCentroidGraph;
 
-        impl CentroidGraph for MultiCentroidGraph {
+        impl CentroidGraphRead for MultiCentroidGraph {
             fn search(&self, query: &[f32], _k: usize) -> Vec<u64> {
                 // Return centroid based on which dimension has highest value
                 if query[0] > query[1] && query[0] > query[2] {
@@ -719,20 +757,30 @@ mod tests {
                 }
             }
 
-            fn add_centroid(&self, _entry: &CentroidEntry) -> crate::error::Result<()> {
-                Ok(())
-            }
-
-            fn remove_centroid(&self, _centroid_id: u64) -> crate::error::Result<()> {
-                Ok(())
-            }
-
             fn get_centroid_vector(&self, _centroid_id: u64) -> Option<Vec<f32>> {
                 None
             }
 
             fn len(&self) -> usize {
                 3
+            }
+        }
+
+        impl CentroidGraph for MultiCentroidGraph {
+            fn add_centroid(
+                &self,
+                _entry: &CentroidEntry,
+                _epoch: u64,
+            ) -> crate::error::Result<()> {
+                Ok(())
+            }
+
+            fn remove_centroid(&self, _centroid_id: u64, _epoch: u64) -> crate::error::Result<()> {
+                Ok(())
+            }
+
+            fn snapshot(&self) -> crate::error::Result<Arc<dyn CentroidGraphRead>> {
+                Ok(Arc::new(MultiCentroidGraph))
             }
         }
 
@@ -785,7 +833,7 @@ mod tests {
         ];
 
         // when
-        delta.apply(VectorDbWrite::Write(writes)).unwrap();
+        delta.apply(VectorDbWrite::Write(writes), 0).unwrap();
         let (frozen, _view, _ctx) = delta.freeze();
 
         // then - should have posting list merges for centroids 1, 2, and 3
@@ -815,7 +863,7 @@ mod tests {
         ];
 
         // when
-        delta.apply(VectorDbWrite::Write(writes)).unwrap();
+        delta.apply(VectorDbWrite::Write(writes), 0).unwrap();
         let (frozen, _view, _ctx) = delta.freeze();
 
         // then - should have a centroid stats merge op with delta = 2
@@ -851,7 +899,7 @@ mod tests {
 
         // when - add a vector
         let write = create_vector_write("vec-1", vec![1.0, 2.0, 3.0]);
-        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        delta.apply(VectorDbWrite::Write(vec![write]), 0).unwrap();
 
         // then - size should be non-zero
         let size = delta.estimate_size();
@@ -871,7 +919,7 @@ mod tests {
             create_vector_write("vec-2", vec![1.0, 0.0, 0.0]),
             create_vector_write("vec-1", vec![0.0, 1.0, 0.0]),
         ];
-        delta.apply(VectorDbWrite::Write(writes)).unwrap();
+        delta.apply(VectorDbWrite::Write(writes), 0).unwrap();
 
         // then - reader should see posting updates for both vectors
         let view = reader.read().expect("lock poisoned");
@@ -975,7 +1023,7 @@ mod tests {
         ];
 
         // when
-        delta.apply(VectorDbWrite::Write(writes)).unwrap();
+        delta.apply(VectorDbWrite::Write(writes), 0).unwrap();
         let (frozen, _view, _ctx) = delta.freeze();
 
         // then - should have metadata index merge ops
@@ -1028,7 +1076,7 @@ mod tests {
         let write = create_vector_write("vec-1", vec![1.0, 2.0, 3.0]);
 
         // when
-        delta.apply(VectorDbWrite::Write(vec![write])).unwrap();
+        delta.apply(VectorDbWrite::Write(vec![write]), 0).unwrap();
         let (frozen, _view, _ctx) = delta.freeze();
 
         // then - should have NO metadata index merge ops
@@ -1053,7 +1101,7 @@ mod tests {
         // given - create a mock that routes vectors to different centroids
         struct MultiCentroidGraph;
 
-        impl CentroidGraph for MultiCentroidGraph {
+        impl CentroidGraphRead for MultiCentroidGraph {
             fn search(&self, query: &[f32], _k: usize) -> Vec<u64> {
                 if query[0] > query[1] && query[0] > query[2] {
                     vec![1]
@@ -1064,20 +1112,30 @@ mod tests {
                 }
             }
 
-            fn add_centroid(&self, _entry: &CentroidEntry) -> crate::error::Result<()> {
-                Ok(())
-            }
-
-            fn remove_centroid(&self, _centroid_id: u64) -> crate::error::Result<()> {
-                Ok(())
-            }
-
             fn get_centroid_vector(&self, _centroid_id: u64) -> Option<Vec<f32>> {
                 None
             }
 
             fn len(&self) -> usize {
                 3
+            }
+        }
+
+        impl CentroidGraph for MultiCentroidGraph {
+            fn add_centroid(
+                &self,
+                _entry: &CentroidEntry,
+                _epoch: u64,
+            ) -> crate::error::Result<()> {
+                Ok(())
+            }
+
+            fn remove_centroid(&self, _centroid_id: u64, _epoch: u64) -> crate::error::Result<()> {
+                Ok(())
+            }
+
+            fn snapshot(&self) -> crate::Result<Arc<dyn CentroidGraphRead>> {
+                Ok(Arc::new(MultiCentroidGraph))
             }
         }
 
@@ -1130,7 +1188,7 @@ mod tests {
         ];
 
         // when
-        delta.apply(VectorDbWrite::Write(writes)).unwrap();
+        delta.apply(VectorDbWrite::Write(writes), 0).unwrap();
         let (frozen, _view, ctx) = delta.freeze();
 
         // then - rebalancer should have correct counts per centroid

--- a/vector/src/hnsw/mod.rs
+++ b/vector/src/hnsw/mod.rs
@@ -6,6 +6,7 @@
 mod usearch;
 
 use crate::error::Result;
+use std::sync::Arc;
 
 use crate::serde::centroid_chunk::CentroidEntry;
 use crate::serde::collection_meta::DistanceMetric;
@@ -13,11 +14,9 @@ use crate::serde::collection_meta::DistanceMetric;
 // Re-export implementations
 pub use usearch::UsearchCentroidGraph;
 
-/// Trait for HNSW-based centroid graph implementations.
+/// Reader trait for HNSW-based centroid graph implementations.
 ///
-/// The graph stores centroids and enables fast approximate nearest neighbor search
-/// to find relevant clusters during query execution.
-pub trait CentroidGraph: Send + Sync {
+pub trait CentroidGraphRead: Send + Sync {
     /// Search for k nearest centroids to a query vector.
     ///
     /// # Arguments
@@ -27,16 +26,6 @@ pub trait CentroidGraph: Send + Sync {
     /// # Returns
     /// Vector of centroid_ids sorted by similarity (closest first)
     fn search(&self, query: &[f32], k: usize) -> Vec<u64>;
-
-    /// Add a centroid to the graph.
-    ///
-    /// Uses interior mutability since the graph is behind `Arc<dyn CentroidGraph>`.
-    fn add_centroid(&self, entry: &CentroidEntry) -> Result<()>;
-
-    /// Remove a centroid from the graph by its ID.
-    ///
-    /// Uses interior mutability since the graph is behind `Arc<dyn CentroidGraph>`.
-    fn remove_centroid(&self, centroid_id: u64) -> Result<()>;
 
     /// Get the vector for a centroid by its ID.
     ///
@@ -52,7 +41,30 @@ pub trait CentroidGraph: Send + Sync {
     }
 }
 
+/// Trait for HNSW-based centroid graph implementations.
+///
+/// The graph stores centroids and enables fast approximate nearest neighbor search
+/// to find relevant clusters during query execution.
+pub trait CentroidGraph: CentroidGraphRead + Send + Sync {
+    /// Add a centroid to the graph, recording the mutation at the given epoch.
+    ///
+    /// Uses interior mutability since the graph is behind `Arc<dyn CentroidGraph>`.
+    fn add_centroid(&self, entry: &CentroidEntry, epoch: u64) -> Result<()>;
+
+    /// Remove a centroid from the graph by its ID at the given epoch.
+    ///
+    /// This is a soft delete: the centroid remains in the underlying index so that
+    /// snapshot reads at earlier epochs can still find it. The centroid is recorded
+    /// as deleted at the given epoch and excluded from searches at that epoch or later.
+    fn remove_centroid(&self, centroid_id: u64, epoch: u64) -> Result<()>;
+
+    /// Take a snapshot of the centroid graph
+    fn snapshot(&self) -> Result<Arc<dyn CentroidGraphRead>>;
+}
+
 /// Build a centroid graph using the default implementation (usearch).
+///
+/// All initial centroids are recorded as added at the given `epoch`.
 pub fn build_centroid_graph(
     centroids: Vec<CentroidEntry>,
     distance_metric: DistanceMetric,

--- a/vector/src/hnsw/usearch.rs
+++ b/vector/src/hnsw/usearch.rs
@@ -1,34 +1,34 @@
 //! HNSW implementation using the usearch library.
 
+use std::cmp::max;
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::fmt;
-use std::sync::RwLock;
-
-use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
+use std::sync::{Arc, RwLock};
 
 use crate::error::{Error, Result};
+use usearch::{Index, IndexOptions, MetricKind, ScalarKind};
+use uuid::Uuid;
 
 use crate::serde::centroid_chunk::CentroidEntry;
 use crate::serde::collection_meta::DistanceMetric;
 
-use super::CentroidGraph;
+use super::{CentroidGraph, CentroidGraphRead};
 
 /// Initial capacity reserved for the usearch index.
 /// Kept artificially high to avoid usearch deadlock issues near capacity limits.
 const INITIAL_CAPACITY: usize = 200_000;
 
-/// Inner state for UsearchCentroidGraph, protected by a single RwLock.
-struct UsearchCentroidGraphInner {
-    /// The usearch index (thread-safe internally)
-    index: Index,
-    /// Map from usearch key to centroid_id
-    key_to_centroid: HashMap<u64, u64>,
-    /// Reverse map from centroid_id to usearch key (for O(1) removal)
-    centroid_to_key: HashMap<u64, u64>,
-    /// Centroid vectors indexed by centroid_id
-    centroid_vectors: HashMap<u64, Vec<f32>>,
-    /// Next usearch key to allocate
-    next_key: u64,
+/// Entry in the delete log for epoch-based snapshot reads.
+/// When a centroid is removed, it is immediately hard-deleted from the usearch
+/// index but recorded here so that snapshot reads at earlier epochs can still
+/// find it.
+#[derive(Debug, Clone)]
+struct DeleteLogEntry {
+    centroid_id: u64,
+    added_epoch: u64,
+    deleted_epoch: u64,
+    vector: Vec<f32>,
 }
 
 /// HNSW graph implementation using the usearch library.
@@ -36,7 +36,7 @@ struct UsearchCentroidGraphInner {
 /// Uses interior mutability for thread-safe mutation behind `Arc<dyn CentroidGraph>`.
 /// The usearch `Index` is internally thread-safe for `add`/`remove`/`search`.
 pub struct UsearchCentroidGraph {
-    inner: RwLock<UsearchCentroidGraphInner>,
+    inner: Arc<RwLock<UsearchCentroidGraphInner>>,
 }
 
 impl fmt::Debug for UsearchCentroidGraph {
@@ -101,7 +101,7 @@ impl UsearchCentroidGraph {
             .reserve(INITIAL_CAPACITY)
             .map_err(|e| Error::Internal(e.to_string()))?;
 
-        // Build mappings and insert
+        // Build mappings and insert. Initial centroids are recorded at epoch 0.
         let mut key_to_centroid = HashMap::with_capacity(centroids.len());
         let mut centroid_to_key = HashMap::with_capacity(centroids.len());
         let mut centroid_vectors = HashMap::with_capacity(centroids.len());
@@ -111,7 +111,7 @@ impl UsearchCentroidGraph {
             index
                 .add(key, &centroid.vector)
                 .map_err(|e| Error::Internal(e.to_string()))?;
-            key_to_centroid.insert(key, centroid.centroid_id);
+            key_to_centroid.insert(key, (centroid.centroid_id, 0u64));
             centroid_to_key.insert(centroid.centroid_id, key);
             centroid_vectors.insert(centroid.centroid_id, centroid.vector.clone());
         }
@@ -119,34 +119,31 @@ impl UsearchCentroidGraph {
         let next_key = centroids.len() as u64;
 
         Ok(Self {
-            inner: RwLock::new(UsearchCentroidGraphInner {
+            inner: Arc::new(RwLock::new(UsearchCentroidGraphInner {
                 index,
                 key_to_centroid,
                 centroid_to_key,
                 centroid_vectors,
                 next_key,
-            }),
+                distance_metric,
+                delete_log: VecDeque::new(),
+                snapshots: Mvcc::new(),
+            })),
         })
+    }
+
+    #[cfg(test)]
+    fn clean_delete_log(&self) {
+        self.inner
+            .write()
+            .expect("lock poisoned")
+            .clean_delete_log();
     }
 }
 
-impl CentroidGraph for UsearchCentroidGraph {
+impl CentroidGraphRead for UsearchCentroidGraph {
     fn search(&self, query: &[f32], k: usize) -> Vec<u64> {
         self.inner.read().expect("lock poisoned").search(query, k)
-    }
-
-    fn add_centroid(&self, entry: &CentroidEntry) -> Result<()> {
-        self.inner
-            .write()
-            .expect("lock poisoned")
-            .add_centroid(entry)
-    }
-
-    fn remove_centroid(&self, centroid_id: u64) -> Result<()> {
-        self.inner
-            .write()
-            .expect("lock poisoned")
-            .remove_centroid(centroid_id)
     }
 
     fn get_centroid_vector(&self, centroid_id: u64) -> Option<Vec<f32>> {
@@ -157,34 +154,170 @@ impl CentroidGraph for UsearchCentroidGraph {
     }
 
     fn len(&self) -> usize {
-        self.inner.read().expect("lock poisoned").len()
+        self.inner.read().expect("lock poisoned").live_count()
     }
 }
 
-impl UsearchCentroidGraphInner {
+impl CentroidGraph for UsearchCentroidGraph {
+    fn add_centroid(&self, entry: &CentroidEntry, epoch: u64) -> Result<()> {
+        self.inner
+            .write()
+            .expect("lock poisoned")
+            .add_centroid(entry, epoch)
+    }
+
+    fn remove_centroid(&self, centroid_id: u64, epoch: u64) -> Result<()> {
+        self.inner
+            .write()
+            .expect("lock poisoned")
+            .remove_centroid(centroid_id, epoch)
+    }
+
+    fn snapshot(&self) -> Result<Arc<dyn CentroidGraphRead>> {
+        let (id, epoch) = self.inner.write().expect("lock poisoned").snapshot();
+        Ok(Arc::new(UsearchCentroidGraphSnapshot {
+            id,
+            epoch,
+            inner: Arc::clone(&self.inner),
+        }))
+    }
+}
+
+struct UsearchCentroidGraphSnapshot {
+    id: Uuid,
+    epoch: u64,
+    inner: Arc<RwLock<UsearchCentroidGraphInner>>,
+}
+
+impl Drop for UsearchCentroidGraphSnapshot {
+    fn drop(&mut self) {
+        let mut inner = self.inner.write().expect("lock poisoned");
+        inner.release_snapshot(self.id);
+    }
+}
+
+impl CentroidGraphRead for UsearchCentroidGraphSnapshot {
     fn search(&self, query: &[f32], k: usize) -> Vec<u64> {
-        let k = k.min(self.key_to_centroid.len());
-        if k == 0 {
-            return Vec::new();
-        }
+        self.inner
+            .read()
+            .expect("lock poisoned")
+            .search_at_epoch(query, k, self.epoch)
+    }
 
-        // Search usearch index — request more than k to account for removed entries
-        let search_k = (k + 10).min(self.key_to_centroid.len() + 10);
-        let results = match self.index.search(query, search_k) {
-            Ok(matches) => matches,
-            Err(_) => return Vec::new(),
-        };
+    fn get_centroid_vector(&self, centroid_id: u64) -> Option<Vec<f32>> {
+        self.inner
+            .read()
+            .expect("lock poisoned")
+            .get_centroid_vector_at_epoch(centroid_id, self.epoch)
+    }
 
-        // Map keys back to centroid_ids, filtering out removed entries
+    fn len(&self) -> usize {
+        self.inner
+            .read()
+            .expect("lock poisoned")
+            .live_count_at_epoch(self.epoch)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Inner state for UsearchCentroidGraph, protected by a single RwLock.
+struct UsearchCentroidGraphInner {
+    /// The usearch index (thread-safe internally)
+    index: Index,
+    /// Map from usearch key to (centroid_id, added_epoch)
+    key_to_centroid: HashMap<u64, (u64, u64)>,
+    /// Reverse map from centroid_id to usearch key (for O(1) removal)
+    centroid_to_key: HashMap<u64, u64>,
+    /// Centroid vectors indexed by centroid_id (only live centroids)
+    centroid_vectors: HashMap<u64, Vec<f32>>,
+    /// Next usearch key to allocate
+    next_key: u64,
+    /// Distance metric for computing distances in delete log lookups
+    distance_metric: DistanceMetric,
+    /// Log of recently deleted centroids, ordered by deletion epoch.
+    /// Entries are kept until all snapshots that might reference them are released.
+    delete_log: VecDeque<DeleteLogEntry>,
+    snapshots: Mvcc,
+}
+
+impl UsearchCentroidGraphInner {
+    /// Search at the current epoch using vanilla (unfiltered) search.
+    fn search(&self, query: &[f32], k: usize) -> Vec<u64> {
+        let results = self
+            .index
+            .search(query, k)
+            .expect("unexpected usearch error");
         results
             .keys
             .iter()
-            .filter_map(|&key| self.key_to_centroid.get(&key).copied())
-            .take(k)
+            .filter_map(|&key| self.key_to_centroid.get(&key).map(|(cid, _)| *cid))
             .collect()
     }
 
-    fn add_centroid(&mut self, entry: &CentroidEntry) -> Result<()> {
+    /// Search at a specific epoch. Uses filtered search to exclude centroids
+    /// added after the epoch, then walks the delete log to recover centroids
+    /// that were deleted after the epoch but were visible at it.
+    fn search_at_epoch(&self, query: &[f32], k: usize, epoch: u64) -> Vec<u64> {
+        // Step 1: filtered search excluding centroids added after the epoch
+        let results = self
+            .index
+            .filtered_search(query, k, |key| {
+                self.key_to_centroid
+                    .get(&key)
+                    .is_some_and(|(_, added_epoch)| *added_epoch <= epoch)
+            })
+            .expect("unexpected usearch error");
+
+        let mut candidates: Vec<(u64, f32)> = results
+            .keys
+            .iter()
+            .zip(results.distances.iter())
+            .filter_map(|(&key, &dist)| self.key_to_centroid.get(&key).map(|(cid, _)| (*cid, dist)))
+            .collect();
+
+        // Step 2: walk delete log for centroids that were visible at this epoch
+        // but have since been deleted
+        for entry in &self.delete_log {
+            if entry.deleted_epoch > epoch && entry.added_epoch <= epoch {
+                let dist = compute_distance(&entry.vector, query, self.distance_metric);
+                // Include if we have fewer than k results, or this beats the worst
+                let dominated =
+                    candidates.len() >= k && candidates.last().is_some_and(|(_, d)| dist >= *d);
+                if !dominated {
+                    candidates.push((entry.centroid_id, dist));
+                    candidates
+                        .sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+                    candidates.truncate(k);
+                }
+            }
+        }
+
+        candidates.into_iter().map(|(cid, _)| cid).collect()
+    }
+
+    fn live_count(&self) -> usize {
+        self.key_to_centroid.len()
+    }
+
+    fn live_count_at_epoch(&self, epoch: u64) -> usize {
+        let live = self
+            .key_to_centroid
+            .values()
+            .filter(|(_, added)| *added <= epoch)
+            .count();
+        let deleted_visible = self
+            .delete_log
+            .iter()
+            .filter(|e| e.added_epoch <= epoch && e.deleted_epoch > epoch)
+            .count();
+        live + deleted_visible
+    }
+
+    fn add_centroid(&mut self, entry: &CentroidEntry, epoch: u64) -> Result<()> {
+        self.snapshots.update_latest_epoch(epoch);
         let key = self.next_key;
         self.next_key += 1;
 
@@ -192,34 +325,137 @@ impl UsearchCentroidGraphInner {
             .add(key, &entry.vector)
             .map_err(|e| Error::Internal(e.to_string()))?;
 
-        self.key_to_centroid.insert(key, entry.centroid_id);
+        self.key_to_centroid.insert(key, (entry.centroid_id, epoch));
         self.centroid_to_key.insert(entry.centroid_id, key);
         self.centroid_vectors
             .insert(entry.centroid_id, entry.vector.clone());
 
+        self.clean_delete_log();
+
         Ok(())
     }
 
-    fn remove_centroid(&mut self, centroid_id: u64) -> Result<()> {
+    fn remove_centroid(&mut self, centroid_id: u64, epoch: u64) -> Result<()> {
+        self.snapshots.update_latest_epoch(epoch);
+
         let key = self.centroid_to_key.remove(&centroid_id).ok_or_else(|| {
             Error::Internal(format!("Centroid {} not found in graph", centroid_id))
         })?;
 
-        self.key_to_centroid.remove(&key);
-        self.centroid_vectors.remove(&centroid_id);
+        let (_, added_epoch) = self
+            .key_to_centroid
+            .remove(&key)
+            .expect("key_to_centroid inconsistency");
+
+        let vector = self
+            .centroid_vectors
+            .remove(&centroid_id)
+            .expect("centroid_vectors inconsistency");
+
         self.index
             .remove(key)
             .map_err(|e| Error::Internal(e.to_string()))?;
 
+        self.delete_log.push_back(DeleteLogEntry {
+            centroid_id,
+            added_epoch,
+            deleted_epoch: epoch,
+            vector,
+        });
+
+        self.clean_delete_log();
+
         Ok(())
+    }
+
+    /// Remove delete log entries that are no longer needed by any snapshot.
+    fn clean_delete_log(&mut self) {
+        let watermark = self.snapshots.retention_watermark();
+        while let Some(front) = self.delete_log.front() {
+            if front.deleted_epoch <= watermark {
+                self.delete_log.pop_front();
+            } else {
+                break;
+            }
+        }
     }
 
     fn get_centroid_vector(&self, centroid_id: u64) -> Option<Vec<f32>> {
         self.centroid_vectors.get(&centroid_id).cloned()
     }
 
-    fn len(&self) -> usize {
-        self.key_to_centroid.len()
+    fn get_centroid_vector_at_epoch(&self, centroid_id: u64, epoch: u64) -> Option<Vec<f32>> {
+        // Check live centroids
+        if let Some(&key) = self.centroid_to_key.get(&centroid_id)
+            && let Some((_, added_epoch)) = self.key_to_centroid.get(&key)
+            && *added_epoch <= epoch
+        {
+            return self.centroid_vectors.get(&centroid_id).cloned();
+        }
+        // Check delete log
+        self.delete_log
+            .iter()
+            .find(|e| {
+                e.centroid_id == centroid_id && e.added_epoch <= epoch && e.deleted_epoch > epoch
+            })
+            .map(|e| e.vector.clone())
+    }
+
+    fn snapshot(&mut self) -> (Uuid, u64) {
+        self.snapshots.reserve_snapshot()
+    }
+
+    fn release_snapshot(&mut self, id: Uuid) {
+        self.snapshots.release_snapshot(id);
+    }
+}
+
+/// Compute distance between two vectors using the given metric, matching
+/// the distance values returned by usearch.
+fn compute_distance(a: &[f32], b: &[f32], metric: DistanceMetric) -> f32 {
+    match metric {
+        // L2sq: sum of squared differences (matches MetricKind::L2sq)
+        DistanceMetric::L2 => a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum(),
+        // IP: 1 - dot_product (matches MetricKind::IP)
+        DistanceMetric::DotProduct => 1.0 - a.iter().zip(b.iter()).map(|(x, y)| x * y).sum::<f32>(),
+    }
+}
+
+struct Mvcc {
+    /// Last written epoch
+    latest_epoch: u64,
+    /// Set of outstanding snapshot epochs
+    snapshots: HashMap<Uuid, u64>,
+}
+
+impl Mvcc {
+    fn new() -> Self {
+        Self {
+            latest_epoch: 0,
+            snapshots: HashMap::new(),
+        }
+    }
+
+    fn update_latest_epoch(&mut self, epoch: u64) {
+        self.latest_epoch = max(epoch, self.latest_epoch);
+    }
+
+    fn reserve_snapshot(&mut self) -> (Uuid, u64) {
+        let id = uuid::Uuid::new_v4();
+        self.snapshots.insert(id, self.latest_epoch);
+        (id, self.latest_epoch)
+    }
+
+    fn release_snapshot(&mut self, id: Uuid) {
+        self.snapshots.remove(&id);
+    }
+
+    fn retention_watermark(&self) -> u64 {
+        self.snapshots
+            .values()
+            .min()
+            .cloned()
+            .unwrap_or(self.latest_epoch)
     }
 }
 
@@ -334,7 +570,7 @@ mod tests {
 
         // when - add a third centroid
         let new_entry = CentroidEntry::new(3, vec![0.0, 0.0, 1.0]);
-        graph.add_centroid(&new_entry).unwrap();
+        graph.add_centroid(&new_entry, 2).unwrap();
 
         // then - graph has 3 centroids and can find the new one
         assert_eq!(graph.len(), 3);
@@ -353,7 +589,7 @@ mod tests {
         let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
 
         // when - remove centroid 2
-        graph.remove_centroid(2).unwrap();
+        graph.remove_centroid(2, 2).unwrap();
 
         // then - graph has 2 centroids and search near [0, 1, 0] returns 1 or 3
         assert_eq!(graph.len(), 2);
@@ -373,9 +609,9 @@ mod tests {
         let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
 
         // when - remove centroid 1, add centroid 4
-        graph.remove_centroid(1).unwrap();
+        graph.remove_centroid(1, 2).unwrap();
         graph
-            .add_centroid(&CentroidEntry::new(4, vec![0.5, 0.5]))
+            .add_centroid(&CentroidEntry::new(4, vec![0.5, 0.5]), 2)
             .unwrap();
 
         // then
@@ -399,20 +635,126 @@ mod tests {
         assert_eq!(graph.get_centroid_vector(99), None);
     }
 
+    // ========================================================================
+    // Epoch-based snapshot read tests
+    // ========================================================================
+
     #[test]
-    fn should_track_vectors_on_add_and_remove() {
-        // given
+    fn search_at_epoch_should_exclude_centroids_added_after_epoch() {
+        // given - build with 2 centroids at epoch 0, add a third at epoch 5
+        let centroids = vec![
+            CentroidEntry::new(1, vec![1.0, 0.0, 0.0]),
+            CentroidEntry::new(2, vec![0.0, 1.0, 0.0]),
+        ];
+        let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
+        let snapshot = graph.snapshot().unwrap();
+        graph
+            .add_centroid(&CentroidEntry::new(3, vec![0.0, 0.0, 1.0]), 5)
+            .unwrap();
+
+        // when - search at epoch 0 (before centroid 3 was added)
+        let results = snapshot.search(&[0.0, 0.0, 0.9], 3);
+
+        // then - centroid 3 should NOT be visible
+        assert!(!results.contains(&3));
+        assert_eq!(results.len(), 2);
+        let results = graph.search(&[0.0, 0.0, 0.9], 3);
+        // centroid 3 should be visible in graph
+        assert_eq!(results[0], 3);
+    }
+
+    #[test]
+    fn search_at_epoch_should_include_deleted_centroid_at_earlier_epoch() {
+        // given - build and delete centroid 2 at epoch 5
+        let centroids = vec![
+            CentroidEntry::new(1, vec![1.0, 0.0, 0.0]),
+            CentroidEntry::new(2, vec![0.0, 1.0, 0.0]),
+            CentroidEntry::new(3, vec![0.0, 0.0, 1.0]),
+        ];
+        let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
+        let snapshot = graph.snapshot().unwrap();
+        graph.remove_centroid(2, 5).unwrap();
+
+        // when - search at epoch 0 (before deletion)
+        let results = snapshot.search(&[0.0, 0.9, 0.0], 3);
+
+        // then - centroid 2 should still be visible via delete log
+        assert!(results.contains(&2));
+        let results = graph.search(&[0.0, 0.9, 0.0], 3);
+        assert!(!results.contains(&2));
+    }
+
+    #[test]
+    fn drop_snapshot_should_clean_delete_log() {
+        // given - build at epoch 0, delete at epoch 3
+        let centroids = vec![
+            CentroidEntry::new(1, vec![1.0, 0.0]),
+            CentroidEntry::new(2, vec![0.0, 1.0]),
+        ];
+        let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
+        let snapshot = graph.snapshot().unwrap();
+        graph.remove_centroid(2, 3).unwrap();
+
+        // snapshot can still find centroid 2 via delete log
+        let results = snapshot.search(&[0.0, 0.9], 2);
+        assert!(results.contains(&2));
+
+        // when - drop the snapshot and force cleanup
+        drop(snapshot);
+        graph.clean_delete_log();
+
+        // then - centroid 2 is gone from the graph and delete log is cleaned
+        assert_eq!(graph.get_centroid_vector(2), None);
+        let inner = graph.inner.read().unwrap();
+        assert!(inner.delete_log.is_empty());
+        assert!(!inner.centroid_to_key.contains_key(&2));
+    }
+
+    #[test]
+    fn drop_snapshot_should_not_interfere_with_other_snapshot() {
+        // given - add centroid at epoch 5, delete at epoch 8
         let centroids = vec![CentroidEntry::new(1, vec![1.0, 0.0])];
         let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
-
-        // when - add centroid
+        let snap1 = graph.snapshot().unwrap();
         graph
-            .add_centroid(&CentroidEntry::new(2, vec![0.0, 1.0]))
+            .add_centroid(&CentroidEntry::new(2, vec![0.0, 1.0]), 5)
             .unwrap();
-        assert_eq!(graph.get_centroid_vector(2), Some(vec![0.0, 1.0]));
+        let snap2 = graph.snapshot().unwrap();
+        graph.remove_centroid(2, 8).unwrap();
 
-        // when - remove centroid
-        graph.remove_centroid(2).unwrap();
+        // when - drop snap1 and force cleanup
+        drop(snap1);
+        graph.clean_delete_log();
+
+        // then - delete log entry is NOT cleaned (snap2 at epoch 5 still needs it)
+        {
+            let inner = graph.inner.read().unwrap();
+            assert_eq!(inner.delete_log.len(), 1);
+            assert_eq!(inner.delete_log[0].centroid_id, 2);
+        }
+
+        // snap2 should still see centroid 2 (added at 5 <= snap epoch 5, deleted at 8 > 5)
+        let results = snap2.search(&[0.0, 0.9], 2);
+        assert!(results.contains(&2));
+
+        drop(snap2);
+    }
+
+    #[test]
+    fn get_centroid_vector_at_epoch_should_find_deleted_centroid() {
+        // given - build and delete centroid 2
+        let centroids = vec![
+            CentroidEntry::new(1, vec![1.0, 0.0]),
+            CentroidEntry::new(2, vec![0.0, 1.0]),
+        ];
+        let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
+        let snapshot = graph.snapshot().unwrap();
+        graph.remove_centroid(2, 5).unwrap();
+
+        // then - current view: centroid 2 gone; snapshot: centroid 2 present
         assert_eq!(graph.get_centroid_vector(2), None);
+        assert_eq!(snapshot.get_centroid_vector(2), Some(vec![0.0, 1.0]));
+
+        drop(snapshot);
     }
 }

--- a/vector/src/lire/commands.rs
+++ b/vector/src/lire/commands.rs
@@ -274,12 +274,13 @@ impl VectorDbWriteDelta {
     pub(crate) fn apply_rebalance_cmd(
         &mut self,
         cmd: RebalanceCommand,
+        epoch: u64,
     ) -> Result<Arc<dyn Any + Send + Sync + 'static>, String> {
         match cmd {
-            RebalanceCommand::Split(cmd) => self.apply_split_cmd(cmd),
+            RebalanceCommand::Split(cmd) => self.apply_split_cmd(cmd, epoch),
             RebalanceCommand::SplitSweep(cmd) => self.apply_split_sweep_cmd(cmd),
             RebalanceCommand::SplitReassign(cmd) => self.apply_split_reassign_cmd(cmd),
-            RebalanceCommand::Merge(cmd) => self.apply_merge_cmd(cmd),
+            RebalanceCommand::Merge(cmd) => self.apply_merge_cmd(cmd, epoch),
             RebalanceCommand::MergeSweep(cmd) => self.apply_merge_sweep_cmd(cmd),
             RebalanceCommand::MergeReassign(cmd) => self.apply_merge_reassign_cmd(cmd),
             RebalanceCommand::SplitFinish(cmd) => self.apply_finish_split(cmd),
@@ -290,6 +291,7 @@ impl VectorDbWriteDelta {
     pub(crate) fn apply_split_cmd(
         &mut self,
         cmd: SplitCommand,
+        epoch: u64,
     ) -> Result<Arc<dyn Any + Send + Sync + 'static>, String> {
         let (c0_id, seq_alloc_put) = self.ctx.id_allocator.allocate_one();
         if let Some(seq_alloc_put) = seq_alloc_put {
@@ -328,17 +330,17 @@ impl VectorDbWriteDelta {
         // 1. Remove c from the centroid graph
         self.ctx
             .centroid_graph
-            .remove_centroid(cmd.c)
+            .remove_centroid(cmd.c, epoch)
             .map_err(|e| e.to_string())?;
 
         // 2. Add c0 and c1 to centroid graph
         self.ctx
             .centroid_graph
-            .add_centroid(&c0)
+            .add_centroid(&c0, epoch)
             .map_err(|e| e.to_string())?;
         self.ctx
             .centroid_graph
-            .add_centroid(&c1)
+            .add_centroid(&c1, epoch)
             .map_err(|e| e.to_string())?;
 
         let mut view = self.view.write().expect("lock poisoned");
@@ -469,6 +471,7 @@ impl VectorDbWriteDelta {
     pub(crate) fn apply_merge_cmd(
         &mut self,
         cmd: MergeCommand,
+        epoch: u64,
     ) -> Result<Arc<dyn Any + Send + Sync + 'static>, String> {
         let c_from_id = cmd.c_from.centroid_id();
         let c_from_postings = cmd.c_from.postings();
@@ -476,7 +479,7 @@ impl VectorDbWriteDelta {
         // 1. Remove c_other from centroid graph
         self.ctx
             .centroid_graph
-            .remove_centroid(c_from_id)
+            .remove_centroid(c_from_id, epoch)
             .map_err(|e| e.to_string())?;
 
         let mut view = self.view.write().expect("lock poisoned");

--- a/vector/src/lire/rebalancer.rs
+++ b/vector/src/lire/rebalancer.rs
@@ -759,17 +759,6 @@ impl IndexRebalancerTask {
             .await
             .map_err(|e| e.to_string())?;
 
-        // Safety check: if c has < 1 vector (e.g. drained by concurrent ops), abort.
-        if posting_list.is_empty() {
-            warn!(
-                c_from,
-                num_vectors = posting_list.len(),
-                "cannot merge empty centroid",
-            );
-            self.send_finish_merge(c_to).await?;
-            return Ok(());
-        }
-
         // Track original vector IDs for sweep phase, and save (id, vector)
         // pairs for reassignment in Phase 3.
         let original_vector_ids: HashSet<u64> = posting_list.iter().map(|p| p.id()).collect();
@@ -890,7 +879,7 @@ mod tests {
     use super::*;
     use crate::delta::{VectorDbDeltaContext, VectorDbDeltaOpts, VectorDbWriteDelta};
     use crate::flusher::VectorDbFlusher;
-    use crate::hnsw::build_centroid_graph;
+    use crate::hnsw::{CentroidGraphRead, build_centroid_graph};
     use crate::serde::centroid_chunk::CentroidEntry;
     use crate::serde::collection_meta::DistanceMetric;
     use crate::serde::key::SeqBlockKey;
@@ -1408,17 +1397,9 @@ mod tests {
         centroids: Vec<(u64, Vec<f32>)>,
     }
 
-    impl CentroidGraph for MockCentroidGraph {
+    impl CentroidGraphRead for MockCentroidGraph {
         fn search(&self, _query: &[f32], _k: usize) -> Vec<u64> {
             self.centroids.iter().map(|(id, _)| *id).collect()
-        }
-
-        fn add_centroid(&self, _entry: &CentroidEntry) -> crate::error::Result<()> {
-            Ok(())
-        }
-
-        fn remove_centroid(&self, _centroid_id: u64) -> crate::error::Result<()> {
-            Ok(())
         }
 
         fn get_centroid_vector(&self, centroid_id: u64) -> Option<Vec<f32>> {
@@ -1430,6 +1411,22 @@ mod tests {
 
         fn len(&self) -> usize {
             self.centroids.len()
+        }
+    }
+
+    impl CentroidGraph for MockCentroidGraph {
+        fn add_centroid(&self, _entry: &CentroidEntry, _epoch: u64) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        fn remove_centroid(&self, _centroid_id: u64, _epoch: u64) -> crate::error::Result<()> {
+            Ok(())
+        }
+
+        fn snapshot(&self) -> crate::Result<Arc<dyn CentroidGraphRead>> {
+            Ok(Arc::new(MockCentroidGraph {
+                centroids: self.centroids.clone(),
+            }))
         }
     }
 

--- a/vector/src/query_engine.rs
+++ b/vector/src/query_engine.rs
@@ -1,5 +1,5 @@
 use crate::error::{Error, Result};
-use crate::hnsw::CentroidGraph;
+use crate::hnsw::CentroidGraphRead;
 use crate::model::{Filter, Query, SearchResult};
 use crate::serde::collection_meta::DistanceMetric;
 use crate::serde::posting_list::PostingList;
@@ -31,14 +31,14 @@ pub(crate) struct QueryEngineOptions {
 /// snapshot. `QueryEngine` is also used by `VectorDbReader` for read-only access.
 pub(crate) struct QueryEngine {
     options: QueryEngineOptions,
-    centroid_graph: Arc<dyn CentroidGraph>,
+    centroid_graph: Arc<dyn CentroidGraphRead>,
     storage: Arc<dyn StorageRead>,
 }
 
 impl QueryEngine {
     pub(crate) fn new(
         options: QueryEngineOptions,
-        centroid_graph: Arc<dyn CentroidGraph>,
+        centroid_graph: Arc<dyn CentroidGraphRead>,
         storage: Arc<dyn StorageRead>,
     ) -> Self {
         Self {

--- a/vector/src/reader.rs
+++ b/vector/src/reader.rs
@@ -8,7 +8,7 @@
 use crate::Vector;
 use crate::db::VectorDbRead;
 use crate::error::{Error, Result};
-use crate::hnsw::{CentroidGraph, build_centroid_graph};
+use crate::hnsw::{CentroidGraphRead, build_centroid_graph};
 use crate::model::{Query, ReaderConfig, SearchResult};
 use crate::query_engine::{QueryEngine, QueryEngineOptions};
 use crate::serde::centroid_chunk::CentroidEntry;
@@ -73,6 +73,7 @@ impl VectorDbReader {
             .collect();
 
         let centroid_graph = build_centroid_graph(live_centroids, config.distance_metric)?;
+        let centroid_graph: Arc<dyn CentroidGraphRead> = centroid_graph.snapshot()?;
 
         let options = QueryEngineOptions {
             dimensions: config.dimensions,
@@ -80,7 +81,6 @@ impl VectorDbReader {
             query_pruning_factor: config.query_pruning_factor,
         };
 
-        let centroid_graph: Arc<dyn CentroidGraph> = Arc::from(centroid_graph);
         let query_engine = QueryEngine::new(options, centroid_graph, storage);
         Ok(Self::new(query_engine))
     }

--- a/vector/src/storage/mod.rs
+++ b/vector/src/storage/mod.rs
@@ -154,7 +154,6 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
     /// Scan all centroid stats records.
     ///
     /// Returns a map of centroid_id to accumulated vector count.
-    #[allow(dead_code)]
     async fn scan_all_centroid_stats(&self) -> Result<Vec<(u64, CentroidStatsValue)>> {
         let mut prefix_buf = bytes::BytesMut::with_capacity(2);
         crate::serde::RecordType::CentroidStats

--- a/vector/src/view_reader.rs
+++ b/vector/src/view_reader.rs
@@ -44,7 +44,8 @@ impl ViewReader {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::delta::VectorDbDeltaView;
+    use crate::delta::{VectorDbDeltaView, VectorDbFrozenView};
+    use crate::hnsw::CentroidGraphRead;
     use crate::serde::key::PostingListKey;
     use crate::serde::posting_list::PostingUpdate;
     use common::Record;
@@ -53,6 +54,18 @@ mod tests {
     use common::storage::in_memory::InMemoryStorage;
     use roaring::RoaringTreemap;
     use std::collections::HashMap;
+    struct NullCentroidGraph;
+    impl CentroidGraphRead for NullCentroidGraph {
+        fn search(&self, _query: &[f32], _k: usize) -> Vec<u64> {
+            vec![]
+        }
+        fn get_centroid_vector(&self, _centroid_id: u64) -> Option<Vec<f32>> {
+            None
+        }
+        fn len(&self) -> usize {
+            0
+        }
+    }
 
     /// Build a VectorDbDeltaView with the given posting updates for a centroid.
     fn make_delta_view(centroid_id: u64, updates: Vec<PostingUpdate>) -> VectorDbDeltaView {
@@ -63,6 +76,17 @@ mod tests {
             deleted_centroids: RoaringTreemap::new(),
             metadata_index_updates: HashMap::new(),
         }
+    }
+
+    /// Build an Arc<VectorDbFrozenView> with the given posting updates for a centroid.
+    fn make_frozen_view(centroid_id: u64, updates: Vec<PostingUpdate>) -> Arc<VectorDbFrozenView> {
+        let dv = make_delta_view(centroid_id, updates);
+        Arc::new(VectorDbFrozenView {
+            posting_updates: dv.posting_updates,
+            deleted_centroids: dv.deleted_centroids,
+            metadata_index_updates: dv.metadata_index_updates,
+            centroid_graph: Arc::new(NullCentroidGraph),
+        })
     }
 
     /// Write a posting list to in-memory storage for the given centroid.
@@ -117,13 +141,13 @@ mod tests {
     async fn should_read_postings_from_frozen_deltas() {
         // given - current is empty, one frozen delta has postings
         let centroid_id = 1u64;
-        let frozen_view = Arc::new(make_delta_view(
+        let frozen_view = make_frozen_view(
             centroid_id,
             vec![
                 PostingUpdate::append(20, vec![3.0]),
                 PostingUpdate::append(21, vec![4.0]),
             ],
-        ));
+        );
 
         let storage = InMemoryStorage::new();
         let snapshot = storage.snapshot().await.unwrap();
@@ -195,10 +219,7 @@ mod tests {
         let centroid_id = 1u64;
 
         let current_view = make_delta_view(centroid_id, vec![PostingUpdate::append(1, vec![10.0])]);
-        let frozen_view = Arc::new(make_delta_view(
-            centroid_id,
-            vec![PostingUpdate::append(2, vec![20.0])],
-        ));
+        let frozen_view = make_frozen_view(centroid_id, vec![PostingUpdate::append(2, vec![20.0])]);
         let storage = InMemoryStorage::new();
         write_snapshot_postings(
             &storage,
@@ -236,10 +257,7 @@ mod tests {
 
         let current_view =
             make_delta_view(centroid_id, vec![PostingUpdate::append(5, vec![100.0])]);
-        let frozen_view = Arc::new(make_delta_view(
-            centroid_id,
-            vec![PostingUpdate::append(5, vec![50.0])],
-        ));
+        let frozen_view = make_frozen_view(centroid_id, vec![PostingUpdate::append(5, vec![50.0])]);
 
         let storage = InMemoryStorage::new();
         let snapshot = storage.snapshot().await.unwrap();
@@ -269,10 +287,7 @@ mod tests {
         // given - frozen and snapshot both have ID 7 with different vectors
         let centroid_id = 1u64;
 
-        let frozen_view = Arc::new(make_delta_view(
-            centroid_id,
-            vec![PostingUpdate::append(7, vec![70.0])],
-        ));
+        let frozen_view = make_frozen_view(centroid_id, vec![PostingUpdate::append(7, vec![70.0])]);
 
         let storage = InMemoryStorage::new();
         write_snapshot_postings(
@@ -348,10 +363,7 @@ mod tests {
 
         let current_view =
             make_delta_view(centroid_id, vec![PostingUpdate::append(3, vec![300.0])]);
-        let frozen_view = Arc::new(make_delta_view(
-            centroid_id,
-            vec![PostingUpdate::append(3, vec![30.0])],
-        ));
+        let frozen_view = make_frozen_view(centroid_id, vec![PostingUpdate::append(3, vec![30.0])]);
         let storage = InMemoryStorage::new();
         write_snapshot_postings(
             &storage,
@@ -386,14 +398,10 @@ mod tests {
         // given - two frozen deltas with overlapping ID; first frozen is newer
         let centroid_id = 1u64;
 
-        let frozen_newer = Arc::new(make_delta_view(
-            centroid_id,
-            vec![PostingUpdate::append(4, vec![400.0])],
-        ));
-        let frozen_older = Arc::new(make_delta_view(
-            centroid_id,
-            vec![PostingUpdate::append(4, vec![40.0])],
-        ));
+        let frozen_newer =
+            make_frozen_view(centroid_id, vec![PostingUpdate::append(4, vec![400.0])]);
+        let frozen_older =
+            make_frozen_view(centroid_id, vec![PostingUpdate::append(4, vec![40.0])]);
 
         let storage = InMemoryStorage::new();
         let snapshot = storage.snapshot().await.unwrap();


### PR DESCRIPTION
## Summary

This patch extends the centroid graph to support a snapshotting mechanism that allows for snapshot-consistent views of the centroids:
- splits the centroid graph trait into reader and writer traits
- adds a snapshot() fn to the writer trait (CentroidGraph)
- implements snapshot consistency in UsearchCentroidGraph. The mechanism works by tracking additions and deletions of centroids. When a centroid is added, the epoch it was added is tracked in the in-memory metadata about the centroids. When a centroid is deleted, it is deleted immediately and the deletions are tracked in a deletion log. Searching now specifies an epoch. When searching at the latest epoch, the search simply searches as before. When searching at earlier epochs, the search filters out centroids added after the epoch and post-merges centroids deleted after the epoch. The deletion log is annotated with the epoch the centroid was deleted. UsearchCentroidGraph tracks the set of outstanding snapshots and prunes the log when the oldest snapshot's epoch advances.
- this change requires a couple tweaks to the write coordinator. First, apply now includes the epoch. Second, the creator of the coordinator can supply an optional initial view.
- when a delta is frozen, vector takes a snapshot of the centroid graph and writes it to the frozen view. Reads use the view associated with the slatedb snapshot they are reading from.

## Test Plan

- unit tests for centroid graph changes
- cohere1M benchmark shows equivalent ingest/query performance

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
