### PR TITLE
[timeseries] add write_timeout and related methods

### DIFF
--- a/timeseries/src/minitsdb.rs
+++ b/timeseries/src/minitsdb.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use common::coordinator::{Durability, WriteCoordinator, WriteCoordinatorConfig, WriteError};
@@ -172,6 +173,9 @@ impl MiniTsdb {
     }
 
     /// Ingest a batch of series with samples in a single operation.
+    ///
+    /// If `timeout` is provided, waits up to the given duration for space in the
+    /// write queue. Otherwise, fails immediately when the queue is full.
     #[tracing::instrument(
         level = "debug",
         skip_all,
@@ -181,7 +185,11 @@ impl MiniTsdb {
             total_samples = series_list.iter().map(|s| s.samples.len()).sum::<usize>()
         )
     )]
-    pub(crate) async fn ingest_batch(&self, series_list: &[Series]) -> Result<()> {
+    pub(crate) async fn ingest_batch(
+        &self,
+        series_list: &[Series],
+        timeout: Option<Duration>,
+    ) -> Result<()> {
         let total_samples = series_list.iter().map(|s| s.samples.len()).sum::<usize>();
 
         tracing::debug!(
@@ -192,10 +200,16 @@ impl MiniTsdb {
         );
 
         let handle = self.write_coordinator.handle(WRITE_CHANNEL);
-        let mut write_handle = handle
-            .try_write(series_list.to_vec())
-            .await
-            .map_err(|e| map_write_error(e.discard_inner()))?;
+        let mut write_handle = match timeout {
+            Some(t) => handle
+                .write_timeout(series_list.to_vec(), t)
+                .await
+                .map_err(|e| map_write_error(e.discard_inner()))?,
+            None => handle
+                .try_write(series_list.to_vec())
+                .await
+                .map_err(|e| map_write_error(e.discard_inner()))?,
+        };
 
         write_handle
             .wait(Durability::Applied)
@@ -214,7 +228,7 @@ impl MiniTsdb {
 
     /// Ingest a single series with samples.
     pub(crate) async fn ingest(&self, series: &Series) -> Result<()> {
-        self.ingest_batch(std::slice::from_ref(series)).await
+        self.ingest_batch(std::slice::from_ref(series), None).await
     }
 
     /// Flush pending data to the storage memtable (not yet durable).
@@ -252,5 +266,158 @@ fn map_write_error(e: WriteError) -> Error {
         WriteError::ApplyError(_, msg) => Error::Internal(msg),
         WriteError::FlushError(msg) => Error::Storage(msg),
         WriteError::Internal(msg) => Error::Internal(msg),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{Label, Sample, Series};
+
+    /// Create a MiniTsdb with a custom queue capacity.
+    async fn load_with_config(
+        bucket: TimeBucket,
+        storage: Arc<dyn Storage>,
+        queue_capacity: usize,
+    ) -> MiniTsdb {
+        let snapshot = storage.snapshot().await.unwrap();
+
+        let mut series_dict = HashMap::new();
+        let next_series_id = snapshot
+            .load_series_dictionary(&bucket, |fingerprint, series_id| {
+                series_dict.insert(fingerprint, series_id);
+            })
+            .await
+            .unwrap();
+
+        let context = TsdbContext {
+            bucket,
+            series_dict: Arc::new(series_dict),
+            next_series_id,
+        };
+
+        let flusher = TsdbFlusher {
+            storage: storage.clone(),
+        };
+
+        let initial_snapshot: Arc<dyn StorageSnapshot> = storage.snapshot().await.unwrap();
+
+        let config = WriteCoordinatorConfig {
+            queue_capacity,
+            ..Default::default()
+        };
+
+        let mut write_coordinator = WriteCoordinator::new(
+            config,
+            vec![WRITE_CHANNEL.to_string()],
+            context,
+            initial_snapshot,
+            flusher,
+        );
+        write_coordinator.start();
+
+        MiniTsdb {
+            bucket,
+            write_coordinator,
+        }
+    }
+
+    fn test_series(name: &str, ts: i64, value: f64) -> Series {
+        Series::new(
+            name,
+            vec![Label::new("host", "server1")],
+            vec![Sample::new(ts, value)],
+        )
+    }
+
+    async fn test_storage() -> Arc<dyn Storage> {
+        use crate::storage::merge_operator::OpenTsdbMergeOperator;
+        use common::{StorageBuilder, StorageConfig, StorageSemantics};
+
+        StorageBuilder::new(&StorageConfig::InMemory)
+            .await
+            .unwrap()
+            .with_semantics(
+                StorageSemantics::new().with_merge_operator(Arc::new(OpenTsdbMergeOperator)),
+            )
+            .build()
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn should_succeed_ingest_batch_with_timeout_when_queue_has_space() {
+        // given - queue has space (capacity=1)
+        let bucket = TimeBucket::hour(60);
+        let storage = test_storage().await;
+        let mini = load_with_config(bucket, storage, 1).await;
+
+        // when
+        let s1 = vec![test_series("cpu", 3_700_000, 1.0)];
+        let result = mini
+            .ingest_batch(&s1, Some(Duration::from_millis(50)))
+            .await;
+
+        // then
+        assert!(result.is_ok(), "expected success, got {:?}", result);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn should_fail_ingest_batch_when_timeout_too_short_for_drain() {
+        // given - queue_capacity=2, coordinator paused
+        let bucket = TimeBucket::hour(60);
+        let storage = test_storage().await;
+        let mini = load_with_config(bucket, storage, 2).await;
+
+        let pause = mini.write_coordinator.pause_handle(WRITE_CHANNEL);
+        pause.pause();
+
+        // fill the queue
+        let handle = mini.write_coordinator.handle(WRITE_CHANNEL);
+        let _wh1 = handle
+            .try_write(vec![test_series("cpu", 3_700_000, 1.0)])
+            .await
+            .unwrap();
+        let _wh2 = handle
+            .try_write(vec![test_series("cpu", 3_700_001, 2.0)])
+            .await
+            .unwrap();
+
+        // verify immediate reject with no timeout
+        let s3 = vec![test_series("cpu", 3_700_002, 3.0)];
+        let result = mini.ingest_batch(&s3, None).await;
+        assert!(
+            matches!(result, Err(Error::Backpressure)),
+            "expected Backpressure with no timeout, got {:?}",
+            result
+        );
+
+        // unpause after 200ms
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            pause.unpause();
+        });
+
+        // when - 10ms timeout is too short, queue is still full
+        let result = mini
+            .ingest_batch(&s3, Some(Duration::from_millis(10)))
+            .await;
+
+        // then
+        assert!(
+            matches!(result, Err(Error::Backpressure)),
+            "expected Backpressure with short timeout, got {:?}",
+            result
+        );
+
+        // when - 5s timeout is long enough to wait for the delayed unpause
+        let result = mini.ingest_batch(&s3, Some(Duration::from_secs(5))).await;
+
+        // then
+        assert!(
+            result.is_ok(),
+            "expected success with long timeout, got {:?}",
+            result
+        );
     }
 }

--- a/timeseries/src/promql/scraper.rs
+++ b/timeseries/src/promql/scraper.rs
@@ -233,7 +233,7 @@ impl Scraper {
 
     /// Ingest samples into the TSDB.
     async fn ingest_samples(&self, samples: Vec<Series>) -> Result<()> {
-        self.tsdb.ingest_samples(samples).await
+        self.tsdb.ingest_samples(samples, None).await
     }
 }
 

--- a/timeseries/src/reader.rs
+++ b/timeseries/src/reader.rs
@@ -321,7 +321,7 @@ mod tests {
                 .sample(1700000001000, 101.0)
                 .build(),
         ];
-        tsdb.ingest_samples(series).await.unwrap();
+        tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
         // Open reader on the same storage
@@ -362,7 +362,7 @@ mod tests {
                 .sample(1700000000000, 0.75)
                 .build(),
         ];
-        tsdb.ingest_samples(series).await.unwrap();
+        tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
         let reader = TimeSeriesDbReader::from_storage(storage);
@@ -420,7 +420,7 @@ mod tests {
                 .sample(1700000000000, 1.0)
                 .build(),
         ];
-        tsdb.ingest_samples(series).await.unwrap();
+        tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
         // Open reader
@@ -441,7 +441,7 @@ mod tests {
                 .sample(1700000002000, 2.0)
                 .build(),
         ];
-        tsdb.ingest_samples(more_series).await.unwrap();
+        tsdb.ingest_samples(more_series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
         // Reader sees newly written data (InMemory storage shares state)
@@ -471,7 +471,7 @@ mod tests {
                 .sample(1700000060000, 160.0)
                 .build(),
         ];
-        tsdb.ingest_samples(series).await.unwrap();
+        tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
         let reader = TimeSeriesDbReader::from_storage(storage);
@@ -693,7 +693,7 @@ mod tests {
                 .sample(1700000060000, 5.0)
                 .build(),
         ];
-        tsdb.ingest_samples(series).await.unwrap();
+        tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
         let reader = TimeSeriesDbReader::from_storage(storage.clone());
@@ -754,7 +754,7 @@ mod tests {
                 .sample(1700000000000, 100.0)
                 .build(),
         ];
-        tsdb.ingest_samples(series).await.unwrap();
+        tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
         let reader = TimeSeriesDbReader::from_storage(storage);

--- a/timeseries/src/server/ingest_consumer.rs
+++ b/timeseries/src/server/ingest_consumer.rs
@@ -229,7 +229,7 @@ async fn process_entry(
         .convert(&request)
         .map_err(|e| format!("OtelConverter failed: {e}"))?;
 
-    tsdb.ingest_samples(series)
+    tsdb.ingest_samples(series, None)
         .await
         .map_err(|e| format!("tsdb ingest failed: {e}"))?;
 

--- a/timeseries/src/server/otel.rs
+++ b/timeseries/src/server/otel.rs
@@ -119,7 +119,7 @@ pub async fn handle_otel_metrics(
     tracing::Span::current().record("series_count", series.len());
     tracing::Span::current().record("samples_count", total_samples);
 
-    state.tsdb.ingest_samples(series).await?;
+    state.tsdb.ingest_samples(series, None).await?;
 
     let response = ExportMetricsServiceResponse {
         partial_success: None,

--- a/timeseries/src/server/remote_write.rs
+++ b/timeseries/src/server/remote_write.rs
@@ -236,7 +236,7 @@ pub async fn handle_remote_write(
     );
 
     // Ingest samples into the TSDB
-    match state.tsdb.ingest_samples(samples).await {
+    match state.tsdb.ingest_samples(samples, None).await {
         Ok(()) => {
             // Increment successful ingestion counter
             state

--- a/timeseries/src/testing/mod.rs
+++ b/timeseries/src/testing/mod.rs
@@ -45,7 +45,7 @@ pub struct TestTsdb {
 impl TestTsdb {
     /// Ingest series into the TSDB (production ingestion path).
     pub async fn ingest_samples(&self, series: Vec<Series>) {
-        self.inner.ingest_samples(series).await.unwrap();
+        self.inner.ingest_samples(series, None).await.unwrap();
     }
 
     /// Flush all dirty buckets to storage.

--- a/timeseries/src/timeseries.rs
+++ b/timeseries/src/timeseries.rs
@@ -137,7 +137,40 @@ impl TimeSeriesDb {
     /// # }
     /// ```
     pub async fn write(&self, series: Vec<Series>) -> Result<()> {
-        self.tsdb.ingest_samples(series).await
+        self.tsdb.ingest_samples(series, None).await
+    }
+
+    /// Writes one or more time series, waiting up to `timeout` for space in
+    /// the write queue.
+    ///
+    /// Behaves identically to [`write`](Self::write) but will wait up to
+    /// `timeout` when the write queue is full instead of failing immediately.
+    /// If the timeout elapses before space becomes available, an error is
+    /// returned and no samples are ingested.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// # use timeseries::{TimeSeriesDb, Config, Series};
+    /// # use common::StorageConfig;
+    /// # use std::time::Duration;
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let config = Config { storage: StorageConfig::InMemory, ..Default::default() };
+    /// # let ts = TimeSeriesDb::open(config).await?;
+    /// let series = vec![
+    ///     Series::builder("cpu_usage")
+    ///         .label("host", "server1")
+    ///         .sample(1700000000000, 0.75)
+    ///         .build(),
+    /// ];
+    ///
+    /// ts.write_timeout(series, Duration::from_secs(30)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn write_timeout(&self, series: Vec<Series>, timeout: Duration) -> Result<()> {
+        self.tsdb.ingest_samples(series, Some(timeout)).await
     }
 
     // ── Read / Query API (RFC 0003) ──────────────────────────────────

--- a/timeseries/src/tsdb.rs
+++ b/timeseries/src/tsdb.rs
@@ -676,6 +676,10 @@ impl Tsdb {
 
     /// Ingest series into the TSDB.
     /// Each series is split by time bucket based on sample timestamps.
+    ///
+    /// If `timeout` is provided, each bucket batch will wait up to the given
+    /// duration for space in the write queue. Otherwise, writes fail
+    /// immediately if the queue is full.
     #[tracing::instrument(
         level = "debug",
         skip_all,
@@ -685,7 +689,11 @@ impl Tsdb {
             buckets_touched = tracing::field::Empty
         )
     )]
-    pub(crate) async fn ingest_samples(&self, series_list: Vec<Series>) -> Result<()> {
+    pub(crate) async fn ingest_samples(
+        &self,
+        series_list: Vec<Series>,
+        timeout: Option<Duration>,
+    ) -> Result<()> {
         let mut bucket_series_map: HashMap<TimeBucket, Vec<Series>> = HashMap::new();
         let mut total_samples = 0;
 
@@ -761,7 +769,7 @@ impl Tsdb {
                     return Err(err);
                 }
             };
-            mini.ingest_batch(&series_list).await?;
+            mini.ingest_batch(&series_list, timeout).await?;
 
             tracing::debug!(
                 bucket = ?bucket,
@@ -937,9 +945,13 @@ impl TsdbEngine {
 
     // ── Write methods (error in read-only mode) ──
 
-    pub(crate) async fn ingest_samples(&self, series_list: Vec<Series>) -> Result<()> {
+    pub(crate) async fn ingest_samples(
+        &self,
+        series_list: Vec<Series>,
+        timeout: Option<Duration>,
+    ) -> Result<()> {
         match self {
-            Self::ReadWrite(tsdb) => tsdb.ingest_samples(series_list).await,
+            Self::ReadWrite(tsdb) => tsdb.ingest_samples(series_list, timeout).await,
             Self::ReadOnly(_) => Err(crate::error::Error::InvalidInput(
                 "write operations are not supported in read-only mode".to_string(),
             )),
@@ -1468,7 +1480,7 @@ mod tests {
             create_sample("http_requests", vec![("env", "prod")], 4_000_000, 42.0),
             create_sample("http_requests", vec![("env", "staging")], 4_000_000, 10.0),
         ];
-        tsdb.ingest_samples(series).await.unwrap();
+        tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
         tsdb
     }
@@ -1703,7 +1715,9 @@ mod tests {
         // Same series in two different buckets
         let series1 = create_sample("cpu", vec![("host", "a")], 4_000_000, 1.0);
         let series2 = create_sample("cpu", vec![("host", "a")], 7_500_000, 2.0);
-        tsdb.ingest_samples(vec![series1, series2]).await.unwrap();
+        tsdb.ingest_samples(vec![series1, series2], None)
+            .await
+            .unwrap();
         tsdb.flush().await.unwrap();
 
         let results = tsdb.find_series(&["cpu"], 0, i64::MAX).await.unwrap();
@@ -1785,7 +1799,7 @@ mod tests {
         let mut series = create_sample("cpu", vec![("host", "a")], 4_000_000, 1.0);
         series.description = Some("CPU usage".to_string());
         series.unit = Some("percent".to_string());
-        tsdb.ingest_samples(vec![series]).await.unwrap();
+        tsdb.ingest_samples(vec![series], None).await.unwrap();
 
         let results = tsdb.find_metadata(None).await.unwrap();
 
@@ -1909,7 +1923,9 @@ mod tests {
         // Same series in two different buckets
         let series1 = create_sample("cpu", vec![("host", "a")], 4_000_000, 1.0);
         let series2 = create_sample("cpu", vec![("host", "a")], 7_500_000, 2.0);
-        tsdb.ingest_samples(vec![series1, series2]).await.unwrap();
+        tsdb.ingest_samples(vec![series1, series2], None)
+            .await
+            .unwrap();
         tsdb.flush().await.unwrap();
 
         let results = tsdb.find_labels(None, 0, i64::MAX).await.unwrap();
@@ -1934,7 +1950,9 @@ mod tests {
         // Same series in two different buckets
         let series1 = create_sample("cpu", vec![("host", "a")], 4_000_000, 1.0);
         let series2 = create_sample("cpu", vec![("host", "a")], 7_500_000, 2.0);
-        tsdb.ingest_samples(vec![series1, series2]).await.unwrap();
+        tsdb.ingest_samples(vec![series1, series2], None)
+            .await
+            .unwrap();
         tsdb.flush().await.unwrap();
 
         let results = tsdb
@@ -1953,10 +1971,13 @@ mod tests {
     async fn find_metadata_should_filter_by_metric(storage: Arc<dyn Storage>) {
         let tsdb = Tsdb::new(storage);
 
-        tsdb.ingest_samples(vec![
-            create_sample("cpu", vec![], 4_000_000, 1.0),
-            create_sample("mem", vec![], 4_000_000, 2.0),
-        ])
+        tsdb.ingest_samples(
+            vec![
+                create_sample("cpu", vec![], 4_000_000, 1.0),
+                create_sample("mem", vec![], 4_000_000, 2.0),
+            ],
+            None,
+        )
         .await
         .unwrap();
 
@@ -1972,7 +1993,7 @@ mod tests {
     async fn eval_query_range_rejects_zero_step(storage: Arc<dyn Storage>) {
         let tsdb = Tsdb::new(storage);
 
-        tsdb.ingest_samples(vec![create_sample("cpu", vec![], 1_000_000, 1.0)])
+        tsdb.ingest_samples(vec![create_sample("cpu", vec![], 1_000_000, 1.0)], None)
             .await
             .unwrap();
         tsdb.flush().await.unwrap();


### PR DESCRIPTION
## Summary

Adds `write_timeout` and related methods.

## Related Issues

Fixes #364.

## Test Plan

New unit tests added and existing updated with the extra `timeout: Option<Duration>` parameter.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
