### PR TITLE
[timeseries/quickstart] Handle SELinux labels in docker compose

### DIFF
--- a/timeseries/quickstart/docker-compose.yml
+++ b/timeseries/quickstart/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "9090:9090"
     volumes:
-      - ./config/prometheus.yaml:/app/prometheus.yaml
+      - ./config/prometheus.yaml:/app/prometheus.yaml:z
       - timeseries-data:/app/data
     environment:
       - RUST_LOG=info
@@ -52,8 +52,8 @@ services:
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - grafana-data:/var/lib/grafana
-      - ./config/grafana-provisioning:/etc/grafana/provisioning
-      - ./dashboards:/var/lib/grafana/dashboards
+      - ./config/grafana-provisioning:/etc/grafana/provisioning:z
+      - ./dashboards:/var/lib/grafana/dashboards:z
     depends_on:
       timeseries-server:
         condition: service_healthy


### PR DESCRIPTION
## Summary
Add `:z` flag to bind-mounted configs in the Docker Compose.

Bind mounts on SELinux systems (e.g. Fedora) do not propagate SELinux flags without explicit relabeling. Without these flags, processes running in container contexts will not be able to access the files by default.

These flags are ignored on non-SELinux systems.

## Fixes
Errors when starting up timeseries-server + silent failures in grafana (no dashboard/datasource in UI)
```
~/dev/opendata/timeseries$ docker compose -f ./quickstart/docker-compose.yml logs timeseries-server               

timeseries-server-1  | 2026-03-28T09:23:58.744922Z ERROR opendata_timeseries: 60: Failed to load configuration: Invalid input: Failed t
o read config file: Permission denied (os error 13)  
```

## Test Plan

Startup succeeds + opendata timeseries dashboard visible in grafana at localhost:3001.
```
~/dev/opendata/timeseries$ docker compose -f ./quickstart/docker-compose.yml up -d --build

[+] up 6/6
 ✔ Image quickstart-timeseries-server       Built                                                                                221.8s
 ✔ Image quickstart-mock-metrics            Built                                                                                221.8s
 ✔ Container quickstart-node-exporter-1     Running                                                                              0.0s
 ✔ Container quickstart-mock-metrics-1      Started                                                                              10.7s
 ✔ Container quickstart-timeseries-server-1 Healthy                                                                              16.3s
 ✔ Container quickstart-grafana-1           Started                                                                              15.0s
```

## Checklist

- [ ] ~Tests added/updated~
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] ~Documentation updated (if applicable)~
