### PR TITLE
some tweaks to keep the vector rfcs and implementation in sync

### DIFF
--- a/vector/bench/src/recall.rs
+++ b/vector/bench/src/recall.rs
@@ -136,7 +136,8 @@ fn recall_at_k(results: &[SearchResult], ground_truth: &[i32], k: usize) -> f64 
         .iter()
         .take(k)
         .filter(|r| {
-            r.external_id
+            r.vector
+                .id
                 .parse::<i32>()
                 .map(|id| gt_set.contains(&id))
                 .unwrap_or(false)

--- a/vector/rfcs/0002-write-api.md
+++ b/vector/rfcs/0002-write-api.md
@@ -5,6 +5,7 @@
 **Authors**:
 
 - [Almog Gavra](https://github.com/agavra)
+- [Rohan Desai](https://github.com/rodesai)
 
 ## Summary
 
@@ -60,23 +61,19 @@ A vector is the primary unit of ingestion, combining an ID, embedding values, an
 ///
 /// Writing a vector with an existing ID replaces the previous vector. The old
 /// vector is marked as deleted and a new internal ID is allocated. This ensures
-/// posting lists and metadata indexes are updated correctly without expensive
-/// read-modify-write cycles.
+/// posting lists and metadata indexes are updated correctly.
 ///
 /// # Embedding Values
 ///
-/// The `values` field contains the embedding vector as f32 values. The length
-/// must match the `dimensions` specified in the `Config` when the database
-/// was created.
+/// Vectors are expected to have an attribute named "vector" that contains the
+/// embedding vector as f32 values. The length  must match the `dimensions` specified
+/// in the `Config` when the database was created.
 #[derive(Debug, Clone)]
 pub struct Vector {
     /// User-provided unique identifier (max 64 bytes UTF-8).
     pub id: String,
 
-    /// The embedding vector (f32 values).
-    pub values: Vec<f32>,
-
-    /// Metadata attributes for filtering.
+    /// Vector along with metadata attributes for filtering.
     pub attributes: Vec<Attribute>,
 }
 
@@ -89,7 +86,7 @@ impl Vector {
 }
 
 pub struct VectorBuilder {
-    ...
+    // ...
 }
 
 impl VectorBuilder {
@@ -253,11 +250,6 @@ pub enum DistanceMetric {
     /// Lower is more similar.
     L2,
 
-    /// Cosine distance: 1 - cosine_similarity
-    /// Range [0, 2]. Lower is more similar.
-    #[default]
-    Cosine,
-
     /// Dot product distance: -dot(x, y)
     /// More negative is more similar (vectors should be normalized).
     DotProduct,
@@ -278,7 +270,7 @@ pub struct MetadataFieldSpec {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MetadataFieldType {
+pub enum FieldType {
     /// Vector embedding type. Use the reserved field name "vector" to define
     /// the embedding field in the schema. API-level only; stored in VectorData.
     Vector,
@@ -408,25 +400,6 @@ impl VectorDb {
 }
 ```
 
-#### Reader Access (Placeholder)
-
-```rust
-impl VectorDb {
-    /// Get a read-only view of the vector database.
-    ///
-    /// The reader provides query access without write capabilities.
-    /// See RFC-XXXX for the VectorDbReader API.
-    pub fn reader(&self) -> VectorDbReader;
-}
-
-/// Read-only view of a vector database.
-///
-/// API to be defined in a future RFC.
-pub struct VectorDbReader {
-    // ...
-}
-```
-
 ### Write Path
 
 When `write()` is called, the following operations occur:
@@ -435,11 +408,9 @@ When `write()` is called, the following operations occur:
 2. **For each vector**:
     - Look up the external ID in `IdDictionary`
     - If found (upsert case):
-        - Delete the old vector: add old internal ID to deleted bitmap (centroid_id=0)
-        - Tombstone old `VectorData` and `VectorMeta` records
+        - Tombstone old `VectorData` records
     - Allocate a new internal ID using block-based sequence allocation (see `SeqBlock` in storage RFC)
-    - Write `VectorData` record with the embedding values (keyed by new internal ID)
-    - Write `VectorMeta` record with the external ID and attributes (keyed by new internal ID)
+    - Write `VectorData` record with the embedding values (keyed by new internal ID) and attributes
     - Update or create `IdDictionary` entry mapping external ID → new internal ID
     - Update `MetadataIndex` entries via merge operators for indexed fields
     - Assign to nearest centroid(s) and update `PostingList` via merge operators
@@ -450,25 +421,7 @@ When `write()` is called, the following operations occur:
 When `delete()` is called:
 
 1. **Look up internal IDs**: For each external ID, look up the internal ID in `IdDictionary`
-2. **Add to deleted bitmap**: Internal IDs are added to the special posting list at `centroid_id=0`
-3. **Tombstone records**: `VectorData`, `VectorMeta`, and `IdDictionary` records are tombstoned
-4. **Deferred cleanup**: Metadata index entries and posting list entries are cleaned up during LIRE
-   maintenance
-
-### Comparison with TimeSeries API
-
-| Aspect               | TimeSeries                           | VectorDb                            |
-|----------------------|--------------------------------------|-------------------------------------|
-| Configuration        | `Config`                             | `Config`                            |
-| Primary write method | `write(Vec<Series>)`                 | `write(Vec<Vector>)`                |
-| Options variant      | `write_with_options()`               | `write_with_options()`              |
-| Data unit            | `Series` (labels + samples)          | `Vector` (id + values + attributes) |
-| Identification       | Labels (including `__name__`)        | `id: String` (external ID)          |
-| Metadata             | `metric_type`, `unit`, `description` | `attributes: Vec<Attribute>`        |
-| Write semantics      | Append samples                       | Upsert (replace existing)           |
-| Delete method        | N/A                                  | `delete(Vec<String>)`               |
-| Durability control   | `WriteOptions::await_durable`        | `WriteOptions::await_durable`       |
-| Reader access        | `fn reader() -> TimeSeriesReader`    | `fn reader() -> VectorDbReader`     |
+2. **Tombstone records**: `VectorData`, and `IdDictionary` records are tombstoned
 
 ## Alternatives
 

--- a/vector/rfcs/0003-read-api.md
+++ b/vector/rfcs/0003-read-api.md
@@ -5,6 +5,7 @@
 **Authors**:
 
 - [Almog Gavra](https://github.com/agavra)
+- [Rohan Desai](https://github.com/rodesai)
 
 ## Summary
 
@@ -63,7 +64,7 @@ This RFC uses the `AttributeValue` enum defined in RFC 0002, which includes a `V
 
 ```rust
 pub enum AttributeValue {
-    Vector(Vec<f32>),  // API-level only; stored in VectorData
+    Vector(Vec<f32>),
     String(String),
     Int64(i64),
     Float64(f64),
@@ -71,11 +72,9 @@ pub enum AttributeValue {
 }
 ```
 
-The vector embedding is stored under the reserved field name `"vector"` in the fields HashMap,
+The vector embedding is stored under the reserved field name `"vector"` in the fields collection,
 enabling a unified data model where all attributes (including the vector) can be queried and
-retrieved consistently. The Vector variant is first as it is the primary data in a vector
-database. At the storage layer, vectors are stored in VectorData records while other attributes
-are stored in VectorMeta records.
+retrieved consistently.
 
 ### VectorDbRead Trait
 
@@ -107,7 +106,7 @@ use async_trait::async_trait;
 ///
 ///     let results = reader.search(query).await?;
 ///     for result in results {
-///         println!("{}: score={}", result.external_id, result.score);
+///         println!("{}: score={}", result.vector.id, result.score);
 ///     }
 ///     Ok(())
 /// }
@@ -167,7 +166,7 @@ pub trait VectorDbRead {
     ///
     /// # Returns
     ///
-    /// `Some(VectorRecord)` if found, `None` if not found or deleted.
+    /// `Some(Vector)` if found, `None` if not found or deleted.
     ///
     /// # Example
     ///
@@ -179,7 +178,7 @@ pub trait VectorDbRead {
     ///     println!("Category: {:?}", record.fields.get("category"));
     /// }
     /// ```
-    async fn get(&self, id: &str) -> Result<Option<VectorRecord>>;
+    async fn get(&self, id: &str) -> Result<Option<Vector>>;
 }
 ```
 
@@ -201,30 +200,39 @@ use common::StorageRead;
 ///
 /// # Obtaining a VectorDbReader
 ///
-/// A `VectorDbReader` can be created in two ways:
+/// A `VectorDbReader` can be created in a few ways:
 ///
-/// 1. From an existing `VectorDb`:
+/// 1. From an existing `VectorDb`, to read the state of the db at the time of creating the reader:
+/// ```ignore
+/// let reader = db.snapshot();
+/// ```
+///
+/// 2. From an existing `VectorDb` to see the latest updates to the db:
 /// ```ignore
 /// let reader = db.reader();
 /// ```
 ///
-/// 2. Opened directly:
+/// 3. Opened directly. In this case th reader will observe a fixed snapshot or the latest writes
+///    depending on config:
 /// ```ignore
 /// let reader = VectorDbReader::open(config).await?;
 /// ```
 ///
 /// # Thread Safety
 ///
-/// `VectorDbReader` is designed to be cloned and shared across threads.
-/// All methods take `&self` and are safe to call concurrently.
+/// `VectorDbReader` is designed to be shareable across threads.  All methods take `&self` and are
+/// safe to call concurrently.
 ///
 /// # Snapshot Semantics
 ///
 /// When opened directly via `open()`, a `VectorDbReader` operates on a storage snapshot taken
-/// at open time. It will not see writes that occur after opening.
+/// at open time, or periodically refreshes to see the latest writes, depending on config.
 ///
 /// When obtained from `VectorDb::reader()`, the reader shares the database's snapshot, which is
 /// updated after each flush operation.
+///
+/// When obtained from `VectorDb::snapshot()`, the reader sees a fixed snapshot taken at the time
+/// snapshot was called.
 ///
 /// # Example
 ///
@@ -256,21 +264,18 @@ use common::StorageRead;
 /// }
 /// ```
 pub struct VectorDbReader {
-    config: Config,
-    storage: Arc<dyn StorageRead>,
-    /// In-memory HNSW graph for centroid search (loaded lazily on first query).
-    centroid_graph: RwLock<Option<CentroidGraph>>,
+    // ...
 }
 
 impl VectorDbReader {
     /// Opens a read-only view of the vector database with the given configuration.
     ///
-    /// This creates a `VectorDbReader` that can query vectors but cannot write. The reader
-    /// operates on a storage snapshot taken at open time.
+    /// This creates a `VectorDbReader` that can query vectors but cannot write.
     ///
     /// # Arguments
     ///
-    /// * `config` - Configuration specifying storage backend and settings.
+    /// * `config` - Configuration specifying storage backend and settings, and optionally
+    ///              a checkpoint to fix reads to.
     ///
     /// # Errors
     ///
@@ -295,21 +300,6 @@ impl VectorDbReader {
             storage,
             centroid_graph: RwLock::new(None),
         })
-    }
-
-    /// Creates a VectorDbReader from an existing storage snapshot.
-    ///
-    /// This is used internally by `VectorDb::reader()` to create readers that share the
-    /// database's snapshot.
-    pub(crate) fn from_snapshot(
-        config: Config,
-        storage: Arc<dyn StorageRead>,
-    ) -> Self {
-        Self {
-            config,
-            storage,
-            centroid_graph: RwLock::new(None),
-        }
     }
 }
 ```
@@ -597,9 +587,9 @@ use std::collections::HashMap;
 ///
 /// Returned by `get()` operations.
 #[derive(Debug, Clone)]
-pub struct VectorRecord {
-    /// External vector ID (user-provided)
-    pub external_id: String,
+pub struct Vector {
+    /// vector ID that the vector was inserted with
+    pub id: String,
 
     /// All fields including vector and metadata
     ///
@@ -618,12 +608,6 @@ pub struct VectorRecord {
 /// Returned by `search()` operations.
 #[derive(Debug, Clone)]
 pub struct SearchResult {
-    /// Internal vector ID (system-assigned)
-    pub internal_id: u64,
-
-    /// External vector ID (user-provided)
-    pub external_id: String,
-
     /// Similarity score (interpretation depends on distance metric)
     ///
     /// - L2: Lower scores = more similar
@@ -631,16 +615,8 @@ pub struct SearchResult {
     /// - DotProduct: Higher scores = more similar
     pub score: f32,
 
-    /// All fields including vector and metadata
-    ///
-    /// The vector embedding is stored under the key `"vector"` as
-    /// `AttributeValue::Vector(Vec<f32>)`.
-    ///
-    /// Contents depend on the `include_fields` query parameter:
-    /// - `FieldSelection::All`: All fields including vector
-    /// - `FieldSelection::None`: Empty map
-    /// - `FieldSelection::Fields(names)`: Only specified fields
-    pub fields: HashMap<String, AttributeValue>,
+    /// The vector found by the search
+    pub vector: Vector
 }
 ```
 
@@ -664,8 +640,20 @@ impl VectorDb {
     /// let results = reader.search(query).await?;
     /// ```
     pub fn reader(&self) -> VectorDbReader {
-        let snapshot = self.snapshot.blocking_read().clone();
-        VectorDbReader::from_snapshot(self.config.clone(), snapshot)
+        ...
+    }
+
+    /// Get a read-only view of the vector database at a fixed snapshot.
+    /// # Example
+    ///
+    /// ```ignore
+    /// let db = VectorDb::open(config).await?;
+    /// let reader = db.snapshot();
+    ///
+    /// let results = reader.search(query).await?;
+    /// ```
+    pub fn snapshot(&self) -> VectorDbReader {
+        ...
     }
 }
 ```
@@ -674,31 +662,27 @@ impl VectorDb {
 
 ### Search Query Execution
 
-The `search()` operation implements the SPANN algorithm with metadata filtering:
+The `search()` operation implements the SPANN algorithm with metadata filtering. Internally,
+it does something similar to the following procedure:
 
 1. **Validate query dimensions** against configured dimensions
-2. **Load centroids** (lazily on first query) and build HNSW graph if needed
-3. **Search HNSW** for nearest centroids
+2. **Search centroids** for nearest centroids
    - Expands search by 10-100x (at least 10, at most 100 centroids)
    - This expansion improves recall for approximate nearest neighbor search
-4. **Load posting lists** for identified centroids to get candidate vector IDs
-5. **Apply metadata filter** (if provided):
+3. **Load posting lists** for identified centroids to get candidate vector IDs
+4. **Apply metadata filter** (if provided):
    - For each filter predicate, load metadata index entries
    - Compute intersection/union/difference of vector ID sets using RoaringTreemap operations
-   - Intersect filtered IDs with posting list candidates
-6. **Filter deleted vectors** using the deleted bitmap (centroid_id=0)
-7. **Load fields** for remaining candidates based on `include_fields`:
+   - Intersect filtered IDs with posting list candidates.
+5. **Score candidates** using configured distance metric (L2, Cosine, or DotProduct)
+6. **Sort results**:
+    - L2: Ascending (lower distances first)
+    - Cosine/DotProduct: Descending (higher scores first)
+7. **Truncate to limit results**
+8. **Load fields** for remaining candidates based on `include_fields`:
    - `FieldSelection::All`: Load all fields from VectorData and VectorMeta
    - `FieldSelection::None`: Skip loading fields entirely
    - `FieldSelection::Fields(names)`: Load only specified fields
-8. **Score candidates** using configured distance metric (L2, Cosine, or DotProduct)
-9. **Sort results**:
-   - L2: Ascending (lower distances first)
-   - Cosine/DotProduct: Descending (higher scores first)
-10. **Truncate to limit results**
-11. **Apply distance threshold** (if provided):
-    - L2: Exclude results where distance > threshold
-    - Cosine/DotProduct: Exclude results where score < threshold
 
 ### Filter Evaluation
 
@@ -724,21 +708,18 @@ need filtering. This is efficient when filters are selective.
 The `get()` operation retrieves a single vector record by external ID:
 
 1. **Lookup internal ID** from `IdDictionary[external_id]`
-2. **Check deleted bitmap**: Return `None` if internal ID is in deleted set (centroid_id=0)
 3. **Load vector data** from `VectorData[internal_id]`
-4. **Load metadata** from `VectorMeta[internal_id]`
-5. **Construct VectorRecord** with external_id and fields (including "vector" field)
+5. **Construct Vector** with id and fields (including "vector" field)
 
 ## Thread Safety
 
 Following the `LogReader` pattern from the log module:
 
 - All methods take `&self` for concurrent access
-- Internal state (`centroid_graph`) uses `RwLock` for safe lazy initialization
 - Storage snapshots are immutable and thread-safe (`Arc<dyn StorageRead>`)
 - Multiple readers can query concurrently without contention
-- Readers obtained from `VectorDb::reader()` share the database's snapshot but are independent
-  objects
+- Readers obtained from `VectorDb::reader()` and `VectorDb::snapshot()` share the database's
+  snapshot but are independent objects
 
 ## Performance Considerations
 

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -11,6 +11,7 @@
 //! - Delta handles dictionary lookup, centroid assignment, and builds RecordOps
 //! - Flusher applies ops atomically to storage
 
+use crate::VectorDbReader;
 use crate::delta::{
     VectorDbDeltaContext, VectorDbDeltaOpts, VectorDbWrite, VectorDbWriteDelta, VectorWrite,
 };
@@ -662,6 +663,10 @@ impl VectorDb {
     ) -> Result<Vec<SearchResult>> {
         self.query_engine().search_exact_nprobe(query, nprobe).await
     }
+
+    pub async fn snapshot(&self) -> Box<dyn VectorDbRead> {
+        Box::new(VectorDbReader::new(self.query_engine())) as Box<dyn VectorDbRead>
+    }
 }
 
 #[async_trait]
@@ -964,7 +969,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].external_id, "vec-1");
+        assert_eq!(results[0].vector.id, "vec-1");
     }
 
     #[tokio::test]

--- a/vector/src/model.rs
+++ b/vector/src/model.rs
@@ -268,7 +268,7 @@ impl Default for Config {
 }
 
 /// Configuration for a read-only vector database client.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReaderConfig {
     /// Storage backend configuration.
     pub storage: StorageConfig,
@@ -315,17 +315,13 @@ impl MetadataFieldSpec {
 /// A search result with vector, score, and metadata.
 #[derive(Debug, Clone)]
 pub struct SearchResult {
-    /// Internal vector ID
-    pub internal_id: u64,
-    /// External vector ID (user-provided)
-    pub external_id: String,
     /// Similarity score (interpretation depends on distance metric)
     ///
     /// - L2: Lower scores = more similar
     /// - DotProduct: Higher scores = more similar
     pub score: f32,
-    /// Attribute key-value pairs
-    pub attributes: HashMap<String, AttributeValue>,
+    /// The vector found by search
+    pub vector: Vector,
 }
 
 /// Query specification for vector search.

--- a/vector/src/query_engine.rs
+++ b/vector/src/query_engine.rs
@@ -1,14 +1,15 @@
 use crate::error::{Error, Result};
 use crate::hnsw::CentroidGraph;
-use crate::model::{AttributeValue, Filter, Query, SearchResult};
+use crate::model::{Filter, Query, SearchResult};
 use crate::serde::collection_meta::DistanceMetric;
 use crate::serde::posting_list::PostingList;
+use crate::serde::vector_data::VectorDataValue;
 use crate::storage::VectorDbStorageReadExt;
 use crate::{Attribute, Vector, distance};
 use common::storage::StorageRead;
 use roaring::RoaringTreemap;
 use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashMap, HashSet};
+use std::collections::{BinaryHeap, HashSet};
 use std::sync::Arc;
 use tracing::debug;
 
@@ -67,16 +68,18 @@ impl QueryEngine {
             return Ok(None);
         };
 
-        // 3. Construct VectorRecord with all fields
+        Ok(Some(Self::vector_data_to_vector(&vector_data)))
+    }
+
+    fn vector_data_to_vector(vector_data: &VectorDataValue) -> Vector {
         let attributes = vector_data
             .fields()
             .map(|field| Attribute::new(field.field_name.clone(), field.value.clone().into()))
             .collect();
-
-        Ok(Some(Vector {
+        Vector {
             id: vector_data.external_id().to_string(),
             attributes,
-        }))
+        }
     }
 
     pub(crate) async fn search(&self, query: &Query) -> Result<Vec<SearchResult>> {
@@ -331,17 +334,9 @@ impl QueryEngine {
                 let Some(vector_data) = vector_data? else {
                     continue;
                 };
-
-                let metadata: HashMap<String, AttributeValue> = vector_data
-                    .fields()
-                    .map(|field| (field.field_name.clone(), field.value.clone().into()))
-                    .collect();
-
                 results.push(SearchResult {
-                    internal_id: sr.internal_id,
-                    external_id: vector_data.external_id().to_string(),
                     score: sr.distance.score(),
-                    attributes: metadata,
+                    vector: Self::vector_data_to_vector(&vector_data),
                 });
 
                 if results.len() == k {
@@ -615,9 +610,9 @@ mod tests {
         assert_eq!(results.len(), 10);
         for result in &results {
             assert!(
-                result.external_id.starts_with("vec-0-"),
+                result.vector.id.starts_with("vec-0-"),
                 "Expected cluster 0 vector, got: {}",
-                result.external_id
+                result.vector.id
             );
         }
         // Verify results are sorted by score (L2 distance, lower = better)
@@ -654,13 +649,15 @@ mod tests {
 
         // then - should only return the new version (not the deleted one)
         assert_eq!(results.len(), 1);
-        assert_eq!(results[0].external_id, "vec-1");
+        assert_eq!(results[0].vector.id, "vec-1");
         let vector = results[0]
+            .vector
             .attributes
             .iter()
-            .find(|f| f.0 == "vector")
+            .find(|f| f.name == "vector")
             .unwrap()
-            .1;
+            .value
+            .clone();
         let crate::model::AttributeValue::Vector(vector) = vector.clone() else {
             panic!("unexpected attr type");
         };
@@ -690,9 +687,9 @@ mod tests {
 
         // then - should be sorted by L2 distance (lower = better)
         assert_eq!(results.len(), 3);
-        assert_eq!(results[0].external_id, "close");
-        assert_eq!(results[1].external_id, "medium");
-        assert_eq!(results[2].external_id, "far");
+        assert_eq!(results[0].vector.id, "close");
+        assert_eq!(results[1].vector.id, "medium");
+        assert_eq!(results[2].vector.id, "far");
 
         // Verify scores are increasing (L2 distance)
         for i in 1..results.len() {
@@ -817,7 +814,7 @@ mod tests {
 
     /// Collect result IDs into a sorted Vec for deterministic comparison.
     fn result_ids(results: &[crate::model::SearchResult]) -> Vec<String> {
-        let mut ids: Vec<String> = results.iter().map(|r| r.external_id.clone()).collect();
+        let mut ids: Vec<String> = results.iter().map(|r| r.vector.id.clone()).collect();
         ids.sort();
         ids
     }
@@ -962,7 +959,7 @@ mod tests {
 
         assert_eq!(results.len(), 1);
         // Closest to [1,0,0] among shoes-1, shoes-2, boots-1 is shoes-1
-        assert_eq!(results[0].external_id, "shoes-1");
+        assert_eq!(results[0].vector.id, "shoes-1");
     }
 
     // --- Search tests ---

--- a/vector/src/reader.rs
+++ b/vector/src/reader.rs
@@ -82,7 +82,11 @@ impl VectorDbReader {
 
         let centroid_graph: Arc<dyn CentroidGraph> = Arc::from(centroid_graph);
         let query_engine = QueryEngine::new(options, centroid_graph, storage);
-        Ok(Self { query_engine })
+        Ok(Self::new(query_engine))
+    }
+
+    pub(crate) fn new(query_engine: QueryEngine) -> Self {
+        Self { query_engine }
     }
 }
 
@@ -166,6 +170,6 @@ mod tests {
 
         // then - closest vector should be vec-1
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0].external_id, "vec-1");
+        assert_eq!(results[0].vector.id, "vec-1");
     }
 }

--- a/vector/tests/sift1m.rs
+++ b/vector/tests/sift1m.rs
@@ -73,7 +73,8 @@ fn recall_at_k(results: &[vector::SearchResult], ground_truth: &[i32], k: usize)
         .iter()
         .take(k)
         .filter(|r| {
-            r.external_id
+            r.vector
+                .id
                 .parse::<i32>()
                 .map(|id| gt_set.contains(&id))
                 .unwrap_or(false)


### PR DESCRIPTION
## Summary

- return the Vector type in search results
- track the vector embeddings in the attributes in Vector
- MetadataFieldType -> FieldType
- update the RFCs to align with curent implementation

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
