### PR TITLE
[timeseries] Improve end/eval time graphing behavior

### DIFF
--- a/timeseries/ui/app.js
+++ b/timeseries/ui/app.js
@@ -71,15 +71,13 @@
     }
     if (params.has("eval")) {
       evalTimeInput.value = params.get("eval");
+    } else {
+      evalTimeInput.value = "";
     }
     if (params.has("end")) {
       endTimeInput.value = params.get("end");
-    }
-    if (!params.has("eval") && !params.has("end")) {
-      initEndTimeToNow();
     } else {
-      if (!params.has("eval")) evalTimeInput.value = formatLocalDatetime(new Date());
-      if (!params.has("end")) endTimeInput.value = formatLocalDatetime(new Date());
+      endTimeInput.value = "";
     }
 
     // Apply active tab
@@ -103,12 +101,6 @@
     var mi = String(date.getMinutes()).padStart(2, "0");
     var s = String(date.getSeconds()).padStart(2, "0");
     return y + "-" + mo + "-" + d + "T" + h + ":" + mi + ":" + s;
-  }
-
-  function initEndTimeToNow() {
-    var now = formatLocalDatetime(new Date());
-    endTimeInput.value = now;
-    evalTimeInput.value = now;
   }
 
   // Tab switching


### PR DESCRIPTION
## Summary

Improves the graphing "end" and "eval" time behavior.

These parameters will be initialized to empty strings so that their values will be omitted from the URL while still defaulting to the current time when executing queries. This is consistent with the Prometheus UI AFAICT.

Since the "end" and "eval" parameters are used in different tabs, I didn't try to ensure the same value of "now" is used for both, as was being done by the `initEndTimeToNow` function, which I removed given it no longer seemed necessary for setting the empty string initial values.

## Related Issues

Fixes #190.
<!-- or: Relates to # -->

## Test Plan

I tested the UI manually in the quickstart stack.

## Checklist

- [ ] Tests added/updated
- [ ] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
