### PR TITLE
[ingest] Use ObjectStoreConfig directly instead of StorageConfig

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -10,7 +10,9 @@ pub use bytes::BytesRange;
 pub use clock::Clock;
 pub use sequence::{DEFAULT_BLOCK_SIZE, SequenceAllocator, SequenceError, SequenceResult};
 pub use serde::seq_block::SeqBlock;
-pub use storage::config::{BlockCacheConfig, FoyerHybridCacheConfig, StorageConfig};
+pub use storage::config::{
+    BlockCacheConfig, FoyerHybridCacheConfig, ObjectStoreConfig, StorageConfig,
+};
 pub use storage::factory::{
     CompactorBuilder, DbBuilder, StorageBuilder, StorageReaderRuntime, StorageSemantics,
     create_object_store, create_storage_read,

--- a/ingest/src/collector.rs
+++ b/ingest/src/collector.rs
@@ -40,11 +40,7 @@ pub struct Collector {
 impl Collector {
     /// Create a new collector from the given configuration.
     pub fn new(config: CollectorConfig) -> Result<Self> {
-        let object_store_config = match &config.storage {
-            common::StorageConfig::InMemory => common::storage::config::ObjectStoreConfig::InMemory,
-            common::StorageConfig::SlateDb(c) => c.object_store.clone(),
-        };
-        let object_store = common::storage::factory::create_object_store(&object_store_config)
+        let object_store = common::storage::factory::create_object_store(&config.object_store)
             .map_err(|e| Error::Storage(e.to_string()))?;
         Ok(Self::with_object_store(config, object_store))
     }
@@ -197,7 +193,7 @@ mod tests {
     use crate::model::encode_batch;
     use crate::queue::QueueProducer;
     use bytes::Bytes;
-    use common::StorageConfig;
+    use common::ObjectStoreConfig;
     use slatedb::object_store::PutPayload;
     use slatedb::object_store::memory::InMemory;
 
@@ -205,7 +201,7 @@ mod tests {
 
     fn test_collector_config() -> CollectorConfig {
         CollectorConfig {
-            storage: StorageConfig::InMemory,
+            object_store: ObjectStoreConfig::InMemory,
             manifest_path: TEST_MANIFEST_PATH.to_string(),
         }
     }

--- a/ingest/src/config.rs
+++ b/ingest/src/config.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use common::StorageConfig;
+use common::ObjectStoreConfig;
 use serde::{Deserialize, Serialize};
 use serde_with::{DurationMilliSeconds, serde_as};
 
@@ -11,8 +11,8 @@ use serde_with::{DurationMilliSeconds, serde_as};
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IngestorConfig {
-    /// Determines where and how ingest data is persisted. See [`StorageConfig`].
-    pub storage: StorageConfig,
+    /// Determines where and how ingest data is persisted. See [`ObjectStoreConfig`].
+    pub object_store: ObjectStoreConfig,
 
     /// Path prefix for data batch objects in object storage.
     ///
@@ -52,8 +52,8 @@ pub struct IngestorConfig {
 /// Controls where the queue manifest and data batches are read from.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CollectorConfig {
-    /// Determines where and how ingest data is read. See [`StorageConfig`].
-    pub storage: StorageConfig,
+    /// Determines where and how ingest data is read. See [`ObjectStoreConfig`].
+    pub object_store: ObjectStoreConfig,
 
     /// Path to the queue manifest in object storage.
     ///

--- a/ingest/src/ingestor.rs
+++ b/ingest/src/ingestor.rs
@@ -334,11 +334,7 @@ pub struct Ingestor {
 impl Ingestor {
     /// Create a new ingestor from the given configuration and clock.
     pub fn new(config: IngestorConfig, clock: Arc<dyn Clock>) -> Result<Self> {
-        let object_store_config = match &config.storage {
-            common::StorageConfig::InMemory => common::storage::config::ObjectStoreConfig::InMemory,
-            common::StorageConfig::SlateDb(c) => c.object_store.clone(),
-        };
-        let object_store = common::storage::factory::create_object_store(&object_store_config)
+        let object_store = common::storage::factory::create_object_store(&config.object_store)
             .map_err(|e| Error::Storage(e.to_string()))?;
         Self::with_object_store(config, object_store, clock)
     }
@@ -410,7 +406,7 @@ mod tests {
     use crate::model::decode_batch;
     use crate::queue::{Manifest, QueueEntry};
     use bytes::Bytes;
-    use common::StorageConfig;
+    use common::ObjectStoreConfig;
     use common::clock::{MockClock, SystemClock};
     use slatedb::object_store::ObjectStore;
     use slatedb::object_store::memory::InMemory;
@@ -425,7 +421,7 @@ mod tests {
 
     fn test_config() -> IngestorConfig {
         IngestorConfig {
-            storage: StorageConfig::InMemory,
+            object_store: ObjectStoreConfig::InMemory,
             data_path_prefix: "test-ingest".to_string(),
             manifest_path: "test/manifest".to_string(),
             flush_interval: Duration::from_hours(24),


### PR DESCRIPTION
The ingest crate only needs an object store, not the full SlateDB config. This removes the unnecessary match/extraction layer.