### PR TITLE
timeseries/promql: align range-vector and scalar functions with RFC 0005

### DIFF
--- a/timeseries/rfcs/0005-promql-function-signatures.md
+++ b/timeseries/rfcs/0005-promql-function-signatures.md
@@ -15,7 +15,9 @@ arguments, string arguments, and scalar return values.
 
 The proposal introduces a typed function argument model and a unified function
 execution interface that can evaluate functions across argument shapes while
-preserving PromQL semantics.
+preserving PromQL semantics. In the current incremental design, expression
+shape (`scalar`, `vector`, `matrix`) remains an evaluator concern, while
+function implementations continue to operate on `EvalSample`-based values.
 
 ## Motivation
 
@@ -66,7 +68,9 @@ Without generalization, PromQL support growth becomes brittle and repetitive.
   `experimental`) as the signature source of truth.
 - Use one runtime-dispatched `PromQLFunction` interface at the function
   boundary.
-- Keep scalar-return boundary semantics as `ExprResult::Scalar`.
+- Keep `ExprResult` as the evaluator boundary for expression shape.
+- Keep `PromQLFunction` implementations returning `Vec<EvalSample>` in the
+  current incremental design.
 - Preserve explicit special handling for series/label-oriented functions
   (`label_replace`, `label_join`, and `info` when supported).
 
@@ -149,11 +153,13 @@ Implication for this RFC:
 
 Use one unified function-call interface at the function boundary.
 
-- Use `PromQLArg` as the function-input channel.
-- Keep `ExprResult` as the expression-output channel.
-- Pass `raw_args` for handlers that must inspect AST literals (for example
-  string-argument functions).
-- Keep one `PromQLFunction` trait for runtime dispatch by function name.
+- `PromQLArg` is the function-input channel for `scalar`, `instant vector`,
+  and `range vector` arguments.
+- `FunctionCallContext` carries evaluation timestamp and raw AST arguments for
+  handlers that must inspect literals directly.
+- `PromQLFunction` remains the single runtime-dispatched function interface.
+- In the current implementation, function handlers return `Vec<EvalSample>`.
+- `ExprResult` remains the expression-output channel owned by evaluator.
 
 ```rust
 pub(crate) enum PromQLArg {
@@ -166,14 +172,6 @@ pub(crate) struct FunctionCallContext<'a> {
     pub eval_timestamp_ms: i64,
     pub raw_args: &'a [Box<Expr>],
 }
-
-pub(crate) trait PromQLFunction {
-    fn apply(
-        &self,
-        evaluated_args: Vec<Option<PromQLArg>>,
-        ctx: &FunctionCallContext<'_>,
-    ) -> EvalResult<ExprResult>;
-}
 ```
 
 Notes:
@@ -185,20 +183,22 @@ Notes:
   validation.
 - String-argument handling uses `raw_args` with `None` in evaluated argument
   slots.
-- `ExprResult` is intentionally not widened with `String` for this change:
-  function string literals are modeled as function inputs, while expression
-  outputs remain scalar/vector/matrix.
+- Function implementations stay simpler if they operate on sample vectors and
+  let evaluator own final expression-shape conversion.
 
 ### Scalar Boundary Semantics
 
 Prometheus function internals represent scalar results as vector samples. This
-engine keeps scalar results as `ExprResult::Scalar` at the function boundary.
+engine keeps scalar results as `ExprResult::Scalar` at the evaluator boundary.
 
 Boundary rule:
 
-- Function handlers may use internal scalar/vector helper representations as
-  needed, but final outputs for scalar-returning signatures must surface as
-  `ExprResult::Scalar`.
+- Scalar-returning function handlers may encode their result as a single-sample
+  `Vec<EvalSample>`.
+- Evaluator unwraps that result to `ExprResult::Scalar` using parser
+  `return_type` metadata.
+- This keeps function bodies simple while preserving correct PromQL expression
+  semantics.
 
 ### Signature Source of Truth
 
@@ -233,8 +233,8 @@ At a high level, evaluator-side function handling is responsible for:
   (`label_replace`, `label_join`, and `info` when parser support exists).
 - Passing both raw AST arguments and evaluated argument values into function
   execution.
-- Enforcing result-shape expectations at the boundary (`ExprResult` consistency
-  with the function signature).
+- Converting function outputs into the declared expression shape using parser
+  metadata (`ExprResult::Scalar` vs `ExprResult::InstantVector`).
 
 ### Registry Design
 
@@ -290,3 +290,4 @@ results.
 | 2026-03-06 | Updated alignment for `promql-parser` `v0.8.x` (`variadic: i32`, `experimental: bool`) and switched RFC variadic semantics to Prometheus-style cardinality. |
 | 2026-03-06 | Added explicit architecture decisions section and reduced implementation-detail sections to keep RFC scope high-level. |
 | 2026-03-09 | Clarified input/output separation for function execution: `PromQLArg` for function inputs, `ExprResult` for expression outputs. |
+| 2026-03-12 | Updated the RFC to match the incremental implementation: `PromQLFunction` remains `Vec<EvalSample>`-based, while evaluator keeps ownership of `ExprResult` conversion and scalar unwrapping. |

--- a/timeseries/src/promql/evaluator.rs
+++ b/timeseries/src/promql/evaluator.rs
@@ -1468,9 +1468,19 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
         // String-typed arguments are passed through as raw AST nodes for
         // string-argument functions such as label_replace/label_join.
         let mut arg_results = Vec::with_capacity(call.args.args.len());
-        let mut has_range_arg = false;
-        for arg in &call.args.args {
-            if arg.value_type() == ValueType::String {
+        for (idx, arg) in call.args.args.iter().enumerate() {
+            let expected_type = if idx < call.func.arg_types.len() {
+                call.func.arg_types[idx]
+            } else if call.func.variadic != 0 && !call.func.arg_types.is_empty() {
+                call.func.arg_types[call.func.arg_types.len() - 1]
+            } else {
+                return Err(EvaluationError::InternalError(format!(
+                    "argument {} is out of bounds for function {}",
+                    idx, call.func.name
+                )));
+            };
+
+            if expected_type == ValueType::String {
                 arg_results.push(None);
                 continue;
             }
@@ -1485,10 +1495,6 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
                     lookback_delta_ms,
                 )
                 .await?;
-
-            if matches!(arg_result, ExprResult::RangeVector(_)) {
-                has_range_arg = true;
-            }
             arg_results.push(Some(arg_result));
         }
 
@@ -1501,51 +1507,17 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
         //   - Function is called with evaluation_ts = -50s (negative!)
         let eval_timestamp_ms = evaluation_ts.as_millis();
 
-        if has_range_arg {
-            if arg_results.len() != 1 {
-                return Err(EvaluationError::InternalError(format!(
-                    "range-vector functions currently require exactly one argument: {}",
-                    call.func.name
-                )));
-            }
-
-            return match arg_results.remove(0) {
-                Some(ExprResult::RangeVector(samples)) => {
-                    if let Some(func) = registry.get_range_function(call.func.name) {
-                        let result = func.apply(samples, eval_timestamp_ms)?;
-                        Ok(ExprResult::InstantVector(result))
-                    } else {
-                        Err(EvaluationError::InternalError(format!(
-                            "Unknown range vector function: {}",
-                            call.func.name
-                        )))
-                    }
-                }
-                Some(_) => Err(EvaluationError::InternalError(format!(
-                    "mixed range/non-range function arguments are not supported: {}",
-                    call.func.name
-                ))),
-                None => Err(EvaluationError::InternalError(format!(
-                    "range-vector functions do not support string arguments: {}",
-                    call.func.name
-                ))),
-            };
-        }
-
         let mut evaluated_args = Vec::with_capacity(arg_results.len());
         for arg_result in arg_results {
             match arg_result {
                 Some(ExprResult::InstantVector(samples)) => {
                     evaluated_args.push(Some(PromQLArg::InstantVector(samples)))
                 }
-                Some(ExprResult::Scalar(scalar)) => {
-                    evaluated_args.push(Some(PromQLArg::Scalar(scalar)))
+                Some(ExprResult::Scalar(value)) => {
+                    evaluated_args.push(Some(PromQLArg::Scalar(value)))
                 }
-                Some(ExprResult::RangeVector(_)) => {
-                    return Err(EvaluationError::InternalError(format!(
-                        "unexpected range-vector argument dispatch for function: {}",
-                        call.func.name
-                    )));
+                Some(ExprResult::RangeVector(samples)) => {
+                    evaluated_args.push(Some(PromQLArg::RangeVector(samples)))
                 }
                 // Preserve string-arg positions here; string-aware functions
                 // read the raw AST nodes from ctx.raw_args instead.
@@ -1559,6 +1531,16 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
                 raw_args: &call.args.args,
             };
             let result = func.apply_call(evaluated_args, &ctx)?;
+            if call.func.return_type == ValueType::Scalar {
+                return match result.as_slice() {
+                    [sample] => Ok(ExprResult::Scalar(sample.value)),
+                    _ => Err(EvaluationError::InternalError(format!(
+                        "scalar-returning function {} must return exactly one sample",
+                        call.func.name
+                    ))),
+                };
+            }
+
             Ok(ExprResult::InstantVector(result))
         } else {
             Err(EvaluationError::InternalError(format!(
@@ -1936,18 +1918,10 @@ impl<'reader, R: QueryReader> Evaluator<'reader, R> {
             .await?
         {
             ExprResult::Scalar(value) => value,
-            // `scalar()` currently returns an instant vector in this engine.
-            // Accept a single-element vector here so k-aggregations can consume scalar params.
-            ExprResult::InstantVector(mut samples) => {
-                if samples.len() == 1 {
-                    samples.pop().map(|sample| sample.value).ok_or_else(|| {
-                        EvaluationError::InternalError(
-                            "aggregation parameter expected one sample".to_string(),
-                        )
-                    })?
-                } else {
-                    f64::NAN
-                }
+            ExprResult::InstantVector(_) => {
+                return Err(EvaluationError::InternalError(
+                    "aggregation parameter must evaluate to a scalar".to_string(),
+                ));
             }
             ExprResult::RangeVector(_) => {
                 return Err(EvaluationError::InternalError(
@@ -3281,6 +3255,111 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn should_evaluate_time_function_as_scalar() {
+        // given
+        let bucket = TimeBucket::hour(1000);
+        let reader = MockQueryReaderBuilder::new(bucket).build();
+        let mut evaluator = Evaluator::new(&reader);
+        let end_time = UNIX_EPOCH + Duration::from_millis(1);
+
+        // when
+        let stmt = EvalStmt {
+            expr: promql_parser::parser::parse("time()").unwrap(),
+            start: end_time,
+            end: end_time,
+            interval: Duration::from_secs(0),
+            lookback_delta: Duration::from_secs(300),
+        };
+        let result = evaluator.evaluate(stmt).await.unwrap();
+
+        // then
+        match result {
+            ExprResult::Scalar(value) => assert_eq!(value, 0.001),
+            ExprResult::InstantVector(_) => panic!("Expected scalar result, got vector"),
+            ExprResult::RangeVector(_) => panic!("Expected scalar result, got range vector"),
+        }
+    }
+
+    #[tokio::test]
+    async fn should_evaluate_pi_function_as_scalar() {
+        // given
+        let bucket = TimeBucket::hour(1000);
+        let reader = MockQueryReaderBuilder::new(bucket).build();
+        let mut evaluator = Evaluator::new(&reader);
+        let end_time = UNIX_EPOCH + Duration::from_secs(2000);
+
+        // when
+        let stmt = EvalStmt {
+            expr: promql_parser::parser::parse("pi()").unwrap(),
+            start: end_time,
+            end: end_time,
+            interval: Duration::from_secs(0),
+            lookback_delta: Duration::from_secs(300),
+        };
+        let result = evaluator.evaluate(stmt).await.unwrap();
+
+        // then
+        match result {
+            ExprResult::Scalar(value) => assert_eq!(value, std::f64::consts::PI),
+            ExprResult::InstantVector(_) => panic!("Expected scalar result, got vector"),
+            ExprResult::RangeVector(_) => panic!("Expected scalar result, got range vector"),
+        }
+    }
+
+    #[tokio::test]
+    async fn should_evaluate_scalar_function_as_scalar() {
+        // given
+        let bucket = TimeBucket::hour(1000);
+        let reader = MockQueryReaderBuilder::new(bucket).build();
+        let mut evaluator = Evaluator::new(&reader);
+        let end_time = UNIX_EPOCH + Duration::from_secs(2000);
+
+        // when
+        let stmt = EvalStmt {
+            expr: promql_parser::parser::parse("scalar(vector(42))").unwrap(),
+            start: end_time,
+            end: end_time,
+            interval: Duration::from_secs(0),
+            lookback_delta: Duration::from_secs(300),
+        };
+        let result = evaluator.evaluate(stmt).await.unwrap();
+
+        // then
+        match result {
+            ExprResult::Scalar(value) => assert_eq!(value, 42.0),
+            ExprResult::InstantVector(_) => panic!("Expected scalar result, got vector"),
+            ExprResult::RangeVector(_) => panic!("Expected scalar result, got range vector"),
+        }
+    }
+
+    #[tokio::test]
+    async fn should_allow_scalar_function_results_as_vector_arguments() {
+        // given
+        let bucket = TimeBucket::hour(1000);
+        let reader = MockQueryReaderBuilder::new(bucket).build();
+        let mut evaluator = Evaluator::new(&reader);
+        let end_time = UNIX_EPOCH + Duration::from_secs(5);
+
+        // when
+        let stmt = EvalStmt {
+            expr: promql_parser::parser::parse("vector(time())").unwrap(),
+            start: end_time,
+            end: end_time,
+            interval: Duration::from_secs(0),
+            lookback_delta: Duration::from_secs(300),
+        };
+        let result = evaluator
+            .evaluate(stmt)
+            .await
+            .unwrap()
+            .expect_instant_vector("Expected instant vector result");
+
+        // then
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 5.0);
+    }
+
+    #[tokio::test]
     async fn should_error_on_string_literal() {
         // given: create an empty mock reader
         let bucket = TimeBucket::hour(1000);
@@ -3810,7 +3889,7 @@ mod tests {
                 "vector",
                 vec![ValueType::Scalar],
                 0,
-                ValueType::Scalar,
+                ValueType::Vector,
                 false,
             ),
             args: FunctionArgs::new_args(Expr::NumberLiteral(NumberLiteral { val: 42.0 })),
@@ -3852,7 +3931,7 @@ mod tests {
                 "vector",
                 vec![ValueType::Scalar],
                 0,
-                ValueType::Scalar,
+                ValueType::Vector,
                 false,
             ),
             args: FunctionArgs::new_args(Expr::Binary(BinaryExpr {

--- a/timeseries/src/promql/functions.rs
+++ b/timeseries/src/promql/functions.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
+use chrono::{DateTime, Datelike, NaiveDate, Timelike, Utc};
+
 use super::evaluator::{EvalResult, EvalSample, EvalSamples};
 use crate::{model::Sample, promql::evaluator::EvaluationError};
 use promql_parser::label::METRIC_NAME;
@@ -113,6 +115,7 @@ fn avg_kahan(values: &[Sample]) -> f64 {
 pub(crate) enum PromQLArg {
     InstantVector(Vec<EvalSample>),
     Scalar(f64),
+    RangeVector(Vec<EvalSamples>),
 }
 
 pub(crate) struct FunctionCallContext<'a> {
@@ -138,9 +141,18 @@ impl PromQLArg {
             )),
         }
     }
+
+    pub fn into_range_vector(self) -> EvalResult<Vec<EvalSamples>> {
+        match self {
+            Self::RangeVector(samples) => Ok(samples),
+            _ => Err(EvaluationError::InternalError(
+                "expected range vector".to_string(),
+            )),
+        }
+    }
 }
 
-/// Trait for PromQL functions that operate on instant vectors
+/// Trait for PromQL functions that operate on evaluated PromQL arguments.
 pub(crate) trait PromQLFunction {
     /// Apply the function to the input samples.
     /// `eval_timestamp_ms` is the evaluation timestamp in milliseconds since UNIX epoch.
@@ -181,17 +193,6 @@ pub(crate) trait PromQLFunction {
 
         self.apply_args(args, ctx.eval_timestamp_ms)
     }
-}
-
-/// Trait for PromQL functions that operate on range vectors (matrix selectors)
-pub(crate) trait RangeFunction {
-    /// Apply the function to range vector samples.
-    /// `eval_timestamp_ms` is the evaluation timestamp in milliseconds since UNIX epoch.
-    fn apply(
-        &self,
-        samples: Vec<EvalSamples>,
-        eval_timestamp_ms: i64,
-    ) -> EvalResult<Vec<EvalSample>>;
 }
 
 /// Function that applies a unary operation to each sample
@@ -299,6 +300,12 @@ fn exact_arity_error(
 fn min_arity_error(function_name: &str, min_args: usize, actual_args: usize) -> EvaluationError {
     EvaluationError::InternalError(format!(
         "{function_name} requires at least {min_args} argument(s), got {actual_args}"
+    ))
+}
+
+fn max_arity_error(function_name: &str, max_args: usize, actual_args: usize) -> EvaluationError {
+    EvaluationError::InternalError(format!(
+        "{function_name} accepts at most {max_args} argument(s), got {actual_args}"
     ))
 }
 
@@ -574,13 +581,11 @@ impl PromQLFunction for LabelJoinFunction {
 /// Function registry that maps function names to their implementations
 pub(crate) struct FunctionRegistry {
     functions: HashMap<String, Box<dyn PromQLFunction>>,
-    range_functions: HashMap<String, Box<dyn RangeFunction>>,
 }
 
 impl FunctionRegistry {
     pub(crate) fn new() -> Self {
         let mut functions: HashMap<String, Box<dyn PromQLFunction>> = HashMap::new();
-        let mut range_functions: HashMap<String, Box<dyn RangeFunction>> = HashMap::new();
 
         // Mathematical functions
         functions.insert("abs".to_string(), Box::new(UnaryFunction { op: f64::abs }));
@@ -666,40 +671,104 @@ impl FunctionRegistry {
 
         // Special functions
         functions.insert("absent".to_string(), Box::new(AbsentFunction));
+        functions.insert(
+            "day_of_month".to_string(),
+            Box::new(DateTimeFunction::new(
+                "day_of_month",
+                DateTimePart::DayOfMonth,
+            )),
+        );
+        functions.insert(
+            "day_of_week".to_string(),
+            Box::new(DateTimeFunction::new(
+                "day_of_week",
+                DateTimePart::DayOfWeek,
+            )),
+        );
+        functions.insert(
+            "day_of_year".to_string(),
+            Box::new(DateTimeFunction::new(
+                "day_of_year",
+                DateTimePart::DayOfYear,
+            )),
+        );
+        functions.insert(
+            "days_in_month".to_string(),
+            Box::new(DateTimeFunction::new(
+                "days_in_month",
+                DateTimePart::DaysInMonth,
+            )),
+        );
+        functions.insert(
+            "hour".to_string(),
+            Box::new(DateTimeFunction::new("hour", DateTimePart::Hour)),
+        );
+        functions.insert(
+            "minute".to_string(),
+            Box::new(DateTimeFunction::new("minute", DateTimePart::Minute)),
+        );
+        functions.insert(
+            "month".to_string(),
+            Box::new(DateTimeFunction::new("month", DateTimePart::Month)),
+        );
+        functions.insert("pi".to_string(), Box::new(PiFunction));
         functions.insert("scalar".to_string(), Box::new(ScalarFunction));
+        functions.insert("timestamp".to_string(), Box::new(TimestampFunction));
+        functions.insert("time".to_string(), Box::new(TimeFunction));
+        functions.insert("vector".to_string(), Box::new(VectorFunction));
+        functions.insert(
+            "year".to_string(),
+            Box::new(DateTimeFunction::new("year", DateTimePart::Year)),
+        );
 
         // Range vector functions
-        range_functions.insert("rate".to_string(), Box::new(RateFunction));
-        range_functions.insert("sum_over_time".to_string(), Box::new(SumOverTimeFunction));
-        range_functions.insert("avg_over_time".to_string(), Box::new(AvgOverTimeFunction));
-        range_functions.insert("min_over_time".to_string(), Box::new(MinOverTimeFunction));
-        range_functions.insert("max_over_time".to_string(), Box::new(MaxOverTimeFunction));
-        range_functions.insert(
+        functions.insert("rate".to_string(), Box::new(RateFunction));
+        functions.insert("sum_over_time".to_string(), Box::new(SumOverTimeFunction));
+        functions.insert("avg_over_time".to_string(), Box::new(AvgOverTimeFunction));
+        functions.insert("min_over_time".to_string(), Box::new(MinOverTimeFunction));
+        functions.insert("max_over_time".to_string(), Box::new(MaxOverTimeFunction));
+        functions.insert(
             "count_over_time".to_string(),
             Box::new(CountOverTimeFunction),
         );
-        range_functions.insert(
+        functions.insert(
             "stddev_over_time".to_string(),
             Box::new(StddevOverTimeFunction),
         );
-        range_functions.insert(
+        functions.insert(
             "stdvar_over_time".to_string(),
             Box::new(StdvarOverTimeFunction),
         );
-        functions.insert("vector".to_string(), Box::new(VectorFunction));
 
-        Self {
-            functions,
-            range_functions,
-        }
+        Self { functions }
     }
 
     pub(crate) fn get(&self, name: &str) -> Option<&dyn PromQLFunction> {
         self.functions.get(name).map(|f| f.as_ref())
     }
+}
 
-    pub(crate) fn get_range_function(&self, name: &str) -> Option<&dyn RangeFunction> {
-        self.range_functions.get(name).map(|f| f.as_ref())
+#[cfg(test)]
+pub(crate) struct RangeFunctionAdapter<'a> {
+    inner: &'a dyn PromQLFunction,
+}
+
+#[cfg(test)]
+impl RangeFunctionAdapter<'_> {
+    pub(crate) fn apply(
+        &self,
+        samples: Vec<EvalSamples>,
+        eval_timestamp_ms: i64,
+    ) -> EvalResult<Vec<EvalSample>> {
+        self.inner
+            .apply(PromQLArg::RangeVector(samples), eval_timestamp_ms)
+    }
+}
+
+#[cfg(test)]
+impl FunctionRegistry {
+    pub(crate) fn get_range_function(&self, name: &str) -> Option<RangeFunctionAdapter<'_>> {
+        self.get(name).map(|inner| RangeFunctionAdapter { inner })
     }
 }
 
@@ -724,18 +793,198 @@ impl PromQLFunction for AbsentFunction {
     }
 }
 
-/// Scalar function: converts single-element vector to scalar (returns as-is or empty)
+/// Pi function: returns PI encoded as a single-sample vector.
+struct PiFunction;
+
+impl PromQLFunction for PiFunction {
+    fn apply(&self, _arg: PromQLArg, _eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        Err(exact_arity_error("pi", 0, 1))
+    }
+
+    fn apply_args(
+        &self,
+        args: Vec<PromQLArg>,
+        eval_timestamp_ms: i64,
+    ) -> EvalResult<Vec<EvalSample>> {
+        if !args.is_empty() {
+            return Err(exact_arity_error("pi", 0, args.len()));
+        }
+
+        Ok(vec![EvalSample {
+            timestamp_ms: eval_timestamp_ms,
+            value: std::f64::consts::PI,
+            labels: HashMap::new(),
+            drop_name: false,
+        }])
+    }
+}
+
+/// Scalar function: encodes a scalar result as a single-sample vector.
 struct ScalarFunction;
 
 impl PromQLFunction for ScalarFunction {
-    fn apply(&self, arg: PromQLArg, _eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
         let samples = arg.into_instant_vector()?;
-        if samples.len() == 1 {
-            // Return the single sample (scalar converts single-element vector to scalar)
-            Ok(samples)
+        let value = if samples.len() == 1 {
+            samples[0].value
         } else {
-            // Return empty vector if input doesn't have exactly one element
-            Ok(vec![])
+            f64::NAN
+        };
+
+        Ok(vec![EvalSample {
+            timestamp_ms: eval_timestamp_ms,
+            value,
+            labels: HashMap::new(),
+            drop_name: false,
+        }])
+    }
+}
+
+struct TimeFunction;
+
+impl PromQLFunction for TimeFunction {
+    fn apply(&self, _arg: PromQLArg, _eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        Err(exact_arity_error("time", 0, 1))
+    }
+
+    fn apply_args(
+        &self,
+        args: Vec<PromQLArg>,
+        eval_timestamp_ms: i64,
+    ) -> EvalResult<Vec<EvalSample>> {
+        if !args.is_empty() {
+            return Err(exact_arity_error("time", 0, args.len()));
+        }
+
+        Ok(vec![EvalSample {
+            timestamp_ms: eval_timestamp_ms,
+            value: eval_timestamp_ms as f64 / 1000.0,
+            labels: HashMap::new(),
+            drop_name: false,
+        }])
+    }
+}
+
+struct TimestampFunction;
+
+impl PromQLFunction for TimestampFunction {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        let mut samples = arg.into_instant_vector()?;
+        for sample in &mut samples {
+            sample.value = sample.timestamp_ms as f64 / 1000.0;
+            sample.timestamp_ms = eval_timestamp_ms;
+            sample.drop_name = true;
+        }
+
+        Ok(samples)
+    }
+}
+
+enum DateTimePart {
+    Year,
+    Month,
+    DayOfMonth,
+    DayOfYear,
+    DayOfWeek,
+    Hour,
+    Minute,
+    DaysInMonth,
+}
+
+impl DateTimePart {
+    fn extract(&self, dt: DateTime<Utc>) -> f64 {
+        match self {
+            Self::Year => dt.year() as f64,
+            Self::Month => dt.month() as f64,
+            Self::DayOfMonth => dt.day() as f64,
+            Self::DayOfYear => dt.ordinal() as f64,
+            Self::DayOfWeek => dt.weekday().num_days_from_sunday() as f64,
+            Self::Hour => dt.hour() as f64,
+            Self::Minute => dt.minute() as f64,
+            Self::DaysInMonth => days_in_month(dt) as f64,
+        }
+    }
+}
+
+fn datetime_from_seconds(value: f64) -> Option<DateTime<Utc>> {
+    if !value.is_finite() {
+        return None;
+    }
+
+    let seconds = value.trunc();
+    if !(i64::MIN as f64..=i64::MAX as f64).contains(&seconds) {
+        return None;
+    }
+
+    DateTime::from_timestamp(seconds as i64, 0)
+}
+
+fn datetime_from_millis(value: i64) -> Option<DateTime<Utc>> {
+    DateTime::from_timestamp(value / 1000, 0)
+}
+
+fn days_in_month(dt: DateTime<Utc>) -> u32 {
+    let start_of_month =
+        NaiveDate::from_ymd_opt(dt.year(), dt.month(), 1).expect("valid start of month");
+    let start_of_next_month = if dt.month() == 12 {
+        NaiveDate::from_ymd_opt(dt.year() + 1, 1, 1).expect("valid start of next month")
+    } else {
+        NaiveDate::from_ymd_opt(dt.year(), dt.month() + 1, 1).expect("valid start of next month")
+    };
+
+    start_of_next_month
+        .signed_duration_since(start_of_month)
+        .num_days() as u32
+}
+
+struct DateTimeFunction {
+    name: &'static str,
+    part: DateTimePart,
+}
+
+impl DateTimeFunction {
+    fn new(name: &'static str, part: DateTimePart) -> Self {
+        Self { name, part }
+    }
+
+    fn sample_value(&self, dt: DateTime<Utc>) -> f64 {
+        self.part.extract(dt)
+    }
+}
+
+impl PromQLFunction for DateTimeFunction {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        let mut samples = arg.into_instant_vector()?;
+        for sample in &mut samples {
+            sample.value = datetime_from_seconds(sample.value)
+                .map(|dt| self.sample_value(dt))
+                .unwrap_or(f64::NAN);
+            sample.timestamp_ms = eval_timestamp_ms;
+            sample.drop_name = true;
+        }
+
+        Ok(samples)
+    }
+
+    fn apply_args(
+        &self,
+        args: Vec<PromQLArg>,
+        eval_timestamp_ms: i64,
+    ) -> EvalResult<Vec<EvalSample>> {
+        match args.len() {
+            0 => Ok(vec![EvalSample {
+                timestamp_ms: eval_timestamp_ms,
+                value: datetime_from_millis(eval_timestamp_ms)
+                    .map(|dt| self.sample_value(dt))
+                    .unwrap_or(f64::NAN),
+                labels: HashMap::new(),
+                drop_name: false,
+            }]),
+            1 => self.apply(
+                args.into_iter().next().expect("single arg"),
+                eval_timestamp_ms,
+            ),
+            _ => Err(max_arity_error(self.name, 1, args.len())),
         }
     }
 }
@@ -743,12 +992,9 @@ impl PromQLFunction for ScalarFunction {
 /// Rate function: calculates per-second rate of change for range vectors
 struct RateFunction;
 
-impl RangeFunction for RateFunction {
-    fn apply(
-        &self,
-        samples: Vec<EvalSamples>,
-        eval_timestamp_ms: i64,
-    ) -> EvalResult<Vec<EvalSample>> {
+impl PromQLFunction for RateFunction {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        let samples = arg.into_range_vector()?;
         // TODO(rohan): handle counter resets
         // TODO(rohan): implement extrapolation
         let mut result = Vec::with_capacity(samples.len());
@@ -790,12 +1036,9 @@ impl RangeFunction for RateFunction {
 /// TODO: Add histogram support when histogram types are implemented
 struct SumOverTimeFunction;
 
-impl RangeFunction for SumOverTimeFunction {
-    fn apply(
-        &self,
-        samples: Vec<EvalSamples>,
-        eval_timestamp_ms: i64,
-    ) -> EvalResult<Vec<EvalSample>> {
+impl PromQLFunction for SumOverTimeFunction {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        let samples = arg.into_range_vector()?;
         Ok(aggr_over_time(samples, eval_timestamp_ms, |values| {
             let mut sum = 0.0;
             let mut c = 0.0;
@@ -813,12 +1056,9 @@ impl RangeFunction for SumOverTimeFunction {
 /// TODO: Add histogram support when histogram types are implemented
 struct AvgOverTimeFunction;
 
-impl RangeFunction for AvgOverTimeFunction {
-    fn apply(
-        &self,
-        samples: Vec<EvalSamples>,
-        eval_timestamp_ms: i64,
-    ) -> EvalResult<Vec<EvalSample>> {
+impl PromQLFunction for AvgOverTimeFunction {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        let samples = arg.into_range_vector()?;
         Ok(aggr_over_time(samples, eval_timestamp_ms, avg_kahan))
     }
 }
@@ -846,12 +1086,9 @@ impl RangeFunction for AvgOverTimeFunction {
 /// for all-NaN input. This manual loop preserves exact PromQL behavior.
 struct MinOverTimeFunction;
 
-impl RangeFunction for MinOverTimeFunction {
-    fn apply(
-        &self,
-        samples: Vec<EvalSamples>,
-        eval_timestamp_ms: i64,
-    ) -> EvalResult<Vec<EvalSample>> {
+impl PromQLFunction for MinOverTimeFunction {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        let samples = arg.into_range_vector()?;
         Ok(aggr_over_time(samples, eval_timestamp_ms, |values| {
             let mut min_val = values[0].value;
             for sample in values.iter().skip(1) {
@@ -879,12 +1116,9 @@ impl RangeFunction for MinOverTimeFunction {
 /// with Prometheus.
 struct MaxOverTimeFunction;
 
-impl RangeFunction for MaxOverTimeFunction {
-    fn apply(
-        &self,
-        samples: Vec<EvalSamples>,
-        eval_timestamp_ms: i64,
-    ) -> EvalResult<Vec<EvalSample>> {
+impl PromQLFunction for MaxOverTimeFunction {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        let samples = arg.into_range_vector()?;
         Ok(aggr_over_time(samples, eval_timestamp_ms, |values| {
             let mut max_val = values[0].value;
             for sample in values.iter().skip(1) {
@@ -902,12 +1136,9 @@ impl RangeFunction for MaxOverTimeFunction {
 /// TODO: Add histogram support - Prometheus counts both floats and histograms
 struct CountOverTimeFunction;
 
-impl RangeFunction for CountOverTimeFunction {
-    fn apply(
-        &self,
-        samples: Vec<EvalSamples>,
-        eval_timestamp_ms: i64,
-    ) -> EvalResult<Vec<EvalSample>> {
+impl PromQLFunction for CountOverTimeFunction {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        let samples = arg.into_range_vector()?;
         Ok(aggr_over_time(samples, eval_timestamp_ms, |values| {
             values.len() as f64
         }))
@@ -969,12 +1200,9 @@ fn variance_kahan(values: &[Sample]) -> f64 {
 /// Only operates on float samples; histogram samples are ignored
 struct StddevOverTimeFunction;
 
-impl RangeFunction for StddevOverTimeFunction {
-    fn apply(
-        &self,
-        samples: Vec<EvalSamples>,
-        eval_timestamp_ms: i64,
-    ) -> EvalResult<Vec<EvalSample>> {
+impl PromQLFunction for StddevOverTimeFunction {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        let samples = arg.into_range_vector()?;
         Ok(aggr_over_time(samples, eval_timestamp_ms, |values| {
             variance_kahan(values).sqrt()
         }))
@@ -985,12 +1213,9 @@ impl RangeFunction for StddevOverTimeFunction {
 /// Only operates on float samples; histogram samples are ignored
 struct StdvarOverTimeFunction;
 
-impl RangeFunction for StdvarOverTimeFunction {
-    fn apply(
-        &self,
-        samples: Vec<EvalSamples>,
-        eval_timestamp_ms: i64,
-    ) -> EvalResult<Vec<EvalSample>> {
+impl PromQLFunction for StdvarOverTimeFunction {
+    fn apply(&self, arg: PromQLArg, eval_timestamp_ms: i64) -> EvalResult<Vec<EvalSample>> {
+        let samples = arg.into_range_vector()?;
         Ok(aggr_over_time(samples, eval_timestamp_ms, variance_kahan))
     }
 }
@@ -2080,16 +2305,19 @@ mod tests {
         let registry = FunctionRegistry::new();
         let func = registry.get("scalar").unwrap();
 
-        // Single element should be returned
+        // Single element should be returned as a scalar-encoded sample.
         let result = func
             .apply(PromQLArg::InstantVector(vec![create_sample(42.0)]), 1000)
             .unwrap();
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].value, 42.0);
+        assert_eq!(result[0].timestamp_ms, 1000);
 
-        // Zero or multiple elements should return empty
+        // Zero or multiple elements should return NaN encoded as a scalar sample.
         let result = func.apply(PromQLArg::InstantVector(vec![]), 1000).unwrap();
-        assert!(result.is_empty());
+        assert_eq!(result.len(), 1);
+        assert!(result[0].value.is_nan());
+        assert_eq!(result[0].timestamp_ms, 1000);
 
         let result = func
             .apply(
@@ -2097,7 +2325,125 @@ mod tests {
                 1000,
             )
             .unwrap();
-        assert!(result.is_empty());
+        assert_eq!(result.len(), 1);
+        assert!(result[0].value.is_nan());
+        assert_eq!(result[0].timestamp_ms, 1000);
+    }
+
+    #[test]
+    fn should_apply_timestamp_function() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("timestamp").unwrap();
+
+        let samples = vec![EvalSample {
+            timestamp_ms: 10_000,
+            value: 123.0,
+            labels: HashMap::from([
+                (METRIC_NAME.to_string(), "metric".to_string()),
+                ("job".to_string(), "api".to_string()),
+            ]),
+            drop_name: false,
+        }];
+
+        let result = func
+            .apply(PromQLArg::InstantVector(samples), 600_000)
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 10.0);
+        assert_eq!(result[0].timestamp_ms, 600_000);
+        assert_eq!(
+            result[0].labels.get(METRIC_NAME),
+            Some(&"metric".to_string())
+        );
+        assert_eq!(result[0].labels.get("job"), Some(&"api".to_string()));
+        assert!(result[0].drop_name);
+    }
+
+    #[test]
+    fn should_apply_minute_function() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("minute").unwrap();
+
+        let result = func
+            .apply(
+                PromQLArg::InstantVector(vec![create_sample_with_labels(
+                    1136239445.0,
+                    &[("__name__", "metric"), ("job", "api")],
+                )]),
+                600_000,
+            )
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 4.0);
+        assert_eq!(result[0].timestamp_ms, 600_000);
+        assert_eq!(
+            result[0].labels.get(METRIC_NAME),
+            Some(&"metric".to_string())
+        );
+        assert_eq!(result[0].labels.get("job"), Some(&"api".to_string()));
+        assert!(result[0].drop_name);
+    }
+
+    #[test]
+    fn should_apply_year_function_without_arguments() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("year").unwrap();
+
+        let result = func.apply_args(vec![], 0).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 1970.0);
+        assert_eq!(result[0].timestamp_ms, 0);
+        assert_eq!(result[0].labels, HashMap::new());
+        assert!(!result[0].drop_name);
+    }
+
+    #[test]
+    fn should_apply_days_in_month_function() {
+        let registry = FunctionRegistry::new();
+        let func = registry.get("days_in_month").unwrap();
+
+        let result = func
+            .apply(
+                PromQLArg::InstantVector(vec![create_sample(1454284800.0)]),
+                1000,
+            )
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 29.0);
+        assert_eq!(result[0].timestamp_ms, 1000);
+        assert!(result[0].drop_name);
+    }
+
+    #[test]
+    fn should_truncate_date_time_function_inputs_to_whole_seconds() {
+        let registry = FunctionRegistry::new();
+        let year = registry.get("year").unwrap();
+
+        let result = year
+            .apply(PromQLArg::InstantVector(vec![create_sample(-0.9)]), 1000)
+            .unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 1970.0);
+        assert_eq!(result[0].timestamp_ms, 1000);
+        assert!(result[0].drop_name);
+    }
+
+    #[test]
+    fn should_truncate_negative_eval_time_to_whole_seconds() {
+        let registry = FunctionRegistry::new();
+        let year = registry.get("year").unwrap();
+
+        let result = year.apply_args(vec![], -1).unwrap();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].value, 1970.0);
+        assert_eq!(result[0].timestamp_ms, -1);
+        assert!(!result[0].drop_name);
     }
 
     fn create_eval_samples(

--- a/timeseries/src/promql/promqltest/testdata/at_modifier.test
+++ b/timeseries/src/promql/promqltest/testdata/at_modifier.test
@@ -189,8 +189,6 @@ eval instant at 10s minute(metric @ 1500)
   {job="2"} 5
 resume
 
-# ignoring timestamp function
-ignore
 # timestamp() takes the time of the sample and not the evaluation time.
 eval instant at 10m timestamp(metric{job="1"} @ 10)
   {job="1"} 10
@@ -202,10 +200,8 @@ eval instant at 10m timestamp(timestamp(metric{job="1"} @ 10))
 
 eval instant at 15m timestamp(timestamp(metric{job="1"} @ 10))
   {job="1"} 900
-resume
 
-# ignoring sum_over_time aggregator functions
-ignore
+
 
 # Time functions inside a subquery.
 
@@ -244,7 +240,7 @@ eval instant at 0s sum_over_time(timestamp(metric{job="1"} @ 10)[100s:10s] @ 300
 eval instant at 0s sum_over_time(timestamp(timestamp(metric{job="1"} @ 999))[10s:1s] @ 10)
   {job="1"} 55
 
-resume
+
 
 clear
 

--- a/timeseries/src/promql/promqltest/testdata/functions.test
+++ b/timeseries/src/promql/promqltest/testdata/functions.test
@@ -573,7 +573,7 @@ eval instant at 10s timestamp(((metric)))
 
 eval instant at 20s timestamp(metric)
   {} 20
-
+resume
 # Tests for label_join.
 load 5m
   testmetric{src="a",src1="b",src2="c",dst="original-destination-value"} 0
@@ -601,6 +601,8 @@ eval instant at 0m label_join(testmetric, "dst", ", ")
 	  testmetric{src="a",src1="b",src2="c"} 0
 	  testmetric{src="d",src1="e",src2="f"} 1
 
+
+ignore
 # test without dst label for label_join
 load 5m
   testmetric1{src="foo",src1="bar",src2="foobar"} 0
@@ -615,7 +617,7 @@ eval instant at 0m label_join(dup, "label", "", "this")
   expect fail msg:vector cannot contain metrics with the same labelset
 
 clear
-
+resume
 # Tests for vector.
 eval instant at 0m vector(1)
   {} 1
@@ -629,7 +631,7 @@ eval instant at 5s vector(time())
 eval instant at 60m vector(time())
   {} 3600
 
-resume
+
 
 # Tests for clamp_max, clamp_min(), and clamp().
 load 5m


### PR DESCRIPTION
Add PromQLArg::RangeVector and move range-vector functions onto the normal PromQLFunction path so evaluator dispatch no longer depends on a separate range-function category.

Make function-call materialization signature-aware in evaluator by using parser arg_types metadata. This preserves positional argument shape and keeps string-typed args AST-backed via FunctionCallContext, which unblocks mixed-signature functions such as label_replace, label_join, round(v, to_nearest), and clamp(v, min, max).

Keep the existing PromQLFunction -> Vec<EvalSample> boundary to avoid a larger refactor. Move scalar builtins (pi, time, scalar) into functions.rs and encode scalar results as single-sample vectors. The evaluator unwraps those into ExprResult::Scalar when parser metadata declares a scalar return type.

### Notes
I think it makes sense to keep PromQLFunction -> Vec<EvalSample> and leave ExprResult at the evaluator boundary for now. That is the smaller incremental step for RFC 0005: functions already operate on sample vectors, while evaluator already owns expression-shape semantics. Moving the trait to ExprResult would create broad churn across the registry, handlers, and tests without unlocking anything required for this change. With the current split, we still get the key pieces in place: unified RangeVector arguments, one dispatch path, zero/optional-arg support, and correct scalar-return handling via parser return_type.

Fixes #317 

## Test Plan

How was this tested?

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
