### PR TITLE
[vector] Use SearchOptions for search

### DIFF
--- a/vector/bench/src/recall.rs
+++ b/vector/bench/src/recall.rs
@@ -19,7 +19,9 @@ use std::path::{Path, PathBuf};
 use bencher::{Bench, Benchmark, Params, Summary};
 use common::StorageBuilder;
 use common::storage::factory::{FoyerCache, FoyerCacheOptions};
-use vector::{Config, DistanceMetric, Query, SearchResult, Vector, VectorDb, VectorDbRead};
+use vector::{
+    Config, DistanceMetric, Query, SearchOptions, SearchResult, Vector, VectorDb, VectorDbRead,
+};
 
 const DEFAULT_NUM_QUERIES: usize = 100;
 
@@ -592,7 +594,14 @@ impl Benchmark for RecallBenchmark {
         for query in queries.iter() {
             let t = std::time::Instant::now();
             let q = Query::new(query.clone()).with_limit(k);
-            let _ = db.search_with_nprobe(&q, dataset.nprobe).await?;
+            let _ = db
+                .search_with_options(
+                    &q,
+                    SearchOptions {
+                        nprobe: Some(dataset.nprobe),
+                    },
+                )
+                .await?;
             let elapsed_us = t.elapsed().as_secs_f64() * 1_000_000.0;
             query_latency.record(elapsed_us);
             cold_latencies_us.push(elapsed_us);
@@ -610,7 +619,14 @@ impl Benchmark for RecallBenchmark {
         for (i, query) in queries.iter().enumerate() {
             let t = std::time::Instant::now();
             let q = Query::new(query.clone()).with_limit(k);
-            let results = db.search_with_nprobe(&q, dataset.nprobe).await?;
+            let results = db
+                .search_with_options(
+                    &q,
+                    SearchOptions {
+                        nprobe: Some(dataset.nprobe),
+                    },
+                )
+                .await?;
             let elapsed_us = t.elapsed().as_secs_f64() * 1_000_000.0;
             query_latency.record(elapsed_us);
             latencies_us.push(elapsed_us);

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -15,7 +15,8 @@ use crate::VectorDbReader;
 use crate::error::{Error, Result};
 use crate::hnsw::{CentroidGraph, build_centroid_graph};
 use crate::model::{
-    AttributeValue, Config, Query, SearchResult, VECTOR_FIELD_NAME, Vector, attributes_to_map,
+    AttributeValue, Config, Query, SearchOptions, SearchResult, VECTOR_FIELD_NAME, Vector,
+    attributes_to_map,
 };
 use crate::query_engine::{QueryEngine, QueryEngineOptions};
 use crate::serde::centroid_chunk::CentroidEntry;
@@ -39,6 +40,13 @@ pub(crate) const WRITE_CHANNEL: &str = "write";
 /// Trait for querying the vector db
 #[async_trait]
 pub trait VectorDbRead {
+    /// Convenience method that calls [`search_with_options`](Self::search_with_options)
+    /// with default options.
+    async fn search(&self, query: &Query) -> Result<Vec<SearchResult>> {
+        self.search_with_options(query, SearchOptions::default())
+            .await
+    }
+
     /// Search for k-nearest neighbors to a query vector.
     ///
     /// This implements the SPANN-style query algorithm:
@@ -49,6 +57,7 @@ pub trait VectorDbRead {
     ///
     /// # Arguments
     /// * `query` - search query
+    /// * `options` - search options
     ///
     /// # Returns
     /// Vector of SearchResults sorted by similarity (best first)
@@ -57,9 +66,11 @@ pub trait VectorDbRead {
     /// Returns an error if:
     /// - Query dimensions don't match collection dimensions
     /// - Storage read fails
-    async fn search(&self, query: &Query) -> Result<Vec<SearchResult>>;
-
-    async fn search_with_nprobe(&self, query: &Query, nprobe: usize) -> Result<Vec<SearchResult>>;
+    async fn search_with_options(
+        &self,
+        query: &Query,
+        options: SearchOptions,
+    ) -> Result<Vec<SearchResult>>;
 
     /// Retrieve a vector record by its external ID.
     ///
@@ -647,12 +658,14 @@ impl VectorDb {
 
 #[async_trait]
 impl VectorDbRead for VectorDb {
-    async fn search(&self, query: &Query) -> Result<Vec<SearchResult>> {
-        self.query_engine().search(query).await
-    }
-
-    async fn search_with_nprobe(&self, query: &Query, nprobe: usize) -> Result<Vec<SearchResult>> {
-        self.query_engine().search_with_nprobe(query, nprobe).await
+    async fn search_with_options(
+        &self,
+        query: &Query,
+        options: SearchOptions,
+    ) -> Result<Vec<SearchResult>> {
+        self.query_engine()
+            .search_with_options(query, options)
+            .await
     }
 
     async fn get(&self, id: &str) -> Result<Option<Vector>> {

--- a/vector/src/lib.rs
+++ b/vector/src/lib.rs
@@ -52,6 +52,6 @@ pub use db::{VectorDb, VectorDbRead};
 pub use error::{Error, Result};
 pub use model::{
     Attribute, AttributeValue, Config, DistanceMetric, FieldSelection, FieldType, Filter,
-    MetadataFieldSpec, Query, ReaderConfig, SearchResult, Vector, VectorBuilder,
+    MetadataFieldSpec, Query, ReaderConfig, SearchOptions, SearchResult, Vector, VectorBuilder,
 };
 pub use reader::VectorDbReader;

--- a/vector/src/model.rs
+++ b/vector/src/model.rs
@@ -267,6 +267,13 @@ impl Default for Config {
     }
 }
 
+/// Options for search operations.
+#[derive(Debug, Clone, Default)]
+pub struct SearchOptions {
+    /// Number of centroids to probe during search.
+    pub nprobe: Option<usize>,
+}
+
 /// Configuration for a read-only vector database client.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReaderConfig {

--- a/vector/src/query_engine.rs
+++ b/vector/src/query_engine.rs
@@ -1,7 +1,7 @@
 use crate::error::{Error, Result};
 use crate::hnsw::CentroidGraph;
 use crate::math::distance;
-use crate::model::{FieldSelection, Filter, Query, SearchResult};
+use crate::model::{FieldSelection, Filter, Query, SearchOptions, SearchResult};
 use crate::serde::collection_meta::DistanceMetric;
 use crate::serde::posting_list::PostingList;
 use crate::serde::vector_data::VectorDataValue;
@@ -83,11 +83,6 @@ impl QueryEngine {
         }
     }
 
-    pub(crate) async fn search(&self, query: &Query) -> Result<Vec<SearchResult>> {
-        let nprobe = query.limit.clamp(10, 100);
-        self.search_with_nprobe(query, nprobe).await
-    }
-
     pub(crate) async fn search_exact_nprobe(
         &self,
         query: &Query,
@@ -136,11 +131,12 @@ impl QueryEngine {
         Ok(results)
     }
 
-    pub(crate) async fn search_with_nprobe(
+    pub(crate) async fn search_with_options(
         &self,
         query: &Query,
-        nprobe: usize,
+        options: SearchOptions,
     ) -> Result<Vec<SearchResult>> {
+        let nprobe = options.nprobe.unwrap_or_else(|| query.limit.clamp(10, 100));
         // 1. Validate query dimensions
         if query.vector.len() != self.options.dimensions as usize {
             return Err(Error::InvalidInput(format!(
@@ -645,7 +641,7 @@ mod tests {
 
         // when - search for vector similar to cluster 0
         let q = Query::new(vec![1.0; 128]).with_limit(10);
-        let results = db.query_engine().search(&q).await.unwrap();
+        let results = db.search(&q).await.unwrap();
 
         // then - should find vectors from cluster 0
         assert_eq!(results.len(), 10);
@@ -683,7 +679,6 @@ mod tests {
 
         // when - search
         let results = db
-            .query_engine()
             .search(&Query::new(vec![1.0, 0.0, 0.0]).with_limit(10))
             .await
             .unwrap();
@@ -721,7 +716,6 @@ mod tests {
 
         // when - search for vectors near origin
         let results = db
-            .query_engine()
             .search(&Query::new(vec![0.0, 0.0, 0.0]).with_limit(3))
             .await
             .unwrap();
@@ -748,10 +742,7 @@ mod tests {
         let db = VectorDb::open(config).await.unwrap();
 
         // when - query with wrong dimensions
-        let result = db
-            .query_engine()
-            .search(&Query::new(vec![1.0, 2.0]).with_limit(10))
-            .await;
+        let result = db.search(&Query::new(vec![1.0, 2.0]).with_limit(10)).await;
 
         // then - should fail
         assert!(result.is_err());
@@ -771,7 +762,6 @@ mod tests {
 
         // when
         let results = db
-            .query_engine()
             .search(&Query::new(vec![1.0, 0.0, 0.0]).with_limit(10))
             .await
             .unwrap();
@@ -794,7 +784,6 @@ mod tests {
 
         // when - search for k=5
         let results = db
-            .query_engine()
             .search(&Query::new(vec![1.0, 0.0]).with_limit(5))
             .await
             .unwrap();
@@ -1030,7 +1019,6 @@ mod tests {
 
         // when - search in between centroids 1 and 2
         let results = db
-            .query_engine()
             .search(&Query::new(vec![0.7, 0.7]).with_limit(10))
             .await
             .unwrap();

--- a/vector/src/reader.rs
+++ b/vector/src/reader.rs
@@ -9,7 +9,7 @@ use crate::Vector;
 use crate::db::VectorDbRead;
 use crate::error::{Error, Result};
 use crate::hnsw::{CentroidGraph, build_centroid_graph};
-use crate::model::{Query, ReaderConfig, SearchResult};
+use crate::model::{Query, ReaderConfig, SearchOptions, SearchResult};
 use crate::query_engine::{QueryEngine, QueryEngineOptions};
 use crate::serde::centroid_chunk::CentroidEntry;
 use crate::storage::VectorDbStorageReadExt;
@@ -92,12 +92,12 @@ impl VectorDbReader {
 
 #[async_trait]
 impl VectorDbRead for VectorDbReader {
-    async fn search(&self, query: &Query) -> Result<Vec<SearchResult>> {
-        self.query_engine.search(query).await
-    }
-
-    async fn search_with_nprobe(&self, query: &Query, nprobe: usize) -> Result<Vec<SearchResult>> {
-        self.query_engine.search_with_nprobe(query, nprobe).await
+    async fn search_with_options(
+        &self,
+        query: &Query,
+        options: SearchOptions,
+    ) -> Result<Vec<SearchResult>> {
+        self.query_engine.search_with_options(query, options).await
     }
 
     async fn get(&self, id: &str) -> Result<Option<Vector>> {

--- a/vector/src/server/handlers.rs
+++ b/vector/src/server/handlers.rs
@@ -60,11 +60,10 @@ pub(crate) async fn handle_search<T: VectorDbRead + Send + Sync + 'static>(
     let format = ResponseFormat::from_headers(&headers);
 
     let request = SearchRequest::from_body(&headers, &body, &state.metadata_fields)?;
-    let results = if let Some(nprobe) = request.nprobe {
-        state.db.search_with_nprobe(&request.query, nprobe).await?
-    } else {
-        state.db.search(&request.query).await?
-    };
+    let results = state
+        .db
+        .search_with_options(&request.query, request.options)
+        .await?;
 
     let result_protos: Vec<SearchResultProto> = results
         .into_iter()

--- a/vector/src/server/request.rs
+++ b/vector/src/server/request.rs
@@ -11,7 +11,7 @@ use super::proto;
 use super::response::is_binary_protobuf;
 use crate::Error;
 use crate::model::VECTOR_FIELD_NAME;
-use crate::{Attribute, AttributeValue, FieldType, Filter, Query};
+use crate::{Attribute, AttributeValue, FieldType, Filter, Query, SearchOptions};
 
 /// Check if the request body is protobuf based on Content-Type header.
 fn is_protobuf_content(headers: &HeaderMap) -> bool {
@@ -118,7 +118,7 @@ impl WriteRequest {
 #[derive(Debug)]
 pub struct SearchRequest {
     pub query: Query,
-    pub nprobe: Option<usize>,
+    pub options: SearchOptions,
 }
 
 impl SearchRequest {
@@ -163,7 +163,9 @@ impl SearchRequest {
         }
         Ok(Self {
             query,
-            nprobe: proto_request.nprobe.map(|n| n as usize),
+            options: SearchOptions {
+                nprobe: proto_request.nprobe.map(|n| n as usize),
+            },
         })
     }
 
@@ -188,7 +190,9 @@ impl SearchRequest {
 
         Ok(Self {
             query,
-            nprobe: json_request.nprobe.map(|n| n as usize),
+            options: SearchOptions {
+                nprobe: json_request.nprobe.map(|n| n as usize),
+            },
         })
     }
 }
@@ -804,7 +808,7 @@ mod tests {
         // then
         assert_eq!(request.query.vector, vec![1.0, 2.0, 3.0]);
         assert_eq!(request.query.limit, 10);
-        assert_eq!(request.nprobe, Some(20));
+        assert_eq!(request.options.nprobe, Some(20));
         assert_eq!(
             request.query.filter,
             Some(Filter::eq("category", "electronics"))
@@ -822,7 +826,7 @@ mod tests {
 
         // then
         assert_eq!(request.query.limit, 5);
-        assert_eq!(request.nprobe, None);
+        assert_eq!(request.options.nprobe, None);
     }
 
     #[test]
@@ -904,7 +908,7 @@ mod tests {
             request.query.filter,
             Some(Filter::eq("category", "electronics"))
         );
-        assert_eq!(request.nprobe, Some(20));
+        assert_eq!(request.options.nprobe, Some(20));
     }
 
     #[test]

--- a/vector/tests/sift1m.rs
+++ b/vector/tests/sift1m.rs
@@ -4,7 +4,7 @@ use std::io::{BufReader, Read};
 use std::path::Path;
 use std::process::Command;
 use tracing_subscriber::EnvFilter;
-use vector::{Config, DistanceMetric, Query, Vector, VectorDb, VectorDbRead};
+use vector::{Config, DistanceMetric, Query, SearchOptions, Vector, VectorDb, VectorDbRead};
 
 fn init_tracing() {
     let _ = tracing_subscriber::fmt()
@@ -139,7 +139,12 @@ async fn sift1m_recall() {
     for (i, query) in queries.iter().enumerate() {
         let q = Query::new(query.clone()).with_limit(k);
         let hnsw_results = db
-            .search_with_nprobe(&q, nprobe)
+            .search_with_options(
+                &q,
+                SearchOptions {
+                    nprobe: Some(nprobe),
+                },
+            )
             .await
             .expect("search failed");
         hnsw_recall += recall_at_k(&hnsw_results, &ground_truth[i], k);
@@ -241,7 +246,12 @@ async fn sift100k_recall() {
         }
         let q = Query::new(query.clone()).with_limit(k);
         let hnsw_results = db
-            .search_with_nprobe(&q, nprobe)
+            .search_with_options(
+                &q,
+                SearchOptions {
+                    nprobe: Some(nprobe),
+                },
+            )
             .await
             .expect("search failed");
         hnsw_recall += recall_at_k(&hnsw_results, &ground_truth[i], k);


### PR DESCRIPTION
## Summary

Adds `SearchOptions` struct and uses this for searches (and requests), replacing the explicit `nprobe` methods/parameter.

## Related Issues

Fixes #339.

## Test Plan

Existing tests were updated with the new methods.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable) (docstring comments updated)
