### PR TITLE
Add workflow for building test Docker images

### DIFF
--- a/.github/workflows/build-test-image.yml
+++ b/.github/workflows/build-test-image.yml
@@ -1,0 +1,89 @@
+name: Build Test Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      service:
+        description: 'Service to build'
+        required: true
+        type: choice
+        options:
+          - timeseries
+          - log
+          - vector
+      ref:
+        description: 'Branch or commit SHA to build from (defaults to current branch)'
+        required: false
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-docker:
+    name: Build test image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/${{ inputs.service }}
+    steps:
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: true
+          swap-storage: true
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Compute image tag
+        id: tag
+        run: |
+          REF="${{ inputs.ref || github.ref_name }}"
+          SHA="$(git rev-parse --short HEAD)"
+          # Sanitize ref for use as Docker tag (replace / with -)
+          SAFE_REF="$(echo "$REF" | sed 's|/|-|g')"
+          TAG="${SAFE_REF}-${SHA}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Image will be tagged: $TAG"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ inputs.service }}/Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}
+          cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache
+          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:buildcache,mode=max
+
+      - name: Output image URI
+        run: |
+          echo "## Test Image Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Image:** \`${{ env.IMAGE_NAME }}:${{ steps.tag.outputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Deploy with:" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "gh workflow run deploy-opendata.yml -R responsive-oss/heracles -f image_tag=${{ steps.tag.outputs.tag }} -f service=opendata-${{ inputs.service }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` workflow (`build-test-image.yml`) for building Docker images from any branch or commit without creating a release tag
- Images are tagged as `{branch}-{sha}` (e.g., `cold-query-tracing-feb425d`) to clearly distinguish them from release builds
- Useful for testing changes in staging/prod before cutting a release

## Test plan
- [ ] Merge this PR
- [ ] Trigger the workflow manually from Actions tab targeting `cold-query-tracing` branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)