### PR TITLE
[vector] Complete implementation of merge_batch

### DIFF
--- a/vector/src/serde/posting_list.rs
+++ b/vector/src/serde/posting_list.rs
@@ -396,91 +396,6 @@ pub(crate) fn merge_decoded_posting_lists(postings: Vec<PostingListValue>) -> Po
     PostingListValue::from_posting_updates(merged).expect("unexpected error")
 }
 
-/// Merge two PostingList values using sort-merge.
-///
-/// Both input PostingList values are assumed to be sorted by id. The merge
-/// performs a sort-merge operation:
-/// - When ids match, the entry from new_value takes precedence
-/// - Output remains sorted by id
-///
-/// This implementation works directly with raw bytes for efficiency,
-/// only parsing the type byte and id to determine merge decisions.
-pub(crate) fn merge_posting_list(
-    mut existing: Bytes,
-    mut new_value: Bytes,
-    dimensions: usize,
-) -> Bytes {
-    let vector_size = dimensions * 4;
-    let append_size = 1 + 8 + vector_size; // type + id + vector
-    let delete_size = 1 + 8; // type + id
-
-    let peek_entry = |buf: &[u8]| -> Option<(u64, usize)> {
-        if buf.is_empty() {
-            return None;
-        }
-        assert!(buf.len() >= delete_size);
-        let entry_type = buf[0];
-        let id = u64::from_le_bytes([
-            buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8],
-        ]);
-        let entry_size = if entry_type == POSTING_UPDATE_TYPE_APPEND_BYTE {
-            append_size
-        } else {
-            delete_size
-        };
-        Some((id, entry_size))
-    };
-
-    // Estimate capacity
-    let total_size = existing.len() + new_value.len();
-    let mut result = BytesMut::with_capacity(total_size);
-    let mut last_id = None;
-
-    loop {
-        let existing_entry = peek_entry(&existing);
-        let new_entry = peek_entry(&new_value);
-
-        let id = match (existing_entry, new_entry) {
-            (None, None) => break,
-            (Some((id, size)), None) => {
-                // Only existing has entries left
-                result.put_slice(&existing[..size]);
-                existing.advance(size);
-                id
-            }
-            (None, Some((id, size))) => {
-                // Only new has entries left
-                result.put_slice(&new_value[..size]);
-                new_value.advance(size);
-                id
-            }
-            (Some((existing_id, existing_size)), Some((new_id, new_size))) => {
-                if existing_id < new_id {
-                    // Take from existing
-                    result.put_slice(&existing[..existing_size]);
-                    existing.advance(existing_size);
-                    existing_id
-                } else if new_id < existing_id {
-                    // Take from new
-                    result.put_slice(&new_value[..new_size]);
-                    new_value.advance(new_size);
-                    new_id
-                } else {
-                    // Same id - new wins, skip existing
-                    result.put_slice(&new_value[..new_size]);
-                    new_value.advance(new_size);
-                    existing.advance(existing_size);
-                    new_id
-                }
-            }
-        };
-        assert!(last_id.is_none_or(|last_id| last_id < id));
-        last_id = Some(id);
-    }
-
-    result.freeze()
-}
-
 /// K-way byte-level merge for posting lists across multiple operands.
 ///
 /// Merges `existing` (oldest, priority 0) with `operands` (priority 1..N, newest last)
@@ -836,7 +751,7 @@ mod tests {
             .encode_to_bytes();
 
         // when
-        let merged = merge_posting_list(existing_value, new_value, 3);
+        let merged = merge_batch_posting_list(Some(existing_value), &[new_value], 3);
         let decoded = PostingListValue::decode_from_bytes(&merged, 3).unwrap();
 
         // then - all 3 unique ids preserved in sorted order
@@ -863,7 +778,7 @@ mod tests {
             .encode_to_bytes();
 
         // when
-        let merged = merge_posting_list(existing_value, new_value, 2);
+        let merged = merge_batch_posting_list(Some(existing_value), &[new_value], 2);
         let decoded = PostingListValue::decode_from_bytes(&merged, 2).unwrap();
 
         // then - id 1 is now a delete, id 2 unchanged, sorted order
@@ -891,7 +806,7 @@ mod tests {
             .encode_to_bytes();
 
         // when
-        let merged = merge_posting_list(existing_value, new_value, 2);
+        let merged = merge_batch_posting_list(Some(existing_value), &[new_value], 2);
         let decoded = PostingListValue::decode_from_bytes(&merged, 2).unwrap();
 
         // then - id 1 has new vector, id 2 unchanged, sorted order
@@ -916,7 +831,7 @@ mod tests {
             .encode_to_bytes();
 
         // when
-        let merged = merge_posting_list(existing_value, new_value, 2);
+        let merged = merge_batch_posting_list(Some(existing_value), &[new_value], 2);
         let decoded = PostingListValue::decode_from_bytes(&merged, 2).unwrap();
 
         // then - new entries are preserved in sorted order
@@ -939,7 +854,7 @@ mod tests {
         let new_value = PostingListValue::new().encode_to_bytes();
 
         // when
-        let merged = merge_posting_list(existing_value, new_value, 2);
+        let merged = merge_batch_posting_list(Some(existing_value), &[new_value], 2);
         let decoded = PostingListValue::decode_from_bytes(&merged, 2).unwrap();
 
         // then - existing entries are preserved in sorted order
@@ -955,7 +870,7 @@ mod tests {
         let new_value = PostingListValue::new().encode_to_bytes();
 
         // when
-        let merged = merge_posting_list(existing_value, new_value, 2);
+        let merged = merge_batch_posting_list(Some(existing_value), &[new_value], 2);
         let decoded = PostingListValue::decode_from_bytes(&merged, 2).unwrap();
 
         // then - result is empty
@@ -983,7 +898,7 @@ mod tests {
             .encode_to_bytes();
 
         // when
-        let merged = merge_posting_list(existing_value, new_value, 1);
+        let merged = merge_batch_posting_list(Some(existing_value), &[new_value], 1);
         let decoded = PostingListValue::decode_from_bytes(&merged, 1).unwrap();
 
         // then - all entries in sorted order: 1, 2, 3, 4, 5
@@ -1063,7 +978,7 @@ mod tests {
             .encode_to_bytes();
 
         // when
-        let merged = merge_posting_list(existing_value, new_value, 1);
+        let merged = merge_batch_posting_list(Some(existing_value), &[new_value], 1);
         let decoded = PostingListValue::decode_from_bytes(&merged, 1).unwrap();
 
         // then - result is in sorted order

--- a/vector/src/storage/merge_operator.rs
+++ b/vector/src/storage/merge_operator.rs
@@ -5,7 +5,7 @@
 
 use crate::serde::centroid_chunk::CentroidChunkValue;
 use crate::serde::centroid_stats::CentroidStatsValue;
-use crate::serde::posting_list::{merge_batch_posting_list, merge_posting_list};
+use crate::serde::posting_list::merge_batch_posting_list;
 use crate::serde::{EncodingError, KEY_VERSION, RecordType};
 use bytes::Bytes;
 use common::serde::key_prefix::KeyPrefix;
@@ -31,43 +31,7 @@ impl VectorDbMergeOperator {
 
 impl common::storage::MergeOperator for VectorDbMergeOperator {
     fn merge(&self, key: &Bytes, existing_value: Option<Bytes>, new_value: Bytes) -> Bytes {
-        // If no existing value, just return the new value
-        let Some(existing) = existing_value else {
-            return new_value;
-        };
-
-        let prefix =
-            KeyPrefix::from_bytes_versioned(key, KEY_VERSION).expect("Failed to decode key prefix");
-
-        let record_tag = prefix.tag();
-
-        let record_type_id = record_tag.record_type();
-        let record_type =
-            RecordType::from_id(record_type_id).expect("Failed to get record type from record tag");
-
-        match record_type {
-            RecordType::Deletions | RecordType::MetadataIndex => {
-                // Deletions and MetadataIndex use RoaringTreemap and merge via union
-                merge_roaring_treemap(existing, new_value).expect("Failed to merge RoaringTreemap")
-            }
-            RecordType::PostingList => {
-                // PostingList deduplicates by id, keeping only the last update per id
-                merge_posting_list(existing, new_value, self.dimensions)
-            }
-            RecordType::CentroidStats => {
-                // CentroidStats sums i32 deltas
-                merge_centroid_stats(existing, new_value)
-            }
-            RecordType::CentroidChunk => {
-                // CentroidChunk appends new entries to existing chunk
-                merge_centroid_chunk(existing, new_value, self.dimensions)
-            }
-            _ => {
-                // For other record types (IdDictionary, VectorData, VectorMeta, etc.),
-                // just use new value. These should use Put, not Merge, but handle gracefully
-                new_value
-            }
-        }
+        self.merge_batch(key, existing_value, &[new_value])
     }
 
     fn merge_batch(&self, key: &Bytes, existing_value: Option<Bytes>, operands: &[Bytes]) -> Bytes {
@@ -89,7 +53,11 @@ impl common::storage::MergeOperator for VectorDbMergeOperator {
             RecordType::CentroidChunk => {
                 merge_batch_centroid_chunk(existing_value, operands, self.dimensions)
             }
-            _ => default_merge_batch(key, existing_value, operands, |k, e, v| self.merge(k, e, v)),
+            _ => {
+                // For other record types (IdDictionary, VectorData, VectorMeta, etc.), just use new value
+                // for each pairwise merge. These should use Put, not Merge, but handle gracefully
+                default_merge_batch(key, existing_value, operands, |_k, _e, v| v)
+            }
         }
     }
 }
@@ -123,36 +91,6 @@ fn merge_batch_roaring_treemap(
         merged |= bitmap;
     }
 
-    let mut buf = Vec::new();
-    merged.serialize_into(&mut buf).map_err(|e| EncodingError {
-        message: format!("Failed to serialize merged RoaringTreemap: {}", e),
-    })?;
-    Ok(Bytes::from(buf))
-}
-
-/// Merge two RoaringTreemap values by unioning them.
-///
-/// Used for:
-/// - Deletions: Union deleted vector IDs
-/// - MetadataIndex: Union vector IDs matching a metadata filter
-fn merge_roaring_treemap(existing: Bytes, new_value: Bytes) -> Result<Bytes, EncodingError> {
-    // Deserialize both bitmaps
-    let existing_bitmap = RoaringTreemap::deserialize_from(Cursor::new(existing.as_ref()))
-        .map_err(|e| EncodingError {
-            message: format!("Failed to deserialize existing RoaringTreemap: {}", e),
-        })?;
-
-    let new_bitmap =
-        RoaringTreemap::deserialize_from(Cursor::new(new_value.as_ref())).map_err(|e| {
-            EncodingError {
-                message: format!("Failed to deserialize new RoaringTreemap: {}", e),
-            }
-        })?;
-
-    // Union the bitmaps
-    let merged = existing_bitmap | new_bitmap;
-
-    // Serialize result
     let mut buf = Vec::new();
     merged.serialize_into(&mut buf).map_err(|e| EncodingError {
         message: format!("Failed to serialize merged RoaringTreemap: {}", e),
@@ -200,27 +138,6 @@ fn merge_batch_centroid_chunk(
     }
 
     CentroidChunkValue::new(entries).encode_to_bytes(dimensions)
-}
-
-/// Merge two CentroidChunk values by appending entries from new to existing.
-fn merge_centroid_chunk(existing: Bytes, new_value: Bytes, dimensions: usize) -> Bytes {
-    let existing_chunk = CentroidChunkValue::decode_from_bytes(&existing, dimensions)
-        .expect("Failed to decode existing CentroidChunkValue");
-    let new_chunk = CentroidChunkValue::decode_from_bytes(&new_value, dimensions)
-        .expect("Failed to decode new CentroidChunkValue");
-    let mut combined_entries = existing_chunk.entries;
-    combined_entries.extend(new_chunk.entries);
-    CentroidChunkValue::new(combined_entries).encode_to_bytes(dimensions)
-}
-
-/// Merge two CentroidStats values by summing their i32 deltas.
-fn merge_centroid_stats(existing: Bytes, new_value: Bytes) -> Bytes {
-    let existing_stats = CentroidStatsValue::decode_from_bytes(&existing)
-        .expect("Failed to decode existing CentroidStatsValue");
-    let new_stats = CentroidStatsValue::decode_from_bytes(&new_value)
-        .expect("Failed to decode new CentroidStatsValue");
-    let merged = CentroidStatsValue::new(existing_stats.num_vectors + new_stats.num_vectors);
-    merged.encode_to_bytes()
 }
 
 #[cfg(test)]
@@ -313,7 +230,7 @@ mod tests {
             .unwrap();
 
         // when
-        let merged = merge_roaring_treemap(existing_value, new_value).unwrap();
+        let merged = merge_batch_roaring_treemap(Some(existing_value), &[new_value]).unwrap();
         let decoded = DeletionsValue::decode_from_bytes(&merged).unwrap();
 
         // then
@@ -365,7 +282,7 @@ mod tests {
             .unwrap();
 
         // when
-        let merged = merge_roaring_treemap(existing_value, new_value).unwrap();
+        let merged = merge_batch_roaring_treemap(Some(existing_value), &[new_value]).unwrap();
         let decoded = MetadataIndexValue::decode_from_bytes(&merged).unwrap();
 
         // then


### PR DESCRIPTION
## Summary

Completes the implementation of `merge_batch` for `VectorDbMergeOperator` for remaining record types after posting lists were implemented in #263.

It then delegates `merge` to `merge_batch` for `VectorDbMergeOperator` and removes non-batch helper functions.

## Related Issues

Relates to #272.

## Test Plan

Added unit tests.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
