### PR TITLE
implement a decoupled indexer to maintain ann index

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,7 @@ dependencies = [
  "opendata-macros",
  "prost",
  "rand 0.8.5",
+ "rayon",
  "reqwest",
  "roaring 0.10.12",
  "rstest",

--- a/common/src/coordinator/mod.rs
+++ b/common/src/coordinator/mod.rs
@@ -829,7 +829,7 @@ mod tests {
     #[async_trait]
     impl Flusher<TestDelta> for TestFlusher {
         async fn flush_delta(
-            &self,
+            &mut self,
             frozen: FrozenTestDelta,
             epoch_range: &Range<u64>,
         ) -> Result<Arc<dyn StorageSnapshot>, String> {

--- a/common/src/coordinator/traits.rs
+++ b/common/src/coordinator/traits.rs
@@ -98,7 +98,7 @@ pub trait Flusher<D: Delta>: Send + Sync + 'static {
     /// Consumes the frozen delta by value and returns a snapshot for readers
     /// along with a broadcast payload for subscribers.
     async fn flush_delta(
-        &self,
+        &mut self,
         frozen: D::Frozen,
         epoch_range: &Range<u64>,
     ) -> Result<Arc<dyn StorageSnapshot>, String>;

--- a/common/src/sequence.rs
+++ b/common/src/sequence.rs
@@ -88,6 +88,7 @@ impl From<DeserializeError> for SequenceError {
 /// Result type alias for sequence allocation operations.
 pub type SequenceResult<T> = std::result::Result<T, SequenceError>;
 
+#[derive(Clone)]
 pub struct AllocatedSeqBlock {
     current_block: Option<SeqBlock>,
     next_sequence: u64,
@@ -139,6 +140,10 @@ impl SequenceAllocator {
     pub async fn load(storage: &dyn Storage, key: Bytes) -> SequenceResult<Self> {
         let block = AllocatedSeqBlock::load(storage, &key).await?;
         Ok(Self { key, block })
+    }
+
+    pub fn new(key: Bytes, block: AllocatedSeqBlock) -> Self {
+        Self { key, block }
     }
 
     /// Returns the next sequence number that would be allocated.
@@ -205,6 +210,10 @@ impl SequenceAllocator {
         let value: Bytes = new_block.serialize();
         let record = Record::new(self.key.clone(), value);
         (new_block, record)
+    }
+
+    pub fn freeze(self) -> (Bytes, AllocatedSeqBlock) {
+        (self.key, self.block)
     }
 }
 

--- a/timeseries/src/flusher.rs
+++ b/timeseries/src/flusher.rs
@@ -19,7 +19,7 @@ pub(crate) struct TsdbFlusher {
 #[async_trait]
 impl Flusher<TsdbWriteDelta> for TsdbFlusher {
     async fn flush_delta(
-        &self,
+        &mut self,
         frozen: FrozenTsdbDelta,
         _epoch_range: &Range<u64>,
     ) -> Result<Arc<dyn StorageSnapshot>, String> {
@@ -115,7 +115,7 @@ mod tests {
     async fn should_flush_delta_to_storage() {
         // given
         let storage = create_test_storage();
-        let flusher = TsdbFlusher {
+        let mut flusher = TsdbFlusher {
             storage: storage.clone(),
         };
         let ctx = TsdbContext {
@@ -142,7 +142,7 @@ mod tests {
     async fn should_skip_empty_delta() {
         // given
         let storage = create_test_storage();
-        let flusher = TsdbFlusher {
+        let mut flusher = TsdbFlusher {
             storage: storage.clone(),
         };
         let ctx = TsdbContext {
@@ -186,7 +186,7 @@ mod tests {
     async fn should_propagate_apply_error() {
         // given
         let storage = create_failing_storage();
-        let flusher = TsdbFlusher {
+        let mut flusher = TsdbFlusher {
             storage: storage.clone(),
         };
         storage.fail_apply(common::StorageError::Storage("test apply error".into()));
@@ -208,7 +208,7 @@ mod tests {
     async fn should_propagate_snapshot_error_after_apply() {
         // given
         let storage = create_failing_storage();
-        let flusher = TsdbFlusher {
+        let mut flusher = TsdbFlusher {
             storage: storage.clone(),
         };
         // Apply succeeds, but snapshot after apply fails
@@ -251,7 +251,7 @@ mod tests {
     async fn should_persist_series_dict_entries() {
         // given
         let storage = create_test_storage();
-        let flusher = TsdbFlusher {
+        let mut flusher = TsdbFlusher {
             storage: storage.clone(),
         };
         let ctx = TsdbContext {

--- a/vector/Cargo.toml
+++ b/vector/Cargo.toml
@@ -33,6 +33,7 @@ dashmap.workspace = true
 fail.workspace = true
 figment.workspace = true
 futures.workspace = true
+rayon = "1.11.0"
 usearch = "2"
 roaring.workspace = true
 rstest.workspace = true

--- a/vector/src/batched/delta.rs
+++ b/vector/src/batched/delta.rs
@@ -1,0 +1,179 @@
+use crate::delta::{VectorDbWrite, VectorWrite};
+use common::coordinator::Delta;
+use std::any::Any;
+use std::sync::Arc;
+use tracing::debug;
+
+/// Mutable delta that accumulates writes and builds RecordOps.
+///
+/// Implements the `Delta` trait for use with WriteCoordinator.
+pub(crate) struct VectorDbWriteDelta {
+    /// Shared view of the delta's current state, readable by concurrent readers.
+    view: Arc<std::sync::RwLock<VectorDbDeltaView>>,
+}
+
+impl Delta for VectorDbWriteDelta {
+    type Context = ();
+    type Write = VectorDbWrite;
+    type Frozen = Arc<VectorDbDeltaView>;
+    type FrozenView = Arc<VectorDbDeltaView>;
+    type ApplyResult = Arc<dyn Any + Send + Sync + 'static>;
+    type DeltaView = Arc<std::sync::RwLock<VectorDbDeltaView>>;
+
+    fn init(_context: Self::Context) -> Self {
+        Self {
+            view: Arc::new(std::sync::RwLock::new(VectorDbDeltaView::new())),
+        }
+    }
+
+    fn apply(
+        &mut self,
+        write: Self::Write,
+    ) -> Result<Arc<dyn Any + Send + Sync + 'static>, String> {
+        match write {
+            VectorDbWrite::Write(writes) => self.apply_write(writes),
+            VectorDbWrite::Rebalance(_cmd) => {
+                panic!("no rebalance commands in batched write")
+            }
+        }
+    }
+
+    fn estimate_size(&self) -> usize {
+        let view = self.view.read().expect("lock poisoned");
+        // view.writes.len() * self.context.opts.dimensions * 4
+        view.writes.len()
+    }
+
+    fn freeze(self) -> (Self::Frozen, Self::FrozenView, Self::Context) {
+        let frozen = Arc::new(VectorDbDeltaView::clone(
+            &self.view.read().expect("lock poisoned"),
+        ));
+        debug!("freezing delta view with {} writes", frozen.writes.len());
+        let frozen_view = frozen.clone();
+        (frozen, frozen_view, ())
+    }
+
+    fn reader(&self) -> Self::DeltaView {
+        self.view.clone()
+    }
+}
+
+impl VectorDbWriteDelta {
+    fn apply_write(
+        &mut self,
+        vector_writes: Vec<VectorWrite>,
+    ) -> Result<Arc<dyn Any + Send + Sync + 'static>, String> {
+        let mut view = self.view.write().expect("lock poisoned");
+        view.apply(vector_writes);
+        drop(view);
+        Ok(Arc::new(()))
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct VectorDbDeltaView {
+    pub(crate) writes: Vec<VectorWrite>,
+}
+
+impl VectorDbDeltaView {
+    fn new() -> Self {
+        Self { writes: Vec::new() }
+    }
+
+    fn apply(&mut self, writes: Vec<VectorWrite>) {
+        self.writes.extend(writes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::AttributeValue;
+
+    fn make_write(id: &str, values: Vec<f32>) -> VectorWrite {
+        VectorWrite {
+            external_id: id.to_string(),
+            values: values.clone(),
+            attributes: vec![("vector".to_string(), AttributeValue::Vector(values))],
+        }
+    }
+
+    fn assert_write(write: &VectorWrite, expected_id: &str, expected_values: &[f32]) {
+        assert_eq!(write.external_id, expected_id);
+        assert_eq!(write.values, expected_values);
+        // The vector attribute should match the values
+        let vector_attr = write
+            .attributes
+            .iter()
+            .find(|(name, _)| name == "vector")
+            .expect("missing vector attribute");
+        match &vector_attr.1 {
+            AttributeValue::Vector(v) => assert_eq!(v.as_slice(), expected_values),
+            other => panic!("expected Vector attribute, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn reader_should_see_applied_writes() {
+        let mut delta = VectorDbWriteDelta::init(());
+        let reader = delta.reader();
+
+        delta
+            .apply(VectorDbWrite::Write(vec![
+                make_write("v1", vec![1.0, 0.0, 0.0]),
+                make_write("v2", vec![0.0, 1.0, 0.0]),
+            ]))
+            .unwrap();
+        delta
+            .apply(VectorDbWrite::Write(vec![make_write(
+                "v3",
+                vec![0.0, 0.0, 1.0],
+            )]))
+            .unwrap();
+
+        let view = reader.read().expect("lock poisoned");
+        assert_eq!(view.writes.len(), 3);
+        assert_write(&view.writes[0], "v1", &[1.0, 0.0, 0.0]);
+        assert_write(&view.writes[1], "v2", &[0.0, 1.0, 0.0]);
+        assert_write(&view.writes[2], "v3", &[0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn frozen_view_should_contain_applied_writes() {
+        let mut delta = VectorDbWriteDelta::init(());
+
+        delta
+            .apply(VectorDbWrite::Write(vec![
+                make_write("v1", vec![1.0, 0.0, 0.0]),
+                make_write("v2", vec![0.0, 1.0, 0.0]),
+            ]))
+            .unwrap();
+
+        let (_frozen, frozen_view, _ctx) = delta.freeze();
+        assert_eq!(frozen_view.writes.len(), 2);
+        assert_write(&frozen_view.writes[0], "v1", &[1.0, 0.0, 0.0]);
+        assert_write(&frozen_view.writes[1], "v2", &[0.0, 1.0, 0.0]);
+    }
+
+    #[test]
+    fn estimate_size_should_return_number_of_vectors() {
+        let mut delta = VectorDbWriteDelta::init(());
+        assert_eq!(delta.estimate_size(), 0);
+
+        delta
+            .apply(VectorDbWrite::Write(vec![make_write(
+                "v1",
+                vec![1.0, 0.0, 0.0],
+            )]))
+            .unwrap();
+        assert_eq!(delta.estimate_size(), 1);
+
+        delta
+            .apply(VectorDbWrite::Write(vec![
+                make_write("v2", vec![0.0, 1.0, 0.0]),
+                make_write("v3", vec![0.0, 0.0, 1.0]),
+            ]))
+            .unwrap();
+        assert_eq!(delta.estimate_size(), 3);
+    }
+}

--- a/vector/src/batched/flusher.rs
+++ b/vector/src/batched/flusher.rs
@@ -1,0 +1,294 @@
+use crate::batched::delta::{VectorDbDeltaView, VectorDbWriteDelta};
+use crate::batched::indexer::Indexer;
+use async_trait::async_trait;
+use common::Storage;
+use common::coordinator::Flusher;
+use common::storage::StorageSnapshot;
+use std::ops::Range;
+use std::sync::Arc;
+
+pub(crate) struct VectorDbFlusher {
+    storage: Arc<dyn Storage>,
+    last_snapshot: Arc<dyn StorageSnapshot>,
+    indexer: Indexer,
+    /// Set after update_index succeeds but a subsequent storage operation fails.
+    /// Once set, the in-memory index state is out of sync with storage and the
+    /// flusher is no longer usable.
+    poisoned: Option<String>,
+}
+
+impl VectorDbFlusher {
+    pub(crate) fn new(
+        storage: Arc<dyn Storage>,
+        initial_snapshot: Arc<dyn StorageSnapshot>,
+        indexer: Indexer,
+    ) -> Self {
+        Self {
+            storage,
+            last_snapshot: initial_snapshot,
+            indexer,
+            poisoned: None,
+        }
+    }
+}
+
+#[async_trait]
+impl Flusher<VectorDbWriteDelta> for VectorDbFlusher {
+    async fn flush_delta(
+        &mut self,
+        frozen: Arc<VectorDbDeltaView>,
+        _epoch_range: &Range<u64>,
+    ) -> Result<Arc<dyn StorageSnapshot>, String> {
+        if let Some(err) = &self.poisoned {
+            return Err(format!("flusher is poisoned due to prior error: {err}"));
+        }
+
+        // do indexing work — this mutates in-memory index state
+        let updates = self
+            .indexer
+            .update_index(frozen.writes.clone(), self.last_snapshot.clone())
+            .await
+            .map_err(|e| e.to_string())?;
+
+        // From this point, in-memory state has diverged from storage.
+        // If any subsequent operation fails, poison the flusher.
+        let result = self.apply_and_snapshot(updates).await;
+        if let Err(err) = &result {
+            self.poisoned = Some(err.clone());
+        }
+        result
+    }
+
+    async fn flush_storage(&self) -> Result<(), String> {
+        self.storage.flush().await.map_err(|e| e.to_string())
+    }
+}
+
+impl VectorDbFlusher {
+    async fn apply_and_snapshot(
+        &mut self,
+        updates: Vec<common::storage::RecordOp>,
+    ) -> Result<Arc<dyn StorageSnapshot>, String> {
+        self.storage
+            .apply(updates)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let snapshot = self.storage.snapshot().await.map_err(|e| e.to_string())?;
+        self.last_snapshot = snapshot.clone();
+        Ok(snapshot)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::batched::delta::VectorDbDeltaView;
+    use crate::batched::indexer::{Indexer, IndexerOpts};
+    use crate::delta::VectorWrite;
+    use crate::hnsw::build_centroid_graph;
+    use crate::model::AttributeValue;
+    use crate::serde::centroid_chunk::CentroidEntry;
+    use crate::serde::collection_meta::DistanceMetric;
+    use crate::serde::key::{IdDictionaryKey, VectorDataKey};
+    use crate::serde::vector_data::VectorDataValue;
+    use crate::storage::merge_operator::VectorDbMergeOperator;
+    use common::coordinator::Flusher;
+    use common::storage::in_memory::{FailingStorage, InMemoryStorage};
+    use common::{SequenceAllocator, Storage};
+    use std::collections::{HashMap, HashSet};
+
+    const DIMS: usize = 3;
+
+    /// Create an InMemoryStorage with the vector merge operator.
+    fn create_storage() -> Arc<dyn Storage> {
+        Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
+            VectorDbMergeOperator::new(DIMS),
+        )))
+    }
+
+    /// Create a FailingStorage wrapping a storage with the vector merge operator.
+    fn create_failing_storage() -> Arc<FailingStorage> {
+        FailingStorage::wrap(create_storage())
+    }
+
+    /// Build a flusher with an Indexer set up for an empty db with one centroid.
+    async fn create_flusher(storage: Arc<dyn Storage>) -> VectorDbFlusher {
+        let seq_key = bytes::Bytes::from_static(&[0x01, 0x02]);
+        let id_allocator = SequenceAllocator::load(storage.as_ref(), seq_key)
+            .await
+            .unwrap();
+
+        // Bootstrap one centroid (gets ID 0)
+        let centroid = CentroidEntry::new(0, vec![0.0; DIMS]);
+        let graph = build_centroid_graph(vec![centroid], DistanceMetric::L2).unwrap();
+        let centroid_graph: Arc<dyn crate::hnsw::CentroidGraph> = Arc::from(graph);
+
+        let (seq_block_key, seq_block) = id_allocator.freeze();
+
+        let indexer = Indexer::new(
+            IndexerOpts {
+                dimensions: DIMS,
+                distance_metric: DistanceMetric::L2,
+                merge_threshold_vectors: 0,
+                split_threshold_vectors: usize::MAX,
+                split_search_neighbourhood: 4,
+                indexed_fields: HashSet::new(),
+                chunk_target: 4096,
+            },
+            HashMap::new(),
+            HashMap::from([(0, 0)]),
+            centroid_graph,
+            seq_block_key,
+            seq_block,
+            0,
+            1,
+        );
+
+        let snapshot = storage.snapshot().await.unwrap();
+        VectorDbFlusher::new(storage, snapshot, indexer)
+    }
+
+    fn make_writes(n: usize) -> Vec<VectorWrite> {
+        (0..n)
+            .map(|i| {
+                let values = vec![i as f32, 0.0, 0.0];
+                VectorWrite {
+                    external_id: format!("vec-{i}"),
+                    values: values.clone(),
+                    attributes: vec![("vector".to_string(), AttributeValue::Vector(values))],
+                }
+            })
+            .collect()
+    }
+
+    fn make_frozen(writes: Vec<VectorWrite>) -> Arc<VectorDbDeltaView> {
+        Arc::new(VectorDbDeltaView { writes })
+    }
+
+    #[tokio::test]
+    async fn should_write_vectors_to_storage() {
+        // given
+        let storage = create_storage();
+        let mut flusher = create_flusher(storage.clone()).await;
+        let writes = make_writes(10);
+        let frozen = make_frozen(writes);
+
+        // when
+        let _snapshot = flusher.flush_delta(frozen, &(0..1)).await.unwrap();
+
+        // then — verify forward index entries exist for all 10 vectors via raw storage reads
+        let mut internal_ids = Vec::new();
+        for i in 0..10 {
+            let ext_id = format!("vec-{i}");
+            // Check ID dictionary entry exists
+            let dict_key = IdDictionaryKey::new(&ext_id).encode();
+            let dict_record = storage
+                .get(dict_key)
+                .await
+                .unwrap()
+                .unwrap_or_else(|| panic!("missing dictionary entry for {ext_id}"));
+            let internal_id = {
+                let mut slice = dict_record.value.as_ref();
+                common::serde::encoding::decode_u64(&mut slice).unwrap()
+            };
+            // Check vector data record exists and has the right external_id
+            let data_key = VectorDataKey::new(internal_id).encode();
+            let data_record = storage
+                .get(data_key)
+                .await
+                .unwrap()
+                .unwrap_or_else(|| panic!("missing vector data for {ext_id}"));
+            let data = VectorDataValue::decode_from_bytes(&data_record.value, DIMS).unwrap();
+            assert_eq!(data.external_id(), ext_id);
+            internal_ids.push(internal_id);
+        }
+
+        // then — all internal IDs should be unique (10 distinct vectors written)
+        let posting_ids: HashSet<u64> = internal_ids.iter().copied().collect();
+        assert_eq!(posting_ids.len(), 10);
+    }
+
+    #[tokio::test]
+    async fn should_propagate_apply_error() {
+        // given
+        let storage = create_failing_storage();
+        let mut flusher = create_flusher(storage.clone() as Arc<dyn Storage>).await;
+        storage.fail_apply(common::StorageError::Storage("test apply error".into()));
+
+        // when
+        let result = flusher
+            .flush_delta(make_frozen(make_writes(1)), &(0..1))
+            .await;
+
+        // then
+        let err = result.err().expect("expected apply error");
+        assert!(
+            err.contains("test apply error"),
+            "expected test apply error message, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_propagate_snapshot_error_after_apply() {
+        // given
+        let storage = create_failing_storage();
+        let mut flusher = create_flusher(storage.clone() as Arc<dyn Storage>).await;
+        storage.fail_snapshot(common::StorageError::Storage("test snapshot error".into()));
+
+        // when
+        let result = flusher
+            .flush_delta(make_frozen(make_writes(1)), &(0..1))
+            .await;
+
+        // then
+        let err = result.err().expect("expected snapshot error");
+        assert!(
+            err.contains("test snapshot error"),
+            "expected test snapshot error message, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_propagate_flush_storage_error() {
+        // given
+        let storage = create_failing_storage();
+        let flusher = create_flusher(storage.clone() as Arc<dyn Storage>).await;
+        storage.fail_flush(common::StorageError::Storage("test flush error".into()));
+
+        // when
+        let result = flusher.flush_storage().await;
+
+        // then
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().contains("test flush error"),
+            "expected test flush error message"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_poison_after_post_index_failure() {
+        // given — apply fails after update_index mutates in-memory state
+        let storage = create_failing_storage();
+        let mut flusher = create_flusher(storage.clone() as Arc<dyn Storage>).await;
+        storage.fail_apply(common::StorageError::Storage("apply failed".into()));
+
+        // when — first flush fails due to apply error
+        let result = flusher
+            .flush_delta(make_frozen(make_writes(1)), &(0..1))
+            .await;
+        assert!(result.is_err());
+
+        // then — subsequent flush is rejected immediately as poisoned
+        storage.fail_apply(common::StorageError::Storage("should not reach".into()));
+        let result = flusher
+            .flush_delta(make_frozen(make_writes(1)), &(1..2))
+            .await;
+        let err = result.err().expect("expected poisoned error");
+        assert!(
+            err.contains("poisoned"),
+            "expected poisoned error message, got: {err}"
+        );
+    }
+}

--- a/vector/src/batched/indexer/drivers.rs
+++ b/vector/src/batched/indexer/drivers.rs
@@ -1,0 +1,29 @@
+use futures::future::BoxFuture;
+use tokio::task::JoinSet;
+
+/// Maximum number of concurrent I/O futures to poll at once.
+const DEFAULT_CONCURRENCY: usize = 256;
+
+/// Driver for i/o heavy batches of tasks
+pub(crate) struct AsyncBatchDriver {}
+
+impl AsyncBatchDriver {
+    pub(crate) async fn execute<T: Send + 'static>(batch: Vec<BoxFuture<'static, T>>) -> Vec<T> {
+        let mut results = Vec::with_capacity(batch.len());
+        let mut pending = batch.into_iter();
+        let mut tasks = JoinSet::new();
+
+        for fut in pending.by_ref().take(DEFAULT_CONCURRENCY) {
+            tasks.spawn(fut);
+        }
+
+        while let Some(result) = tasks.join_next().await {
+            results.push(result.expect("async batch task failed"));
+            if let Some(fut) = pending.next() {
+                tasks.spawn(fut);
+            }
+        }
+
+        results
+    }
+}

--- a/vector/src/batched/indexer/merge.rs
+++ b/vector/src/batched/indexer/merge.rs
@@ -1,0 +1,250 @@
+use crate::Result;
+use crate::batched::indexer::IndexerOpts;
+use crate::batched::indexer::drivers::AsyncBatchDriver;
+use crate::batched::indexer::split::ReassignVector;
+use crate::batched::indexer::state::{VectorIndexDelta, VectorIndexState, VectorIndexView};
+use crate::serde::posting_list::PostingList;
+use common::StorageRead;
+use futures::future::BoxFuture;
+use std::sync::Arc;
+
+struct MergeCentroid {
+    c: u64,
+    postings: PostingList,
+}
+
+pub(crate) struct MergeCentroids {
+    opts: Arc<IndexerOpts>,
+    snapshot: Arc<dyn StorageRead>,
+}
+
+impl MergeCentroids {
+    pub(crate) fn new(opts: &Arc<IndexerOpts>, snapshot: &Arc<dyn StorageRead>) -> Self {
+        Self {
+            opts: opts.clone(),
+            snapshot: snapshot.clone(),
+        }
+    }
+
+    pub(crate) async fn execute(
+        self,
+        state: &VectorIndexState,
+        delta: &mut VectorIndexDelta,
+    ) -> Result<Vec<ReassignVector>> {
+        let view = VectorIndexView::new(delta, state, self.snapshot.clone());
+
+        // find all centroids that need to be merged
+        let counts = view.centroid_counts();
+        // compute the centroids that need to be split
+        let to_merge = counts
+            .iter()
+            .filter(|(_k, v)| **v < self.opts.merge_threshold_vectors as u64)
+            .map(|(&k, _v)| k)
+            .collect::<Vec<_>>();
+        if to_merge.is_empty() {
+            return Ok(vec![]);
+        }
+        // Don't merge if all centroids would be merged — there are no targets left
+        if to_merge.len() >= counts.len() {
+            return Ok(vec![]);
+        }
+
+        // read postings of all mergees
+        let mut to_resolve = Vec::with_capacity(to_merge.len());
+        for c in to_merge {
+            let posting_fut = view.posting_list(c, self.opts.dimensions)?;
+            to_resolve.push(Box::pin(async move {
+                Ok(MergeCentroid {
+                    c,
+                    postings: posting_fut.await?,
+                })
+            }) as BoxFuture<'static, Result<MergeCentroid>>)
+        }
+        let resolve_results = AsyncBatchDriver::execute(to_resolve).await;
+        let mut resolved = Vec::with_capacity(resolve_results.len());
+        for r in resolve_results {
+            resolved.push(r?);
+        }
+
+        // execute merges
+        let total_moved = resolved.iter().map(|m| m.postings.len()).sum();
+        let mut reassignments = Vec::with_capacity(total_moved);
+        for merge in resolved {
+            delta.delete_centroids(vec![merge.c]);
+            for p in merge.postings {
+                reassignments.push(ReassignVector {
+                    vector_id: p.id(),
+                    vector: p.vector().to_vec(),
+                    current_centroid: merge.c,
+                })
+            }
+        }
+
+        // return reassign set
+        Ok(reassignments)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::batched::indexer::IndexerOpts;
+    use crate::batched::indexer::test_utils::IndexerOpTestHarness;
+    use crate::serde::centroid_chunk::CentroidEntry;
+    use crate::serde::collection_meta::DistanceMetric;
+    use crate::storage::VectorDbStorageReadExt;
+    use common::StorageRead;
+    use std::collections::HashSet;
+
+    const DIMS: usize = 2;
+    const MERGE_THRESHOLD: usize = 3;
+
+    const CENTROID_A: u64 = 100;
+    const CENTROID_B: u64 = 101;
+    const CENTROID_C: u64 = 102;
+
+    fn create_opts() -> Arc<IndexerOpts> {
+        Arc::new(IndexerOpts {
+            dimensions: DIMS,
+            distance_metric: DistanceMetric::L2,
+            merge_threshold_vectors: MERGE_THRESHOLD,
+            split_threshold_vectors: usize::MAX,
+            split_search_neighbourhood: 4,
+            indexed_fields: HashSet::new(),
+            chunk_target: 4096,
+        })
+    }
+
+    #[tokio::test]
+    async fn should_merge_centroids_below_threshold() {
+        // given — 3 centroids: A has 1 vector (below threshold=3), B has 2 (below),
+        // C has 4 (above). A and B should be merged, C should not.
+        let mut h = IndexerOpTestHarness::with_centroids(
+            vec![
+                CentroidEntry::new(CENTROID_A, vec![1.0, 0.0]),
+                CentroidEntry::new(CENTROID_B, vec![0.0, 1.0]),
+                CentroidEntry::new(CENTROID_C, vec![-1.0, 0.0]),
+            ],
+            DIMS,
+        )
+        .await;
+        let opts = create_opts();
+
+        let writes = vec![
+            // 1 vector at A (below threshold)
+            h.make_write("a1", vec![0.9, 0.1]),
+            // 2 vectors at B (below threshold)
+            h.make_write("b1", vec![0.1, 0.9]),
+            h.make_write("b2", vec![0.2, 0.8]),
+            // 4 vectors at C (above threshold)
+            h.make_write("c1", vec![-0.9, 0.1]),
+            h.make_write("c2", vec![-0.8, 0.2]),
+            h.make_write("c3", vec![-0.95, 0.05]),
+            h.make_write("c4", vec![-0.85, 0.15]),
+        ];
+        h.write_and_apply(&opts, writes).await;
+
+        // collect IDs for vectors at A and B
+        let id_a1 = h.storage.lookup_internal_id("a1").await.unwrap().unwrap();
+        let id_b1 = h.storage.lookup_internal_id("b1").await.unwrap().unwrap();
+        let id_b2 = h.storage.lookup_internal_id("b2").await.unwrap().unwrap();
+
+        // when
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        let merge = MergeCentroids::new(&opts, &(snapshot as Arc<dyn StorageRead>));
+        let reassignments = merge.execute(&h.state, &mut delta).await.unwrap();
+        let ops = delta.freeze(&mut h.state);
+        h.storage.apply(ops).await.unwrap();
+
+        // then — A and B should be deleted
+        let deletions = h.storage.get_deleted_vectors().await.unwrap();
+        assert!(deletions.contains(CENTROID_A), "A should be deleted");
+        assert!(deletions.contains(CENTROID_B), "B should be deleted");
+        assert!(!deletions.contains(CENTROID_C), "C should not be deleted");
+
+        // then — all 3 vectors from A and B should be in the reassignment set
+        let reassign_ids: HashSet<u64> = reassignments.iter().map(|r| r.vector_id).collect();
+        assert_eq!(reassign_ids.len(), 3);
+        assert!(reassign_ids.contains(&id_a1));
+        assert!(reassign_ids.contains(&id_b1));
+        assert!(reassign_ids.contains(&id_b2));
+
+        // then — each reassignment should reference its original centroid
+        let a1_r = reassignments.iter().find(|r| r.vector_id == id_a1).unwrap();
+        assert_eq!(a1_r.current_centroid, CENTROID_A);
+        let b1_r = reassignments.iter().find(|r| r.vector_id == id_b1).unwrap();
+        assert_eq!(b1_r.current_centroid, CENTROID_B);
+        let b2_r = reassignments.iter().find(|r| r.vector_id == id_b2).unwrap();
+        assert_eq!(b2_r.current_centroid, CENTROID_B);
+    }
+
+    #[tokio::test]
+    async fn should_not_merge_when_all_centroids_below_threshold() {
+        // given — 2 centroids both below threshold. Merging would leave no targets,
+        // so the guard should prevent any merges.
+        let mut h = IndexerOpTestHarness::with_centroids(
+            vec![
+                CentroidEntry::new(CENTROID_A, vec![1.0, 0.0]),
+                CentroidEntry::new(CENTROID_B, vec![0.0, 1.0]),
+            ],
+            DIMS,
+        )
+        .await;
+        let opts = create_opts(); // threshold = 3
+
+        let writes = vec![
+            h.make_write("a1", vec![0.9, 0.1]),
+            h.make_write("b1", vec![0.1, 0.9]),
+        ];
+        h.write_and_apply(&opts, writes).await;
+
+        // when
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        let merge = MergeCentroids::new(&opts, &(snapshot as Arc<dyn StorageRead>));
+        let reassignments = merge.execute(&h.state, &mut delta).await.unwrap();
+
+        // then — no merges, no reassignments
+        assert!(
+            reassignments.is_empty(),
+            "should not merge when all centroids are below threshold"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_not_merge_centroids_at_or_above_threshold() {
+        // given — 2 centroids both at or above threshold
+        let mut h = IndexerOpTestHarness::with_centroids(
+            vec![
+                CentroidEntry::new(CENTROID_A, vec![1.0, 0.0]),
+                CentroidEntry::new(CENTROID_B, vec![0.0, 1.0]),
+            ],
+            DIMS,
+        )
+        .await;
+        let opts = create_opts(); // threshold = 3
+
+        let writes = vec![
+            h.make_write("a1", vec![0.9, 0.1]),
+            h.make_write("a2", vec![0.8, 0.2]),
+            h.make_write("a3", vec![0.95, 0.05]),
+            h.make_write("b1", vec![0.1, 0.9]),
+            h.make_write("b2", vec![0.2, 0.8]),
+            h.make_write("b3", vec![0.05, 0.95]),
+        ];
+        h.write_and_apply(&opts, writes).await;
+
+        // when
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        let merge = MergeCentroids::new(&opts, &(snapshot as Arc<dyn StorageRead>));
+        let reassignments = merge.execute(&h.state, &mut delta).await.unwrap();
+
+        // then — no merges
+        assert!(
+            reassignments.is_empty(),
+            "should not merge centroids at or above threshold"
+        );
+    }
+}

--- a/vector/src/batched/indexer/mod.rs
+++ b/vector/src/batched/indexer/mod.rs
@@ -1,0 +1,104 @@
+mod drivers;
+mod merge;
+mod split;
+pub(crate) mod state;
+#[cfg(test)]
+pub(crate) mod test_utils;
+mod vector;
+
+use crate::DistanceMetric;
+use crate::Result;
+use crate::batched::indexer::merge::MergeCentroids;
+use crate::batched::indexer::split::SplitCentroids;
+use crate::batched::indexer::state::{CentroidChunkManager, VectorIndexDelta, VectorIndexState};
+use crate::batched::indexer::vector::{ReassignVectors, WriteVectors};
+use crate::delta::VectorWrite;
+use crate::hnsw::CentroidGraph;
+use bytes::Bytes;
+use common::StorageRead;
+use common::sequence::AllocatedSeqBlock;
+use common::storage::RecordOp;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tracing::debug;
+
+const INDEXING_ROUNDS: usize = 1;
+
+pub(crate) struct IndexerOpts {
+    pub(crate) dimensions: usize,
+    pub(crate) distance_metric: DistanceMetric,
+    pub(crate) merge_threshold_vectors: usize,
+    pub(crate) split_threshold_vectors: usize,
+    pub(crate) split_search_neighbourhood: usize,
+    pub(crate) indexed_fields: HashSet<String>,
+    pub(crate) chunk_target: usize,
+}
+
+pub(crate) struct Indexer {
+    opts: Arc<IndexerOpts>,
+    state: VectorIndexState,
+}
+
+impl Indexer {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        opts: IndexerOpts,
+        dictionary: HashMap<String, u64>,
+        centroid_counts: HashMap<u64, u64>,
+        centroid_graph: Arc<dyn CentroidGraph>,
+        sequence_block_key: Bytes,
+        sequence_block: AllocatedSeqBlock,
+        initial_chunk_id: u32,
+        initial_chunk_count: usize,
+    ) -> Self {
+        let chunk_manager = CentroidChunkManager::new(
+            opts.dimensions,
+            opts.chunk_target,
+            initial_chunk_id,
+            initial_chunk_count,
+        );
+        Self {
+            opts: Arc::new(opts),
+            state: VectorIndexState::new(
+                dictionary,
+                centroid_counts,
+                centroid_graph,
+                sequence_block_key,
+                sequence_block,
+                chunk_manager,
+            ),
+        }
+    }
+
+    pub(crate) async fn update_index(
+        &mut self,
+        updates: Vec<VectorWrite>,
+        snapshot: Arc<dyn StorageRead>,
+    ) -> Result<Vec<RecordOp>> {
+        let mut delta = VectorIndexDelta::new(&self.state);
+        // write all vectors
+        let write = WriteVectors::new(&self.opts, &snapshot, updates);
+        write.execute(&self.state, &mut delta).await?;
+        for _ in 0..INDEXING_ROUNDS {
+            // apply merges
+            let merge = MergeCentroids::new(&self.opts, &snapshot);
+            let reassigns = merge.execute(&self.state, &mut delta).await?;
+            // apply merge reassignments
+            let reassign = ReassignVectors::new(&self.opts, &snapshot, reassigns);
+            reassign.execute(&self.state, &mut delta).await?;
+            // run split-reassign loop until no more splits. don't run merges as part of this loop
+            // as it is not guaranteed to converge
+            loop {
+                let split = SplitCentroids::new(&self.opts, &snapshot);
+                let result = split.execute(&self.state, &mut delta).await?;
+                debug!("processed splits: {:?}", result);
+                if result.splits.is_empty() {
+                    break;
+                }
+                let reassign = ReassignVectors::new(&self.opts, &snapshot, result.reassignments);
+                reassign.execute(&self.state, &mut delta).await?;
+            }
+        }
+        Ok(delta.freeze(&mut self.state))
+    }
+}

--- a/vector/src/batched/indexer/split.rs
+++ b/vector/src/batched/indexer/split.rs
@@ -1,0 +1,741 @@
+use crate::batched::indexer::IndexerOpts;
+use crate::batched::indexer::drivers::AsyncBatchDriver;
+use crate::batched::indexer::state::{
+    DirtyCentroidGraph, VectorIndexDelta, VectorIndexState, VectorIndexView,
+};
+use crate::lire::commands::SplitPostings;
+use crate::lire::{heuristics, kmeans};
+use crate::serde::centroid_chunk::CentroidEntry;
+use crate::serde::posting_list::{Posting, PostingList};
+use crate::{DistanceMetric, Result, distance};
+use common::StorageRead;
+use futures::future::BoxFuture;
+use rayon::iter::IntoParallelIterator;
+use rayon::iter::ParallelIterator;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tokio::task::spawn_blocking;
+
+const MAX_SPLITS: usize = usize::MAX;
+
+#[derive(Clone, Debug)]
+pub(crate) struct ReassignVector {
+    pub(crate) vector_id: u64,
+    pub(crate) vector: Vec<f32>,
+    pub(crate) current_centroid: u64,
+}
+
+struct SplitResult {
+    c: u64,
+    c_0: SplitPostings,
+    c_1: SplitPostings,
+    reassign_vectors: Vec<ReassignVector>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SplitSummary {
+    #[allow(dead_code)]
+    pub(crate) c: u64,
+    #[allow(dead_code)]
+    pub(crate) new_centroids: Vec<CentroidEntry>,
+}
+
+#[derive(Debug)]
+pub(crate) struct SplitCentroidsResult {
+    pub(crate) splits: Vec<SplitSummary>,
+    pub(crate) reassignments: Vec<ReassignVector>,
+}
+
+pub(crate) struct SplitCentroids {
+    opts: Arc<IndexerOpts>,
+    snapshot: Arc<dyn StorageRead>,
+    max_splits: usize,
+}
+
+impl SplitCentroids {
+    pub(crate) fn new(opts: &Arc<IndexerOpts>, snapshot: &Arc<dyn StorageRead>) -> Self {
+        Self::new_with_max_splits(opts, snapshot, MAX_SPLITS)
+    }
+
+    fn new_with_max_splits(
+        opts: &Arc<IndexerOpts>,
+        snapshot: &Arc<dyn StorageRead>,
+        max_splits: usize,
+    ) -> Self {
+        Self {
+            opts: opts.clone(),
+            snapshot: snapshot.clone(),
+            max_splits,
+        }
+    }
+
+    pub(crate) async fn execute(
+        self,
+        state: &VectorIndexState,
+        delta: &mut VectorIndexDelta,
+    ) -> Result<SplitCentroidsResult> {
+        let view = VectorIndexView::new(delta, state, self.snapshot.clone());
+
+        // find all centroids that need to be split, resolve their neighbours, and build up
+        // a set of all postings that need to be fetched
+        let counts = view.centroid_counts();
+        // compute the centroids that need to be split, biggest first, capped at MAX_SPLITS
+        let mut to_split: Vec<_> = counts
+            .into_iter()
+            .filter(|(_k, v)| *v >= self.opts.split_threshold_vectors as u64)
+            .collect();
+        to_split.sort_by(|a, b| b.1.cmp(&a.1));
+        to_split.truncate(self.max_splits);
+        let to_split: Vec<u64> = to_split.into_iter().map(|(k, _v)| k).collect();
+        if to_split.is_empty() {
+            return Ok(SplitCentroidsResult {
+                splits: vec![],
+                reassignments: Vec::new(),
+            });
+        }
+
+        // initialize the set of postings to fetch with the split centroids
+        let mut postings_to_retrive =
+            HashSet::with_capacity(to_split.len() * self.opts.split_search_neighbourhood);
+        postings_to_retrive.extend(to_split.clone());
+        let mut splits = Vec::with_capacity(to_split.len());
+        let centroid_graph = view.centroid_graph();
+        // collect each centroids neighbours and add to postings to fetch, and initialize splits
+        for c in to_split {
+            let c_vec = centroid_graph
+                .centroid(c)
+                .expect("unexpected missing centroid");
+            let neighbours = centroid_graph
+                .search(&c_vec.vector, self.opts.split_search_neighbourhood + 1)
+                .into_iter()
+                .filter(|&neighbour| c != neighbour)
+                .collect::<Vec<_>>();
+            postings_to_retrive.extend(neighbours.clone());
+            splits.push(SplitCentroid {
+                c,
+                neighbours,
+                centroid_graph: centroid_graph.clone(),
+                dimensions: self.opts.dimensions,
+                distance_metric: self.opts.distance_metric,
+            })
+        }
+
+        // find all relevant postings (centroids and neighbours)
+        let mut posting_reads = Vec::with_capacity(postings_to_retrive.len());
+        for c in postings_to_retrive {
+            let read_fut = view.posting_list(c, self.opts.dimensions)?;
+            posting_reads.push(Box::pin(async move { read_fut.await.map(|p| (c, p)) })
+                as BoxFuture<'static, Result<(u64, PostingList)>>);
+        }
+        let results = AsyncBatchDriver::execute(posting_reads).await;
+        let mut postings = HashMap::new();
+        for r in results {
+            let (c, c_postings) = r?;
+            postings.insert(c, c_postings);
+        }
+        let postings = Arc::new(postings);
+
+        // execute splits. spawn a blocking task to avoid tying up runtime as this is compute heavy
+        let results: Vec<_> = spawn_blocking(move || {
+            splits
+                .into_par_iter()
+                .map(|split| split.execute(postings.clone()))
+                .collect()
+        })
+        .await
+        .expect("unexpected join error");
+
+        // update delta
+        let mut reassignments = HashMap::new();
+        let mut splits = Vec::with_capacity(results.len());
+        for result in results {
+            // track reassignments
+            reassignments.extend(
+                result
+                    .reassign_vectors
+                    .into_iter()
+                    .map(|r| (r.vector_id, r)),
+            );
+
+            // delete old centroid
+            delta.delete_centroids(vec![result.c]);
+
+            // create new centroids with postings
+            let mut new_centroids = Vec::with_capacity(2);
+            for new_centroid in [result.c_0, result.c_1] {
+                let entry = delta.add_centroid(new_centroid.centroid_vec().to_vec());
+                for p in new_centroid.postings() {
+                    delta.remove_from_posting(result.c, p.id());
+                    delta.add_to_posting(entry.centroid_id, p.id(), p.vector().to_vec());
+                }
+                new_centroids.push(entry);
+            }
+            splits.push(SplitSummary {
+                c: result.c,
+                new_centroids,
+            })
+        }
+
+        // return reassign set
+        let reassignments: Vec<_> = reassignments.values().cloned().collect();
+        Ok(SplitCentroidsResult {
+            splits,
+            reassignments,
+        })
+    }
+}
+
+struct SplitCentroid {
+    c: u64,
+    neighbours: Vec<u64>,
+    centroid_graph: Arc<DirtyCentroidGraph>,
+    distance_metric: DistanceMetric,
+    dimensions: usize,
+}
+
+impl SplitCentroid {
+    fn execute(self, postings: Arc<HashMap<u64, PostingList>>) -> SplitResult {
+        let c_postings = postings
+            .get(&self.c)
+            .expect("unexpected missing postings for c");
+        assert!(
+            c_postings.len() >= 2,
+            "tried to split centroid {} with less than 2 postings",
+            self.c
+        );
+        let c_vectors: Vec<(u64, Vec<f32>)> = c_postings
+            .iter()
+            .map(|p| (p.id(), p.vector().to_vec()))
+            .collect();
+
+        // Run two_means clustering to find new centroids
+        let c_vector_refs: Vec<(u64, &[f32])> = c_vectors
+            .iter()
+            .map(|(id, v)| (*id, v.as_slice()))
+            .collect();
+        let clustering = kmeans::for_metric(self.distance_metric);
+        let (c0_vector, c1_vector) = clustering.two_means(&c_vector_refs, self.dimensions);
+        // Assign each vector to closer centroid
+        let mut c0_postings = Vec::new();
+        let mut c1_postings = Vec::new();
+        for (id, vector) in &c_vectors {
+            let d0 = distance::compute_distance(vector, &c0_vector, self.distance_metric);
+            let d1 = distance::compute_distance(vector, &c1_vector, self.distance_metric);
+
+            if d0 <= d1 {
+                c0_postings.push(Posting::new(*id, vector.clone()));
+            } else {
+                c1_postings.push(Posting::new(*id, vector.clone()));
+            }
+        }
+
+        // Compute reassignments
+        let mut reassignments = Vec::with_capacity(c0_postings.len() + c1_postings.len());
+        let c_vector = self
+            .centroid_graph
+            .centroid(self.c)
+            .expect("unexpected missing centroid");
+        reassignments.extend(self.compute_split_reassignments(
+            self.c,
+            c_postings,
+            &c_vector.vector,
+            &c0_vector,
+            &c1_vector,
+        ));
+        reassignments.extend(self.compute_neighbour_reassignments(
+            &c_vector.vector,
+            &c0_vector,
+            &c1_vector,
+            postings.as_ref(),
+        ));
+
+        SplitResult {
+            c: self.c,
+            c_0: SplitPostings::new(c0_vector, c0_postings),
+            c_1: SplitPostings::new(c1_vector, c1_postings),
+            reassign_vectors: reassignments,
+        }
+    }
+
+    fn compute_split_reassignments(
+        &self,
+        centroid_id: u64,
+        postings: &[Posting],
+        c_vector: &[f32],
+        c0_vector: &[f32],
+        c1_vector: &[f32],
+    ) -> Vec<ReassignVector> {
+        // use the heuristic for c's vectors from the spfresh paper to cheaply determine if
+        // a vector may need reassignment. If it may, then check in the centroid graph for
+        // its nearest centroid. If the nearest centroid is not c0 or c1, then include in
+        // the reassignment set.
+        let mut reassignments = Vec::with_capacity(postings.len());
+        for p in postings {
+            if !heuristics::split_heuristic(
+                p.vector(),
+                c_vector,
+                c0_vector,
+                c1_vector,
+                self.distance_metric,
+            ) {
+                continue;
+            }
+            reassignments.push(ReassignVector {
+                vector_id: p.id(),
+                vector: p.vector().to_vec(),
+                current_centroid: centroid_id,
+            })
+        }
+        reassignments
+    }
+
+    fn compute_neighbour_reassignments(
+        &self,
+        c_vector: &[f32],
+        c0_vector: &[f32],
+        c1_vector: &[f32],
+        postings: &HashMap<u64, PostingList>,
+    ) -> Vec<ReassignVector> {
+        let mut reassignments: Vec<ReassignVector> = Vec::new();
+
+        // Process each neighbour's postings to find reassignments
+        for neighbour_id in &self.neighbours {
+            let neighbour_postings = postings
+                .get(neighbour_id)
+                .expect("missing postings for neighbour");
+
+            for p in neighbour_postings.iter() {
+                // use the heuristic for neighbour vectors from the spfresh paper to cheaply
+                // determine if a vector may need reassignment. If it may, then check in the
+                // centroid graph for its nearest centroid. If the nearest centroid is changed,
+                // then add to reassignment set.
+                if !heuristics::neighbour_split_heuristic(
+                    p.vector(),
+                    c_vector,
+                    c0_vector,
+                    c1_vector,
+                    self.distance_metric,
+                ) {
+                    continue;
+                }
+                let vector = p.vector().to_vec();
+
+                reassignments.push(ReassignVector {
+                    vector_id: p.id(),
+                    vector,
+                    current_centroid: *neighbour_id,
+                });
+            }
+        }
+        reassignments
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::batched::indexer::IndexerOpts;
+    use crate::batched::indexer::test_utils::IndexerOpTestHarness;
+    use crate::serde::centroid_chunk::CentroidEntry;
+    use crate::storage::VectorDbStorageReadExt;
+    use common::StorageRead;
+
+    const DIMS: usize = 2;
+    const CENTROID_ID: u64 = 0;
+    const SPLIT_THRESHOLD: usize = 4;
+
+    fn create_opts() -> Arc<IndexerOpts> {
+        Arc::new(IndexerOpts {
+            dimensions: DIMS,
+            distance_metric: DistanceMetric::L2,
+            merge_threshold_vectors: 0,
+            split_threshold_vectors: SPLIT_THRESHOLD,
+            split_search_neighbourhood: 4,
+            indexed_fields: HashSet::new(),
+            chunk_target: 4096,
+        })
+    }
+
+    const CENTROID_A: u64 = 100;
+    const CENTROID_B: u64 = 101;
+
+    #[tokio::test]
+    async fn should_split_centroid_and_create_new_centroids_in_storage() {
+        // given — centroid A (at [0.5, 0.5]) has 6 vectors triggering a split.
+        // centroid B (at [-1, 0]) is a neighbour with 2 vectors.
+        let mut h = IndexerOpTestHarness::with_centroids(
+            vec![
+                CentroidEntry::new(CENTROID_A, vec![0.5, 0.5]),
+                CentroidEntry::new(CENTROID_B, vec![-1.0, 0.0]),
+            ],
+            DIMS,
+        )
+        .await;
+        let opts = create_opts(); // split_threshold = 4
+        // Vectors near A in two clear sub-clusters
+        // Cluster near [1, 0]: a1, a2, a3
+        // Cluster near [0, 1]: a4, a5, a6
+        // Vectors at B (near [-1, 0]): b1, b2 (below threshold, won't split)
+        // b1 at [-0.8, 0.4] — after A splits, the new centroid near [0,1]
+        // is closer to b1 than the old A centroid [0.5,0.5] was, so b1
+        // should pass the neighbour heuristic.
+        let writes = vec![
+            h.make_write("a1", vec![0.9, 0.1]),
+            h.make_write("a2", vec![0.8, 0.2]),
+            h.make_write("a3", vec![0.95, 0.05]),
+            h.make_write("a4", vec![0.1, 0.9]),
+            h.make_write("a5", vec![0.2, 0.8]),
+            h.make_write("a6", vec![0.05, 0.95]),
+            h.make_write("b1", vec![-0.8, 0.4]),
+            h.make_write("b2", vec![-0.9, 0.1]),
+        ];
+        h.write_and_apply(&opts, writes).await;
+        // Collect internal IDs for A's vectors and b1
+        let mut a_ids = HashSet::new();
+        for ext_id in ["a1", "a2", "a3", "a4", "a5", "a6"] {
+            a_ids.insert(h.storage.lookup_internal_id(ext_id).await.unwrap().unwrap());
+        }
+        let id_b1 = h.storage.lookup_internal_id("b1").await.unwrap().unwrap();
+
+        // when — run SplitCentroids
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        let split = SplitCentroids::new(&opts, &(snapshot.clone() as Arc<dyn StorageRead>));
+        let result = split.execute(&h.state, &mut delta).await.unwrap();
+
+        // then — only A should split (6 vectors >= threshold 4), not B (2 vectors)
+        assert_eq!(result.splits.len(), 1);
+        let summary = &result.splits[0];
+        assert_eq!(summary.c, CENTROID_A, "should have split centroid A");
+        assert_eq!(summary.new_centroids.len(), 2);
+        let ops = delta.freeze(&mut h.state);
+        h.storage.apply(ops).await.unwrap();
+        // then — old centroid A should be in deletions bitmap, B should not
+        let deletions = h.storage.get_deleted_vectors().await.unwrap();
+        assert!(deletions.contains(CENTROID_A), "A should be deleted");
+        assert!(!deletions.contains(CENTROID_B), "B should not be deleted");
+        // then — the two new centroids from the summary should exist in storage
+        // and each should have exactly 3 of A's 6 vectors
+        let mut all_posted_ids = HashSet::new();
+        for new_centroid in &summary.new_centroids {
+            let scan = h.storage.scan_all_centroids(DIMS).await.unwrap();
+            assert!(
+                scan.entries
+                    .iter()
+                    .any(|e| e.centroid_id == new_centroid.centroid_id),
+                "new centroid {} should be in storage chunks",
+                new_centroid.centroid_id
+            );
+            let posting = h
+                .storage
+                .get_posting_list(new_centroid.centroid_id, DIMS)
+                .await
+                .unwrap();
+            assert_eq!(
+                posting.len(),
+                3,
+                "each new centroid should have exactly 3 vectors"
+            );
+            for p in posting.iter() {
+                assert!(
+                    a_ids.contains(&p.id()),
+                    "posting id {} should be one of A's vectors",
+                    p.id()
+                );
+                all_posted_ids.insert(p.id());
+            }
+        }
+        assert_eq!(
+            all_posted_ids, a_ids,
+            "all 6 of A's vectors should be distributed across the two new centroids"
+        );
+        let reassign_ids: HashSet<u64> = result.reassignments.iter().map(|r| r.vector_id).collect();
+        assert!(
+            reassign_ids.contains(&id_b1),
+            "b1 should be in reassignment set from neighbour heuristic"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_split_single_centroid_with_no_neighbours() {
+        let mut h = IndexerOpTestHarness::with_single_centroid(CENTROID_ID, DIMS).await;
+        let opts = create_opts();
+        let writes = vec![
+            h.make_write("a", vec![0.9, 0.1]),
+            h.make_write("b", vec![0.8, 0.2]),
+            h.make_write("c", vec![0.1, 0.9]),
+            h.make_write("d", vec![0.2, 0.8]),
+        ];
+        h.write_and_apply(&opts, writes).await;
+
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        let split = SplitCentroids::new(&opts, &(snapshot as Arc<dyn StorageRead>));
+        let result = split.execute(&h.state, &mut delta).await.unwrap();
+
+        assert_eq!(result.splits.len(), 1);
+        let ops = delta.freeze(&mut h.state);
+        h.storage.apply(ops).await.unwrap();
+        let deletions = h.storage.get_deleted_vectors().await.unwrap();
+        assert!(deletions.contains(CENTROID_ID));
+        let scan = h.storage.scan_all_centroids(DIMS).await.unwrap();
+        assert_eq!(scan.entries.len(), 2);
+        let mut total = 0;
+        for entry in &scan.entries {
+            total += h
+                .storage
+                .get_posting_list(entry.centroid_id, DIMS)
+                .await
+                .unwrap()
+                .len();
+        }
+        assert_eq!(total, 4);
+        assert_eq!(result.reassignments.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn should_search_neighbour_postings_during_split() {
+        let mut h = IndexerOpTestHarness::with_centroids(
+            vec![
+                CentroidEntry::new(CENTROID_A, vec![0.5, 0.5]),
+                CentroidEntry::new(CENTROID_B, vec![0.0, 1.0]),
+            ],
+            DIMS,
+        )
+        .await;
+        let opts = Arc::new(IndexerOpts {
+            dimensions: DIMS,
+            distance_metric: DistanceMetric::L2,
+            merge_threshold_vectors: 0,
+            split_threshold_vectors: SPLIT_THRESHOLD,
+            split_search_neighbourhood: 1,
+            indexed_fields: HashSet::new(),
+            chunk_target: 4096,
+        });
+        let writes = vec![
+            h.make_write("a1", vec![0.9, 0.1]),
+            h.make_write("a2", vec![0.8, 0.2]),
+            h.make_write("a3", vec![0.6, 0.9]),
+            h.make_write("a4", vec![0.5, 0.8]),
+            h.make_write("b1", vec![0.05, 0.95]),
+        ];
+        h.write_and_apply(&opts, writes).await;
+        let id_b1 = h.storage.lookup_internal_id("b1").await.unwrap().unwrap();
+
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        let split = SplitCentroids::new(&opts, &(snapshot as Arc<dyn StorageRead>));
+        let result = split.execute(&h.state, &mut delta).await.unwrap();
+
+        assert_eq!(result.splits.len(), 1);
+        let reassign_ids: HashSet<u64> = result.reassignments.iter().map(|r| r.vector_id).collect();
+        assert!(
+            reassign_ids.contains(&id_b1),
+            "b1 should be reassigned via neighbour search"
+        );
+        let b1_reassign = result
+            .reassignments
+            .iter()
+            .find(|r| r.vector_id == id_b1)
+            .unwrap();
+        assert_eq!(b1_reassign.current_centroid, CENTROID_B);
+    }
+
+    #[tokio::test]
+    async fn should_only_split_centroids_over_threshold() {
+        let mut h = IndexerOpTestHarness::with_centroids(
+            vec![
+                CentroidEntry::new(CENTROID_A, vec![1.0, 0.0]),
+                CentroidEntry::new(CENTROID_B, vec![0.0, 1.0]),
+            ],
+            DIMS,
+        )
+        .await;
+        let opts = create_opts();
+        let writes = vec![
+            h.make_write("a1", vec![0.9, 0.1]),
+            h.make_write("a2", vec![0.8, 0.2]),
+            h.make_write("a3", vec![0.95, 0.05]),
+            h.make_write("a4", vec![0.85, 0.15]),
+            h.make_write("a5", vec![0.92, 0.08]),
+            h.make_write("a6", vec![0.88, 0.12]),
+            h.make_write("b1", vec![0.1, 0.9]),
+            h.make_write("b2", vec![0.2, 0.8]),
+        ];
+        h.write_and_apply(&opts, writes).await;
+
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        let split = SplitCentroids::new(&opts, &(snapshot as Arc<dyn StorageRead>));
+        let result = split.execute(&h.state, &mut delta).await.unwrap();
+
+        assert_eq!(
+            result.splits.len(),
+            1,
+            "only the centroid over threshold should split"
+        );
+        let ops = delta.freeze(&mut h.state);
+        h.storage.apply(ops).await.unwrap();
+        let deletions = h.storage.get_deleted_vectors().await.unwrap();
+        assert!(deletions.contains(CENTROID_A), "A should be deleted");
+        assert!(!deletions.contains(CENTROID_B), "B should not be deleted");
+        let posting_b = h.storage.get_posting_list(CENTROID_B, DIMS).await.unwrap();
+        assert_eq!(posting_b.len(), 2, "B's postings should be untouched");
+    }
+
+    #[tokio::test]
+    async fn should_respect_max_splits() {
+        let mut h = IndexerOpTestHarness::with_centroids(
+            vec![
+                CentroidEntry::new(CENTROID_A, vec![1.0, 0.0]),
+                CentroidEntry::new(CENTROID_B, vec![0.0, 1.0]),
+            ],
+            DIMS,
+        )
+        .await;
+        let opts = create_opts();
+        let writes = vec![
+            h.make_write("a1", vec![0.9, 0.1]),
+            h.make_write("a2", vec![0.8, 0.2]),
+            h.make_write("a3", vec![0.95, 0.05]),
+            h.make_write("a4", vec![0.85, 0.15]),
+            h.make_write("b1", vec![0.1, 0.9]),
+            h.make_write("b2", vec![0.2, 0.8]),
+            h.make_write("b3", vec![0.05, 0.95]),
+            h.make_write("b4", vec![0.15, 0.85]),
+        ];
+        h.write_and_apply(&opts, writes).await;
+
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        let split =
+            SplitCentroids::new_with_max_splits(&opts, &(snapshot as Arc<dyn StorageRead>), 1);
+        let result = split.execute(&h.state, &mut delta).await.unwrap();
+
+        assert_eq!(result.splits.len(), 1, "should respect max_splits=1");
+        let ops = delta.freeze(&mut h.state);
+        h.storage.apply(ops).await.unwrap();
+        let deletions = h.storage.get_deleted_vectors().await.unwrap();
+        let a_deleted = deletions.contains(CENTROID_A);
+        let b_deleted = deletions.contains(CENTROID_B);
+        assert!(
+            a_deleted ^ b_deleted,
+            "exactly one centroid should be deleted, got A={a_deleted} B={b_deleted}"
+        );
+    }
+
+    // ---- SplitCentroid (unit) ----
+
+    #[tokio::test]
+    async fn split_centroid_should_partition_vectors_into_two_clusters() {
+        let h = IndexerOpTestHarness::with_single_centroid(CENTROID_ID, DIMS).await;
+        let delta = VectorIndexDelta::new(&h.state);
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &h.state, snapshot);
+        let centroid_graph = view.centroid_graph();
+
+        let postings: HashMap<u64, PostingList> = HashMap::from([(
+            CENTROID_ID,
+            vec![
+                Posting::new(1, vec![0.9, 0.1]),
+                Posting::new(2, vec![0.8, 0.2]),
+                Posting::new(3, vec![0.1, 0.9]),
+                Posting::new(4, vec![0.2, 0.8]),
+            ],
+        )]);
+
+        let split = SplitCentroid {
+            c: CENTROID_ID,
+            neighbours: vec![],
+            centroid_graph,
+            dimensions: DIMS,
+            distance_metric: DistanceMetric::L2,
+        };
+        let result = split.execute(Arc::new(postings));
+
+        assert_eq!(result.c, CENTROID_ID);
+        let c0_ids: HashSet<u64> = result.c_0.postings().iter().map(|p| p.id()).collect();
+        let c1_ids: HashSet<u64> = result.c_1.postings().iter().map(|p| p.id()).collect();
+        assert_eq!(c0_ids.len() + c1_ids.len(), 4);
+        assert!(c0_ids.is_disjoint(&c1_ids));
+        let cluster_a = if c0_ids.contains(&1) {
+            &c0_ids
+        } else {
+            &c1_ids
+        };
+        let cluster_b = if c0_ids.contains(&3) {
+            &c0_ids
+        } else {
+            &c1_ids
+        };
+        assert!(cluster_a.contains(&1) && cluster_a.contains(&2));
+        assert!(cluster_b.contains(&3) && cluster_b.contains(&4));
+    }
+
+    #[tokio::test]
+    async fn should_return_split_reassignments_for_vectors_passing_heuristic() {
+        let h = IndexerOpTestHarness::with_single_centroid(CENTROID_ID, DIMS).await;
+        let delta = VectorIndexDelta::new(&h.state);
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &h.state, snapshot);
+        let centroid_graph = view.centroid_graph();
+
+        let c_vector = vec![0.0, 0.0];
+        let c0_vector = vec![1.0, 0.0];
+        let c1_vector = vec![0.0, 1.0];
+        let passing = Posting::new(10, vec![0.1, 0.1]);
+        let failing = Posting::new(11, vec![0.9, 0.1]);
+
+        let split = SplitCentroid {
+            c: CENTROID_ID,
+            neighbours: vec![],
+            centroid_graph,
+            dimensions: DIMS,
+            distance_metric: DistanceMetric::L2,
+        };
+        let reassignments = split.compute_split_reassignments(
+            CENTROID_ID,
+            &[passing, failing],
+            &c_vector,
+            &c0_vector,
+            &c1_vector,
+        );
+
+        assert_eq!(reassignments.len(), 1);
+        assert_eq!(reassignments[0].vector_id, 10);
+        assert_eq!(reassignments[0].current_centroid, CENTROID_ID);
+    }
+
+    #[tokio::test]
+    async fn should_return_neighbour_reassignments_for_vectors_passing_heuristic() {
+        let h = IndexerOpTestHarness::with_single_centroid(CENTROID_ID, DIMS).await;
+        let delta = VectorIndexDelta::new(&h.state);
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &h.state, snapshot);
+        let centroid_graph = view.centroid_graph();
+
+        let c_vector = vec![0.5, 0.5];
+        let c0_vector = vec![1.0, 0.0];
+        let c1_vector = vec![0.0, 1.0];
+        let neighbour_id: u64 = 99;
+        let passing = Posting::new(20, vec![0.9, 0.1]);
+        let failing = Posting::new(21, vec![0.5, 0.5]);
+
+        let mut postings: HashMap<u64, PostingList> = HashMap::new();
+        postings.insert(neighbour_id, vec![passing, failing]);
+
+        let split = SplitCentroid {
+            c: CENTROID_ID,
+            neighbours: vec![neighbour_id],
+            centroid_graph,
+            dimensions: DIMS,
+            distance_metric: DistanceMetric::L2,
+        };
+        let reassignments =
+            split.compute_neighbour_reassignments(&c_vector, &c0_vector, &c1_vector, &postings);
+
+        assert_eq!(reassignments.len(), 1);
+        assert_eq!(reassignments[0].vector_id, 20);
+        assert_eq!(reassignments[0].current_centroid, neighbour_id);
+    }
+}

--- a/vector/src/batched/indexer/state.rs
+++ b/vector/src/batched/indexer/state.rs
@@ -1,0 +1,977 @@
+use crate::AttributeValue;
+use crate::Result;
+use crate::hnsw::CentroidGraph;
+use crate::serde::FieldValue;
+use crate::serde::centroid_chunk::CentroidEntry;
+use crate::serde::key::{PostingListKey, VectorDataKey};
+use crate::serde::posting_list::{
+    PostingList, PostingListValue, PostingUpdate, merge_decoded_posting_lists,
+};
+use crate::serde::vector_data::{Field, VectorDataValue};
+use crate::storage::{VectorDbStorageReadExt, record};
+use bytes::Bytes;
+use common::sequence::AllocatedSeqBlock;
+use common::storage::RecordOp;
+use common::{Record, SequenceAllocator, StorageRead};
+use futures::future::BoxFuture;
+use roaring::RoaringTreemap;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+#[derive(Debug, Clone)]
+pub(crate) struct CentroidChunkManager {
+    current_chunk_count: usize,
+    current_chunk_id: u32,
+    chunk_target: usize,
+    dimensions: usize,
+}
+
+impl CentroidChunkManager {
+    pub(crate) fn new(
+        dimensions: usize,
+        chunk_target: usize,
+        current_chunk_id: u32,
+        current_chunk_count: usize,
+    ) -> Self {
+        Self {
+            current_chunk_count,
+            current_chunk_id,
+            chunk_target,
+            dimensions,
+        }
+    }
+}
+
+impl CentroidChunkManager {
+    fn allocate_centroids(&mut self, centroids: Vec<CentroidEntry>) -> Vec<RecordOp> {
+        let mut chunk_batches: HashMap<u32, Vec<CentroidEntry>> = HashMap::new();
+        for entry in centroids {
+            if self.current_chunk_count >= self.chunk_target {
+                self.current_chunk_id += 1;
+                self.current_chunk_count = 0;
+            }
+            chunk_batches
+                .entry(self.current_chunk_id)
+                .or_default()
+                .push(entry.clone());
+            self.current_chunk_count += 1;
+        }
+        let mut ops = Vec::with_capacity(chunk_batches.len());
+        for (chunk_id, entries) in chunk_batches {
+            ops.push(record::merge_centroid_chunk(
+                chunk_id,
+                entries,
+                self.dimensions,
+            ));
+        }
+        ops
+    }
+}
+
+/// In-memory preserved state of vector index
+pub(crate) struct VectorIndexState {
+    dictionary: HashMap<String, u64>,
+    centroid_counts: HashMap<u64, u64>,
+    centroid_graph: Arc<dyn CentroidGraph>,
+    sequence_block_key: Bytes,
+    sequence_block: AllocatedSeqBlock,
+    chunk_manager: CentroidChunkManager,
+}
+
+impl VectorIndexState {
+    pub(crate) fn new(
+        dictionary: HashMap<String, u64>,
+        centroid_counts: HashMap<u64, u64>,
+        centroid_graph: Arc<dyn CentroidGraph>,
+        sequence_block_key: Bytes,
+        sequence_block: AllocatedSeqBlock,
+        chunk_manager: CentroidChunkManager,
+    ) -> Self {
+        Self {
+            dictionary,
+            centroid_counts,
+            centroid_graph,
+            sequence_block_key,
+            sequence_block,
+            chunk_manager,
+        }
+    }
+
+    pub(crate) fn dictionary(&self) -> &HashMap<String, u64> {
+        &self.dictionary
+    }
+
+    pub(crate) fn centroid_counts(&self) -> &HashMap<u64, u64> {
+        &self.centroid_counts
+    }
+}
+
+pub(crate) struct VectorIndexDelta {
+    new_centroids: HashMap<u64, CentroidEntry>,
+    deleted_centroids: HashSet<u64>,
+    centroid_count_deltas: HashMap<u64, i64>,
+    posting_updates: HashMap<u64, Vec<PostingUpdate>>,
+    inverted_index_updates: HashMap<Bytes, RoaringTreemap>,
+    dictionary_updates: HashMap<String, u64>,
+    vector_updates: HashMap<u64, VectorDataValue>,
+    vector_deletes: HashSet<u64>,
+    id_allocator: SequenceAllocator,
+    current_posting: HashMap<u64, u64>,
+    ops: Vec<RecordOp>,
+}
+
+impl VectorIndexDelta {
+    pub(crate) fn new(initial_state: &VectorIndexState) -> Self {
+        Self {
+            new_centroids: HashMap::new(),
+            deleted_centroids: HashSet::new(),
+            centroid_count_deltas: HashMap::new(),
+            posting_updates: HashMap::new(),
+            inverted_index_updates: HashMap::new(),
+            dictionary_updates: HashMap::new(),
+            vector_updates: HashMap::new(),
+            vector_deletes: HashSet::new(),
+            current_posting: HashMap::new(),
+            id_allocator: SequenceAllocator::new(
+                initial_state.sequence_block_key.clone(),
+                initial_state.sequence_block.clone(),
+            ),
+            ops: vec![],
+        }
+    }
+
+    pub(crate) fn add_vector(
+        &mut self,
+        external_id: &str,
+        attributes: &[(String, AttributeValue)],
+    ) -> u64 {
+        let (vector_id, seq_alloc_put) = self.id_allocator.allocate_one();
+        if let Some(seq_alloc_put) = seq_alloc_put {
+            self.ops.push(RecordOp::Put(seq_alloc_put.into()));
+        }
+        let fields: Vec<Field> = attributes
+            .iter()
+            .map(|(name, value)| Field::new(name, value.clone().into()))
+            .collect();
+        let value = VectorDataValue::new(external_id, fields);
+        self.vector_updates.insert(vector_id, value);
+        self.dictionary_updates
+            .insert(String::from(external_id), vector_id);
+        vector_id
+    }
+
+    pub(crate) fn delete_vector(&mut self, vector_id: u64) {
+        self.vector_deletes.insert(vector_id);
+    }
+
+    pub(crate) fn add_centroid(&mut self, vector: Vec<f32>) -> CentroidEntry {
+        let (id, seq_alloc_put) = self.id_allocator.allocate_one();
+        if let Some(seq_alloc_put) = seq_alloc_put {
+            self.ops.push(RecordOp::Put(seq_alloc_put.into()));
+        }
+        let centroid = CentroidEntry::new(id, vector);
+        self.centroid_count_deltas.insert(id, 0);
+        self.new_centroids.insert(id, centroid.clone());
+        centroid
+    }
+
+    pub(crate) fn delete_centroids(&mut self, centroids: Vec<u64>) {
+        for c in &centroids {
+            self.centroid_count_deltas.remove(c);
+            self.new_centroids.remove(c);
+        }
+        self.deleted_centroids.extend(centroids);
+    }
+
+    pub(crate) fn add_to_posting(&mut self, centroid_id: u64, vector_id: u64, vector: Vec<f32>) {
+        self.current_posting.insert(vector_id, centroid_id);
+        self.posting_updates
+            .entry(centroid_id)
+            .or_default()
+            .push(PostingUpdate::append(vector_id, vector));
+        let c = self.centroid_count_deltas.entry(centroid_id).or_insert(0);
+        *c += 1;
+    }
+
+    pub(crate) fn remove_from_posting(&mut self, centroid_id: u64, vector_id: u64) {
+        if self.current_posting.get(&vector_id).cloned() == Some(centroid_id) {
+            self.current_posting.remove(&vector_id);
+        }
+        self.posting_updates
+            .entry(centroid_id)
+            .or_default()
+            .push(PostingUpdate::delete(vector_id));
+        let c = self.centroid_count_deltas.entry(centroid_id).or_insert(0);
+        *c -= 1;
+    }
+
+    pub(crate) fn add_to_inverted_index(
+        &mut self,
+        field_name: String,
+        field_value: FieldValue,
+        vector_id: u64,
+    ) {
+        let key = crate::serde::key::MetadataIndexKey::new(field_name, field_value).encode();
+        #[allow(clippy::unwrap_or_default)]
+        self.inverted_index_updates
+            .entry(key)
+            .or_insert_with(RoaringTreemap::new)
+            .insert(vector_id);
+    }
+
+    pub(crate) fn freeze(self, state: &mut VectorIndexState) -> Vec<RecordOp> {
+        let VectorIndexDelta {
+            new_centroids,
+            deleted_centroids,
+            centroid_count_deltas,
+            posting_updates,
+            inverted_index_updates,
+            dictionary_updates,
+            vector_updates,
+            vector_deletes,
+            id_allocator,
+            current_posting: _,
+            mut ops,
+        } = self;
+
+        // === Apply mutations to state ===
+
+        // Update centroid counts
+        for (&centroid_id, &delta) in &centroid_count_deltas {
+            let count = state.centroid_counts.entry(centroid_id).or_insert(0);
+            *count = count.saturating_add_signed(delta);
+        }
+        for &centroid_id in &deleted_centroids {
+            state.centroid_counts.remove(&centroid_id);
+        }
+
+        // Update dictionary
+        for (external_id, &internal_id) in &dictionary_updates {
+            state.dictionary.insert(external_id.clone(), internal_id);
+        }
+
+        // Delete centroids from graph before adding new ones so new centroids
+        // are not connected to deleted centroids.
+        for &centroid_id in &deleted_centroids {
+            let _ = state.centroid_graph.remove_centroid(centroid_id);
+        }
+        for entry in new_centroids.values() {
+            let _ = state.centroid_graph.add_centroid(entry);
+        }
+
+        // Update sequence allocator
+        let (key, block) = id_allocator.freeze();
+        state.sequence_block_key = key;
+        state.sequence_block = block;
+
+        // === Construct record ops ===
+
+        // Dictionary puts
+        for (external_id, &internal_id) in &dictionary_updates {
+            ops.push(record::put_id_dictionary(external_id, internal_id));
+        }
+
+        // Vector data puts
+        for (vector_id, value) in vector_updates {
+            let key = VectorDataKey::new(vector_id).encode();
+            let encoded = value.encode_to_bytes();
+            ops.push(RecordOp::Put(Record::new(key, encoded).into()));
+        }
+
+        // Vector data deletes
+        for vector_id in &vector_deletes {
+            ops.push(record::delete_vector_data(*vector_id));
+        }
+
+        // New centroid chunks
+        let centroid_entries: Vec<CentroidEntry> = new_centroids.into_values().collect();
+        if !centroid_entries.is_empty() {
+            ops.extend(state.chunk_manager.allocate_centroids(centroid_entries));
+        }
+
+        // Posting list merges
+        for (centroid_id, updates) in posting_updates {
+            if let Ok(op) = record::merge_posting_list(centroid_id, updates) {
+                ops.push(op);
+            }
+        }
+
+        // Centroid stats deltas (skip deleted centroids)
+        for (&centroid_id, &delta) in &centroid_count_deltas {
+            if !deleted_centroids.contains(&centroid_id) && delta != 0 {
+                ops.push(record::merge_centroid_stats(centroid_id, delta as i32));
+            }
+        }
+
+        // Metadata inverted index merges
+        for (encoded_key, vector_ids) in &inverted_index_updates {
+            if let Ok(op) = record::merge_metadata_index_bitmap(encoded_key.clone(), vector_ids) {
+                ops.push(op);
+            }
+        }
+
+        // Deleted centroids bitmap
+        if !deleted_centroids.is_empty() {
+            let bitmap = deleted_centroids
+                .iter()
+                .copied()
+                .collect::<RoaringTreemap>();
+            let op = record::merge_deleted_vectors(bitmap)
+                .expect("failure to construct deleted vectors row");
+            ops.push(op);
+        }
+
+        // Centroid posting and stats tombstones at the end
+        for &centroid_id in &deleted_centroids {
+            let posting_key = PostingListKey::new(centroid_id).encode();
+            ops.push(RecordOp::Delete(posting_key));
+            let stats_key = crate::serde::key::CentroidStatsKey::new(centroid_id).encode();
+            ops.push(RecordOp::Delete(stats_key));
+        }
+
+        ops
+    }
+}
+
+pub(crate) struct VectorIndexView<'a> {
+    delta: &'a VectorIndexDelta,
+    state: &'a VectorIndexState,
+    snapshot: Arc<dyn StorageRead>,
+}
+
+impl<'a> VectorIndexView<'a> {
+    pub(crate) fn new(
+        delta: &'a VectorIndexDelta,
+        state: &'a VectorIndexState,
+        snapshot: Arc<dyn StorageRead>,
+    ) -> Self {
+        Self {
+            delta,
+            state,
+            snapshot,
+        }
+    }
+
+    pub(crate) fn vector_id(&self, external_id: &str) -> Option<u64> {
+        if let Some(id) = self.delta.dictionary_updates.get(external_id) {
+            return Some(*id);
+        }
+        self.state.dictionary().get(external_id).cloned()
+    }
+
+    pub(crate) fn posting_list(
+        &self,
+        centroid_id: u64,
+        dimensions: usize,
+    ) -> Result<BoxFuture<'static, Result<PostingList>>> {
+        let mut all_postings = Vec::with_capacity(2);
+        if let Some(current) = self.delta.posting_updates.get(&centroid_id) {
+            all_postings.push(PostingListValue::from_posting_updates(current.clone())?);
+        }
+        let snapshot = self.snapshot.clone();
+        Ok(Box::pin(async move {
+            all_postings.push(snapshot.get_posting_list(centroid_id, dimensions).await?);
+            Ok(merge_decoded_posting_lists(all_postings).into())
+        }))
+    }
+
+    pub(crate) fn vector_data(
+        &self,
+        vector_id: u64,
+        dimensions: usize,
+    ) -> BoxFuture<'static, Result<Option<VectorDataValue>>> {
+        if self.delta.vector_deletes.contains(&vector_id) {
+            Box::pin(async { Ok(None) })
+        } else if let Some(d) = self.delta.vector_updates.get(&vector_id) {
+            let v = d.clone();
+            Box::pin(async move { Ok(Some(v)) })
+        } else {
+            let snapshot = self.snapshot.clone();
+            Box::pin(async move { snapshot.get_vector_data(vector_id, dimensions).await })
+        }
+    }
+
+    /// The last written posting for the vector in this delta only
+    pub(crate) fn last_written_posting(&self, vector_id: u64) -> Option<u64> {
+        self.delta.current_posting.get(&vector_id).cloned()
+    }
+
+    pub(crate) fn centroid_counts(&self) -> HashMap<u64, u64> {
+        let mut counts = self.state.centroid_counts().clone();
+        for (&k, &v) in self.delta.centroid_count_deltas.iter() {
+            let base_count = counts.entry(k).or_insert(0);
+            *base_count = base_count.saturating_add_signed(v);
+        }
+        counts
+    }
+
+    pub(crate) fn centroid_graph(&self) -> Arc<DirtyCentroidGraph> {
+        Arc::new(DirtyCentroidGraph {
+            new_centroids: self.delta.new_centroids.clone(),
+            deleted_centroids: self.delta.deleted_centroids.clone(),
+            inner: self.state.centroid_graph.clone(),
+        })
+    }
+}
+
+pub(crate) struct DirtyCentroidGraph {
+    new_centroids: HashMap<u64, CentroidEntry>,
+    deleted_centroids: HashSet<u64>,
+    inner: Arc<dyn CentroidGraph>,
+}
+
+impl DirtyCentroidGraph {
+    pub(crate) fn search(&self, query: &[f32], k: usize) -> Vec<u64> {
+        let include: Vec<_> = self.new_centroids.values().collect();
+        self.inner
+            .search_with_include_exclude(query, k, &include, &self.deleted_centroids)
+    }
+
+    pub(crate) fn centroid(&self, centroid_id: u64) -> Option<CentroidEntry> {
+        if self.deleted_centroids.contains(&centroid_id) {
+            None
+        } else if let Some(c) = self.new_centroids.get(&centroid_id) {
+            Some(c.clone())
+        } else {
+            self.inner
+                .get_centroid_vector(centroid_id)
+                .map(|v| CentroidEntry::new(centroid_id, v))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::hnsw::build_centroid_graph;
+    use crate::model::AttributeValue;
+    use crate::serde::collection_meta::DistanceMetric;
+    use crate::storage::VectorDbStorageReadExt;
+    use crate::storage::merge_operator::VectorDbMergeOperator;
+    use common::storage::in_memory::InMemoryStorage;
+    use common::{SequenceAllocator, Storage};
+
+    const DIMS: usize = 2;
+
+    /// Create storage + state for an empty db with one centroid (ID 1000) at the origin.
+    async fn setup() -> (Arc<dyn Storage>, VectorIndexState) {
+        setup_with_centroids(vec![CentroidEntry::new(1000, vec![0.0; DIMS])]).await
+    }
+
+    async fn setup_with_centroids(
+        centroids: Vec<CentroidEntry>,
+    ) -> (Arc<dyn Storage>, VectorIndexState) {
+        let storage: Arc<dyn Storage> = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
+            VectorDbMergeOperator::new(DIMS),
+        )));
+        let seq_key = Bytes::from_static(&[0x01, 0x02]);
+        let allocator = SequenceAllocator::load(storage.as_ref(), seq_key)
+            .await
+            .unwrap();
+        let counts: HashMap<u64, u64> = centroids.iter().map(|c| (c.centroid_id, 0u64)).collect();
+        let graph = build_centroid_graph(centroids, DistanceMetric::L2).unwrap();
+        let centroid_graph: Arc<dyn CentroidGraph> = Arc::from(graph);
+        let (key, block) = allocator.freeze();
+        let state = VectorIndexState::new(
+            HashMap::new(),
+            counts,
+            centroid_graph,
+            key,
+            block,
+            CentroidChunkManager::new(DIMS, 4096, 0, 1),
+        );
+        (storage, state)
+    }
+
+    fn make_attributes(values: Vec<f32>) -> Vec<(String, AttributeValue)> {
+        vec![("vector".to_string(), AttributeValue::Vector(values))]
+    }
+
+    // ---- add_vector ----
+
+    #[tokio::test]
+    async fn add_vector_should_write_dictionary_and_vector_data() {
+        // given
+        let (storage, mut state) = setup().await;
+        let mut delta = VectorIndexDelta::new(&state);
+
+        // when
+        let id = delta.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
+        let ops = delta.freeze(&mut state);
+        storage.apply(ops).await.unwrap();
+
+        // then
+        assert_eq!(state.dictionary()["v1"], id);
+        let stored_id = storage.lookup_internal_id("v1").await.unwrap().unwrap();
+        assert_eq!(stored_id, id);
+        let data = storage.get_vector_data(id, DIMS).await.unwrap().unwrap();
+        assert_eq!(data.external_id(), "v1");
+        assert_eq!(data.vector_field(), &[1.0, 2.0]);
+    }
+
+    // ---- delete_vector ----
+
+    #[tokio::test]
+    async fn delete_vector_should_remove_from_storage() {
+        // given
+        let (storage, mut state) = setup().await;
+        let mut delta = VectorIndexDelta::new(&state);
+        let id = delta.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        // when
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.delete_vector(id);
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        // then
+        assert!(storage.get_vector_data(id, DIMS).await.unwrap().is_none());
+    }
+
+    // ---- add_centroid ----
+
+    #[tokio::test]
+    async fn add_centroid_should_write_chunk_and_update_graph() {
+        // given
+        let (storage, mut state) = setup().await;
+        let mut delta = VectorIndexDelta::new(&state);
+
+        // when
+        let entry = delta.add_centroid(vec![1.0, 0.0]);
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        // then
+        assert_eq!(
+            state.centroid_graph.get_centroid_vector(entry.centroid_id),
+            Some(vec![1.0, 0.0])
+        );
+        assert_eq!(*state.centroid_counts().get(&entry.centroid_id).unwrap(), 0);
+        let scan = storage.scan_all_centroids(DIMS).await.unwrap();
+        assert!(
+            scan.entries
+                .iter()
+                .any(|e| e.centroid_id == entry.centroid_id)
+        );
+    }
+
+    // ---- delete_centroids ----
+
+    #[tokio::test]
+    async fn delete_centroids_should_remove_from_graph_and_write_deletions() {
+        // given — add a centroid with some postings (so stats exist)
+        let (storage, mut state) = setup().await;
+        let mut delta = VectorIndexDelta::new(&state);
+        let entry = delta.add_centroid(vec![1.0, 0.0]);
+        delta.add_to_posting(entry.centroid_id, 10, vec![1.0, 0.0]);
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+        // verify stats exist before deletion
+        let stats = storage.get_centroid_stats(entry.centroid_id).await.unwrap();
+        assert_eq!(stats.num_vectors, 1);
+
+        // when
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.delete_centroids(vec![entry.centroid_id]);
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        // then
+        assert!(
+            state
+                .centroid_graph
+                .get_centroid_vector(entry.centroid_id)
+                .is_none()
+        );
+        assert!(!state.centroid_counts().contains_key(&entry.centroid_id));
+        let deletions = storage.get_deleted_vectors().await.unwrap();
+        assert!(deletions.contains(entry.centroid_id));
+        let stats = storage.get_centroid_stats(entry.centroid_id).await.unwrap();
+        assert_eq!(stats.num_vectors, 0, "centroid stats should be deleted");
+        assert!(
+            storage
+                .get_posting_list(entry.centroid_id, DIMS)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    // ---- add_to_posting ----
+
+    #[tokio::test]
+    async fn add_to_posting_should_write_posting_and_update_count() {
+        let (storage, mut state) = setup().await;
+        let mut delta = VectorIndexDelta::new(&state);
+
+        delta.add_to_posting(1000, 10, vec![1.0, 0.0]);
+        delta.add_to_posting(1000, 11, vec![0.0, 1.0]);
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        // state
+        assert_eq!(*state.centroid_counts().get(&1000).unwrap(), 2);
+
+        // storage: posting list
+        let posting = storage.get_posting_list(1000, DIMS).await.unwrap();
+        assert_eq!(posting.len(), 2);
+        let ids: HashSet<u64> = posting.iter().map(|p| p.id()).collect();
+        assert!(ids.contains(&10));
+        assert!(ids.contains(&11));
+
+        // storage: centroid stats
+        let stats = storage.get_centroid_stats(1000).await.unwrap();
+        assert_eq!(stats.num_vectors, 2);
+    }
+
+    // ---- remove_from_posting ----
+
+    #[tokio::test]
+    async fn remove_from_posting_should_update_count_and_produce_posting_merge() {
+        let (_storage, mut state) = setup().await;
+        let mut delta = VectorIndexDelta::new(&state);
+
+        // add two, remove one — all in the same delta
+        delta.add_to_posting(1000, 10, vec![1.0, 0.0]);
+        delta.add_to_posting(1000, 11, vec![0.0, 1.0]);
+        delta.remove_from_posting(1000, 10);
+        let ops = delta.freeze(&mut state);
+
+        // state: net count = 1
+        assert_eq!(*state.centroid_counts().get(&1000).unwrap(), 1);
+
+        // ops: posting merge and stats merge are present
+        let posting_key = PostingListKey::new(1000).encode();
+        assert!(
+            ops.iter()
+                .any(|op| matches!(op, RecordOp::Merge(r) if r.record.key == posting_key))
+        );
+        let stats_key = crate::serde::key::CentroidStatsKey::new(1000).encode();
+        assert!(
+            ops.iter()
+                .any(|op| matches!(op, RecordOp::Merge(r) if r.record.key == stats_key))
+        );
+    }
+
+    // ---- add_to_inverted_index ----
+
+    #[tokio::test]
+    async fn add_to_inverted_index_should_write_metadata_bitmap() {
+        let (storage, mut state) = setup().await;
+        let mut delta = VectorIndexDelta::new(&state);
+
+        delta.add_to_inverted_index(
+            "color".to_string(),
+            FieldValue::String("red".to_string()),
+            10,
+        );
+        delta.add_to_inverted_index(
+            "color".to_string(),
+            FieldValue::String("red".to_string()),
+            11,
+        );
+        delta.add_to_inverted_index(
+            "color".to_string(),
+            FieldValue::String("blue".to_string()),
+            12,
+        );
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        let red = storage
+            .get_metadata_index("color", FieldValue::String("red".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(red.len(), 2);
+        assert!(red.contains(10));
+        assert!(red.contains(11));
+
+        let blue = storage
+            .get_metadata_index("color", FieldValue::String("blue".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(blue.len(), 1);
+        assert!(blue.contains(12));
+    }
+
+    // ---- freeze: delete before add ----
+
+    #[tokio::test]
+    async fn freeze_should_delete_centroids_before_adding_new_ones() {
+        let (_storage, mut state) = setup_with_centroids(vec![
+            CentroidEntry::new(1000, vec![0.0; DIMS]),
+            CentroidEntry::new(1001, vec![1.0, 1.0]),
+        ])
+        .await;
+
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.delete_centroids(vec![1000]);
+        let new_entry = delta.add_centroid(vec![1.0, 0.0]);
+        delta.freeze(&mut state);
+
+        assert!(state.centroid_graph.get_centroid_vector(1000).is_none());
+        assert!(
+            state
+                .centroid_graph
+                .get_centroid_vector(new_entry.centroid_id)
+                .is_some()
+        );
+    }
+
+    // ---- freeze: skip stats for deleted centroids ----
+
+    #[tokio::test]
+    async fn freeze_should_delete_stats_for_deleted_centroids() {
+        let (storage, mut state) = setup().await;
+
+        // Write some stats first
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.add_to_posting(1000, 10, vec![1.0, 0.0]);
+        delta.add_to_posting(1000, 11, vec![0.0, 1.0]);
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+        assert_eq!(
+            storage.get_centroid_stats(1000).await.unwrap().num_vectors,
+            2
+        );
+
+        // when — delete the centroid
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.delete_centroids(vec![1000]);
+        let ops = delta.freeze(&mut state);
+
+        // then — should NOT have a stats merge (no point updating stats for deleted centroid)
+        let stats_key = crate::serde::key::CentroidStatsKey::new(1000).encode();
+        assert!(
+            !ops.iter()
+                .any(|op| matches!(op, RecordOp::Merge(r) if r.record.key == stats_key))
+        );
+
+        // then — SHOULD have a stats delete tombstone
+        assert!(
+            ops.iter()
+                .any(|op| matches!(op, RecordOp::Delete(k) if k.as_ref() == stats_key.as_ref()))
+        );
+
+        // then — after applying, stats should be gone
+        storage.apply(ops).await.unwrap();
+        assert_eq!(
+            storage.get_centroid_stats(1000).await.unwrap().num_vectors,
+            0
+        );
+    }
+
+    // ======== VectorIndexView tests ========
+
+    // ---- vector_id ----
+
+    #[tokio::test]
+    async fn view_vector_id_should_prefer_delta_over_state() {
+        let (storage, mut state) = setup().await;
+
+        // Put "v1" in state via a prior delta
+        let mut delta = VectorIndexDelta::new(&state);
+        let old_id = delta.add_vector("v1", &make_attributes(vec![1.0, 0.0]));
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+        assert_eq!(state.dictionary()["v1"], old_id);
+
+        // New delta adds "v1" again (upsert) — gets a new ID
+        let mut delta = VectorIndexDelta::new(&state);
+        let new_id = delta.add_vector("v1", &make_attributes(vec![2.0, 0.0]));
+        assert_ne!(old_id, new_id);
+
+        let snapshot = storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &state, snapshot);
+
+        // view should return the delta's new ID, not the state's old one
+        assert_eq!(view.vector_id("v1"), Some(new_id));
+    }
+
+    #[tokio::test]
+    async fn view_vector_id_should_fall_back_to_state() {
+        let (storage, mut state) = setup().await;
+
+        // Put "v1" in state
+        let mut delta = VectorIndexDelta::new(&state);
+        let id = delta.add_vector("v1", &make_attributes(vec![1.0, 0.0]));
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        // Fresh delta — no updates for "v1"
+        let delta = VectorIndexDelta::new(&state);
+        let snapshot = storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &state, snapshot);
+
+        assert_eq!(view.vector_id("v1"), Some(id));
+        assert_eq!(view.vector_id("unknown"), None);
+    }
+
+    // ---- vector_data ----
+
+    #[tokio::test]
+    async fn view_vector_data_should_return_delta_update_over_storage() {
+        let (storage, mut state) = setup().await;
+
+        // Write v1 to storage
+        let mut delta = VectorIndexDelta::new(&state);
+        let id = delta.add_vector("v1", &make_attributes(vec![1.0, 0.0]));
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        // New delta overwrites v1
+        let mut delta = VectorIndexDelta::new(&state);
+        let new_id = delta.add_vector("v1", &make_attributes(vec![9.0, 9.0]));
+
+        let snapshot = storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &state, snapshot);
+
+        // delta's version wins
+        let data = view.vector_data(new_id, DIMS).await.unwrap().unwrap();
+        assert_eq!(data.vector_field(), &[9.0, 9.0]);
+
+        // old ID falls through to storage
+        let old_data = view.vector_data(id, DIMS).await.unwrap().unwrap();
+        assert_eq!(old_data.vector_field(), &[1.0, 0.0]);
+    }
+
+    #[tokio::test]
+    async fn view_vector_data_should_return_none_for_deleted() {
+        let (storage, mut state) = setup().await;
+
+        // Write v1 to storage
+        let mut delta = VectorIndexDelta::new(&state);
+        let id = delta.add_vector("v1", &make_attributes(vec![1.0, 0.0]));
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        // New delta deletes v1
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.delete_vector(id);
+
+        let snapshot = storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &state, snapshot);
+
+        assert!(view.vector_data(id, DIMS).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn view_vector_data_should_read_from_storage_for_unknown() {
+        let (storage, mut state) = setup().await;
+
+        // Write v1 to storage
+        let mut delta = VectorIndexDelta::new(&state);
+        let id = delta.add_vector("v1", &make_attributes(vec![1.0, 0.0]));
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        // Fresh delta — no updates
+        let delta = VectorIndexDelta::new(&state);
+        let snapshot = storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &state, snapshot);
+
+        let data = view.vector_data(id, DIMS).await.unwrap().unwrap();
+        assert_eq!(data.vector_field(), &[1.0, 0.0]);
+
+        // Unknown ID returns None
+        assert!(view.vector_data(9999, DIMS).await.unwrap().is_none());
+    }
+
+    // ---- posting_list ----
+
+    #[tokio::test]
+    async fn view_posting_list_should_merge_delta_and_storage() {
+        let (storage, mut state) = setup().await;
+
+        // Write postings to storage
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.add_to_posting(1000, 10, vec![1.0, 0.0]);
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+
+        // New delta adds another posting
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.add_to_posting(1000, 11, vec![0.0, 1.0]);
+
+        let snapshot = storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &state, snapshot);
+
+        // Should see both: 10 from storage, 11 from delta
+        let posting = view.posting_list(1000, DIMS).unwrap().await.unwrap();
+        assert_eq!(posting.len(), 2);
+        let ids: HashSet<u64> = posting.iter().map(|p| p.id()).collect();
+        assert!(ids.contains(&10));
+        assert!(ids.contains(&11));
+    }
+
+    // ---- last_written_posting ----
+
+    #[tokio::test]
+    async fn view_last_written_posting_should_reflect_delta() {
+        let (storage, state) = setup().await;
+
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.add_to_posting(1000, 10, vec![1.0, 0.0]);
+        // Move vector 10 to a different centroid within the same delta
+        delta.remove_from_posting(1000, 10);
+        delta.add_to_posting(2000, 10, vec![1.0, 0.0]);
+
+        let snapshot = storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &state, snapshot);
+
+        // Should reflect the latest posting in the delta
+        assert_eq!(view.last_written_posting(10), Some(2000));
+        // Unknown vector returns None
+        assert_eq!(view.last_written_posting(99), None);
+    }
+
+    // ---- centroid_counts ----
+
+    #[tokio::test]
+    async fn view_centroid_counts_should_merge_state_and_delta() {
+        let (storage, mut state) = setup().await;
+
+        // Add postings to state via a prior delta (centroid 1000 gets count=2)
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.add_to_posting(1000, 10, vec![1.0, 0.0]);
+        delta.add_to_posting(1000, 11, vec![0.0, 1.0]);
+        storage.apply(delta.freeze(&mut state)).await.unwrap();
+        assert_eq!(*state.centroid_counts().get(&1000).unwrap(), 2);
+
+        // New delta adds one more posting
+        let mut delta = VectorIndexDelta::new(&state);
+        delta.add_to_posting(1000, 12, vec![0.5, 0.5]);
+
+        let snapshot = storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &state, snapshot);
+
+        // Should be state(2) + delta(+1) = 3
+        let counts = view.centroid_counts();
+        assert_eq!(*counts.get(&1000).unwrap(), 3);
+    }
+
+    // ---- centroid_graph (DirtyCentroidGraph) ----
+
+    #[tokio::test]
+    async fn view_centroid_graph_should_include_new_and_exclude_deleted() {
+        let (storage, state) = setup_with_centroids(vec![
+            CentroidEntry::new(1000, vec![0.0, 0.0]),
+            CentroidEntry::new(1001, vec![1.0, 0.0]),
+        ])
+        .await;
+
+        let mut delta = VectorIndexDelta::new(&state);
+        // Delete centroid 1000, add a new one at [0, 1]
+        delta.delete_centroids(vec![1000]);
+        let new_c = delta.add_centroid(vec![0.0, 1.0]);
+
+        let snapshot = storage.snapshot().await.unwrap();
+        let view = VectorIndexView::new(&delta, &state, snapshot);
+        let graph = view.centroid_graph();
+
+        // Deleted centroid should not be found
+        assert!(graph.centroid(1000).is_none());
+
+        // Existing centroid should still be found
+        assert!(graph.centroid(1001).is_some());
+
+        // New centroid should be found
+        assert!(graph.centroid(new_c.centroid_id).is_some());
+        assert_eq!(
+            graph.centroid(new_c.centroid_id).unwrap().vector,
+            vec![0.0, 1.0]
+        );
+
+        // Search near [0, 1] should find new centroid, not deleted one
+        let results = graph.search(&[0.0, 0.9], 1);
+        assert_eq!(results[0], new_c.centroid_id);
+    }
+}

--- a/vector/src/batched/indexer/test_utils.rs
+++ b/vector/src/batched/indexer/test_utils.rs
@@ -1,0 +1,73 @@
+use crate::batched::indexer::IndexerOpts;
+use crate::batched::indexer::state::{CentroidChunkManager, VectorIndexDelta, VectorIndexState};
+use crate::batched::indexer::vector::WriteVectors;
+use crate::delta::VectorWrite;
+use crate::hnsw::build_centroid_graph;
+use crate::model::AttributeValue;
+use crate::serde::centroid_chunk::CentroidEntry;
+use crate::serde::collection_meta::DistanceMetric;
+use crate::storage::merge_operator::VectorDbMergeOperator;
+use common::storage::in_memory::InMemoryStorage;
+use common::{SequenceAllocator, Storage, StorageRead};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+pub struct IndexerOpTestHarness {
+    pub storage: Arc<dyn Storage>,
+    pub state: VectorIndexState,
+}
+
+impl IndexerOpTestHarness {
+    /// Create a harness with a single centroid at the origin.
+    pub async fn with_single_centroid(centroid_id: u64, dimensions: usize) -> Self {
+        Self::with_centroids(
+            vec![CentroidEntry::new(centroid_id, vec![0.0; dimensions])],
+            dimensions,
+        )
+        .await
+    }
+
+    /// Create a harness with the given centroids.
+    pub async fn with_centroids(centroids: Vec<CentroidEntry>, dimensions: usize) -> Self {
+        let storage: Arc<dyn Storage> = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
+            VectorDbMergeOperator::new(dimensions),
+        )));
+        let seq_key = bytes::Bytes::from_static(&[0x01, 0x02]);
+        let allocator = SequenceAllocator::load(storage.as_ref(), seq_key)
+            .await
+            .unwrap();
+        let centroid_counts: HashMap<u64, u64> =
+            centroids.iter().map(|c| (c.centroid_id, 0u64)).collect();
+        let graph = build_centroid_graph(centroids, DistanceMetric::L2).unwrap();
+        let centroid_graph: Arc<dyn crate::hnsw::CentroidGraph> = Arc::from(graph);
+        let (key, block) = allocator.freeze();
+        let state = VectorIndexState::new(
+            HashMap::new(),
+            centroid_counts,
+            centroid_graph,
+            key,
+            block,
+            CentroidChunkManager::new(dimensions, 4096, 0, 1),
+        );
+        Self { storage, state }
+    }
+
+    /// Create a simple VectorWrite with a vector attribute.
+    pub fn make_write(&self, id: &str, values: Vec<f32>) -> VectorWrite {
+        VectorWrite {
+            external_id: id.to_string(),
+            values: values.clone(),
+            attributes: vec![("vector".to_string(), AttributeValue::Vector(values))],
+        }
+    }
+
+    /// Run WriteVectors, freeze the delta, and apply the resulting ops to storage.
+    pub async fn write_and_apply(&mut self, opts: &Arc<IndexerOpts>, writes: Vec<VectorWrite>) {
+        let snapshot = self.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&self.state);
+        let wv = WriteVectors::new(opts, &(snapshot as Arc<dyn StorageRead>), writes);
+        wv.execute(&self.state, &mut delta).await.unwrap();
+        let ops = delta.freeze(&mut self.state);
+        self.storage.apply(ops).await.unwrap();
+    }
+}

--- a/vector/src/batched/indexer/vector.rs
+++ b/vector/src/batched/indexer/vector.rs
@@ -1,0 +1,679 @@
+use crate::Error::Internal;
+use crate::Result;
+use crate::batched::indexer::IndexerOpts;
+use crate::batched::indexer::drivers::AsyncBatchDriver;
+use crate::batched::indexer::split::ReassignVector;
+use crate::batched::indexer::state::{VectorIndexDelta, VectorIndexState, VectorIndexView};
+use crate::delta::VectorWrite;
+use crate::model::VECTOR_FIELD_NAME;
+use crate::serde::FieldValue;
+use crate::serde::vector_data::VectorDataValue;
+use common::StorageRead;
+use futures::future::BoxFuture;
+use rayon::iter::IntoParallelIterator;
+use rayon::iter::ParallelIterator;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::task;
+use tracing::debug;
+
+/// An upsert where we need to resolve the old vector data from storage.
+struct ResolvedUpsert {
+    write: VectorWrite,
+    old: (u64, VectorDataValue),
+}
+
+pub(crate) struct WriteVectors {
+    opts: Arc<IndexerOpts>,
+    snapshot: Arc<dyn StorageRead>,
+    writes: Vec<VectorWrite>,
+}
+
+impl WriteVectors {
+    pub(crate) fn new(
+        opts: &Arc<IndexerOpts>,
+        snapshot: &Arc<dyn StorageRead>,
+        writes: Vec<VectorWrite>,
+    ) -> Self {
+        Self {
+            opts: opts.clone(),
+            snapshot: snapshot.clone(),
+            writes,
+        }
+    }
+
+    pub(crate) async fn execute(
+        self,
+        state: &VectorIndexState,
+        delta: &mut VectorIndexDelta,
+    ) -> Result<()> {
+        if self.writes.is_empty() {
+            return Ok(());
+        }
+        let view = VectorIndexView::new(delta, state, self.snapshot.clone());
+
+        // compact so last write for each external id wins
+        let writes = Self::compact_writes(self.writes);
+
+        // Partition into inserts (new vectors) vs upserts (existing external_id).
+        // Centroid assignment is computed separately on the blocking pool so it can run
+        // in parallel with the upsert storage reads.
+        let centroid_graph = view.centroid_graph();
+        let assignment_inputs: Vec<_> = writes
+            .iter()
+            .map(|write| (write.external_id.clone(), write.values.clone()))
+            .collect();
+        let assignment_handle =
+            task::spawn_blocking(move || Self::assign_centroids(assignment_inputs, centroid_graph));
+
+        let mut inserts = Vec::with_capacity(writes.len());
+        let mut upsert_futures: Vec<BoxFuture<'static, Result<ResolvedUpsert>>> = Vec::new();
+
+        for w in writes {
+            let Some(old_vector_id) = view.vector_id(&w.external_id) else {
+                inserts.push(w);
+                continue;
+            };
+            // Upsert — need to read old vector data from storage
+            let data_fut = view.vector_data(old_vector_id, self.opts.dimensions);
+            upsert_futures.push(Box::pin(async move {
+                let old_data = data_fut.await?.ok_or_else(|| {
+                    Internal(format!("missing vector data for id {}", old_vector_id))
+                })?;
+                Ok(ResolvedUpsert {
+                    write: w,
+                    old: (old_vector_id, old_data),
+                })
+            }));
+        }
+
+        // Resolve upserts concurrently (bounded by AsyncBatchDriver) while the
+        // centroid assignments run on the blocking pool.
+        let (centroid_assignments, upsert_results) =
+            tokio::join!(assignment_handle, AsyncBatchDriver::execute(upsert_futures));
+        let centroid_assignments = centroid_assignments
+            .map_err(|e| Internal(format!("centroid assignment task failed: {e}")))??;
+        let mut upserts = Vec::with_capacity(upsert_results.len());
+        for result in upsert_results {
+            upserts.push(result?);
+        }
+        drop(view);
+
+        // Apply inserts to delta (no old data to clean up)
+        for insert in inserts {
+            let centroid = *centroid_assignments
+                .get(&insert.external_id)
+                .ok_or_else(|| {
+                    Internal(format!(
+                        "missing centroid assignment for external_id={}",
+                        insert.external_id
+                    ))
+                })?;
+            let vector_id = delta.add_vector(&insert.external_id, &insert.attributes);
+            delta.add_to_posting(centroid, vector_id, insert.values.clone());
+            for (attr_name, attr_value) in &insert.attributes {
+                if attr_name == VECTOR_FIELD_NAME {
+                    continue;
+                }
+                if !self.opts.indexed_fields.contains(attr_name) {
+                    continue;
+                }
+                let field_value: FieldValue = attr_value.clone().into();
+                delta.add_to_inverted_index(attr_name.clone(), field_value, vector_id);
+            }
+        }
+
+        // Apply upserts to delta
+        for upsert in upserts {
+            let centroid = *centroid_assignments
+                .get(&upsert.write.external_id)
+                .ok_or_else(|| {
+                    Internal(format!(
+                        "missing centroid assignment for external_id={}",
+                        upsert.write.external_id
+                    ))
+                })?;
+            let (old_vector_id, _old_vector_data) = upsert.old;
+            delta.delete_vector(old_vector_id);
+            // todo: delete from old postings and inverted index
+            let vector_id = delta.add_vector(&upsert.write.external_id, &upsert.write.attributes);
+            delta.add_to_posting(centroid, vector_id, upsert.write.values.clone());
+            for (attr_name, attr_value) in &upsert.write.attributes {
+                if attr_name == VECTOR_FIELD_NAME {
+                    continue;
+                }
+                if !self.opts.indexed_fields.contains(attr_name) {
+                    continue;
+                }
+                let field_value: FieldValue = attr_value.clone().into();
+                delta.add_to_inverted_index(attr_name.clone(), field_value, vector_id);
+            }
+        }
+        Ok(())
+    }
+
+    fn assign_centroids(
+        writes: Vec<(String, Vec<f32>)>,
+        centroid_graph: Arc<crate::batched::indexer::state::DirtyCentroidGraph>,
+    ) -> Result<HashMap<String, u64>> {
+        let assignments: Vec<_> = writes
+            .into_par_iter()
+            .map(|(external_id, values)| {
+                centroid_graph
+                    .search(&values, 1)
+                    .first()
+                    .copied()
+                    .ok_or_else(|| Internal("no centroids found".to_string()))
+                    .map(|centroid| (external_id, centroid))
+            })
+            .collect();
+
+        let mut centroid_assignments = HashMap::with_capacity(assignments.len());
+        for assignment in assignments {
+            let (external_id, centroid) = assignment?;
+            centroid_assignments.insert(external_id, centroid);
+        }
+
+        Ok(centroid_assignments)
+    }
+
+    fn compact_writes(updates: Vec<VectorWrite>) -> Vec<VectorWrite> {
+        let mut compacted = HashMap::with_capacity(updates.len());
+        for update in updates {
+            compacted.insert(update.external_id.clone(), update);
+        }
+        compacted.into_values().collect()
+    }
+}
+
+struct VerifiedVectorReassignment {
+    reassignment: ReassignVector,
+    centroid: u64,
+}
+
+struct ResolvedVectorReassignment {
+    reassignment: ReassignVector,
+    data: VectorDataValue,
+    centroid: u64,
+}
+
+pub(crate) struct ReassignVectors {
+    opts: Arc<IndexerOpts>,
+    snapshot: Arc<dyn StorageRead>,
+    reassignments: Vec<ReassignVector>,
+}
+
+impl ReassignVectors {
+    pub(crate) fn new(
+        opts: &Arc<IndexerOpts>,
+        snapshot: &Arc<dyn StorageRead>,
+        reassignments: Vec<ReassignVector>,
+    ) -> Self {
+        Self {
+            opts: opts.clone(),
+            snapshot: snapshot.clone(),
+            reassignments,
+        }
+    }
+
+    pub(crate) async fn execute(
+        mut self,
+        state: &VectorIndexState,
+        delta: &mut VectorIndexDelta,
+    ) -> Result<()> {
+        if self.reassignments.is_empty() {
+            return Ok(());
+        }
+        let view = VectorIndexView::new(delta, state, self.snapshot);
+        let centroid_graph = view.centroid_graph();
+
+        // update current centroid in case centroid was moved as part of a split/merge
+        self.reassignments.iter_mut().for_each(|r| {
+            if let Some(p) = view.last_written_posting(r.vector_id) {
+                r.current_centroid = p;
+            }
+        });
+
+        // determine which vectors actually need a new assignment
+        let reassignments: Vec<_> = self
+            .reassignments
+            .into_par_iter()
+            .filter_map(|r| {
+                let &closest_centroid = centroid_graph
+                    .search(&r.vector, 1)
+                    .first()
+                    .expect("no centroids");
+                if closest_centroid == r.current_centroid {
+                    None
+                } else {
+                    Some(VerifiedVectorReassignment {
+                        reassignment: r,
+                        centroid: closest_centroid,
+                    })
+                }
+            })
+            .collect();
+
+        // pull the old vector data so we can update inverted indexes
+        let mut to_resolve = Vec::with_capacity(reassignments.len());
+        for r in reassignments {
+            let data_fut = view.vector_data(r.reassignment.vector_id, self.opts.dimensions);
+            to_resolve.push(Box::pin(async move {
+                Ok(ResolvedVectorReassignment {
+                    reassignment: r.reassignment,
+                    data: data_fut.await?.expect("missing vector data"),
+                    centroid: r.centroid,
+                })
+            })
+                as BoxFuture<Result<ResolvedVectorReassignment>>);
+        }
+        let resolve_results = AsyncBatchDriver::execute(to_resolve).await;
+        let mut resolved = Vec::with_capacity(resolve_results.len());
+        for result in resolve_results {
+            resolved.push(result?);
+        }
+        drop(view);
+
+        // execute the reassignments
+        for r in resolved {
+            debug!("old data: {:?}", r.data);
+            delta.remove_from_posting(r.reassignment.current_centroid, r.reassignment.vector_id);
+            delta.add_to_posting(r.centroid, r.reassignment.vector_id, r.reassignment.vector);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::batched::indexer::test_utils::IndexerOpTestHarness;
+    use crate::model::AttributeValue;
+    use crate::serde::collection_meta::DistanceMetric;
+    use crate::serde::vector_data::Field;
+    use crate::storage::VectorDbStorageReadExt;
+    use std::collections::HashSet;
+
+    const DIMS: usize = 3;
+    const CENTROID_ID: u64 = 0;
+
+    fn create_opts() -> Arc<IndexerOpts> {
+        Arc::new(IndexerOpts {
+            dimensions: DIMS,
+            distance_metric: DistanceMetric::L2,
+            merge_threshold_vectors: 0,
+            split_threshold_vectors: usize::MAX,
+            split_search_neighbourhood: 4,
+            indexed_fields: HashSet::from(["category".to_string()]),
+            chunk_target: 4096,
+        })
+    }
+
+    fn make_write(id: &str, values: Vec<f32>, category: &str) -> VectorWrite {
+        VectorWrite {
+            external_id: id.to_string(),
+            values: values.clone(),
+            attributes: vec![
+                ("vector".to_string(), AttributeValue::Vector(values)),
+                (
+                    "category".to_string(),
+                    AttributeValue::String(category.to_string()),
+                ),
+                (
+                    "description".to_string(),
+                    AttributeValue::String(format!("{id} description")),
+                ),
+            ],
+        }
+    }
+
+    fn make_data(id: &str, values: Vec<f32>, category: &str) -> VectorDataValue {
+        let fields = vec![
+            Field::new("vector".to_string(), FieldValue::Vector(values)),
+            Field::new(
+                "category".to_string(),
+                FieldValue::String(category.to_string()),
+            ),
+            Field::new(
+                "description".to_string(),
+                FieldValue::String(format!("{id} description")),
+            ),
+        ];
+        VectorDataValue::new(id.to_string(), fields)
+    }
+
+    #[tokio::test]
+    async fn should_update_delta_correctly_from_write_vectors() {
+        // given — empty state, 3 new vectors with different categories
+        let mut h = IndexerOpTestHarness::with_single_centroid(CENTROID_ID, DIMS).await;
+        let opts = create_opts();
+        let writes = vec![
+            make_write("a", vec![1.0, 0.0, 0.0], "shoes"),
+            make_write("b", vec![0.0, 1.0, 0.0], "shoes"),
+            make_write("c", vec![0.0, 0.0, 1.0], "boots"),
+        ];
+
+        // when
+        h.write_and_apply(&opts, writes).await;
+
+        // then:
+        // storage should have dictionary + vector data for each vector
+        let expected = vec![
+            ("a", vec![1.0, 0.0, 0.0], "shoes"),
+            ("b", vec![0.0, 1.0, 0.0], "shoes"),
+            ("c", vec![0.0, 0.0, 1.0], "boots"),
+        ];
+        let mut expected_postings: HashMap<u64, Vec<f32>> = HashMap::new();
+        let mut internal_ids = HashMap::new();
+        for (ext_id, values, category) in &expected {
+            let internal_id = h
+                .storage
+                .lookup_internal_id(ext_id)
+                .await
+                .unwrap()
+                .unwrap_or_else(|| panic!("missing dictionary entry for {ext_id}"));
+            internal_ids.insert(ext_id.to_string(), internal_id);
+            let data = h
+                .storage
+                .get_vector_data(internal_id, DIMS)
+                .await
+                .unwrap()
+                .unwrap_or_else(|| panic!("missing vector data for {ext_id}"));
+            assert_eq!(data, make_data(ext_id, values.clone(), category));
+            expected_postings.insert(internal_id, values.clone());
+        }
+        // posting list should contain exactly the 3 vectors with correct IDs and values
+        let posting = h.storage.get_posting_list(CENTROID_ID, DIMS).await.unwrap();
+        assert_eq!(posting.len(), 3);
+        for p in posting.iter() {
+            let expected_vec = expected_postings
+                .get(&p.id())
+                .unwrap_or_else(|| panic!("unexpected vector id {} in posting list", p.id()));
+            assert_eq!(
+                p.vector(),
+                Some(expected_vec.as_slice()),
+                "vector mismatch for posting id {}",
+                p.id()
+            );
+        }
+        // inverted index should have correct entries
+        let shoes_bitmap = h
+            .storage
+            .get_metadata_index("category", FieldValue::String("shoes".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(shoes_bitmap.len(), 2);
+        assert!(shoes_bitmap.contains(internal_ids["a"]));
+        assert!(shoes_bitmap.contains(internal_ids["b"]));
+        let boots_bitmap = h
+            .storage
+            .get_metadata_index("category", FieldValue::String("boots".to_string()))
+            .await
+            .unwrap();
+        assert_eq!(boots_bitmap.len(), 1);
+        assert!(boots_bitmap.contains(internal_ids["c"]));
+        // non-indexed field "description" should have no inverted index entries
+        for id in ["a", "b", "c"] {
+            let bitmap = h
+                .storage
+                .get_metadata_index(
+                    "description",
+                    FieldValue::String(format!("{id} description")),
+                )
+                .await
+                .unwrap();
+            assert!(
+                bitmap.is_empty(),
+                "non-indexed field 'description' should have no inverted index entries for {id}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn should_update_delta_correctly_from_write_vectors_on_update() {
+        // given — insert 2 vectors first
+        let mut h = IndexerOpTestHarness::with_single_centroid(CENTROID_ID, DIMS).await;
+        let opts = create_opts();
+        h.write_and_apply(
+            &opts,
+            vec![
+                make_write("a", vec![1.0, 0.0, 0.0], "shoes"),
+                make_write("b", vec![0.0, 1.0, 0.0], "shoes"),
+            ],
+        )
+        .await;
+        let old_id_a = h.storage.lookup_internal_id("a").await.unwrap().unwrap();
+        let old_id_b = h.storage.lookup_internal_id("b").await.unwrap().unwrap();
+
+        // when — upsert both with new values
+        h.write_and_apply(
+            &opts,
+            vec![
+                make_write("a", vec![2.0, 0.0, 0.0], "shoes"),
+                make_write("b", vec![0.0, 2.0, 0.0], "shoes"),
+            ],
+        )
+        .await;
+
+        // then — old vector data should be deleted from storage
+        assert!(
+            h.storage
+                .get_vector_data(old_id_a, DIMS)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            h.storage
+                .get_vector_data(old_id_b, DIMS)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        // then — dictionary lookups should resolve to new vector data with updated values
+        let new_id_a = h.storage.lookup_internal_id("a").await.unwrap().unwrap();
+        let new_id_b = h.storage.lookup_internal_id("b").await.unwrap().unwrap();
+        assert_ne!(old_id_a, new_id_a);
+        assert_ne!(old_id_b, new_id_b);
+        let data_a = h
+            .storage
+            .get_vector_data(new_id_a, DIMS)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(data_a, make_data("a", vec![2.0, 0.0, 0.0], "shoes"));
+        let data_b = h
+            .storage
+            .get_vector_data(new_id_b, DIMS)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(data_b, make_data("b", vec![0.0, 2.0, 0.0], "shoes"));
+    }
+
+    #[tokio::test]
+    async fn should_compact_duplicate_writes_from_write_vectors() {
+        // given — 3 writes with the same external_id
+        let mut h = IndexerOpTestHarness::with_single_centroid(CENTROID_ID, DIMS).await;
+        let opts = create_opts();
+        let writes = vec![
+            make_write("x", vec![1.0, 0.0, 0.0], "shoes"),
+            make_write("x", vec![2.0, 0.0, 0.0], "clothes"),
+            make_write("x", vec![3.0, 0.0, 0.0], "furniture"),
+        ];
+
+        // when
+        h.write_and_apply(&opts, writes).await;
+
+        // then — storage should have the last write's values
+        let internal_id = h.storage.lookup_internal_id("x").await.unwrap().unwrap();
+        let data = h
+            .storage
+            .get_vector_data(internal_id, DIMS)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(data, make_data("x", vec![3.0, 0.0, 0.0], "furniture"));
+        // then — posting list should have exactly 1 entry
+        let posting = h.storage.get_posting_list(CENTROID_ID, DIMS).await.unwrap();
+        assert_eq!(posting.len(), 1);
+    }
+
+    // ---- ReassignVectors tests ----
+
+    #[tokio::test]
+    async fn should_reassign_vectors_after_split() {
+        // given — all vectors initially at centroid 0 (single centroid db).
+        // Then centroid 0 is "split" into two new centroids via the delta,
+        // and vectors should be reassigned to their nearest new centroid.
+        let mut h = IndexerOpTestHarness::with_single_centroid(CENTROID_ID, DIMS).await;
+        let opts = create_opts();
+        let writes = vec![
+            make_write("a", vec![0.9, 0.1, 0.0], "shoes"),
+            make_write("b", vec![0.1, 0.9, 0.0], "shoes"),
+            make_write("c", vec![0.2, 0.8, 0.0], "boots"),
+        ];
+        h.write_and_apply(&opts, writes).await;
+        let id_a = h.storage.lookup_internal_id("a").await.unwrap().unwrap();
+        let id_b = h.storage.lookup_internal_id("b").await.unwrap().unwrap();
+        let id_c = h.storage.lookup_internal_id("c").await.unwrap().unwrap();
+        // Simulate a split: delete centroid 0, add two new centroids via the delta
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        delta.delete_centroids(vec![CENTROID_ID]);
+        let c_a = delta.add_centroid(vec![1.0, 0.0, 0.0]);
+        let c_b = delta.add_centroid(vec![0.0, 1.0, 0.0]);
+
+        // All vectors claim current_centroid=0 (the deleted centroid)
+        let reassignments = vec![
+            ReassignVector {
+                vector_id: id_a,
+                vector: vec![0.9, 0.1, 0.0],
+                current_centroid: CENTROID_ID,
+            },
+            ReassignVector {
+                vector_id: id_b,
+                vector: vec![0.1, 0.9, 0.0],
+                current_centroid: CENTROID_ID,
+            },
+            ReassignVector {
+                vector_id: id_c,
+                vector: vec![0.2, 0.8, 0.0],
+                current_centroid: CENTROID_ID,
+            },
+        ];
+
+        // when
+        let rv = ReassignVectors::new(&opts, &(snapshot as Arc<dyn StorageRead>), reassignments);
+        rv.execute(&h.state, &mut delta).await.unwrap();
+        let ops = delta.freeze(&mut h.state);
+        h.storage.apply(ops).await.unwrap();
+
+        // then — "a" (near [1,0,0]) should be at c_a, "b" and "c" (near [0,1,0]) at c_b
+        let posting_a = h
+            .storage
+            .get_posting_list(c_a.centroid_id, DIMS)
+            .await
+            .unwrap();
+        let ids_a: HashSet<u64> = posting_a.iter().map(|p| p.id()).collect();
+        assert!(ids_a.contains(&id_a), "c_a should contain vector a");
+        assert!(!ids_a.contains(&id_b), "c_a should not contain vector b");
+        assert!(!ids_a.contains(&id_c), "c_a should not contain vector c");
+        let posting_b = h
+            .storage
+            .get_posting_list(c_b.centroid_id, DIMS)
+            .await
+            .unwrap();
+        let ids_b: HashSet<u64> = posting_b.iter().map(|p| p.id()).collect();
+        assert!(ids_b.contains(&id_b), "c_b should contain vector b");
+        assert!(ids_b.contains(&id_c), "c_b should contain vector c");
+        assert!(!ids_b.contains(&id_a), "c_b should not contain vector a");
+    }
+
+    #[tokio::test]
+    async fn should_skip_reassignment_when_already_at_closest_centroid() {
+        // given — vector "a" is at centroid 0, which is already its nearest centroid
+        let mut h = IndexerOpTestHarness::with_single_centroid(CENTROID_ID, DIMS).await;
+        let opts = create_opts();
+        let writes = vec![make_write("a", vec![0.9, 0.1, 0.0], "shoes")];
+        h.write_and_apply(&opts, writes).await;
+        let id_a = h.storage.lookup_internal_id("a").await.unwrap().unwrap();
+
+        let reassignments = vec![ReassignVector {
+            vector_id: id_a,
+            vector: vec![0.9, 0.1, 0.0],
+            current_centroid: CENTROID_ID,
+        }];
+
+        // when
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        let rv = ReassignVectors::new(&opts, &(snapshot as Arc<dyn StorageRead>), reassignments);
+        rv.execute(&h.state, &mut delta).await.unwrap();
+        let ops = delta.freeze(&mut h.state);
+
+        // then — no posting merges written (vector stays put)
+        let posting_ops: Vec<_> = ops
+            .iter()
+            .filter(|op| matches!(op, common::storage::RecordOp::Merge(_)))
+            .collect();
+        assert!(
+            posting_ops.is_empty(),
+            "no posting merges should be written when vector stays put"
+        );
+    }
+
+    #[tokio::test]
+    async fn should_use_delta_posting_as_true_current_centroid() {
+        // This tests the case where a reassignment is queued for a vector from a
+        // neighbouring centroid, but that neighbour was ALSO split in the same round.
+        // The vector was already moved to a new centroid by the earlier split, so
+        // current_centroid in the ReassignVector is stale. The reassigner should
+        // check the delta's current_posting to get the true current centroid.
+        let mut h = IndexerOpTestHarness::with_single_centroid(CENTROID_ID, DIMS).await;
+        let opts = create_opts();
+        // Write vector "a" to centroid 0
+        let writes = vec![make_write("a", vec![0.9, 0.1, 0.0], "shoes")];
+        h.write_and_apply(&opts, writes).await;
+        let id_a = h.storage.lookup_internal_id("a").await.unwrap().unwrap();
+        let snapshot = h.storage.snapshot().await.unwrap();
+        let mut delta = VectorIndexDelta::new(&h.state);
+        delta.delete_centroids(vec![CENTROID_ID]);
+        let c0 = delta.add_centroid(vec![1.0, 0.0, 0.0]); // "a" is nearest to this
+        let c1 = delta.add_centroid(vec![0.0, 1.0, 0.0]);
+        // The earlier split already moved "a" to c0 in this delta
+        delta.add_to_posting(c0.centroid_id, id_a, vec![0.9, 0.1, 0.0]);
+
+        // Now a neighbour reassignment comes in with stale current_centroid=CENTROID_ID
+        let reassignments = vec![ReassignVector {
+            vector_id: id_a,
+            vector: vec![0.9, 0.1, 0.0],
+            current_centroid: CENTROID_ID, // stale — "a" is actually at c0 now
+        }];
+
+        // when
+        let rv = ReassignVectors::new(&opts, &(snapshot as Arc<dyn StorageRead>), reassignments);
+        rv.execute(&h.state, &mut delta).await.unwrap();
+        let ops = delta.freeze(&mut h.state);
+        h.storage.apply(ops).await.unwrap();
+
+        // then — "a" should remain at c0 (its nearest centroid). The reassigner
+        // should have corrected current_centroid from the delta's posting and
+        // seen that c0 is already the closest, so no move happens.
+        let posting_c0 = h
+            .storage
+            .get_posting_list(c0.centroid_id, DIMS)
+            .await
+            .unwrap();
+        let ids_c0: HashSet<u64> = posting_c0.iter().map(|p| p.id()).collect();
+        assert!(ids_c0.contains(&id_a), "c0 should still contain vector a");
+        // c1 should not have "a"
+        let posting_c1 = h
+            .storage
+            .get_posting_list(c1.centroid_id, DIMS)
+            .await
+            .unwrap();
+        let ids_c1: HashSet<u64> = posting_c1.iter().map(|p| p.id()).collect();
+        assert!(!ids_c1.contains(&id_a), "c1 should not contain vector a");
+    }
+}

--- a/vector/src/batched/mod.rs
+++ b/vector/src/batched/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod delta;
+pub(crate) mod flusher;
+pub(crate) mod indexer;

--- a/vector/src/delta.rs
+++ b/vector/src/delta.rs
@@ -396,6 +396,10 @@ mod tests {
                 .map(|(_, v)| v.clone())
         }
 
+        fn all_centroid_ids(&self) -> Vec<u64> {
+            todo!()
+        }
+
         fn len(&self) -> usize {
             self.centroids.len()
         }
@@ -729,6 +733,10 @@ mod tests {
 
             fn get_centroid_vector(&self, _centroid_id: u64) -> Option<Vec<f32>> {
                 None
+            }
+
+            fn all_centroid_ids(&self) -> Vec<u64> {
+                todo!()
             }
 
             fn len(&self) -> usize {
@@ -1074,6 +1082,10 @@ mod tests {
 
             fn get_centroid_vector(&self, _centroid_id: u64) -> Option<Vec<f32>> {
                 None
+            }
+
+            fn all_centroid_ids(&self) -> Vec<u64> {
+                todo!()
             }
 
             fn len(&self) -> usize {

--- a/vector/src/flusher.rs
+++ b/vector/src/flusher.rs
@@ -24,7 +24,7 @@ pub struct VectorDbFlusher {
 #[async_trait]
 impl Flusher<VectorDbWriteDelta> for VectorDbFlusher {
     async fn flush_delta(
-        &self,
+        &mut self,
         frozen: VectorDbImmutableDelta,
         _epoch_range: &Range<u64>,
     ) -> Result<Arc<dyn StorageSnapshot>, String> {
@@ -74,7 +74,7 @@ mod tests {
     async fn should_propagate_apply_error() {
         // given
         let storage = create_failing_storage();
-        let flusher = VectorDbFlusher {
+        let mut flusher = VectorDbFlusher {
             storage: storage.clone(),
         };
         storage.fail_apply(common::StorageError::Storage("test apply error".into()));
@@ -96,7 +96,7 @@ mod tests {
     async fn should_propagate_snapshot_error_after_apply() {
         // given
         let storage = create_failing_storage();
-        let flusher = VectorDbFlusher {
+        let mut flusher = VectorDbFlusher {
             storage: storage.clone(),
         };
         // Apply succeeds, but snapshot after apply fails

--- a/vector/src/hnsw/mod.rs
+++ b/vector/src/hnsw/mod.rs
@@ -6,6 +6,7 @@
 mod usearch;
 
 use crate::error::Result;
+use std::collections::HashSet;
 
 use crate::serde::centroid_chunk::CentroidEntry;
 use crate::serde::collection_meta::DistanceMetric;
@@ -28,6 +29,29 @@ pub trait CentroidGraph: Send + Sync {
     /// Vector of centroid_ids sorted by similarity (closest first)
     fn search(&self, query: &[f32], k: usize) -> Vec<u64>;
 
+    /// Search for k nearest centroids to a query vector. Exclude centroids with ids
+    /// from an exclude set. After search, factor in centroids from an include set.
+    /// The centroids from the include set are not part of the current graph, so must
+    /// be factored in after the graph search.
+    ///
+    /// # Arguments
+    /// * `query` - Query vector
+    /// * `k` - Number of nearest centroids to return
+    /// * `include` - New centroids to be considered after searching the graph
+    /// * `exclude` - Centroids to be excluded from the graph search
+    ///
+    /// # Returns
+    /// Vector of centroid_ids sorted by similarity (closest first)
+    fn search_with_include_exclude(
+        &self,
+        _query: &[f32],
+        _k: usize,
+        _include: &[&CentroidEntry],
+        _exclude: &HashSet<u64>,
+    ) -> Vec<u64> {
+        unimplemented!();
+    }
+
     /// Add a centroid to the graph.
     ///
     /// Uses interior mutability since the graph is behind `Arc<dyn CentroidGraph>`.
@@ -42,6 +66,9 @@ pub trait CentroidGraph: Send + Sync {
     ///
     /// Returns `None` if the centroid is not in the graph.
     fn get_centroid_vector(&self, centroid_id: u64) -> Option<Vec<f32>>;
+
+    /// Return all live centroid IDs currently present in the graph.
+    fn all_centroid_ids(&self) -> Vec<u64>;
 
     /// Returns the number of centroids in the graph.
     fn len(&self) -> usize;

--- a/vector/src/hnsw/usearch.rs
+++ b/vector/src/hnsw/usearch.rs
@@ -1,6 +1,6 @@
 //! HNSW implementation using the usearch library.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::RwLock;
 
@@ -29,6 +29,8 @@ struct UsearchCentroidGraphInner {
     centroid_vectors: HashMap<u64, Vec<f32>>,
     /// Next usearch key to allocate
     next_key: u64,
+    /// Distance metric used for computing distances
+    distance_metric: DistanceMetric,
 }
 
 /// HNSW graph implementation using the usearch library.
@@ -125,6 +127,7 @@ impl UsearchCentroidGraph {
                 centroid_to_key,
                 centroid_vectors,
                 next_key,
+                distance_metric,
             }),
         })
     }
@@ -133,6 +136,19 @@ impl UsearchCentroidGraph {
 impl CentroidGraph for UsearchCentroidGraph {
     fn search(&self, query: &[f32], k: usize) -> Vec<u64> {
         self.inner.read().expect("lock poisoned").search(query, k)
+    }
+
+    fn search_with_include_exclude(
+        &self,
+        query: &[f32],
+        k: usize,
+        include: &[&CentroidEntry],
+        exclude: &HashSet<u64>,
+    ) -> Vec<u64> {
+        self.inner
+            .read()
+            .expect("lock poisoned")
+            .search_with_include_exclude(query, k, include, exclude)
     }
 
     fn add_centroid(&self, entry: &CentroidEntry) -> Result<()> {
@@ -154,6 +170,10 @@ impl CentroidGraph for UsearchCentroidGraph {
             .read()
             .expect("lock poisoned")
             .get_centroid_vector(centroid_id)
+    }
+
+    fn all_centroid_ids(&self) -> Vec<u64> {
+        self.inner.read().expect("lock poisoned").all_centroid_ids()
     }
 
     fn len(&self) -> usize {
@@ -182,6 +202,61 @@ impl UsearchCentroidGraphInner {
             .filter_map(|&key| self.key_to_centroid.get(&key).copied())
             .take(k)
             .collect()
+    }
+
+    fn search_with_include_exclude(
+        &self,
+        query: &[f32],
+        k: usize,
+        include: &[&CentroidEntry],
+        exclude: &HashSet<u64>,
+    ) -> Vec<u64> {
+        let graph_size = self.key_to_centroid.len();
+        let search_k = (k + 10).min(graph_size + 10);
+
+        let mut candidates: Vec<(u64, f32)> = Vec::with_capacity(k + include.len());
+
+        if graph_size > 0 && search_k > 0 {
+            // Build set of usearch keys to exclude
+            let excluded_keys: HashSet<u64> = exclude
+                .iter()
+                .filter_map(|centroid_id| self.centroid_to_key.get(centroid_id).copied())
+                .collect();
+
+            let results = if excluded_keys.is_empty() {
+                self.index.search(query, search_k)
+            } else {
+                self.index
+                    .filtered_search(query, search_k, |key| !excluded_keys.contains(&key))
+            };
+
+            if let Ok(results) = results {
+                for (&key, &dist) in results.keys.iter().zip(results.distances.iter()) {
+                    if let Some(&centroid_id) = self.key_to_centroid.get(&key) {
+                        candidates.push((centroid_id, dist));
+                    }
+                }
+            }
+        }
+
+        // Compute distances for include centroids (not in the graph)
+        for entry in include {
+            let dist = self.compute_distance(query, &entry.vector);
+            candidates.push((entry.centroid_id, dist));
+        }
+
+        // Sort by distance ascending and take top k
+        candidates.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+        candidates.into_iter().take(k).map(|(id, _)| id).collect()
+    }
+
+    fn compute_distance(&self, a: &[f32], b: &[f32]) -> f32 {
+        match self.distance_metric {
+            DistanceMetric::L2 => a.iter().zip(b.iter()).map(|(x, y)| (x - y) * (x - y)).sum(),
+            DistanceMetric::DotProduct => {
+                1.0 - a.iter().zip(b.iter()).map(|(x, y)| x * y).sum::<f32>()
+            }
+        }
     }
 
     fn add_centroid(&mut self, entry: &CentroidEntry) -> Result<()> {
@@ -216,6 +291,10 @@ impl UsearchCentroidGraphInner {
 
     fn get_centroid_vector(&self, centroid_id: u64) -> Option<Vec<f32>> {
         self.centroid_vectors.get(&centroid_id).cloned()
+    }
+
+    fn all_centroid_ids(&self) -> Vec<u64> {
+        self.centroid_vectors.keys().copied().collect()
     }
 
     fn len(&self) -> usize {
@@ -414,5 +493,111 @@ mod tests {
         // when - remove centroid
         graph.remove_centroid(2).unwrap();
         assert_eq!(graph.get_centroid_vector(2), None);
+    }
+
+    // ---- search_with_include_exclude ----
+
+    #[test]
+    fn should_exclude_centroids_from_search() {
+        // given - 3 centroids, query near centroid 1
+        let centroids = vec![
+            CentroidEntry::new(1, vec![1.0, 0.0, 0.0]),
+            CentroidEntry::new(2, vec![0.0, 1.0, 0.0]),
+            CentroidEntry::new(3, vec![0.0, 0.0, 1.0]),
+        ];
+        let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
+        let exclude = HashSet::from([1]);
+
+        // when - search near centroid 1 but exclude it
+        let results = graph.search_with_include_exclude(&[0.9, 0.1, 0.0], 1, &[], &exclude);
+
+        // then - should return centroid 2 or 3, not 1
+        assert_eq!(results.len(), 1);
+        assert_ne!(results[0], 1, "excluded centroid should not appear");
+    }
+
+    #[test]
+    fn should_include_centroids_not_in_graph() {
+        // given - graph has centroids 1 and 2, include adds centroid 99 closer to query
+        let centroids = vec![
+            CentroidEntry::new(1, vec![1.0, 0.0]),
+            CentroidEntry::new(2, vec![0.0, 1.0]),
+        ];
+        let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
+        let include_entry = CentroidEntry::new(99, vec![0.5, 0.5]);
+
+        // when - search near [0.5, 0.5], include centroid 99 which is right there
+        let results =
+            graph.search_with_include_exclude(&[0.5, 0.5], 1, &[&include_entry], &HashSet::new());
+
+        // then - centroid 99 should be the closest
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], 99);
+    }
+
+    #[test]
+    fn should_combine_include_and_exclude() {
+        // given - 3 centroids in graph, exclude 1, include 99
+        let centroids = vec![
+            CentroidEntry::new(1, vec![1.0, 0.0, 0.0]),
+            CentroidEntry::new(2, vec![0.0, 1.0, 0.0]),
+            CentroidEntry::new(3, vec![0.0, 0.0, 1.0]),
+        ];
+        let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
+        let exclude = HashSet::from([1]);
+        let include_entry = CentroidEntry::new(99, vec![0.9, 0.1, 0.0]);
+
+        // when - query near [1,0,0], exclude centroid 1 (the nearest graph centroid),
+        // but include 99 which is also near [1,0,0]
+        let results =
+            graph.search_with_include_exclude(&[1.0, 0.0, 0.0], 2, &[&include_entry], &exclude);
+
+        // then - should include 99 and one of 2/3, but not 1
+        assert_eq!(results.len(), 2);
+        assert!(results.contains(&99));
+        assert!(!results.contains(&1));
+    }
+
+    #[test]
+    fn should_fall_back_to_normal_search_with_empty_include_exclude() {
+        // given
+        let centroids = vec![
+            CentroidEntry::new(1, vec![1.0, 0.0]),
+            CentroidEntry::new(2, vec![0.0, 1.0]),
+        ];
+        let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
+
+        // when - no include, no exclude
+        let results = graph.search_with_include_exclude(&[0.9, 0.1], 1, &[], &HashSet::new());
+
+        // then - same as regular search
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0], 1);
+    }
+
+    #[test]
+    fn should_rank_include_and_graph_results_by_distance() {
+        // given - graph centroid at [1,0], include centroid at [0,1]
+        let centroids = vec![CentroidEntry::new(1, vec![1.0, 0.0])];
+        let graph = UsearchCentroidGraph::build(centroids, DistanceMetric::L2).unwrap();
+        let include_entry = CentroidEntry::new(99, vec![0.0, 1.0]);
+
+        // when - query at [0.1, 0.9] — closer to include centroid 99
+        let results =
+            graph.search_with_include_exclude(&[0.1, 0.9], 2, &[&include_entry], &HashSet::new());
+
+        // then - 99 should be first (closer), 1 second
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0], 99);
+        assert_eq!(results[1], 1);
+
+        // when - query at [0.9, 0.1] — closer to graph centroid 1
+        let results =
+            graph.search_with_include_exclude(&[0.9, 0.1], 2, &[&include_entry], &HashSet::new());
+
+        // then - 1 should be first (closer), 99 second
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0], 1);
+        assert_eq!(results[1], 99);
     }
 }

--- a/vector/src/lib.rs
+++ b/vector/src/lib.rs
@@ -47,6 +47,8 @@ pub mod server;
 pub(crate) mod storage;
 pub(crate) mod view_reader;
 
+#[allow(dead_code)]
+mod batched;
 #[cfg(test)]
 pub(crate) mod test_utils;
 

--- a/vector/src/lire/mod.rs
+++ b/vector/src/lire/mod.rs
@@ -1,4 +1,4 @@
 pub(crate) mod commands;
-mod heuristics;
+pub(crate) mod heuristics;
 pub(crate) mod kmeans;
 pub(crate) mod rebalancer;

--- a/vector/src/lire/rebalancer.rs
+++ b/vector/src/lire/rebalancer.rs
@@ -1428,6 +1428,10 @@ mod tests {
                 .map(|(_, v)| v.clone())
         }
 
+        fn all_centroid_ids(&self) -> Vec<u64> {
+            self.centroids.iter().map(|(id, _)| *id).collect()
+        }
+
         fn len(&self) -> usize {
             self.centroids.len()
         }

--- a/vector/src/query_engine.rs
+++ b/vector/src/query_engine.rs
@@ -100,9 +100,8 @@ impl QueryEngine {
             )));
         }
 
-        // Brute-force: compute distance from query to every centroid
-        let num_centroids = self.centroid_graph.len();
-        let all_centroid_ids = self.centroid_graph.search(&query.vector, num_centroids);
+        // Brute-force: compute distance from query to every live centroid
+        let all_centroid_ids = self.centroid_graph.all_centroid_ids();
         let mut scored: Vec<(u64, distance::VectorDistance)> = all_centroid_ids
             .iter()
             .filter_map(|&cid| {


### PR DESCRIPTION
## Summary

Implements a decoupled indexer for maintaining the ann index:

The basic idea here is that we add a new write path that changes how we maintain the vector index:
- The write coordinator delta just tracks recently applied writes in a Vec
- When frozen delta just makes a copy of these writes and passes an Arc of that to the views and flusher
- The flusher takes the entire write batch and updates the index in bulk.

Most of the work is now being done during flush to convert the raw batch of vector writes into a batch of updates to storage that maintain a good vector index. This transformation is done by a new component called Indexer.

The Indexer owns the writer's in-memory state, and is responsible for both maintaining it and computing the storage ops for a given write batch. The entry point to Indexer is update_index. update_index takes a batch of writes and the last applied storage snapshot, and is responsible for both returning the resulting storage ops and making any required mutations to the in-memory state (e.g. the centroid graph, dictionary, sequence tracker, etc). It works by initializing a indexer-specific delta called VectorIndexDelta, and then passing both the delta and the data (e.g. the write batch or resulting intermediate data) through various ops. Each op makes changes to the delta to represent the changes required for indexing like adding forward index entries, updating postings, adding/removing centroids, etc. Finally, once the round of indexing has completed, the delta is frozen which commits all the changes to the in-memory state and computes the resulting storage ops. This approach ensures we can gracefully handle i/o failures on the indexing path, as no mutations are actually applied until the full set of mutations is computed.

The Indexer runs through the following ops:
- WriteVectors - this op is responsible for taking the vectors in the write batch and making sure storage references them correctly in the forward index, postings, and inverted index. It's also responsible for deleting the state of updated vectors.
- MergeCentroids - this op is responsible for finding centroids with small clusters, deleting them, and returning their postings for reassignment.
- SplitCentroids - this op finds centroids with large clusters and splits them by running kmeans to find new centroids. It also finds vectors that need to be reassigned and returns them.
- ReassignVectors - this op takes vectors that may need to be reassigned and updates their postings if required.

For each batch, the indexer first runs WriteVectors to add the new vectors to the db. It then runs MergeCentroids to clear any small centroids. Finally, it runs SplitCentroids and ReassignCentroids in a loop until all centroids are below the threshold. We don't run merge after the initial merge for a batch as there is no guarantee that the process will converge. This is consistent with the proof from spfresh which assumes merges happen decoupled from chains of splits. It does diverge from the spfresh implementation which merges when reads detect small centroids, but I don't think this is a very important distinction.

Internally, each op may need to do i/o to read the state of the db. For example, the SplitCentroids op reads posting lists for centroids that are to be split and their neighbours. The basic pattern is to do all these i/os in batch first, and then schedule the compute work required for the op (e.g. for SplitCentroids running kmeans and figuring out what vectors need to be reassigned).

Also includes a couple tweaks to common modules
- allows freezing the sequence tracker so its latest state can be extracted/cloned to create a new in-progress instance when initializing a new index delta
- changes Flusher to take &mut self so it can update its internal state when applying flush

## Test Plan

- unit tests added
- ran the sift100K integration test with a db that uses this write path
- ran the cohere1M benchmark with a db that uses this write path. Ingest throughput is ~1K vectors/second on a 12-core node - equivalent to the previous write path.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
