### PR TITLE
feat(timeseries): implement PromQL label_replace and label_join

### DIFF
--- a/timeseries/src/promql/evaluator.rs
+++ b/timeseries/src/promql/evaluator.rs
@@ -9,13 +9,14 @@ use crate::index::{ForwardIndexLookup, InvertedIndexLookup, SeriesSpec};
 use crate::model::Sample;
 use crate::model::SeriesFingerprint;
 use crate::model::{Label, SeriesId, TimeBucket};
-use crate::promql::functions::{FunctionRegistry, PromQLArg};
+use crate::promql::functions::{FunctionCallContext, FunctionRegistry, PromQLArg};
 use crate::promql::selector::evaluate_selector_with_reader;
 use crate::promql::timestamp::Timestamp;
 use crate::query::QueryReader;
 use crate::util::Result;
 use promql_parser::label::METRIC_NAME;
 use promql_parser::parser::token::*;
+use promql_parser::parser::value::ValueType;
 use promql_parser::parser::{
     AggregateExpr, AtModifier, BinaryExpr, Call, EvalStmt, Expr, LabelModifier, MatrixSelector,
     Offset, SubqueryExpr, VectorMatchCardinality, VectorSelector,
@@ -1464,17 +1465,14 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
         interval_ms: i64,
         lookback_delta_ms: i64,
     ) -> EvalResult<ExprResult> {
-        // Evaluate all non-string arguments. We keep rejecting string literals
-        // here until string-argument functions are implemented.
+        // String-typed arguments are passed through as raw AST nodes for
+        // string-argument functions such as label_replace/label_join.
         let mut arg_results = Vec::with_capacity(call.args.args.len());
         let mut has_range_arg = false;
         for arg in &call.args.args {
-            if let Expr::StringLiteral(lit) = arg.as_ref() {
-                return Err(EvaluationError::InternalError(format!(
-                    "string literal \"{}\" passed as argument to function '{}': \
-                     string arguments are not yet supported",
-                    lit.val, call.func.name
-                )));
+            if arg.value_type() == ValueType::String {
+                arg_results.push(None);
+                continue;
             }
 
             let arg_result = self
@@ -1491,7 +1489,7 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
             if matches!(arg_result, ExprResult::RangeVector(_)) {
                 has_range_arg = true;
             }
-            arg_results.push(arg_result);
+            arg_results.push(Some(arg_result));
         }
 
         let registry = FunctionRegistry::new();
@@ -1512,7 +1510,7 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
             }
 
             return match arg_results.remove(0) {
-                ExprResult::RangeVector(samples) => {
+                Some(ExprResult::RangeVector(samples)) => {
                     if let Some(func) = registry.get_range_function(call.func.name) {
                         let result = func.apply(samples, eval_timestamp_ms)?;
                         Ok(ExprResult::InstantVector(result))
@@ -1523,8 +1521,12 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
                         )))
                     }
                 }
-                _ => Err(EvaluationError::InternalError(format!(
+                Some(_) => Err(EvaluationError::InternalError(format!(
                     "mixed range/non-range function arguments are not supported: {}",
+                    call.func.name
+                ))),
+                None => Err(EvaluationError::InternalError(format!(
+                    "range-vector functions do not support string arguments: {}",
                     call.func.name
                 ))),
             };
@@ -1533,21 +1535,30 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
         let mut evaluated_args = Vec::with_capacity(arg_results.len());
         for arg_result in arg_results {
             match arg_result {
-                ExprResult::InstantVector(samples) => {
-                    evaluated_args.push(PromQLArg::InstantVector(samples))
+                Some(ExprResult::InstantVector(samples)) => {
+                    evaluated_args.push(Some(PromQLArg::InstantVector(samples)))
                 }
-                ExprResult::Scalar(scalar) => evaluated_args.push(PromQLArg::Scalar(scalar)),
-                ExprResult::RangeVector(_) => {
+                Some(ExprResult::Scalar(scalar)) => {
+                    evaluated_args.push(Some(PromQLArg::Scalar(scalar)))
+                }
+                Some(ExprResult::RangeVector(_)) => {
                     return Err(EvaluationError::InternalError(format!(
                         "unexpected range-vector argument dispatch for function: {}",
                         call.func.name
                     )));
                 }
+                // Preserve string-arg positions here; string-aware functions
+                // read the raw AST nodes from ctx.raw_args instead.
+                None => evaluated_args.push(None),
             }
         }
 
         if let Some(func) = registry.get(call.func.name) {
-            let result = func.apply_args(evaluated_args, eval_timestamp_ms)?;
+            let ctx = FunctionCallContext {
+                eval_timestamp_ms,
+                raw_args: &call.args.args,
+            };
+            let result = func.apply_call(evaluated_args, &ctx)?;
             Ok(ExprResult::InstantVector(result))
         } else {
             Err(EvaluationError::InternalError(format!(
@@ -3303,7 +3314,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_error_on_string_literal_as_function_argument() {
+    async fn should_evaluate_label_replace_with_raw_string_arguments() {
         // given: create an empty mock reader
         let bucket = TimeBucket::hour(1000);
         let reader = MockQueryReaderBuilder::new(bucket).build();
@@ -3315,17 +3326,60 @@ mod tests {
             expr: promql_parser::parser::Expr::Call(promql_parser::parser::Call {
                 func: promql_parser::parser::Function {
                     name: "label_replace",
-                    arg_types: vec![ValueType::String],
+                    arg_types: vec![
+                        ValueType::Vector,
+                        ValueType::String,
+                        ValueType::String,
+                        ValueType::String,
+                        ValueType::String,
+                    ],
                     variadic: 0,
                     return_type: ValueType::Vector,
                     experimental: false,
                 },
                 args: promql_parser::parser::FunctionArgs {
-                    args: vec![Box::new(promql_parser::parser::Expr::StringLiteral(
-                        promql_parser::parser::StringLiteral {
-                            val: "replacement".to_string(),
-                        },
-                    ))],
+                    args: vec![
+                        Box::new(promql_parser::parser::Expr::Call(
+                            promql_parser::parser::Call {
+                                func: promql_parser::parser::Function::new(
+                                    "vector",
+                                    vec![ValueType::Scalar],
+                                    0,
+                                    ValueType::Vector,
+                                    false,
+                                ),
+                                args: promql_parser::parser::FunctionArgs::new_args(
+                                    promql_parser::parser::Expr::NumberLiteral(
+                                        promql_parser::parser::NumberLiteral { val: 1.0 },
+                                    ),
+                                ),
+                            },
+                        )),
+                        Box::new(promql_parser::parser::Expr::Paren(
+                            promql_parser::parser::ParenExpr {
+                                expr: Box::new(promql_parser::parser::Expr::StringLiteral(
+                                    promql_parser::parser::StringLiteral {
+                                        val: "dst".to_string(),
+                                    },
+                                )),
+                            },
+                        )),
+                        Box::new(promql_parser::parser::Expr::StringLiteral(
+                            promql_parser::parser::StringLiteral {
+                                val: "replacement".to_string(),
+                            },
+                        )),
+                        Box::new(promql_parser::parser::Expr::StringLiteral(
+                            promql_parser::parser::StringLiteral {
+                                val: "src".to_string(),
+                            },
+                        )),
+                        Box::new(promql_parser::parser::Expr::StringLiteral(
+                            promql_parser::parser::StringLiteral {
+                                val: "(.*)".to_string(),
+                            },
+                        )),
+                    ],
                 },
             }),
             start: end_time,
@@ -3336,16 +3390,22 @@ mod tests {
 
         let result = evaluator.evaluate(stmt).await;
 
-        // then: should return a context-specific error (string arg not yet supported)
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(
-            err.to_string().contains("string literal")
-                && err.to_string().contains("label_replace")
-                && err.to_string().contains("not yet supported"),
-            "Error message should mention string literal, function name, and 'not yet supported', got: {}",
-            err
-        );
+        // then: raw string args should reach label_replace and be applied
+        let result = result.expect("label_replace should succeed");
+        match result {
+            ExprResult::InstantVector(samples) => {
+                assert_eq!(samples.len(), 1);
+                assert_eq!(samples[0].value, 1.0);
+                assert_eq!(
+                    samples[0].labels.get("dst"),
+                    Some(&"replacement".to_string())
+                );
+            }
+            ExprResult::Scalar(_) => panic!("Expected instant vector result, got scalar"),
+            ExprResult::RangeVector(_) => {
+                panic!("Expected instant vector result, got range vector")
+            }
+        }
     }
 
     #[allow(clippy::type_complexity)]

--- a/timeseries/src/promql/functions.rs
+++ b/timeseries/src/promql/functions.rs
@@ -1,7 +1,10 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use super::evaluator::{EvalResult, EvalSample, EvalSamples};
 use crate::{model::Sample, promql::evaluator::EvaluationError};
+use promql_parser::label::METRIC_NAME;
+use promql_parser::parser::Expr;
+use regex::Regex;
 
 /// Kahan summation increment with Neumaier improvement (1974)
 ///
@@ -111,6 +114,12 @@ pub(crate) enum PromQLArg {
     InstantVector(Vec<EvalSample>),
     Scalar(f64),
 }
+
+pub(crate) struct FunctionCallContext<'a> {
+    pub eval_timestamp_ms: i64,
+    pub raw_args: &'a [Box<Expr>],
+}
+
 impl PromQLArg {
     pub fn into_instant_vector(self) -> EvalResult<Vec<EvalSample>> {
         match self {
@@ -153,6 +162,24 @@ pub(crate) trait PromQLFunction {
         }
 
         self.apply(args.remove(0), eval_timestamp_ms)
+    }
+
+    fn apply_call(
+        &self,
+        evaluated_args: Vec<Option<PromQLArg>>,
+        ctx: &FunctionCallContext<'_>,
+    ) -> EvalResult<Vec<EvalSample>> {
+        let mut args = Vec::with_capacity(evaluated_args.len());
+        for arg in evaluated_args {
+            let Some(arg) = arg else {
+                return Err(EvaluationError::InternalError(
+                    "string arguments are not yet supported for this function".to_string(),
+                ));
+            };
+            args.push(arg);
+        }
+
+        self.apply_args(args, ctx.eval_timestamp_ms)
     }
 }
 
@@ -269,6 +296,54 @@ fn exact_arity_error(
     ))
 }
 
+fn min_arity_error(function_name: &str, min_args: usize, actual_args: usize) -> EvaluationError {
+    EvaluationError::InternalError(format!(
+        "{function_name} requires at least {min_args} argument(s), got {actual_args}"
+    ))
+}
+
+// Prometheus' current UTF-8 label-name validation only rejects empty names.
+// Rust strings are already guaranteed to be valid UTF-8.
+fn is_valid_label_name(label: &str) -> bool {
+    !label.is_empty()
+}
+
+fn output_labelset_key(labels: &HashMap<String, String>, drop_name: bool) -> Vec<(String, String)> {
+    let mut key: Vec<(String, String)> = labels
+        .iter()
+        .filter(|(name, _)| !drop_name || name.as_str() != METRIC_NAME)
+        .map(|(name, value)| (name.clone(), value.clone()))
+        .collect();
+    key.sort_unstable();
+    key
+}
+
+fn extract_string_arg(expr: &Expr, function_name: &str, arg_index: usize) -> EvalResult<String> {
+    match expr {
+        Expr::StringLiteral(string) => Ok(string.val.clone()),
+        Expr::Paren(paren) => extract_string_arg(&paren.expr, function_name, arg_index),
+        _ => Err(EvaluationError::InternalError(format!(
+            "expected string literal for argument {} to function '{}'",
+            arg_index + 1,
+            function_name
+        ))),
+    }
+}
+
+fn ensure_unique_labelsets(samples: &[EvalSample]) -> EvalResult<()> {
+    let mut seen_labelsets = HashSet::with_capacity(samples.len());
+    for sample in samples {
+        let labelset_key = output_labelset_key(&sample.labels, sample.drop_name);
+        if !seen_labelsets.insert(labelset_key) {
+            return Err(EvaluationError::InternalError(
+                "vector cannot contain metrics with the same labelset".to_string(),
+            ));
+        }
+    }
+
+    Ok(())
+}
+
 struct ClampMaxFunction;
 
 impl PromQLFunction for ClampMaxFunction {
@@ -362,6 +437,140 @@ impl PromQLFunction for ClampFunction {
     }
 }
 
+struct LabelReplaceFunction;
+
+impl PromQLFunction for LabelReplaceFunction {
+    fn apply(&self, _arg: PromQLArg, _eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        Err(exact_arity_error("label_replace", 5, 1))
+    }
+
+    fn apply_call(
+        &self,
+        evaluated_args: Vec<Option<PromQLArg>>,
+        ctx: &FunctionCallContext<'_>,
+    ) -> EvalResult<Vec<EvalSample>> {
+        if evaluated_args.len() != 5 || ctx.raw_args.len() != 5 {
+            return Err(exact_arity_error("label_replace", 5, ctx.raw_args.len()));
+        }
+
+        let mut args_iter = evaluated_args.into_iter();
+        let Some(PromQLArg::InstantVector(mut samples)) = args_iter
+            .next()
+            .expect("validated evaluated_args.len() == 5")
+        else {
+            return Err(EvaluationError::InternalError(
+                "label_replace expects an instant vector as its first argument".to_string(),
+            ));
+        };
+
+        let dst_label = extract_string_arg(&ctx.raw_args[1], "label_replace", 1)?;
+        let replacement = extract_string_arg(&ctx.raw_args[2], "label_replace", 2)?;
+        let src_label = extract_string_arg(&ctx.raw_args[3], "label_replace", 3)?;
+        let regex_src = extract_string_arg(&ctx.raw_args[4], "label_replace", 4)?;
+
+        if !is_valid_label_name(&dst_label) {
+            return Err(EvaluationError::InternalError(format!(
+                "invalid label name {:?}",
+                dst_label
+            )));
+        }
+
+        let regex = Regex::new(&format!("^(?s:{regex_src})$"))
+            .map_err(|err| EvaluationError::InternalError(err.to_string()))?;
+
+        for sample in &mut samples {
+            let src_value = sample.labels.get(&src_label).cloned().unwrap_or_default();
+
+            if let Some(captures) = regex.captures(&src_value) {
+                let mut replaced = String::new();
+                captures.expand(&replacement, &mut replaced);
+
+                if replaced.is_empty() {
+                    sample.labels.remove(&dst_label);
+                } else {
+                    sample.labels.insert(dst_label.clone(), replaced);
+                }
+
+                if dst_label == METRIC_NAME {
+                    sample.drop_name = false;
+                }
+            }
+        }
+
+        ensure_unique_labelsets(&samples)?;
+        Ok(samples)
+    }
+}
+
+struct LabelJoinFunction;
+
+impl PromQLFunction for LabelJoinFunction {
+    fn apply(&self, _arg: PromQLArg, _eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        Err(min_arity_error("label_join", 3, 1))
+    }
+
+    fn apply_call(
+        &self,
+        evaluated_args: Vec<Option<PromQLArg>>,
+        ctx: &FunctionCallContext<'_>,
+    ) -> EvalResult<Vec<EvalSample>> {
+        let actual_args = ctx.raw_args.len();
+        if actual_args < 3 || evaluated_args.len() != actual_args {
+            return Err(min_arity_error("label_join", 3, actual_args));
+        }
+
+        let mut args_iter = evaluated_args.into_iter();
+        let Some(PromQLArg::InstantVector(mut samples)) = args_iter
+            .next()
+            .expect("validated evaluated_args.len() == ctx.raw_args.len() >= 3")
+        else {
+            return Err(EvaluationError::InternalError(
+                "label_join expects an instant vector as its first argument".to_string(),
+            ));
+        };
+
+        let dst_label = extract_string_arg(&ctx.raw_args[1], "label_join", 1)?;
+        let separator = extract_string_arg(&ctx.raw_args[2], "label_join", 2)?;
+        let src_labels = ctx.raw_args[3..]
+            .iter()
+            .enumerate()
+            .map(|(index, arg)| extract_string_arg(arg, "label_join", index + 3))
+            .collect::<EvalResult<Vec<_>>>()?;
+
+        if !is_valid_label_name(&dst_label) {
+            return Err(EvaluationError::InternalError(format!(
+                "invalid label name {:?}",
+                dst_label
+            )));
+        }
+
+        for sample in &mut samples {
+            let mut joined = String::new();
+            for (index, src_label) in src_labels.iter().enumerate() {
+                if index > 0 {
+                    joined.push_str(&separator);
+                }
+                if let Some(value) = sample.labels.get(src_label) {
+                    joined.push_str(value);
+                }
+            }
+
+            if joined.is_empty() {
+                sample.labels.remove(&dst_label);
+            } else {
+                sample.labels.insert(dst_label.clone(), joined);
+            }
+
+            if dst_label == METRIC_NAME {
+                sample.drop_name = false;
+            }
+        }
+
+        ensure_unique_labelsets(&samples)?;
+        Ok(samples)
+    }
+}
+
 /// Function registry that maps function names to their implementations
 pub(crate) struct FunctionRegistry {
     functions: HashMap<String, Box<dyn PromQLFunction>>,
@@ -422,6 +631,8 @@ impl FunctionRegistry {
             "floor".to_string(),
             Box::new(UnaryFunction { op: f64::floor }),
         );
+        functions.insert("label_join".to_string(), Box::new(LabelJoinFunction));
+        functions.insert("label_replace".to_string(), Box::new(LabelReplaceFunction));
         functions.insert("ln".to_string(), Box::new(UnaryFunction { op: f64::ln }));
         functions.insert(
             "log10".to_string(),
@@ -802,6 +1013,8 @@ impl PromQLFunction for VectorFunction {
 mod tests {
     use super::*;
     use crate::model::Sample;
+    use promql_parser::label::METRIC_NAME;
+    use promql_parser::parser::{Expr, ParenExpr, StringLiteral};
     use rstest::rstest;
     use std::collections::HashMap;
 
@@ -864,6 +1077,55 @@ mod tests {
             labels: HashMap::new(),
             drop_name: false,
         }
+    }
+
+    fn create_sample_with_labels(value: f64, labels: &[(&str, &str)]) -> EvalSample {
+        EvalSample {
+            timestamp_ms: 1000,
+            value,
+            labels: labels
+                .iter()
+                .map(|(name, value)| (name.to_string(), value.to_string()))
+                .collect(),
+            drop_name: false,
+        }
+    }
+
+    fn string_arg(value: &str) -> Expr {
+        Expr::StringLiteral(StringLiteral {
+            val: value.to_string(),
+        })
+    }
+
+    fn paren_string_arg(value: &str) -> Expr {
+        Expr::Paren(ParenExpr {
+            expr: Box::new(string_arg(value)),
+        })
+    }
+
+    fn box_exprs(args: Vec<Expr>) -> Box<[Box<Expr>]> {
+        args.into_iter().map(Box::new).collect()
+    }
+
+    fn label_replace_raw_args(dst: &str, replacement: &str, src: &str, regex: &str) -> Vec<Expr> {
+        vec![
+            Expr::NumberLiteral(promql_parser::parser::NumberLiteral { val: 0.0 }),
+            paren_string_arg(dst),
+            string_arg(replacement),
+            string_arg(src),
+            string_arg(regex),
+        ]
+    }
+
+    fn label_join_raw_args(dst: &str, separator: &str, src_labels: &[&str]) -> Vec<Expr> {
+        let mut args = vec![
+            Expr::NumberLiteral(promql_parser::parser::NumberLiteral { val: 0.0 }),
+            paren_string_arg(dst),
+            string_arg(separator),
+        ];
+
+        args.extend(src_labels.iter().map(|label| string_arg(label)));
+        args
     }
 
     #[test]
@@ -980,6 +1242,490 @@ mod tests {
             "unexpected error: {}",
             err
         );
+    }
+
+    #[test]
+    fn should_apply_label_replace_with_full_string_match() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_replace").unwrap();
+        let raw_args = box_exprs(label_replace_raw_args(
+            "dst",
+            "destination-value-$1",
+            "src",
+            "source-value-(.*)",
+        ));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let result = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![
+                        create_sample_with_labels(
+                            1.0,
+                            &[(METRIC_NAME, "testmetric"), ("src", "source-value-10")],
+                        ),
+                        create_sample_with_labels(
+                            2.0,
+                            &[(METRIC_NAME, "testmetric"), ("src", "source-value-20")],
+                        ),
+                    ])),
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(
+            result[0].labels.get("dst"),
+            Some(&"destination-value-10".to_string())
+        );
+        assert_eq!(
+            result[1].labels.get("dst"),
+            Some(&"destination-value-20".to_string())
+        );
+    }
+
+    #[test]
+    fn should_apply_label_replace_with_dotall_regex() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_replace").unwrap();
+        let raw_args = box_exprs(label_replace_raw_args(
+            "dst",
+            "matched",
+            "src",
+            "source.*10",
+        ));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let result = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![create_sample_with_labels(
+                        1.0,
+                        &[(METRIC_NAME, "testmetric"), ("src", "source\nvalue-10")],
+                    )])),
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap();
+
+        assert_eq!(result[0].labels.get("dst"), Some(&"matched".to_string()));
+    }
+
+    #[test]
+    fn should_not_apply_label_replace_on_substring_match() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_replace").unwrap();
+        let raw_args = box_exprs(label_replace_raw_args(
+            "dst",
+            "value-$1",
+            "src",
+            "value-(.*)",
+        ));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let result = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![create_sample_with_labels(
+                        1.0,
+                        &[
+                            (METRIC_NAME, "testmetric"),
+                            ("src", "source-value-10"),
+                            ("dst", "original-destination-value"),
+                        ],
+                    )])),
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result[0].labels.get("dst"),
+            Some(&"original-destination-value".to_string())
+        );
+    }
+
+    #[test]
+    fn should_drop_destination_label_when_label_replace_replacement_is_empty() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_replace").unwrap();
+        let raw_args = box_exprs(label_replace_raw_args("dst", "", "dst", ".*"));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let result = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![create_sample_with_labels(
+                        1.0,
+                        &[
+                            (METRIC_NAME, "testmetric"),
+                            ("src", "source-value-10"),
+                            ("dst", "original-destination-value"),
+                        ],
+                    )])),
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap();
+
+        assert!(!result[0].labels.contains_key("dst"));
+    }
+
+    #[test]
+    fn should_apply_label_replace_with_utf8_destination_label_name() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_replace").unwrap();
+        let raw_args = box_exprs(label_replace_raw_args(
+            "\u{00ff}",
+            "value-$1",
+            "src",
+            "source-value-(.*)",
+        ));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let result = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![create_sample_with_labels(
+                        1.0,
+                        &[(METRIC_NAME, "testmetric"), ("src", "source-value-10")],
+                    )])),
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result[0].labels.get("\u{00ff}"),
+            Some(&"value-10".to_string())
+        );
+    }
+
+    #[test]
+    fn should_error_when_label_replace_destination_label_is_empty() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_replace").unwrap();
+        let raw_args = box_exprs(label_replace_raw_args("", "", "src", "(.*)"));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let err = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![create_sample_with_labels(
+                        1.0,
+                        &[(METRIC_NAME, "testmetric"), ("src", "source-value-10")],
+                    )])),
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("invalid label name"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn should_error_when_label_replace_produces_duplicate_output_labelsets() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_replace").unwrap();
+        let raw_args = box_exprs(label_replace_raw_args("src", "", "", ""));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let err = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![
+                        create_sample_with_labels(
+                            1.0,
+                            &[(METRIC_NAME, "testmetric"), ("src", "source-value-10")],
+                        ),
+                        create_sample_with_labels(
+                            2.0,
+                            &[(METRIC_NAME, "testmetric"), ("src", "source-value-20")],
+                        ),
+                    ])),
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("vector cannot contain metrics with the same labelset"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn should_apply_label_join_with_source_labels_in_order() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_join").unwrap();
+        let raw_args = box_exprs(label_join_raw_args("dst", "-", &["src", "src1", "src2"]));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let result = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![
+                        create_sample_with_labels(
+                            1.0,
+                            &[
+                                (METRIC_NAME, "testmetric"),
+                                ("src", "a"),
+                                ("src1", "b"),
+                                ("src2", "c"),
+                            ],
+                        ),
+                        create_sample_with_labels(
+                            2.0,
+                            &[
+                                (METRIC_NAME, "testmetric"),
+                                ("src", "d"),
+                                ("src1", "e"),
+                                ("src2", "f"),
+                            ],
+                        ),
+                    ])),
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap();
+
+        assert_eq!(result[0].labels.get("dst"), Some(&"a-b-c".to_string()));
+        assert_eq!(result[1].labels.get("dst"), Some(&"d-e-f".to_string()));
+    }
+
+    #[test]
+    fn should_apply_label_join_without_source_labels() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_join").unwrap();
+        let raw_args = box_exprs(label_join_raw_args("dst", ", ", &[]));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let result = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![create_sample_with_labels(
+                        1.0,
+                        &[
+                            (METRIC_NAME, "testmetric"),
+                            ("src", "a"),
+                            ("src1", "b"),
+                            ("dst", "original-destination-value"),
+                        ],
+                    )])),
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap();
+
+        assert!(!result[0].labels.contains_key("dst"));
+    }
+
+    #[test]
+    fn should_error_when_label_join_destination_label_is_empty() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_join").unwrap();
+        let raw_args = box_exprs(label_join_raw_args("", "-", &["src"]));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let err = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![create_sample_with_labels(
+                        1.0,
+                        &[(METRIC_NAME, "testmetric"), ("src", "a")],
+                    )])),
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap_err();
+
+        assert!(
+            err.to_string().contains("invalid label name"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn should_error_when_label_join_produces_duplicate_output_labelsets() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_join").unwrap();
+        let raw_args = box_exprs(label_join_raw_args("label", "", &["this"]));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+
+        let err = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![
+                        create_sample_with_labels(
+                            1.0,
+                            &[(METRIC_NAME, "dup"), ("label", "a"), ("this", "a")],
+                        ),
+                        create_sample_with_labels(
+                            2.0,
+                            &[(METRIC_NAME, "dup"), ("label", "b"), ("this", "a")],
+                        ),
+                    ])),
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("vector cannot contain metrics with the same labelset"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn should_preserve_metric_name_when_label_replace_writes_name_label() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_replace").unwrap();
+        let raw_args = box_exprs(label_replace_raw_args(
+            "__name__", "rate_$1", "__name__", "(.+)",
+        ));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+        let mut sample =
+            create_sample_with_labels(1.0, &[(METRIC_NAME, "metric_total"), ("env", "1")]);
+        sample.drop_name = true;
+
+        let result = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![sample])),
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result[0].labels.get(METRIC_NAME),
+            Some(&"rate_metric_total".to_string())
+        );
+        assert!(!result[0].drop_name);
+    }
+
+    #[test]
+    fn should_preserve_metric_name_when_label_join_writes_name_label() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("label_join").unwrap();
+        let raw_args = box_exprs(label_join_raw_args("__name__", "_", &["__name__", "env"]));
+        let ctx = FunctionCallContext {
+            eval_timestamp_ms: 1000,
+            raw_args: &raw_args,
+        };
+        let mut sample =
+            create_sample_with_labels(1.0, &[(METRIC_NAME, "metric_total"), ("env", "1")]);
+        sample.drop_name = true;
+
+        let result = func
+            .apply_call(
+                vec![
+                    Some(PromQLArg::InstantVector(vec![sample])),
+                    None,
+                    None,
+                    None,
+                    None,
+                ],
+                &ctx,
+            )
+            .unwrap();
+
+        assert_eq!(
+            result[0].labels.get(METRIC_NAME),
+            Some(&"metric_total_1".to_string())
+        );
+        assert!(!result[0].drop_name);
     }
 
     #[test]

--- a/timeseries/src/promql/promqltest/testdata/at_modifier.test
+++ b/timeseries/src/promql/promqltest/testdata/at_modifier.test
@@ -100,15 +100,15 @@ eval instant at 25s metric{job="1"} @ 50 + metric{job="1"} @ 100
   {job="1"} 15
 
 # ignoring label_replace function
-ignore
+
 
 eval instant at 25s rate(metric{job="1"}[100s] @ 100) + label_replace(rate(metric{job="2"}[123s] @ 200), "job", "1", "", "")
   {job="1"} 0.3
   
-resume
+
 
 # ignoring aggregator functions
-ignore
+
 
 eval instant at 25s sum_over_time(metric{job="1"}[100s] @ 100) + label_replace(sum_over_time(metric{job="2"}[100s] @ 100), "job", "1", "", "")
   {job="1"} 165
@@ -116,7 +116,7 @@ eval instant at 25s sum_over_time(metric{job="1"}[100s] @ 100) + label_replace(s
 eval instant at 25s sum_over_time(metric{job="1"}[100] @ 100) + label_replace(sum_over_time(metric{job="2"}[100] @ 100), "job", "1", "", "")
   {job="1"} 165
 
-resume
+
 
 
 # Subqueries.

--- a/timeseries/src/promql/promqltest/testdata/name_label_dropping.test
+++ b/timeseries/src/promql/promqltest/testdata/name_label_dropping.test
@@ -1,0 +1,161 @@
+# Test for __name__ label drop.
+load 5m
+	metric_total{env="1"}		0 60 120
+	another_metric_total{env="1"}	60 120 180
+
+# Does not drop __name__ for vector selector.
+eval instant at 10m metric_total{env="1"}
+	metric_total{env="1"} 120
+
+ignore
+# Drops __name__ for unary operators.
+eval instant at 10m -metric_total
+	{env="1"} -120
+resume
+
+# Drops __name__ for binary operators.
+eval instant at 10m metric_total + another_metric_total
+	{env="1"} 300
+
+# Does not drop __name__ for binary comparison operators.
+eval instant at 10m metric_total <= another_metric_total
+	metric_total{env="1"} 120
+
+# Drops __name__ for binary comparison operators with "bool" modifier.
+eval instant at 10m metric_total <= bool another_metric_total
+	{env="1"} 1
+
+# Drops __name__ for vector-scalar operations.
+eval instant at 10m metric_total * 2
+	{env="1"} 240
+
+# Drops __name__ for instant-vector functions.
+eval instant at 10m clamp(metric_total, 0, 100)
+	{env="1"} 100
+
+# Drops __name__ for round function.
+eval instant at 10m round(metric_total)
+	{env="1"} 120
+
+# Drops __name__ for range-vector functions.
+eval instant at 10m rate(metric_total{env="1"}[10m])
+	{env="1"} 0.2
+
+# ignoring last_over_time unimplemented
+ignore
+
+# Does not drop __name__ for last_over_time function.
+eval instant at 10m last_over_time(metric_total{env="1"}[10m])
+	metric_total{env="1"} 120
+
+
+
+# Does not drop __name__ for first_over_time function.
+eval instant at 10m first_over_time(metric_total{env="1"}[10m])
+	metric_total{env="1"} 60
+
+resume
+# Drops name for other _over_time functions.
+eval instant at 10m max_over_time(metric_total{env="1"}[10m])
+	{env="1"} 120
+
+# Allows relabeling (to-be-dropped) __name__  via label_replace.
+eval instant at 10m label_replace(rate({env="1"}[10m]), "my_name", "rate_$1", "__name__", "(.+)")
+	{my_name="rate_metric_total", env="1"} 0.2
+	{my_name="rate_another_metric_total", env="1"} 0.2
+
+# Allows preserving __name__ via label_replace.
+eval instant at 10m label_replace(rate({env="1"}[10m]), "__name__", "rate_$1", "__name__", "(.+)")
+	rate_metric_total{env="1"} 0.2
+	rate_another_metric_total{env="1"} 0.2
+
+# Allows relabeling (to-be-dropped) __name__  via label_join.
+eval instant at 10m label_join(rate({env="1"}[10m]), "my_name", "_", "__name__")
+	{my_name="metric_total", env="1"} 0.2
+	{my_name="another_metric_total", env="1"} 0.2
+
+# Allows preserving __name__ via label_join.
+eval instant at 10m label_join(rate({env="1"}[10m]), "__name__", "_", "__name__", "env")
+	metric_total_1{env="1"} 0.2
+	another_metric_total_1{env="1"} 0.2
+
+
+# Does not drop metric names from aggregation operators.
+eval instant at 10m sum by (__name__, env) (metric_total{env="1"})
+	metric_total{env="1"} 120
+
+# ignoring delayed label dropping
+ignore
+# Aggregation operators by __name__ lead to duplicate labelset errors (aggregation is partitioned by not yet removed __name__ label).
+# This is an accidental side effect of delayed __name__ label dropping
+eval instant at 10m sum by (__name__) (rate({env="1"}[10m]))
+  expect fail
+
+resume
+
+# Aggregation operators aggregate metrics with same labelset and to-be-dropped names.
+# This is an accidental side effect of delayed __name__ label dropping
+eval instant at 10m sum(rate({env="1"}[10m])) by (env)
+	{env="1"} 0.4
+
+
+# Aggregationk operators propagate __name__ label dropping information.
+eval instant at 10m topk(10, sum by (__name__, env) (metric_total{env="1"}))
+	metric_total{env="1"} 120
+
+eval instant at 10m topk(10, sum by (__name__, env) (rate(metric_total{env="1"}[10m])))
+	{env="1"} 0.2
+
+
+clear
+
+# More testing for __name__ label drop with different input series.
+load 1m
+  metric_total{env="1"} 0+1x10
+  metric_total{env="2"} 0+3x10
+
+# Metric name is preserved as there is no function that drops it.
+eval instant at 10m sum by (__name__) (metric_total{env="1"})
+  metric_total 10
+
+# Metric name is dropped at the end because of rate and because there is no label function to preserve it.
+eval instant at 10m sum by (__name__) (rate(metric_total{env="2"}[5m]))
+  {} 0.05
+
+# Metric name is preserved with label_replace even though it would have been dropped with rate.
+eval instant at 10m label_replace(sum by (__name__) (rate(metric_total{env="2"}[5m])), "__name__", "$1", "__name__", "(.+)")
+  metric_total 0.05
+
+# ignoring many-to-many opertor or
+ignore
+
+# Combining the above cases in an OR expression, we drop the name if any of the series drops it.
+eval instant at 10m sum by (__name__) (metric_total{env="1"} or rate(metric_total{env="2"}[5m]))
+  {} 10.05
+
+# Changing the order of the OR expression should not change the result.
+eval instant at 10m sum by (__name__) (rate(metric_total{env="2"}[5m]) or metric_total{env="1"})
+  {} 10.05
+
+# With non-matching first selector, we use the second to determine if __name__ is dropped.
+eval instant at 10m sum by (__name__) (metric_total{env="3"} or rate(metric_total{env="2"}[5m]))
+  {} 0.05
+
+# Same as above, but with reversed order.
+eval instant at 10m sum by (__name__) (rate(metric_total{env="3"}[5m]) or metric_total{env="1"})
+  metric_total 10
+
+resume
+
+clear
+
+# ignore unary operator 
+ignore
+# Test delayed name removal with range queries and OR operator.
+load 10m
+  metric_a 1 _
+  metric_b 3 4
+
+eval range from 0 to 20m step 10m -metric_a or -metric_b
+  {} -1 -4 _
+resume


### PR DESCRIPTION
Pass string-typed function arguments through evaluator dispatch as raw AST arguments and call functions through apply_call() at the runtime boundary.

Implement label_replace() and label_join() with direct function-level coverage, re-enable the related at_modifier promqltest cases, and add the upstream name_label_dropping.test coverage needed for label-function __name__ handling.

Fixes #308 

## Checklist

- [ ] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
