### PR TITLE
Complete implementation of `merge_batch` and remove `merge`

### DIFF
--- a/common/src/storage/in_memory.rs
+++ b/common/src/storage/in_memory.rs
@@ -304,10 +304,10 @@ impl Storage for InMemoryStorage {
                         .get(&op.record.key)
                         .filter(|s| !s.is_expired(now))
                         .map(|s| s.value.clone());
-                    let merged_value = self.merge_operator.as_ref().unwrap().merge(
+                    let merged_value = self.merge_operator.as_ref().unwrap().merge_batch(
                         &op.record.key,
                         existing_value,
-                        op.record.value.clone(),
+                        &[op.record.value],
                     );
                     let expire_ts = compute_expire_ts(now, op.options.ttl, self.default_ttl);
                     data.insert(
@@ -397,7 +397,7 @@ impl Storage for InMemoryStorage {
                 .filter(|s| !s.is_expired(now))
                 .map(|s| s.value.clone());
             let merged_value =
-                merge_op.merge(&op.record.key, existing_value, op.record.value.clone());
+                merge_op.merge_batch(&op.record.key, existing_value, &[op.record.value]);
             let expire_ts = compute_expire_ts(now, op.options.ttl, self.default_ttl);
             data.insert(
                 op.record.key,
@@ -651,10 +651,6 @@ mod tests {
     struct AppendMergeOperator;
 
     impl MergeOperator for AppendMergeOperator {
-        fn merge(&self, key: &Bytes, existing_value: Option<Bytes>, new_value: Bytes) -> Bytes {
-            self.merge_batch(key, existing_value, &[new_value])
-        }
-
         fn merge_batch(
             &self,
             _key: &Bytes,

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -170,33 +170,16 @@ pub struct WriteResult {
 
 /// Trait for merging existing values with new values.
 ///
-/// Merge operators must be associative: `merge(merge(a, b), c) == merge(a, merge(b, c))`.
+/// Merge operators must be associative: `merge_batch(merge_batch(a, [b]), [c]) == merge_batch(a, merge_batch(b, [c]))`.
 /// This ensures consistent merging behavior regardless of the order of operations.
 pub trait MergeOperator: Send + Sync {
-    /// Merges an existing value with a new value to produce a merged result.
-    ///
-    /// # Arguments
-    /// * `key` - The key associated with the values being merged
-    /// * `existing_value` - The current value stored in the database (if any)
-    /// * `new_value` - The new value to merge with the existing value
-    ///
-    /// # Returns
-    /// The merged value.
-    fn merge(&self, key: &Bytes, existing_value: Option<Bytes>, new_value: Bytes) -> Bytes;
-
     /// Merges a batch of operands with an optional existing value.
-    ///
-    /// The default implementation applies pairwise merging. Implementations can
-    /// override this for better performance by constructing a single merge result once
-    /// for multiple input values.
     ///
     /// # Arguments
     /// * `key` - The key associated with the values being merged
     /// * `existing_value` - The current value stored in the database (if any)
     /// * `operands` - A slice of operands to merge, ordered from oldest to newest
-    fn merge_batch(&self, key: &Bytes, existing_value: Option<Bytes>, operands: &[Bytes]) -> Bytes {
-        default_merge_batch(key, existing_value, operands, |k, e, v| self.merge(k, e, v))
-    }
+    fn merge_batch(&self, key: &Bytes, existing_value: Option<Bytes>, operands: &[Bytes]) -> Bytes;
 }
 
 pub fn default_merge_batch(

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -62,7 +62,7 @@ impl SlateDbMergeOperator for SlateDbMergeOperatorAdapter {
         existing_value: Option<Bytes>,
         value: Bytes,
     ) -> Result<Bytes, MergeOperatorError> {
-        Ok(self.operator.merge(key, existing_value, value))
+        Ok(self.operator.merge_batch(key, existing_value, &[value]))
     }
 
     fn merge_batch(
@@ -657,10 +657,6 @@ mod tests {
     struct ConcatMergeOperator;
 
     impl MergeOperator for ConcatMergeOperator {
-        fn merge(&self, key: &Bytes, existing_value: Option<Bytes>, new_value: Bytes) -> Bytes {
-            self.merge_batch(key, existing_value, &[new_value])
-        }
-
         fn merge_batch(
             &self,
             _key: &Bytes,

--- a/timeseries/src/storage/merge_operator.rs
+++ b/timeseries/src/storage/merge_operator.rs
@@ -13,10 +13,6 @@ use common::storage::default_merge_batch;
 pub(crate) struct OpenTsdbMergeOperator;
 
 impl common::storage::MergeOperator for OpenTsdbMergeOperator {
-    fn merge(&self, key: &Bytes, existing_value: Option<Bytes>, new_value: Bytes) -> Bytes {
-        self.merge_batch(key, existing_value, &[new_value])
-    }
-
     fn merge_batch(&self, key: &Bytes, existing_value: Option<Bytes>, operands: &[Bytes]) -> Bytes {
         // Decode record type from key
         let key_prefix = KeyPrefix::from_bytes(key.as_ref()).unwrap();
@@ -442,7 +438,7 @@ mod tests {
         };
 
         // when
-        let merged = operator.merge(&key, Some(existing_value.clone()), new_value.clone());
+        let merged = operator.merge_batch(&key, Some(existing_value), &[new_value]);
 
         // then - verify the merge actually happened (not just returning new_value)
         // For InvertedIndex, check it's a union
@@ -492,7 +488,7 @@ mod tests {
         .unwrap();
 
         // when
-        let result = operator.merge(&key, None, new_value);
+        let result = operator.merge_batch(&key, None, &[new_value]);
 
         // then
         let decoded = InvertedIndexValue::decode(result.as_ref()).unwrap();
@@ -508,7 +504,8 @@ mod tests {
         let new_value = Bytes::from(b"new_value".to_vec());
 
         // when
-        let result = operator.merge(&key, Some(existing_value), new_value.clone());
+        let result =
+            operator.merge_batch(&key, Some(existing_value), std::slice::from_ref(&new_value));
 
         // then - should return new_value without merging
         assert_eq!(result, new_value);

--- a/vector/src/storage/merge_operator.rs
+++ b/vector/src/storage/merge_operator.rs
@@ -30,10 +30,6 @@ impl VectorDbMergeOperator {
 }
 
 impl common::storage::MergeOperator for VectorDbMergeOperator {
-    fn merge(&self, key: &Bytes, existing_value: Option<Bytes>, new_value: Bytes) -> Bytes {
-        self.merge_batch(key, existing_value, &[new_value])
-    }
-
     fn merge_batch(&self, key: &Bytes, existing_value: Option<Bytes>, operands: &[Bytes]) -> Bytes {
         let prefix = KeyPrefix::from_bytes_with_validation(key, SUBSYSTEM, KEY_VERSION)
             .expect("Failed to decode key prefix");
@@ -318,7 +314,7 @@ mod tests {
             .unwrap();
 
         // when
-        let merged = operator.merge(&key, Some(existing_value), new_value);
+        let merged = operator.merge_batch(&key, Some(existing_value), &[new_value]);
 
         // then - verify the merge actually happened (union)
         let decoded = DeletionsValue::decode_from_bytes(&merged).unwrap();
@@ -346,7 +342,7 @@ mod tests {
             .unwrap();
 
         // when
-        let merged = operator.merge(&key, Some(existing_value), new_value);
+        let merged = operator.merge_batch(&key, Some(existing_value), &[new_value]);
 
         // then - verify the merge actually happened (union)
         let decoded = MetadataIndexValue::decode_from_bytes(&merged).unwrap();
@@ -370,7 +366,7 @@ mod tests {
             .encode_to_bytes();
 
         // when
-        let merged = operator.merge(&key, Some(existing_value), new_value);
+        let merged = operator.merge_batch(&key, Some(existing_value), &[new_value]);
 
         // then - verify the merge produced deduplicated result
         let decoded = PostingListValue::decode_from_bytes(&merged, 2).unwrap();
@@ -385,7 +381,7 @@ mod tests {
         let new_value = Bytes::from(b"new_value".to_vec());
 
         // when
-        let result = operator.merge(&key, None, new_value.clone());
+        let result = operator.merge_batch(&key, None, std::slice::from_ref(&new_value));
 
         // then
         assert_eq!(result, new_value);
@@ -411,7 +407,7 @@ mod tests {
         let new_value = CentroidStatsValue::new(new_count).encode_to_bytes();
 
         // when
-        let merged = operator.merge(&key, Some(existing_value), new_value);
+        let merged = operator.merge_batch(&key, Some(existing_value), &[new_value]);
 
         // then
         let decoded = CentroidStatsValue::decode_from_bytes(&merged).unwrap();
@@ -552,7 +548,8 @@ mod tests {
         let new_value = Bytes::from(b"new_value".to_vec());
 
         // when
-        let result = operator.merge(&key, Some(existing_value), new_value.clone());
+        let result =
+            operator.merge_batch(&key, Some(existing_value), std::slice::from_ref(&new_value));
 
         // then - should return new_value without merging
         assert_eq!(result, new_value);


### PR DESCRIPTION
## Summary

- Implements `MergeOperator::merge_batch()` in a couple of test structs that only implemented `merge()`
- Removes trait method `MergeOperator::merge()` entirely

## Related Issues

Fixes #272.
<!-- or: Relates to # -->

## Test Plan

Existing tests updated to call `merge_batch()` instead of `merge()`.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
