### PR TITLE
[ingest] add native batch compression support (zstd)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,6 +2522,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "ulid",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ proptest = "1"
 dashu-float = "0.4"
 snap = "1"
 criterion = "0.5"
+zstd = "0.13"
 tempfile = "3"
 opendata-macros = { path = "./macros" }
 

--- a/ingest/Cargo.toml
+++ b/ingest/Cargo.toml
@@ -18,6 +18,7 @@ tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 ulid.workspace = true
+zstd.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/ingest/rfcs/0001-stateless-ingest.md
+++ b/ingest/rfcs/0001-stateless-ingest.md
@@ -220,6 +220,11 @@ pub struct IngestorConfig {
   ///
   /// Defaults to 1000.
   pub max_buffered_inputs: usize,
+
+  /// Compression algorithm applied to the record block in data batches.
+  ///
+  /// Defaults to `None` (uncompressed).
+  pub batch_compression: CompressionType,
 }
 ```
 The queue manifest takes the name specified in `manifest_path`.
@@ -259,26 +264,56 @@ Method `close()` flushes unflushed entries and terminates the ingestor.
 ### Data Batch Format
 
 A data batch is the unit of data that an ingestor flushes to object storage.
-Each batch is a compact binary file that contains a sequence of length-prefixed records followed by a fixed-size footer:
+Each batch is a compact binary file that contains an optionally compressed block of
+length-prefixed records followed by a fixed-size footer:
 
 ```ascii
-┌──────────────────────────────────┐
-│  record 0: [len: u32 LE][data]   │
-│  record 1: [len: u32 LE][data]   │
-│  ...                             │
-│  record N: [len: u32 LE][data]   │
-├──────────────────────────────────┤
-│  footer (6 bytes, fixed):        │
-│    record_count : u32 LE         │
-│    version      : u16 LE         │
-└──────────────────────────────────┘
+┌──────────────────────────────────────────┐
+│  compressed record block (variable):     │
+│    record 0: [len: u32 LE][data]         │
+│    record 1: [len: u32 LE][data]         │
+│    ...                                   │
+│    record N: [len: u32 LE][data]         │
+├──────────────────────────────────────────┤
+│  footer (7 bytes, fixed):                │
+│    compression_type : u8                 │
+│    record_count     : u32 LE             │
+│    version          : u16 LE  (= 1)     │
+└──────────────────────────────────────────┘
 ```
 
 Each record stores one opaque byte entry preceded by its length as a little-endian `u32`.
 Records are written in ingestion order.
-The footer is always the last 6 bytes of the file: a little-endian `u32` record count followed by a little-endian `u16` version.
+The footer is always the last 7 bytes of the file and is never compressed.
 The current version is `1`.
-The footer allows a reader to verify the record count and detect format changes.
+
+#### Compression
+
+The `compression_type` byte in the footer indicates how the record block is compressed:
+
+| Value  | Algorithm | Notes |
+|--------|-----------|-------|
+| `0x00` | None      | Record block is stored uncompressed |
+| `0x01` | ZSTD      | Record block is compressed with Zstandard at level 3 |
+| `0x02`–`0xFF` | Reserved | For future algorithms (e.g., LZ4, Snappy) |
+
+```rust
+#[repr(u8)]
+pub enum CompressionType {
+    None = 0,
+    Zstd = 1,
+}
+```
+
+When compression is enabled, the ingestor first serializes all records into a contiguous buffer
+of length-prefixed entries, then compresses that buffer as a single unit.
+The compressed bytes are written to the batch file followed by the uncompressed footer.
+
+On the read side, the collector reads the footer to determine the compression type,
+decompresses the record block if needed, and then parses the length-prefixed entries as usual.
+
+Compression is configured per-ingestor via the `batch_compression` field in `IngestorConfig`
+(see below). The default is `None` (uncompressed).
 
 The semantics of the entries are defined by the database that consumes the data.
 The ingest module does not interpret the entries; it preserves them as-is.
@@ -453,6 +488,7 @@ None at this time.
 | 2026-03-11 | Replaced max_unflushed_bytes with max_buffered_inputs using a bounded channel |
 | 2026-03-11 | Changed queue metadata to per-range format with start_index and ingestion_time per metadata item |
 | 2026-03-11 | Replaced IngestEntry with ingest(entries: Vec\<Bytes\>, metadata: Bytes) |
+| 2026-03-30 | Added native compression support to data batch format |
 
 
 

--- a/ingest/src/collector.rs
+++ b/ingest/src/collector.rs
@@ -194,7 +194,7 @@ fn delete_dequeued_batches(object_store: Arc<dyn ObjectStore>, entries: Vec<Queu
 mod tests {
     use super::*;
     use crate::config::CollectorConfig;
-    use crate::model::encode_batch;
+    use crate::model::{CompressionType, encode_batch};
     use crate::queue::QueueProducer;
     use bytes::Bytes;
     use common::StorageConfig;
@@ -215,7 +215,7 @@ mod tests {
     }
 
     async fn write_batch(store: &Arc<dyn ObjectStore>, location: &str, entries: &[Bytes]) {
-        let payload = encode_batch(entries);
+        let payload = encode_batch(entries, CompressionType::None).unwrap();
         let path = Path::from(location);
         store.put(&path, PutPayload::from(payload)).await.unwrap();
     }

--- a/ingest/src/config.rs
+++ b/ingest/src/config.rs
@@ -4,6 +4,8 @@ use common::StorageConfig;
 use serde::{Deserialize, Serialize};
 use serde_with::{DurationMilliSeconds, serde_as};
 
+use crate::model::CompressionType;
+
 /// Configuration for an [`Ingestor`](crate::Ingestor).
 ///
 /// Controls where data batches and the queue manifest are stored, how often
@@ -45,6 +47,12 @@ pub struct IngestorConfig {
     /// Defaults to 1000.
     #[serde(default = "default_max_buffered_inputs")]
     pub max_buffered_inputs: usize,
+
+    /// Compression algorithm applied to the record block in data batches.
+    ///
+    /// Defaults to `None` (uncompressed).
+    #[serde(default)]
+    pub batch_compression: CompressionType,
 }
 
 /// Configuration for a [`Collector`](crate::Collector).

--- a/ingest/src/ingestor.rs
+++ b/ingest/src/ingestor.rs
@@ -10,7 +10,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::config::IngestorConfig;
 use crate::error::{Error, Result};
-use crate::model::encode_batch;
+use crate::model::{CompressionType, encode_batch};
 use crate::queue::{Metadata, QueueProducer};
 use crate::util::millis;
 
@@ -151,6 +151,7 @@ struct BatchWriterTask {
     data_path_prefix: String,
     flush_interval: Duration,
     flush_size_bytes: usize,
+    batch_compression: CompressionType,
     batch: Batch,
     clock: Arc<dyn Clock>,
 }
@@ -162,6 +163,7 @@ impl BatchWriterTask {
         data_path_prefix: String,
         flush_interval: Duration,
         flush_size_bytes: usize,
+        batch_compression: CompressionType,
         clock: Arc<dyn Clock>,
     ) -> Self {
         Self {
@@ -170,6 +172,7 @@ impl BatchWriterTask {
             data_path_prefix,
             flush_interval,
             flush_size_bytes,
+            batch_compression,
             batch: Batch::new(),
             clock,
         }
@@ -228,7 +231,7 @@ impl BatchWriterTask {
     }
 
     async fn write_and_enqueue(&self, entries: Vec<Bytes>, metadata: Vec<Metadata>) -> Result<()> {
-        let payload = encode_batch(&entries);
+        let payload = encode_batch(&entries, self.batch_compression)?;
         let id = ulid::Ulid::new();
         let path = Path::from(format!("{}/{}.batch", self.data_path_prefix, id));
         self.object_store
@@ -252,24 +255,21 @@ struct BatchWriter {
 impl BatchWriter {
     fn new(
         object_store: Arc<dyn ObjectStore>,
-        queue_manifest_path: String,
-        data_path_prefix: String,
-        flush_interval: Duration,
-        flush_size_bytes: usize,
-        max_buffered_inputs: usize,
+        config: &IngestorConfig,
         clock: Arc<dyn Clock>,
     ) -> Self {
-        let (sender, receiver) = mpsc::channel(max_buffered_inputs);
+        let (sender, receiver) = mpsc::channel(config.max_buffered_inputs);
         let producer = Arc::new(QueueProducer::with_object_store(
-            queue_manifest_path,
+            config.manifest_path.clone(),
             object_store.clone(),
         ));
         let mut task = BatchWriterTask::new(
             object_store,
             producer.clone(),
-            data_path_prefix,
-            flush_interval,
-            flush_size_bytes,
+            config.data_path_prefix.clone(),
+            config.flush_interval,
+            config.flush_size_bytes,
+            config.batch_compression,
             clock,
         );
         let shutdown = CancellationToken::new();
@@ -348,15 +348,7 @@ impl Ingestor {
         object_store: Arc<dyn ObjectStore>,
         clock: Arc<dyn Clock>,
     ) -> Result<Self> {
-        let writer = BatchWriter::new(
-            object_store,
-            config.manifest_path,
-            config.data_path_prefix,
-            config.flush_interval,
-            config.flush_size_bytes,
-            config.max_buffered_inputs,
-            clock.clone(),
-        );
+        let writer = BatchWriter::new(object_store, &config, clock.clone());
         Ok(Self { writer, clock })
     }
 
@@ -431,6 +423,7 @@ mod tests {
             flush_interval: Duration::from_hours(24),
             flush_size_bytes: 64 * 1024 * 1024,
             max_buffered_inputs: 1000,
+            batch_compression: CompressionType::None,
         }
     }
 

--- a/ingest/src/lib.rs
+++ b/ingest/src/lib.rs
@@ -10,3 +10,4 @@ pub use collector::{CollectedBatch, Collector};
 pub use config::{CollectorConfig, IngestorConfig};
 pub use error::{Error, Result};
 pub use ingestor::{DurabilityWatcher, Ingestor, WriteHandle};
+pub use model::CompressionType;

--- a/ingest/src/model.rs
+++ b/ingest/src/model.rs
@@ -1,28 +1,70 @@
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
 
 const ENTRY_LEN_SIZE: usize = 4;
 const FORMAT_VERSION: u16 = 1;
+const COMPRESSION_TYPE_SIZE: usize = 1;
 const ENTRIES_COUNT_SIZE: usize = 4;
 const VERSION_SIZE: usize = 2;
-const FOOTER_SIZE: usize = ENTRIES_COUNT_SIZE + VERSION_SIZE;
+const FOOTER_SIZE: usize = COMPRESSION_TYPE_SIZE + ENTRIES_COUNT_SIZE + VERSION_SIZE;
 
-pub(crate) fn encode_batch(entries: &[Bytes]) -> Bytes {
+/// The default ZSTD compression level used when `CompressionType::Zstd` is selected.
+const ZSTD_LEVEL: i32 = 3;
+
+/// Compression algorithm applied to the record block of a data batch.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CompressionType {
+    #[default]
+    None = 0,
+    Zstd = 1,
+}
+
+impl TryFrom<u8> for CompressionType {
+    type Error = Error;
+
+    fn try_from(value: u8) -> Result<Self> {
+        match value {
+            0 => Ok(CompressionType::None),
+            1 => Ok(CompressionType::Zstd),
+            other => Err(Error::Serialization(format!(
+                "unsupported compression type: {other}"
+            ))),
+        }
+    }
+}
+
+pub(crate) fn encode_batch(entries: &[Bytes], compression: CompressionType) -> Result<Bytes> {
     let data_size: usize = entries.iter().map(|e| ENTRY_LEN_SIZE + e.len()).sum();
-    let mut buf = BytesMut::with_capacity(data_size + FOOTER_SIZE);
+    let mut entry_buf = BytesMut::with_capacity(data_size);
 
     for entry in entries {
         debug_assert!(entry.len() <= u32::MAX as usize);
-        buf.put_u32_le(entry.len() as u32);
-        buf.put_slice(entry);
+        entry_buf.put_u32_le(entry.len() as u32);
+        entry_buf.put_slice(entry);
     }
+
+    let compressed = match compression {
+        CompressionType::None => entry_buf.freeze(),
+        CompressionType::Zstd => {
+            let compressed = zstd::bulk::compress(&entry_buf, ZSTD_LEVEL)
+                .map_err(|e| Error::Serialization(format!("zstd compression failed: {e}")))?;
+            Bytes::from(compressed)
+        }
+    };
+
+    let mut buf = BytesMut::with_capacity(compressed.len() + FOOTER_SIZE);
+    buf.put_slice(&compressed);
+    buf.put_u8(compression as u8);
 
     debug_assert!(entries.len() <= u32::MAX as usize);
     buf.put_u32_le(entries.len() as u32);
     buf.put_u16_le(FORMAT_VERSION);
 
-    buf.freeze()
+    Ok(buf.freeze())
 }
 
 pub(crate) fn decode_batch(mut data: Bytes) -> Result<Vec<Bytes>> {
@@ -35,6 +77,7 @@ pub(crate) fn decode_batch(mut data: Bytes) -> Result<Vec<Bytes>> {
     let footer_start = data.len() - FOOTER_SIZE;
     let mut footer = data.split_off(footer_start);
 
+    let compression_type = CompressionType::try_from(footer.get_u8())?;
     let record_count = footer.get_u32_le() as usize;
     let version = footer.get_u16_le();
 
@@ -45,16 +88,25 @@ pub(crate) fn decode_batch(mut data: Bytes) -> Result<Vec<Bytes>> {
         )));
     }
 
+    let mut entry_data = match compression_type {
+        CompressionType::None => data,
+        CompressionType::Zstd => {
+            let decompressed = zstd::stream::decode_all(data.as_ref())
+                .map_err(|e| Error::Serialization(format!("zstd decompression failed: {e}")))?;
+            Bytes::from(decompressed)
+        }
+    };
+
     let mut entries = Vec::with_capacity(record_count);
     for _ in 0..record_count {
-        if data.remaining() < ENTRY_LEN_SIZE {
+        if entry_data.remaining() < ENTRY_LEN_SIZE {
             return Err(Error::Serialization("truncated record length".to_string()));
         }
-        let len = data.get_u32_le() as usize;
-        if data.remaining() < len {
+        let len = entry_data.get_u32_le() as usize;
+        if entry_data.remaining() < len {
             return Err(Error::Serialization("truncated record data".to_string()));
         }
-        entries.push(data.split_to(len));
+        entries.push(entry_data.split_to(len));
     }
 
     Ok(entries)
@@ -71,7 +123,7 @@ mod tests {
             Bytes::from("world"),
             Bytes::from("foo"),
         ];
-        let encoded = encode_batch(&entries);
+        let encoded = encode_batch(&entries, CompressionType::None).unwrap();
         let decoded = decode_batch(encoded).unwrap();
         assert_eq!(decoded, entries);
     }
@@ -79,7 +131,7 @@ mod tests {
     #[test]
     fn should_roundtrip_empty_batch() {
         let entries: Vec<Bytes> = vec![];
-        let encoded = encode_batch(&entries);
+        let encoded = encode_batch(&entries, CompressionType::None).unwrap();
         assert_eq!(encoded.len(), FOOTER_SIZE);
         let decoded = decode_batch(encoded).unwrap();
         assert!(decoded.is_empty());
@@ -88,7 +140,7 @@ mod tests {
     #[test]
     fn should_roundtrip_empty_record() {
         let entries = vec![Bytes::new()];
-        let encoded = encode_batch(&entries);
+        let encoded = encode_batch(&entries, CompressionType::None).unwrap();
         let decoded = decode_batch(encoded).unwrap();
         assert_eq!(decoded, entries);
     }
@@ -96,8 +148,13 @@ mod tests {
     #[test]
     fn should_reject_truncated_data() {
         let entries = vec![Bytes::from("hello")];
-        let mut encoded = BytesMut::from(encode_batch(&entries).as_ref());
+        let mut encoded = BytesMut::from(
+            encode_batch(&entries, CompressionType::None)
+                .unwrap()
+                .as_ref(),
+        );
         encoded.truncate(encoded.len() - FOOTER_SIZE - 1);
+        encoded.put_u8(CompressionType::None as u8);
         encoded.put_u32_le(1);
         encoded.put_u16_le(FORMAT_VERSION);
         let result = decode_batch(encoded.freeze());
@@ -107,9 +164,67 @@ mod tests {
     #[test]
     fn should_reject_unsupported_version() {
         let mut buf = BytesMut::new();
+        buf.put_u8(0);
         buf.put_u32_le(0);
         buf.put_u16_le(99);
         let result = decode_batch(buf.freeze());
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn should_roundtrip_batch_with_zstd() {
+        let entries = vec![
+            Bytes::from("hello"),
+            Bytes::from("world"),
+            Bytes::from("foo"),
+        ];
+        let encoded = encode_batch(&entries, CompressionType::Zstd).unwrap();
+        let decoded = decode_batch(encoded).unwrap();
+        assert_eq!(decoded, entries);
+    }
+
+    #[test]
+    fn should_roundtrip_empty_batch_with_zstd() {
+        let entries: Vec<Bytes> = vec![];
+        let encoded = encode_batch(&entries, CompressionType::Zstd).unwrap();
+        let decoded = decode_batch(encoded).unwrap();
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn should_roundtrip_large_batch_with_zstd() {
+        let entries: Vec<Bytes> = (0..1000)
+            .map(|i| Bytes::from(format!("entry-{:04}", i)))
+            .collect();
+        let encoded = encode_batch(&entries, CompressionType::Zstd).unwrap();
+        let decoded = decode_batch(encoded).unwrap();
+        assert_eq!(decoded, entries);
+    }
+
+    #[test]
+    fn should_compress_smaller_than_uncompressed_for_repetitive_data() {
+        let entries: Vec<Bytes> = (0..100)
+            .map(|_| Bytes::from("repeated-data-that-compresses-well"))
+            .collect();
+        let uncompressed = encode_batch(&entries, CompressionType::None).unwrap();
+        let compressed = encode_batch(&entries, CompressionType::Zstd).unwrap();
+        assert!(
+            compressed.len() < uncompressed.len(),
+            "compressed ({}) should be smaller than uncompressed ({})",
+            compressed.len(),
+            uncompressed.len()
+        );
+    }
+
+    #[test]
+    fn should_reject_unsupported_compression_type() {
+        let mut buf = BytesMut::new();
+        buf.put_u8(0xFF); // unsupported compression type
+        buf.put_u32_le(0);
+        buf.put_u16_le(FORMAT_VERSION);
+        let result = decode_batch(buf.freeze());
+        assert!(
+            matches!(result, Err(Error::Serialization(msg)) if msg.contains("unsupported compression type"))
+        );
     }
 }


### PR DESCRIPTION
Add a compression_type field to the batch footer so batches are self-describing. The ingestor compresses the record block with a configurable algorithm (currently None or Zstd at level 3) before writing to object storage. The collector reads the footer to determine compression and decompresses transparently.