### PR TITLE
add tree validator and admin tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4044,9 +4044,9 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slatedb"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc33982c2d4f2f66fddb6e4bd050c6fcc415944221c0c2775a407b5af0af3388"
+checksum = "d945c6cd6f239873e640c5b7bb204f5638ed5681b02145cdcc2e80b2d3882b8a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4091,9 +4091,9 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f25d1e125ea2f5dcf315e7cc40bc4adce655b382d2350ec37b66d7e97802ff"
+checksum = "2893ff22bb9a1013af0fb5e85380307ccd9d0a4fa8a111e187a48750e14b9a47"
 dependencies = [
  "chrono",
  "tokio",
@@ -4101,9 +4101,9 @@ dependencies = [
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5f20e6b8c7d01cb6a4050a495d3a2e8c435bc8ce439c9b0b72fa2d3096bed8"
+checksum = "2c33d5597404e23b9706aa32a1723399f022f0513a289d1059df8810a282dcc4"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ serde_json = "1.0"
 serde_with = { version = "3", features = ["base64"] }
 serde_yaml = "0.9"
 foyer = "0.18"
-slatedb = "0.11.1"
+slatedb = "0.11.2"
 slatedb-common = "0.11.1"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full", "test-util"] }

--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -15,6 +15,7 @@ pub use slatedb::db_cache::CachedEntry;
 use slatedb::db_cache::DbCache;
 pub use slatedb::db_cache::foyer::{FoyerCache, FoyerCacheOptions};
 pub use slatedb::db_cache::foyer_hybrid::FoyerHybridCache;
+use slatedb::object_store::limit::LimitStore;
 use slatedb::object_store::{self, ObjectStore};
 pub use slatedb::{CompactorBuilder, DbBuilder};
 use tracing::info;
@@ -152,9 +153,10 @@ impl StorageBuilder {
 /// This struct holds non-serializable runtime configuration for `DbReader`.
 /// Unlike `StorageBuilder`, it only exposes options relevant to readers
 /// (currently just block cache).
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct StorageReaderRuntime {
     pub(crate) block_cache: Option<Arc<dyn DbCache>>,
+    pub(crate) object_store: Option<Arc<dyn ObjectStore>>,
 }
 
 impl StorageReaderRuntime {
@@ -172,6 +174,11 @@ impl StorageReaderRuntime {
     /// This option only affects SlateDB storage; it is ignored for in-memory storage.
     pub fn with_block_cache(mut self, cache: Arc<dyn DbCache>) -> Self {
         self.block_cache = Some(cache);
+        self
+    }
+
+    pub fn with_object_store(mut self, object_store: Arc<dyn ObjectStore>) -> Self {
+        self.object_store = Some(object_store);
         self
     }
 }
@@ -234,6 +241,8 @@ pub fn create_object_store(config: &ObjectStoreConfig) -> StorageResult<Arc<dyn 
                 .map_err(|e| {
                     StorageError::Storage(format!("Failed to create AWS S3 store: {}", e))
                 })?;
+            println!("CREATE OBJECT STORE WITH IO LIMIT");
+            let store = LimitStore::new(store, 100);
             Ok(Arc::new(store))
         }
         ObjectStoreConfig::Local(local_config) => {
@@ -285,7 +294,11 @@ pub async fn create_storage_read(
             Ok(Arc::new(storage))
         }
         StorageConfig::SlateDb(slate_config) => {
-            let object_store = create_object_store(&slate_config.object_store)?;
+            let object_store = if let Some(object_store) = &runtime.object_store {
+                object_store.clone()
+            } else {
+                create_object_store(&slate_config.object_store)?
+            };
 
             let mut options = reader_options;
             if let Some(op) = semantics.merge_operator {

--- a/vector/bench/README.md
+++ b/vector/bench/README.md
@@ -54,6 +54,444 @@ tar xzf sift.tar.gz --strip-components=1
 # Expected files: sift_base.fvecs, sift_query.fvecs, sift_groundtruth.ivecs
 ```
 
+### SIFT10M, SIFT50M, SIFT100M, and SIFT1B
+
+These benchmark entries use the BIGANN SIFT1B dataset:
+
+- `sift10m`
+- `sift50m`
+- `sift100m`
+- `sift1b`
+
+All four use the same base and query files:
+
+- `bigann/bigann_base.bvecs`
+- `bigann/bigann_query.bvecs`
+
+They differ only in:
+
+- how many base vectors the benchmark ingests
+- which ground-truth file is used
+
+The benchmark reads `bvecs` directly, so unlike DEEP you do **not** need to convert the base/query files.
+
+Expected layout:
+
+```text
+vector/bench/data/bigann/
+├── bigann_base.bvecs
+├── bigann_query.bvecs
+├── bigann_groundtruth_10M.ivecs
+├── bigann_groundtruth_50M.ivecs
+├── bigann_groundtruth_100M.ivecs
+└── bigann_groundtruth_1B.ivecs
+```
+
+Run these commands from the **workspace root**.
+
+```bash
+mkdir -p vector/bench/data/bigann
+
+curl -L -o vector/bench/data/bigann/bigann_base.bvecs.gz \
+  ftp://ftp.irisa.fr/local/texmex/corpus/bigann_base.bvecs.gz
+
+curl -L -o vector/bench/data/bigann/bigann_query.bvecs.gz \
+  ftp://ftp.irisa.fr/local/texmex/corpus/bigann_query.bvecs.gz
+
+curl -L -o vector/bench/data/bigann/bigann_gnd.tar.gz \
+  ftp://ftp.irisa.fr/local/texmex/corpus/bigann_gnd.tar.gz
+
+gzip -dc vector/bench/data/bigann/bigann_base.bvecs.gz \
+  > vector/bench/data/bigann/bigann_base.bvecs
+
+gzip -dc vector/bench/data/bigann/bigann_query.bvecs.gz \
+  > vector/bench/data/bigann/bigann_query.bvecs
+
+mkdir -p /tmp/bigann_gnd_extract
+tar xzf vector/bench/data/bigann/bigann_gnd.tar.gz -C /tmp/bigann_gnd_extract
+
+cp /tmp/bigann_gnd_extract/gnd/idx_10M.ivecs \
+  vector/bench/data/bigann/bigann_groundtruth_10M.ivecs
+
+cp /tmp/bigann_gnd_extract/gnd/idx_50M.ivecs \
+  vector/bench/data/bigann/bigann_groundtruth_50M.ivecs
+
+cp /tmp/bigann_gnd_extract/gnd/idx_100M.ivecs \
+  vector/bench/data/bigann/bigann_groundtruth_100M.ivecs
+
+cp /tmp/bigann_gnd_extract/gnd/idx_1000M.ivecs \
+  vector/bench/data/bigann/bigann_groundtruth_1B.ivecs
+
+ls -lh vector/bench/data/bigann
+```
+
+Then choose whichever dataset you want in your benchmark config.
+
+For `sift10m`:
+
+```toml
+[[params.recall]]
+dataset = "sift10m"
+```
+
+For `sift50m`:
+
+```toml
+[[params.recall]]
+dataset = "sift50m"
+```
+
+For `sift100m`:
+
+```toml
+[[params.recall]]
+dataset = "sift100m"
+```
+
+For `sift1b`:
+
+```toml
+[[params.recall]]
+dataset = "sift1b"
+```
+
+Notes:
+
+- `sift10m` ingests the first 10,000,000 vectors from `bigann_base.bvecs`.
+- `sift50m` ingests the first 50,000,000 vectors from `bigann_base.bvecs`.
+- `sift100m` ingests the first 100,000,000 vectors from `bigann_base.bvecs`.
+- `sift1b` ingests the full `bigann_base.bvecs`.
+- BIGANN is large. `bigann_base.bvecs.gz` is about 91 GB compressed on IRISA and expands substantially when decompressed.
+
+### DEEP10M and DEEP1B
+
+96 dimensions, L2 distance, `fvecs` format. These benchmark entries expect local DEEP vectors converted into the same
+`fvecs` / `ivecs` file layout as the other benchmarks.
+
+Create this directory layout under `vector/bench/data/deep/`:
+
+```text
+vector/bench/data/deep/
+├── deep_base.fvecs
+├── deep_query.fvecs
+├── deep_groundtruth_10M.ivecs
+└── deep_groundtruth_1B.ivecs
+```
+
+Important:
+
+- `deep10m` and `deep1b` do **not** use the same ground-truth file.
+- For `deep10m`, use the Yandex 10M debug subset files together:
+  `base.10M.fbin` and `query.public.10K.fbin`, then generate ground truth locally with
+  `gen_deep_groundtruth`.
+- For `deep1b`, use the Yandex full-dataset files together:
+  `base.1B.fbin`, `query.public.10K.fbin`, and `groundtruth.public.10K.ibin`.
+- Do **not** mix the Yandex 10M debug subset with `matsui528/deep1b_gt`.
+- The benchmark now runs a brute-force sanity check for `deep10m` before ingest. If that check fails, your DEEP files
+  do not match each other.
+
+The benchmark expects **all vectors in `fvecs` format** and **ground truth in `ivecs` format**.
+
+#### Copy-paste setup for `deep10m`
+
+Run these commands from the **workspace root**. Do not `cd` into `vector/bench/data/deep` first.
+
+This setup intentionally uses:
+
+- `base.10M.fbin` from Yandex for the base vectors
+- `query.public.10K.fbin` from Yandex for the queries
+- `gen_deep_groundtruth` to generate the ground truth locally
+
+That avoids relying on a questionable prepublished `deep10m` ground-truth pairing.
+
+```bash
+mkdir -p vector/bench/data/deep
+
+curl -L -o vector/bench/data/deep/base.10M.fbin \
+  https://storage.yandexcloud.net/yandex-research/ann-datasets/DEEP/base.10M.fbin
+
+curl -L -o vector/bench/data/deep/query.public.10K.fbin \
+  https://storage.yandexcloud.net/yandex-research/ann-datasets/DEEP/query.public.10K.fbin
+
+python3 - <<'PY'
+from pathlib import Path
+import numpy as np
+
+root = Path("vector/bench/data/deep")
+
+def fbin_to_fvecs(src: Path, dst: Path) -> None:
+    with src.open("rb") as f:
+        n = int(np.fromfile(f, dtype=np.uint32, count=1)[0])
+        d = int(np.fromfile(f, dtype=np.uint32, count=1)[0])
+    data = np.memmap(src, dtype=np.float32, mode="r", offset=8, shape=(n, d))
+    out = np.memmap(
+        dst,
+        dtype=np.dtype([("dim", "<i4"), ("vec", "<f4", (d,))]),
+        mode="w+",
+        shape=(n,),
+    )
+    chunk = 100_000
+    for start in range(0, n, chunk):
+        end = min(start + chunk, n)
+        out["dim"][start:end] = d
+        out["vec"][start:end] = data[start:end]
+    out.flush()
+
+fbin_to_fvecs(root / "base.10M.fbin", root / "deep_base.fvecs")
+fbin_to_fvecs(root / "query.public.10K.fbin", root / "deep_query.fvecs")
+PY
+
+cargo run -p opendata-vector --release --bin gen_deep_groundtruth -- \
+  --base-fbin vector/bench/data/deep/base.10M.fbin \
+  --query-fbin vector/bench/data/deep/query.public.10K.fbin \
+  --output-ivecs vector/bench/data/deep/deep_groundtruth_10M.ivecs \
+  --top-k 100 \
+  --distance-metric l2
+
+ls -lh vector/bench/data/deep
+```
+
+Then run:
+
+```bash
+cargo run -p vector-bench --release -- --config bench.toml
+```
+
+with:
+
+```toml
+[[params.recall]]
+dataset = "deep10m"
+```
+
+If the files are aligned correctly, the benchmark will print:
+
+```text
+deep10m sanity check passed for query 0
+```
+
+before ingestion starts.
+
+#### Copy-paste setup for `deep1b`
+
+Run these commands from the **workspace root**. `base.1B.fbin` alone is around 388 GB.
+
+This setup intentionally uses:
+
+- `base.1B.fbin` from Yandex for the base vectors
+- `query.public.10K.fbin` from Yandex for the queries
+- `groundtruth.public.10K.ibin` from Yandex for the ground truth
+
+```bash
+mkdir -p vector/bench/data/deep
+
+curl -L -o vector/bench/data/deep/base.1B.fbin \
+  https://storage.yandexcloud.net/yandex-research/ann-datasets/DEEP/base.1B.fbin
+
+curl -L -o vector/bench/data/deep/query.public.10K.fbin \
+  https://storage.yandexcloud.net/yandex-research/ann-datasets/DEEP/query.public.10K.fbin
+
+curl -L -o vector/bench/data/deep/groundtruth.public.10K.ibin \
+  https://storage.yandexcloud.net/yandex-research/ann-datasets/DEEP/groundtruth.public.10K.ibin
+
+python3 - <<'PY'
+from pathlib import Path
+import numpy as np
+
+root = Path("vector/bench/data/deep")
+
+def fbin_to_fvecs(src: Path, dst: Path) -> None:
+    with src.open("rb") as f:
+        n = int(np.fromfile(f, dtype=np.uint32, count=1)[0])
+        d = int(np.fromfile(f, dtype=np.uint32, count=1)[0])
+    data = np.memmap(src, dtype=np.float32, mode="r", offset=8, shape=(n, d))
+    out = np.memmap(
+        dst,
+        dtype=np.dtype([("dim", "<i4"), ("vec", "<f4", (d,))]),
+        mode="w+",
+        shape=(n,),
+    )
+    chunk = 100_000
+    for start in range(0, n, chunk):
+        end = min(start + chunk, n)
+        out["dim"][start:end] = d
+        out["vec"][start:end] = data[start:end]
+    out.flush()
+
+def ibin_to_ivecs(src: Path, dst: Path) -> None:
+    with src.open("rb") as f:
+        n = int(np.fromfile(f, dtype=np.uint32, count=1)[0])
+        d = int(np.fromfile(f, dtype=np.uint32, count=1)[0])
+    data = np.memmap(src, dtype=np.int32, mode="r", offset=8, shape=(n, d))
+    out = np.memmap(
+        dst,
+        dtype=np.dtype([("dim", "<i4"), ("vec", "<i4", (d,))]),
+        mode="w+",
+        shape=(n,),
+    )
+    chunk = 100_000
+    for start in range(0, n, chunk):
+        end = min(start + chunk, n)
+        out["dim"][start:end] = d
+        out["vec"][start:end] = data[start:end]
+    out.flush()
+
+fbin_to_fvecs(root / "base.1B.fbin", root / "deep_base.fvecs")
+fbin_to_fvecs(root / "query.public.10K.fbin", root / "deep_query.fvecs")
+ibin_to_ivecs(root / "groundtruth.public.10K.ibin", root / "deep_groundtruth_1B.ivecs")
+PY
+
+ls -lh vector/bench/data/deep
+```
+
+#### Smaller DEEP subset for a quick smoke test
+
+The smallest public DEEP subset with matching published ground truth that I found is `deep1M`, from
+`matsui528/deep1b_gt`.
+
+Source: <https://github.com/matsui528/deep1b_gt>
+
+That repo publishes:
+
+- `deep1M_groundtruth.ivecs`
+- a `download_deep1b.py` helper
+- a `pickup_vecs.py` helper to build `deep1M_base.fvecs` from the first 1M base vectors
+
+There does not appear to be a standard public `deep100K` package with matching ground truth. If you want exactly
+100K, the practical approach is to start from `deep1M`, take the first 100K base vectors, and recompute exact ground
+truth locally for that 100K subset.
+
+The current benchmark does not have a built-in `deep1m` dataset entry, but `deep1M` is the best public DEEP
+smoke-test-sized subset I found.
+
+### Upstash Wikipedia BGE-M3
+
+The benchmark includes an English Wikipedia BGE-M3 dataset entry named `wikipedia_bge_m3_en`.
+
+Expected local layout:
+
+```text
+vector/bench/data/wikipedia-bge-m3/en/
+├── base.fvecs
+├── query.fvecs
+└── groundtruth.ivecs
+```
+
+Dataset characteristics:
+
+- 1024 dimensions
+- dot-product search
+- embeddings generated with `BAAI/bge-m3`
+
+Recommended sourcing flow:
+
+1. Download the English split from `Upstash/wikipedia-2024-06-bge-m3`.
+   Source: <https://huggingface.co/datasets/Upstash/wikipedia-2024-06-bge-m3>
+2. Extract paragraph embeddings and write them to `base.fvecs`.
+3. Prepare a held-out query set in the same 1024-d format and write it to `query.fvecs`.
+4. Compute exact top-k neighbors for those queries and write them to `groundtruth.ivecs`.
+
+Notes:
+
+- The benchmark does **not** read Hugging Face parquet directly; convert embeddings to `fvecs` first.
+- The benchmark assumes vectors are already in the same embedding space as the base set. If you generate queries with
+  `BAAI/bge-m3`, use the same model and normalization settings you used for the base vectors when you computed ground
+  truth.
+
+#### Copy-paste setup for `wikipedia_bge_m3_en`
+
+This example builds a runnable benchmark dataset from the first 1,000,000 English embeddings and the next 1,000
+embeddings as queries.
+
+```bash
+python3 -m venv .venv-vector-bench
+source .venv-vector-bench/bin/activate
+pip install -U pip
+pip install datasets numpy faiss-cpu
+
+mkdir -p vector/bench/data/wikipedia-bge-m3/en
+
+python3 - <<'PY'
+from pathlib import Path
+import numpy as np
+import faiss
+from datasets import load_dataset
+
+OUT = Path("vector/bench/data/wikipedia-bge-m3/en")
+BASE_COUNT = 1_000_000
+QUERY_COUNT = 1_000
+TOPK = 100
+
+def write_fvecs(path: Path, arr: np.ndarray) -> None:
+    arr = np.asarray(arr, dtype=np.float32)
+    n, d = arr.shape
+    out = np.memmap(
+        path,
+        dtype=np.dtype([("dim", "<i4"), ("vec", "<f4", (d,))]),
+        mode="w+",
+        shape=(n,),
+    )
+    out["dim"][:] = d
+    out["vec"][:] = arr
+    out.flush()
+
+def write_ivecs(path: Path, arr: np.ndarray) -> None:
+    arr = np.asarray(arr, dtype=np.int32)
+    n, d = arr.shape
+    out = np.memmap(
+        path,
+        dtype=np.dtype([("dim", "<i4"), ("vec", "<i4", (d,))]),
+        mode="w+",
+        shape=(n,),
+    )
+    out["dim"][:] = d
+    out["vec"][:] = arr
+    out.flush()
+
+dataset = load_dataset(
+    "Upstash/wikipedia-2024-06-bge-m3",
+    "en",
+    split="train",
+    streaming=True,
+)
+
+base = []
+queries = []
+for row in dataset:
+    vec = np.asarray(row["embedding"], dtype=np.float32)
+    if len(base) < BASE_COUNT:
+        base.append(vec)
+    elif len(queries) < QUERY_COUNT:
+        queries.append(vec)
+    else:
+        break
+
+base = np.vstack(base)
+queries = np.vstack(queries)
+
+index = faiss.IndexFlatIP(base.shape[1])
+index.add(base)
+_, gt = index.search(queries, TOPK)
+
+write_fvecs(OUT / "base.fvecs", base)
+write_fvecs(OUT / "query.fvecs", queries)
+write_ivecs(OUT / "groundtruth.ivecs", gt)
+PY
+```
+
+Then run:
+
+```bash
+cargo run -p vector-bench --release -- --config bench.toml
+```
+
+with:
+
+```toml
+[[params.recall]]
+dataset = "wikipedia_bge_m3_en"
+```
+
 ### Cohere1M
 
 1M vectors, 768 dimensions, cosine distance. Uses Cohere's `embed-english-v3.0` embeddings from
@@ -111,7 +549,7 @@ The benchmark is configured via a TOML config file passed with `--config`. The c
 
 | Parameter           | Type   | Description                                                        |
 |---------------------|--------|--------------------------------------------------------------------|
-| `dataset`           | string | Dataset name (`sift1m`, `cohere1m`, `sift10m`, etc.)               |
+| `dataset`           | string | Dataset name (`sift1m`, `cohere1m`, `deep10m`, `deep1b`, `wikipedia_bge_m3_en`, `sift10m`, etc.) |
 | `dimensions`        | u16    | Vector dimensions (default: from dataset)                          |
 | `distance_metric`   | string | `l2`, `cosine`, or `dot_product` (default: from dataset)           |
 | `split_threshold`   | usize  | Centroid split threshold (default: from dataset)                   |

--- a/vector/bench/src/recall.rs
+++ b/vector/bench/src/recall.rs
@@ -13,17 +13,24 @@
 
 use std::collections::HashSet;
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{self, BufReader, Read};
 use std::path::{Path, PathBuf};
+use std::thread;
 
 use bencher::{Bench, Benchmark, Params, Summary};
-use common::StorageBuilder;
+use common::StorageConfig;
+use common::storage::config::SlateDbStorageConfig;
 use common::storage::factory::{FoyerCache, FoyerCacheOptions};
+use common::{StorageBuilder, StorageReaderRuntime, create_object_store};
+use tokio::sync::mpsc;
 use vector::{
-    Config, DistanceMetric, Query, SearchOptions, SearchResult, Vector, VectorDb, VectorDbRead,
+    Config, DistanceMetric, Query, ReaderConfig, SearchOptions, SearchResult, Vector, VectorDb,
+    VectorDbRead, VectorDbReader,
 };
 
 const DEFAULT_NUM_QUERIES: usize = 100;
+const BASE_VECTOR_CHUNK_SIZE: usize = 1_000_000;
+const INGEST_WRITE_BATCH_SIZE: usize = 10;
 
 fn load_vector_config(path: &str) -> Config {
     let contents =
@@ -32,6 +39,12 @@ fn load_vector_config(path: &str) -> Config {
         .unwrap_or_else(|e| panic!("failed to parse {}: {}", path, e));
     println!("  Vector config: {:?}", config);
     config
+}
+
+fn load_storage_config(path: &str) -> StorageConfig {
+    let contents =
+        std::fs::read_to_string(path).unwrap_or_else(|e| panic!("failed to read {}: {}", path, e));
+    serde_yaml::from_str(&contents).unwrap_or_else(|e| panic!("failed to parse {}: {}", path, e))
 }
 
 fn skip_ingest() -> bool {
@@ -50,7 +63,111 @@ fn data_dir() -> PathBuf {
         .join("bench/data")
 }
 
+/// normalize a vector to the unit hypersphere
+fn normalize_vec(v: &mut [f32]) {
+    let norm: f32 = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        v.iter_mut().for_each(|x| *x /= norm);
+    }
+}
+
 // -- Vector file readers ------------------------------------------------------
+
+struct VectorFileBatchReader {
+    reader: BufReader<File>,
+    format: VecFormat,
+    dimensions: usize,
+    remaining: Option<usize>,
+    normalize: bool,
+}
+
+impl VectorFileBatchReader {
+    fn open(
+        path: &Path,
+        format: VecFormat,
+        dimensions: usize,
+        max_vectors: Option<usize>,
+        normalize: bool,
+    ) -> anyhow::Result<Self> {
+        let file =
+            File::open(path).unwrap_or_else(|e| panic!("failed to open {}: {}", path.display(), e));
+        Ok(Self {
+            reader: BufReader::new(file),
+            format,
+            dimensions,
+            remaining: max_vectors,
+            normalize,
+        })
+    }
+
+    fn read_batch(&mut self, max_rows: usize) -> anyhow::Result<Option<Vec<Vec<f32>>>> {
+        if self.remaining == Some(0) {
+            return Ok(None);
+        }
+
+        let batch_cap = self.remaining.unwrap_or(max_rows).min(max_rows);
+        let mut rows = Vec::with_capacity(batch_cap);
+        while rows.len() < batch_cap {
+            let Some(mut values) = self.read_vector()? else {
+                break;
+            };
+            if self.normalize {
+                normalize_vec(&mut values);
+            }
+            rows.push(values);
+            if let Some(remaining) = &mut self.remaining {
+                *remaining -= 1;
+                if *remaining == 0 {
+                    break;
+                }
+            }
+        }
+
+        if rows.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(rows))
+        }
+    }
+
+    fn read_vector(&mut self) -> anyhow::Result<Option<Vec<f32>>> {
+        let Some(dim) = read_dim_prefix(&mut self.reader)? else {
+            return Ok(None);
+        };
+        if dim != self.dimensions {
+            anyhow::bail!(
+                "dimension mismatch while streaming vectors: expected {}, got {}",
+                self.dimensions,
+                dim
+            );
+        }
+
+        match self.format {
+            VecFormat::Fvecs => {
+                let mut values = vec![0f32; dim];
+                let byte_slice = unsafe {
+                    std::slice::from_raw_parts_mut(values.as_mut_ptr() as *mut u8, dim * 4)
+                };
+                self.reader.read_exact(byte_slice)?;
+                Ok(Some(values))
+            }
+            VecFormat::Bvecs => {
+                let mut bytes = vec![0u8; dim];
+                self.reader.read_exact(&mut bytes)?;
+                Ok(Some(bytes.into_iter().map(|v| v as f32).collect()))
+            }
+        }
+    }
+}
+
+fn read_dim_prefix(reader: &mut impl Read) -> anyhow::Result<Option<usize>> {
+    let mut dim_buf = [0u8; 4];
+    match reader.read_exact(&mut dim_buf) {
+        Ok(()) => Ok(Some(u32::from_le_bytes(dim_buf) as usize)),
+        Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => Ok(None),
+        Err(err) => Err(err.into()),
+    }
+}
 
 fn read_fvecs(path: &Path) -> Vec<Vec<f32>> {
     let file =
@@ -178,31 +295,123 @@ struct Dataset {
     /// Path to a YAML file with vector `Config` overrides. When set, the config
     /// from this file is used instead of constructing one from dataset fields.
     vector_config: Option<String>,
+    /// Optional path to a YAML file with a separate StorageConfig for cold-reader
+    /// queries. When both writer and reader storage are SlateDb, the reader uses
+    /// the writer's data path/object store and the override's settings/cache.
+    reader_storage_config: Option<String>,
     /// File format for base and query vectors.
     format: VecFormat,
     /// Maximum number of base vectors to ingest. `None` = all.
     max_vectors: Option<usize>,
+    normalize: bool,
 }
 
 impl Dataset {
-    /// Load base vectors, respecting `format` and `max_vectors`.
-    fn load_base_vectors(&self, data_dir: &Path) -> Vec<Vec<f32>> {
-        let path = data_dir.join(self.base_file);
-        match self.format {
-            VecFormat::Fvecs => {
-                let vecs = read_fvecs(&path);
-                match self.max_vectors {
-                    Some(n) => vecs.into_iter().take(n).collect(),
-                    None => vecs,
+    fn base_path(&self, data_dir: &Path) -> PathBuf {
+        data_dir.join(self.base_file)
+    }
+
+    fn query_path(&self, data_dir: &Path) -> PathBuf {
+        data_dir.join(self.query_file)
+    }
+
+    fn estimated_base_vector_count(&self, data_dir: &Path) -> anyhow::Result<usize> {
+        let path = self.base_path(data_dir);
+        let bytes = std::fs::metadata(&path)?.len() as usize;
+        let record_size = match self.format {
+            VecFormat::Fvecs => 4 + self.dimensions as usize * 4,
+            VecFormat::Bvecs => 4 + self.dimensions as usize,
+        };
+        if !bytes.is_multiple_of(record_size) {
+            anyhow::bail!(
+                "file size {} for {} is not a multiple of record size {}",
+                bytes,
+                path.display(),
+                record_size
+            );
+        }
+        let total = bytes / record_size;
+        Ok(self.max_vectors.map_or(total, |n| n.min(total)))
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn spawn_base_vector_stream(
+        &self,
+        data_dir: &Path,
+        batch_size: usize,
+    ) -> anyhow::Result<(
+        mpsc::Receiver<anyhow::Result<Option<Vec<Vec<f32>>>>>,
+        thread::JoinHandle<()>,
+    )> {
+        let path = self.base_path(data_dir);
+        let format = self.format;
+        let dimensions = self.dimensions as usize;
+        let max_vectors = self.max_vectors;
+        let normalize = self.normalize;
+        let (tx, rx) = mpsc::channel(1);
+
+        let handle = thread::spawn(move || {
+            let mut reader = match VectorFileBatchReader::open(
+                &path,
+                format,
+                dimensions,
+                max_vectors,
+                normalize,
+            ) {
+                Ok(reader) => reader,
+                Err(err) => {
+                    let _ = tx.blocking_send(Err(err));
+                    return;
+                }
+            };
+
+            loop {
+                match reader.read_batch(batch_size) {
+                    Ok(Some(batch)) => {
+                        if tx.blocking_send(Ok(Some(batch))).is_err() {
+                            return;
+                        }
+                    }
+                    Ok(None) => {
+                        let _ = tx.blocking_send(Ok(None));
+                        return;
+                    }
+                    Err(err) => {
+                        let _ = tx.blocking_send(Err(err));
+                        return;
+                    }
                 }
             }
-            VecFormat::Bvecs => read_bvecs(&path, self.max_vectors),
+        });
+
+        Ok((rx, handle))
+    }
+
+    fn resolve_reader_storage_config(
+        &self,
+        writer_storage: &StorageConfig,
+    ) -> anyhow::Result<StorageConfig> {
+        let Some(path) = &self.reader_storage_config else {
+            return Ok(writer_storage.clone());
+        };
+
+        let override_storage = load_storage_config(path);
+        match (writer_storage, override_storage) {
+            (StorageConfig::SlateDb(writer), StorageConfig::SlateDb(reader)) => {
+                Ok(StorageConfig::SlateDb(SlateDbStorageConfig {
+                    path: writer.path.clone(),
+                    object_store: writer.object_store.clone(),
+                    settings_path: reader.settings_path,
+                    block_cache: reader.block_cache,
+                }))
+            }
+            (_, storage) => Ok(storage),
         }
     }
 
     /// Load query vectors, respecting `format`.
     fn load_query_vectors(&self, data_dir: &Path) -> Vec<Vec<f32>> {
-        let path = data_dir.join(self.query_file);
+        let path = self.query_path(data_dir);
         match self.format {
             VecFormat::Fvecs => read_fvecs(&path)
                 .into_iter()
@@ -271,6 +480,9 @@ impl From<&Dataset> for Params {
         if let Some(ref path) = d.vector_config {
             p.insert("vector_config", path.clone());
         }
+        if let Some(ref path) = d.reader_storage_config {
+            p.insert("reader_storage_config", path.clone());
+        }
         p
     }
 }
@@ -325,6 +537,11 @@ impl From<Params> for Dataset {
                 .get("vector_config")
                 .map(|s| s.to_string())
                 .or_else(|| default.vector_config.clone()),
+            reader_storage_config: p
+                .get("reader_storage_config")
+                .map(|s| s.to_string())
+                .or_else(|| default.reader_storage_config.clone()),
+            normalize: default.normalize,
         }
     }
 }
@@ -344,8 +561,10 @@ const SIFT1M: Dataset = Dataset {
     block_cache_bytes: Some(1073741824),
     data_dir: None,
     vector_config: None,
+    reader_storage_config: None,
     format: VecFormat::Fvecs,
     max_vectors: None,
+    normalize: false,
 };
 
 const COHERE1M: Dataset = Dataset {
@@ -363,8 +582,73 @@ const COHERE1M: Dataset = Dataset {
     block_cache_bytes: None,
     data_dir: None,
     vector_config: None,
+    reader_storage_config: None,
     format: VecFormat::Fvecs,
     max_vectors: None,
+    normalize: false,
+};
+
+const DEEP10M: Dataset = Dataset {
+    name: "deep10m",
+    dimensions: 96,
+    distance_metric: DistanceMetric::L2,
+    base_file: "deep/deep_base.fvecs",
+    query_file: "deep/deep_query.fvecs",
+    ground_truth_file: "deep/deep_groundtruth_10M.ivecs",
+    split_threshold: 1500,
+    merge_threshold: 500,
+    query_pruning_factor: Some(0.5),
+    nprobe: 100,
+    num_queries: DEFAULT_NUM_QUERIES,
+    block_cache_bytes: None,
+    data_dir: None,
+    vector_config: None,
+    reader_storage_config: None,
+    format: VecFormat::Fvecs,
+    max_vectors: Some(10_000_000),
+    normalize: false,
+};
+
+const DEEP1B: Dataset = Dataset {
+    name: "deep1b",
+    dimensions: 96,
+    distance_metric: DistanceMetric::L2,
+    base_file: "deep/deep_base.fvecs",
+    query_file: "deep/deep_query.fvecs",
+    ground_truth_file: "deep/deep_groundtruth_1B.ivecs",
+    split_threshold: 1500,
+    merge_threshold: 500,
+    query_pruning_factor: Some(0.5),
+    nprobe: 100,
+    num_queries: DEFAULT_NUM_QUERIES,
+    block_cache_bytes: None,
+    data_dir: None,
+    vector_config: None,
+    reader_storage_config: None,
+    format: VecFormat::Fvecs,
+    max_vectors: None,
+    normalize: false,
+};
+
+const WIKIPEDIA_BGE_M3_EN: Dataset = Dataset {
+    name: "wikipedia_bge_m3_en",
+    dimensions: 1024,
+    distance_metric: DistanceMetric::DotProduct,
+    base_file: "wikipedia-bge-m3/en/base.fvecs",
+    query_file: "wikipedia-bge-m3/en/query.fvecs",
+    ground_truth_file: "wikipedia-bge-m3/en/groundtruth.ivecs",
+    split_threshold: 1500,
+    merge_threshold: 500,
+    query_pruning_factor: Some(0.5),
+    nprobe: 100,
+    num_queries: DEFAULT_NUM_QUERIES,
+    block_cache_bytes: None,
+    data_dir: None,
+    vector_config: None,
+    reader_storage_config: None,
+    format: VecFormat::Fvecs,
+    max_vectors: None,
+    normalize: false,
 };
 
 // BigANN / SIFT1B variants — all share the same base and query files but
@@ -385,8 +669,10 @@ const SIFT10M: Dataset = Dataset {
     block_cache_bytes: None,
     data_dir: None,
     vector_config: None,
+    reader_storage_config: None,
     format: VecFormat::Bvecs,
     max_vectors: Some(10_000_000),
+    normalize: false,
 };
 
 const SIFT50M: Dataset = Dataset {
@@ -404,8 +690,10 @@ const SIFT50M: Dataset = Dataset {
     block_cache_bytes: None,
     data_dir: None,
     vector_config: None,
+    reader_storage_config: None,
     format: VecFormat::Bvecs,
     max_vectors: Some(50_000_000),
+    normalize: false,
 };
 
 const SIFT100M: Dataset = Dataset {
@@ -423,8 +711,10 @@ const SIFT100M: Dataset = Dataset {
     block_cache_bytes: None,
     data_dir: None,
     vector_config: None,
+    reader_storage_config: None,
     format: VecFormat::Bvecs,
     max_vectors: Some(100_000_000),
+    normalize: false,
 };
 
 const SIFT1B: Dataset = Dataset {
@@ -442,11 +732,23 @@ const SIFT1B: Dataset = Dataset {
     block_cache_bytes: None,
     data_dir: None,
     vector_config: None,
+    reader_storage_config: None,
     format: VecFormat::Bvecs,
     max_vectors: None,
+    normalize: false,
 };
 
-const ALL_DATASETS: &[&Dataset] = &[&SIFT1M, &COHERE1M, &SIFT10M, &SIFT50M, &SIFT100M, &SIFT1B];
+const ALL_DATASETS: &[&Dataset] = &[
+    &SIFT1M,
+    &COHERE1M,
+    &DEEP10M,
+    &DEEP1B,
+    &WIKIPEDIA_BGE_M3_EN,
+    &SIFT10M,
+    &SIFT50M,
+    &SIFT100M,
+    &SIFT1B,
+];
 
 fn lookup_dataset(name: &str) -> Option<&'static Dataset> {
     ALL_DATASETS.iter().find(|d| d.name == name).copied()
@@ -514,39 +816,81 @@ impl Benchmark for RecallBenchmark {
             sb = sb.map_slatedb(|db| db.with_db_cache(std::sync::Arc::new(cache)));
             println!("  Block cache: {} bytes", bytes);
         }
+        let reader_storage = dataset.resolve_reader_storage_config(&config.storage)?;
+        let reader_config = ReaderConfig {
+            storage: reader_storage,
+            dimensions: config.dimensions,
+            distance_metric: config.distance_metric,
+            query_pruning_factor: config.query_pruning_factor,
+            metadata_fields: config.metadata_fields.clone(),
+        };
         let db = VectorDb::open_with_storage(config, sb).await?;
 
         // -- Ingest -----------------------------------------------------------
         let mut ingest_secs = None;
         let mut num_vectors = 0u64;
+
         if skip {
             println!("  Skipping ingest (VECTOR_BENCH_SKIP_INGEST=1)");
         } else {
-            println!("  Loading {} base vectors...", dataset.name);
-            let base_vectors = dataset.load_base_vectors(&data);
+            num_vectors = dataset.estimated_base_vector_count(&data)? as u64;
             println!(
-                "  Loaded {} base vectors (dim={})",
-                base_vectors.len(),
-                dataset.dimensions
+                "  Streaming {} base vectors for {} (dim={}) in chunks of {}",
+                num_vectors, dataset.name, dataset.dimensions, BASE_VECTOR_CHUNK_SIZE
             );
-            num_vectors = base_vectors.len() as u64;
+            let (mut stream, reader_thread) =
+                dataset.spawn_base_vector_stream(&data, BASE_VECTOR_CHUNK_SIZE)?;
+            let Some(first_message) = stream.recv().await else {
+                anyhow::bail!("base vector stream closed before yielding any data");
+            };
+            let Some(mut base_vectors) = first_message? else {
+                anyhow::bail!("dataset {} has no base vectors to ingest", dataset.name);
+            };
 
             let ingest_start = std::time::Instant::now();
-            let batch_size = 10;
-            let num_batches = base_vectors.len().div_ceil(batch_size);
-            for (batch_idx, chunk) in base_vectors.chunks(batch_size).enumerate() {
-                let batch: Vec<Vector> = chunk
-                    .iter()
-                    .enumerate()
-                    .map(|(i, values)| {
-                        let index = batch_idx * batch_size + i;
-                        Vector::new(index.to_string(), values.clone())
-                    })
-                    .collect();
-                db.write(batch).await?;
-                if (batch_idx + 1) % 10_000 == 0 {
-                    println!("  Written batch {}/{}", batch_idx + 1, num_batches);
+            let num_batches = (num_vectors as usize).div_ceil(INGEST_WRITE_BATCH_SIZE);
+            let mut batch_idx = 0usize;
+            let mut vector_offset = 0usize;
+            loop {
+                println!(
+                    "  Loaded chunk: {} vectors ({} / {})",
+                    base_vectors.len(),
+                    vector_offset + base_vectors.len(),
+                    num_vectors
+                );
+                for (chunk_idx, chunk) in base_vectors.chunks(INGEST_WRITE_BATCH_SIZE).enumerate() {
+                    let batch: Vec<Vector> = chunk
+                        .iter()
+                        .enumerate()
+                        .map(|(i, values)| {
+                            let index = vector_offset + chunk_idx * INGEST_WRITE_BATCH_SIZE + i;
+                            Vector::new(index.to_string(), values.clone())
+                        })
+                        .collect();
+                    db.write(batch).await?;
+                    batch_idx += 1;
+                    if batch_idx.is_multiple_of(10_000) {
+                        println!("  Written batch {}/{}", batch_idx, num_batches);
+                    }
                 }
+                vector_offset += base_vectors.len();
+                let Some(message) = stream.recv().await else {
+                    break;
+                };
+                let Some(next_batch) = message? else {
+                    break;
+                };
+                base_vectors = next_batch;
+            }
+            reader_thread
+                .join()
+                .map_err(|_| anyhow::anyhow!("base vector streaming thread panicked"))?;
+            if vector_offset != num_vectors as usize {
+                anyhow::bail!(
+                    "streamed {} vectors but expected {}",
+                    vector_offset,
+                    num_vectors
+                );
             }
             db.flush().await?;
             ingest_secs = Some(ingest_start.elapsed().as_secs_f64());
@@ -559,10 +903,54 @@ impl Benchmark for RecallBenchmark {
         }
         println!("  Num centroids: {}", db.num_centroids());
 
-        // -- Query & measure recall -------------------------------------------
-        println!("start warmup");
-        let query_latency = bench.histogram("cold_query_latency_us");
+        // -- Cold reader queries ----------------------------------------------
+        println!("start cold reader phase");
+        let cold_query_latency = bench.histogram("cold_query_latency_us");
         let mut cold_latencies_us = Vec::with_capacity(queries.len());
+        let object_store = match &reader_config.storage {
+            StorageConfig::SlateDb(slate_config) => {
+                println!("CREATE STATIC OBJECT STORE");
+                Some(create_object_store(&slate_config.object_store)?)
+            }
+            _ => None,
+        };
+        let mut runtime = StorageReaderRuntime::default();
+        if let Some(object_store) = object_store {
+            runtime = runtime.with_object_store(object_store);
+        }
+        for query in queries.iter().take(10) {
+            let reader =
+                VectorDbReader::open_with_runtime(reader_config.clone(), runtime.clone()).await?;
+            let t = std::time::Instant::now();
+            let q = Query::new(query.clone()).with_limit(k);
+            let _ = reader
+                .search_with_options(
+                    &q,
+                    SearchOptions {
+                        nprobe: Some(dataset.nprobe),
+                    },
+                )
+                .await?;
+            let elapsed_us = t.elapsed().as_secs_f64() * 1_000_000.0;
+            cold_query_latency.record(elapsed_us);
+            cold_latencies_us.push(elapsed_us);
+        }
+        cold_latencies_us.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let cold_p50 = percentile(&cold_latencies_us, 50.0);
+        let cold_p90 = percentile(&cold_latencies_us, 90.0);
+        let cold_p99 = percentile(&cold_latencies_us, 99.0);
+        println!(
+            "  cold reader p50 = {:.2} ms, p90 = {:.2} ms, p99 = {:.2} ms",
+            cold_p50 / 1000.0,
+            cold_p90 / 1000.0,
+            cold_p99 / 1000.0
+        );
+        println!("end cold reader phase");
+
+        // -- Warmup -----------------------------------------------------------
+        println!("start warmup");
+        let warm_query_latency = bench.histogram("warm_query_latency_us");
+        let mut warm_latencies_us = Vec::with_capacity(queries.len());
         for query in queries.iter() {
             let t = std::time::Instant::now();
             let q = Query::new(query.clone()).with_limit(k);
@@ -575,12 +963,12 @@ impl Benchmark for RecallBenchmark {
                 )
                 .await?;
             let elapsed_us = t.elapsed().as_secs_f64() * 1_000_000.0;
-            query_latency.record(elapsed_us);
-            cold_latencies_us.push(elapsed_us);
+            warm_query_latency.record(elapsed_us);
+            warm_latencies_us.push(elapsed_us);
         }
-        cold_latencies_us.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        let p90 = percentile(&cold_latencies_us, 90.0);
-        println!("p90 = {:.2}", p90 / 1000.0);
+        warm_latencies_us.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let warm_p90 = percentile(&warm_latencies_us, 90.0);
+        println!("warm p90 = {:.2}", warm_p90 / 1000.0);
         println!("end warmup");
 
         let query_latency = bench.histogram("query_latency_us");
@@ -630,6 +1018,9 @@ impl Benchmark for RecallBenchmark {
             .add("qps", qps)
             .add("num_queries", queries.len() as f64)
             .add("num_centroids", db.num_centroids() as f64)
+            .add("cold_p50_latency_us", cold_p50)
+            .add("cold_p90_latency_us", cold_p90)
+            .add("cold_p99_latency_us", cold_p99)
             .add("p50_latency_us", p50)
             .add("p90_latency_us", p90)
             .add("p99_latency_us", p99);

--- a/vector/src/admin.rs
+++ b/vector/src/admin.rs
@@ -1,0 +1,112 @@
+use crate::db::VectorDb;
+use crate::error::{Error, Result};
+use crate::model::Config;
+use crate::serde::vector_id::VectorId;
+use crate::storage::merge_operator::VectorDbMergeOperator;
+use crate::write::indexer::tree::Indexer;
+use crate::write::indexer::tree::validator::validate as validate_tree_index;
+use common::Storage;
+use common::{StorageBuilder, StorageSemantics};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// Administrative entry point for vector index maintenance.
+///
+/// This API intentionally exposes only coarse-grained maintenance operations
+/// and keeps the tree indexer itself internal.
+pub struct VectorDbAdmin {
+    config: Config,
+    storage: Arc<dyn Storage>,
+}
+
+impl VectorDbAdmin {
+    /// Open a vector database for administrative operations.
+    pub async fn open(config: Config) -> Result<Self> {
+        let merge_op = VectorDbMergeOperator::new(config.dimensions as usize);
+        let storage = StorageBuilder::new(&config.storage)
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to create storage: {e}")))?
+            .with_semantics(StorageSemantics::new().with_merge_operator(Arc::new(merge_op)))
+            .build()
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to create storage: {e}")))?;
+        Ok(Self { config, storage })
+    }
+
+    /// Run one index-maintenance round with no new vector writes.
+    pub async fn index_once(&self) -> Result<()> {
+        let snapshot = self.snapshot().await?;
+        let mut indexer = self.load_indexer(snapshot.clone()).await?;
+        let result = indexer.update_index(vec![], 1, snapshot, 0).await?;
+        if !result.ops.is_empty() {
+            self.storage
+                .apply(result.ops)
+                .await
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            self.storage
+                .flush()
+                .await
+                .map_err(|e| Error::Storage(e.to_string()))?;
+        }
+        Ok(())
+    }
+
+    /// Validate the persisted centroid tree against the reconstructed in-memory state.
+    pub async fn validate_index(&self) -> Result<()> {
+        let snapshot = self.snapshot().await?;
+        let indexer = self.load_indexer(snapshot.clone()).await?;
+        validate_tree_index(snapshot, indexer.state(), self.config.dimensions as usize).await
+    }
+
+    /// Render the current persisted tree state level by level.
+    pub async fn print_tree(&self) -> Result<String> {
+        let snapshot = self.snapshot().await?;
+        let state =
+            VectorDb::load_indexer_state(self.storage.clone(), snapshot, &self.config, 0).await?;
+
+        let mut out = String::new();
+        let depth = state.centroids_meta().depth as u16;
+        out.push_str(&format!("root count={}\n", state.root_centroid_count()));
+
+        let mut by_level: BTreeMap<u16, Vec<(VectorId, u64)>> = BTreeMap::new();
+        for (&centroid_id, centroid) in state.centroids() {
+            let count = state
+                .centroid_counts()
+                .get(&(centroid.level))
+                .and_then(|counts| counts.get(&centroid_id))
+                .copied()
+                .unwrap_or(0);
+            by_level
+                .entry(centroid.level as u16)
+                .or_default()
+                .push((centroid_id, count));
+        }
+
+        for level in (0..depth).rev() {
+            out.push_str(&format!("level {level}\n"));
+            let mut entries = by_level.remove(&level).unwrap_or_default();
+            entries.sort_by_key(|(centroid_id, _)| *centroid_id);
+            for (centroid_id, count) in entries {
+                out.push_str(&format!("  centroid {centroid_id} count={count}\n"));
+            }
+        }
+
+        Ok(out)
+    }
+
+    async fn snapshot(&self) -> Result<Arc<dyn common::storage::StorageSnapshot>> {
+        self.storage
+            .snapshot()
+            .await
+            .map_err(|e| Error::Storage(format!("Failed to create snapshot: {e}")))
+    }
+
+    async fn load_indexer(
+        &self,
+        snapshot: Arc<dyn common::storage::StorageSnapshot>,
+    ) -> Result<Indexer> {
+        let state =
+            VectorDb::load_indexer_state(self.storage.clone(), snapshot, &self.config, 0).await?;
+        Ok(Indexer::new(VectorDb::indexer_opts(&self.config), state))
+    }
+}

--- a/vector/src/bin/admin.rs
+++ b/vector/src/bin/admin.rs
@@ -1,0 +1,55 @@
+use figment::Figment;
+use figment::providers::{Format, Serialized, Yaml};
+use std::env;
+use std::process;
+use tracing_subscriber::EnvFilter;
+use vector::{Config, VectorDbAdmin};
+
+fn load_vector_config(path: &str) -> Config {
+    Figment::from(Serialized::defaults(Config::default()))
+        .merge(Yaml::file(path))
+        .extract()
+        .unwrap_or_else(|e| panic!("Failed to load config file '{}': {}", path, e))
+}
+
+fn usage(program: &str) {
+    eprintln!("Usage: {program} <config.yaml> <index|validate|print-tree>");
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        usage(&args[0]);
+        process::exit(2);
+    }
+
+    let config = load_vector_config(&args[1]);
+    let admin = VectorDbAdmin::open(config).await.unwrap_or_else(|e| {
+        eprintln!("Failed to open vector database admin: {e}");
+        process::exit(1);
+    });
+
+    let result = match args[2].as_str() {
+        "index" => admin.index_once().await,
+        "validate" => admin.validate_index().await,
+        "print-tree" => admin.print_tree().await.map(|tree| {
+            print!("{tree}");
+        }),
+        _ => {
+            usage(&args[0]);
+            process::exit(2);
+        }
+    };
+
+    if let Err(e) = result {
+        eprintln!("Command failed: {e}");
+        process::exit(1);
+    }
+}

--- a/vector/src/bin/gen_deep_groundtruth.rs
+++ b/vector/src/bin/gen_deep_groundtruth.rs
@@ -1,0 +1,427 @@
+//! Generate exact ground truth for DEEP-style datasets from `.fbin` inputs.
+//!
+//! Usage:
+//!   cargo run -p opendata-vector --release --bin gen_deep_groundtruth -- \
+//!     --base-fbin vector/bench/data/deep/base.10M.fbin \
+//!     --query-fbin vector/bench/data/deep/query.public.10K.fbin \
+//!     --output-ivecs vector/bench/data/deep/deep_groundtruth_10M.ivecs \
+//!     --top-k 100
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::fs::File;
+use std::io::{self, BufReader, BufWriter, Read, Write};
+use std::path::{Path, PathBuf};
+
+use rayon::prelude::*;
+
+const DEFAULT_TOP_K: usize = 100;
+const DEFAULT_CHUNK_VECTORS: usize = 16_384;
+const DEFAULT_MAX_QUERIES: usize = 1_000;
+const QUERY_PROGRESS_STEP: usize = 10;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DistanceMetric {
+    L2,
+    DotProduct,
+}
+
+impl DistanceMetric {
+    fn parse(s: &str) -> Self {
+        match s {
+            "l2" => Self::L2,
+            "dot_product" => Self::DotProduct,
+            _ => panic!("unsupported distance metric: {s}"),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct Args {
+    base_fbin: PathBuf,
+    query_fbin: PathBuf,
+    output_ivecs: PathBuf,
+    top_k: usize,
+    chunk_vectors: usize,
+    distance_metric: DistanceMetric,
+    max_base: Option<usize>,
+    max_queries: Option<usize>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct Candidate {
+    id: u32,
+    score: f32,
+}
+
+impl PartialEq for Candidate {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id && self.score.to_bits() == other.score.to_bits()
+    }
+}
+
+impl Eq for Candidate {}
+
+impl PartialOrd for Candidate {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for Candidate {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.score
+            .total_cmp(&other.score)
+            .then_with(|| self.id.cmp(&other.id))
+    }
+}
+
+struct FbinHeader {
+    count: usize,
+    dims: usize,
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = parse_args();
+
+    println!("Loading queries from {}", args.query_fbin.display());
+    let (queries, query_dims) = read_all_fbin(&args.query_fbin, args.max_queries)?;
+    println!(
+        "Loaded {} query vectors (dims={})",
+        queries.len(),
+        query_dims
+    );
+
+    let header = read_fbin_header(&args.base_fbin)?;
+    let total_base = args.max_base.unwrap_or(header.count).min(header.count);
+    if header.dims != query_dims {
+        anyhow::bail!(
+            "dimension mismatch: base dims={}, query dims={}",
+            header.dims,
+            query_dims
+        );
+    }
+    if args.top_k == 0 {
+        anyhow::bail!("--top-k must be > 0");
+    }
+    if total_base < args.top_k {
+        anyhow::bail!(
+            "--top-k ({}) exceeds base vector count ({})",
+            args.top_k,
+            total_base
+        );
+    }
+
+    println!(
+        "Computing exhaustive ground truth for {} base vectors x {} queries, top_k={}, metric={:?}, chunk_vectors={}",
+        total_base,
+        queries.len(),
+        args.top_k,
+        args.distance_metric,
+        args.chunk_vectors
+    );
+
+    let ground_truth = compute_ground_truth(
+        &args.base_fbin,
+        &queries,
+        header.dims,
+        total_base,
+        args.top_k,
+        args.chunk_vectors,
+        args.distance_metric,
+    )?;
+
+    write_ivecs(&args.output_ivecs, &ground_truth)?;
+    println!(
+        "Wrote {} query rows to {}",
+        ground_truth.len(),
+        args.output_ivecs.display()
+    );
+
+    Ok(())
+}
+
+fn parse_args() -> Args {
+    let mut base_fbin = None;
+    let mut query_fbin = None;
+    let mut output_ivecs = None;
+    let mut top_k = DEFAULT_TOP_K;
+    let mut chunk_vectors = DEFAULT_CHUNK_VECTORS;
+    let mut distance_metric = DistanceMetric::L2;
+    let mut max_base = None;
+    let mut max_queries = Some(DEFAULT_MAX_QUERIES);
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--base-fbin" => base_fbin = Some(PathBuf::from(args.next().expect("missing value"))),
+            "--query-fbin" => query_fbin = Some(PathBuf::from(args.next().expect("missing value"))),
+            "--output-ivecs" => {
+                output_ivecs = Some(PathBuf::from(args.next().expect("missing value")))
+            }
+            "--top-k" => {
+                top_k = args
+                    .next()
+                    .expect("missing value")
+                    .parse()
+                    .expect("invalid k")
+            }
+            "--chunk-vectors" => {
+                chunk_vectors = args
+                    .next()
+                    .expect("missing value")
+                    .parse()
+                    .expect("invalid chunk size")
+            }
+            "--distance-metric" => {
+                distance_metric = DistanceMetric::parse(&args.next().expect("missing value"))
+            }
+            "--max-base" => {
+                max_base = Some(
+                    args.next()
+                        .expect("missing value")
+                        .parse()
+                        .expect("invalid max_base"),
+                )
+            }
+            "--max-queries" => {
+                max_queries = Some(
+                    args.next()
+                        .expect("missing value")
+                        .parse()
+                        .expect("invalid max_queries"),
+                )
+            }
+            "--help" | "-h" => {
+                print_usage_and_exit();
+            }
+            other => panic!("unknown argument: {other}"),
+        }
+    }
+
+    Args {
+        base_fbin: base_fbin.unwrap_or_else(|| panic!("missing --base-fbin")),
+        query_fbin: query_fbin.unwrap_or_else(|| panic!("missing --query-fbin")),
+        output_ivecs: output_ivecs.unwrap_or_else(|| panic!("missing --output-ivecs")),
+        top_k,
+        chunk_vectors,
+        distance_metric,
+        max_base,
+        max_queries,
+    }
+}
+
+fn print_usage_and_exit() -> ! {
+    eprintln!(
+        "Usage:
+  cargo run -p opendata-vector --release --bin gen_deep_groundtruth -- \\
+    --base-fbin <path> \\
+    --query-fbin <path> \\
+    --output-ivecs <path> \\
+    [--top-k 100] \\
+    [--chunk-vectors 16384] \\
+    [--distance-metric l2|dot_product] \\
+    [--max-base N] \\
+    [--max-queries N]
+
+Defaults:
+  --max-queries 1000"
+    );
+    std::process::exit(0);
+}
+
+fn read_fbin_header(path: &Path) -> anyhow::Result<FbinHeader> {
+    let mut reader = BufReader::new(File::open(path)?);
+    let count = read_u32(&mut reader)? as usize;
+    let dims = read_u32(&mut reader)? as usize;
+    Ok(FbinHeader { count, dims })
+}
+
+fn read_all_fbin(path: &Path, limit: Option<usize>) -> anyhow::Result<(Vec<Vec<f32>>, usize)> {
+    let mut reader = BufReader::new(File::open(path)?);
+    let count = read_u32(&mut reader)? as usize;
+    let dims = read_u32(&mut reader)? as usize;
+    let rows = limit.unwrap_or(count).min(count);
+    let mut bytes = vec![0u8; rows * dims * 4];
+    reader.read_exact(&mut bytes)?;
+
+    let mut values = Vec::with_capacity(rows);
+    for row in 0..rows {
+        let start = row * dims * 4;
+        let end = start + dims * 4;
+        let mut vector = vec![0f32; dims];
+        let dst =
+            unsafe { std::slice::from_raw_parts_mut(vector.as_mut_ptr() as *mut u8, dims * 4) };
+        dst.copy_from_slice(&bytes[start..end]);
+        values.push(vector);
+    }
+
+    Ok((values, dims))
+}
+
+fn compute_ground_truth(
+    base_fbin: &Path,
+    queries: &[Vec<f32>],
+    dims: usize,
+    total_base: usize,
+    top_k: usize,
+    chunk_vectors: usize,
+    metric: DistanceMetric,
+) -> anyhow::Result<Vec<Vec<i32>>> {
+    let mut reader = BufReader::new(File::open(base_fbin)?);
+    let header_count = read_u32(&mut reader)? as usize;
+    let header_dims = read_u32(&mut reader)? as usize;
+    if header_dims != dims {
+        anyhow::bail!(
+            "base dims changed between reads: expected {}, got {}",
+            dims,
+            header_dims
+        );
+    }
+    if total_base > header_count {
+        anyhow::bail!(
+            "requested {} base vectors but file only has {}",
+            total_base,
+            header_count
+        );
+    }
+
+    let mut heaps = vec![BinaryHeap::<Candidate>::with_capacity(top_k + 1); queries.len()];
+    let bytes_per_vector = dims * 4;
+    let mut processed = 0usize;
+    let mut reported_queries = 0usize;
+
+    while processed < total_base {
+        let rows = (total_base - processed).min(chunk_vectors);
+        let mut bytes = vec![0u8; rows * bytes_per_vector];
+        reader.read_exact(&mut bytes)?;
+
+        let chunk_vectors = bytes_to_vectors(&bytes, rows, dims);
+        let start_id = processed as u32;
+
+        heaps
+            .par_iter_mut()
+            .enumerate()
+            .for_each(|(query_idx, heap)| {
+                process_query_chunk(
+                    heap,
+                    &queries[query_idx],
+                    &chunk_vectors,
+                    start_id,
+                    top_k,
+                    metric,
+                )
+            });
+
+        processed += rows;
+        let completed_queries = processed * queries.len() / total_base;
+        while reported_queries + QUERY_PROGRESS_STEP <= completed_queries {
+            reported_queries += QUERY_PROGRESS_STEP;
+            println!(
+                "  processed ~{}/{} query vectors ({:.1}%)",
+                reported_queries,
+                queries.len(),
+                processed as f64 * 100.0 / total_base as f64
+            );
+        }
+    }
+
+    if reported_queries < queries.len() {
+        println!(
+            "  processed {}/{} query vectors (100.0%)",
+            queries.len(),
+            queries.len()
+        );
+    }
+
+    heaps
+        .into_iter()
+        .map(|heap| finalize_heap(heap, top_k))
+        .collect::<anyhow::Result<Vec<_>>>()
+}
+
+fn bytes_to_vectors(bytes: &[u8], rows: usize, dims: usize) -> Vec<Vec<f32>> {
+    let mut out = Vec::with_capacity(rows);
+    for row in 0..rows {
+        let start = row * dims * 4;
+        let end = start + dims * 4;
+        let mut vector = vec![0f32; dims];
+        let dst =
+            unsafe { std::slice::from_raw_parts_mut(vector.as_mut_ptr() as *mut u8, dims * 4) };
+        dst.copy_from_slice(&bytes[start..end]);
+        out.push(vector);
+    }
+    out
+}
+
+fn process_query_chunk(
+    heap: &mut BinaryHeap<Candidate>,
+    query: &[f32],
+    base_chunk: &[Vec<f32>],
+    start_id: u32,
+    top_k: usize,
+    metric: DistanceMetric,
+) {
+    for (offset, base) in base_chunk.iter().enumerate() {
+        let score = match metric {
+            DistanceMetric::L2 => l2_distance(query, base),
+            DistanceMetric::DotProduct => -dot_product(query, base),
+        };
+        let candidate = Candidate {
+            id: start_id + offset as u32,
+            score,
+        };
+
+        if heap.len() < top_k {
+            heap.push(candidate);
+            continue;
+        }
+
+        if let Some(worst) = heap.peek()
+            && candidate < *worst
+        {
+            heap.pop();
+            heap.push(candidate);
+        }
+    }
+}
+
+fn finalize_heap(mut heap: BinaryHeap<Candidate>, top_k: usize) -> anyhow::Result<Vec<i32>> {
+    if heap.len() != top_k {
+        anyhow::bail!(
+            "expected heap size {}, got {} while finalizing ground truth",
+            top_k,
+            heap.len()
+        );
+    }
+
+    let mut values = heap.drain().collect::<Vec<_>>();
+    values.sort_by(|a, b| a.score.total_cmp(&b.score).then_with(|| a.id.cmp(&b.id)));
+    Ok(values.into_iter().map(|c| c.id as i32).collect())
+}
+
+fn l2_distance(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(x, y)| (x - y) * (x - y)).sum()
+}
+
+fn dot_product(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
+}
+
+fn read_u32(reader: &mut impl Read) -> io::Result<u32> {
+    let mut buf = [0u8; 4];
+    reader.read_exact(&mut buf)?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+fn write_ivecs(path: &Path, rows: &[Vec<i32>]) -> anyhow::Result<()> {
+    let file = File::create(path)?;
+    let mut writer = BufWriter::new(file);
+    for row in rows {
+        writer.write_all(&(row.len() as u32).to_le_bytes())?;
+        let bytes = unsafe { std::slice::from_raw_parts(row.as_ptr() as *const u8, row.len() * 4) };
+        writer.write_all(bytes)?;
+    }
+    writer.flush()?;
+    Ok(())
+}

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -118,8 +118,6 @@ pub trait VectorDbRead {
 pub(crate) struct LastAppliedSnapshot {
     pub(crate) snapshot: Arc<dyn StorageSnapshot>,
     pub(crate) centroid_index: Arc<LeveledCentroidIndex<'static>>,
-    // TODO: clean me up
-    #[allow(dead_code)]
     pub(crate) centroid_cache: Arc<AllCentroidsCache>,
     pub(crate) centroid_count: usize,
 }
@@ -761,6 +759,20 @@ impl VectorDb {
             .lock()
             .expect("lock_poisoned")
             .centroid_count
+    }
+
+    pub async fn validate_cache(&self) {
+        let las = self
+            .last_applied_snapshot
+            .lock()
+            .expect("lock_poisoned")
+            .clone();
+        crate::write::indexer::tree::validator::validate_state_and_storage_consistent(
+            &las,
+            self.config.dimensions as usize,
+        )
+        .await
+        .expect("validation failed");
     }
 
     /// Create a QueryEngine from the current snapshot for executing queries.

--- a/vector/src/lib.rs
+++ b/vector/src/lib.rs
@@ -31,6 +31,9 @@
 //! # }
 //! ```
 
+extern crate core;
+
+pub mod admin;
 pub mod db;
 pub(crate) mod error;
 pub mod hnsw;
@@ -48,6 +51,7 @@ pub(crate) mod test_utils;
 pub(crate) mod write;
 
 // Public API exports
+pub use admin::VectorDbAdmin;
 pub use db::{VectorDb, VectorDbRead};
 pub use error::{Error, Result};
 pub use model::{

--- a/vector/src/storage/mod.rs
+++ b/vector/src/storage/mod.rs
@@ -224,7 +224,6 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
         Ok(centroids)
     }
 
-    #[allow(dead_code)]
     async fn scan_all_posting_lists(
         &self,
         dimensions: usize,

--- a/vector/src/write/flusher.rs
+++ b/vector/src/write/flusher.rs
@@ -93,6 +93,14 @@ impl Flusher<VectorDbWriteDelta> for VectorDbFlusher {
 }
 
 impl VectorDbFlusher {
+    #[allow(unused_variables)]
+    async fn validate(&self, snapshot: Arc<dyn StorageSnapshot>) {
+        #[cfg(debug_assertions)]
+        {
+            self.indexer.validate(snapshot).await;
+        }
+    }
+
     async fn apply_and_snapshot(
         &mut self,
         index_outputs: IndexUpdateResults,
@@ -104,6 +112,7 @@ impl VectorDbFlusher {
             .map_err(|e| e.to_string())?;
 
         let snapshot = self.storage.snapshot().await.map_err(|e| e.to_string())?;
+        self.validate(snapshot.clone()).await;
         let stored_reader = StoredCentroidReader::new(
             self.opts.dimensions as usize,
             snapshot.clone(),

--- a/vector/src/write/indexer/tree/mod.rs
+++ b/vector/src/write/indexer/tree/mod.rs
@@ -18,6 +18,8 @@ use crate::write::indexer::tree::state::{VectorIndexDelta, VectorIndexState, Vec
 use crate::write::indexer::tree::vector::{ReassignVectors, WriteVectors};
 use common::StorageRead;
 use common::storage::RecordOp;
+#[cfg(debug_assertions)]
+use common::storage::StorageSnapshot;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
@@ -31,6 +33,7 @@ mod split;
 pub(crate) mod state;
 #[cfg(test)]
 pub(crate) mod test_utils;
+pub(crate) mod validator;
 mod vector;
 
 #[derive(Debug, Default)]
@@ -76,8 +79,6 @@ impl Indexer {
         }
     }
 
-    // TODO: clean me up
-    #[allow(dead_code)]
     pub(crate) fn state(&self) -> &VectorIndexState {
         &self.state
     }
@@ -311,6 +312,13 @@ impl Indexer {
             leaf_centroids: self.leaf_centroid_count(),
             centroid_tree_depth: TreeDepth::of(self.state.centroids_meta().depth),
         })
+    }
+
+    #[cfg(debug_assertions)]
+    pub(crate) async fn validate(&self, snapshot: Arc<dyn StorageSnapshot>) {
+        validator::validate(snapshot, &self.state, self.opts.dimensions)
+            .await
+            .expect("validation failed");
     }
 
     async fn reassign_vectors(

--- a/vector/src/write/indexer/tree/state.rs
+++ b/vector/src/write/indexer/tree/state.rs
@@ -83,8 +83,6 @@ impl VectorIndexState {
         &self.centroid_counts
     }
 
-    // TODO: clean me up
-    #[allow(dead_code)]
     pub(crate) fn root_centroid_count(&self) -> u64 {
         self.root_centroid_count
     }

--- a/vector/src/write/indexer/tree/test_utils.rs
+++ b/vector/src/write/indexer/tree/test_utils.rs
@@ -10,7 +10,7 @@ use crate::write::delta::VectorWrite;
 use crate::write::indexer::tree::centroids::AllCentroidsCacheWriter;
 use crate::write::indexer::tree::posting_list::PostingList;
 use crate::write::indexer::tree::state::{VectorIndexDelta, VectorIndexState};
-use crate::write::indexer::tree::{IndexerOpts, vector::WriteVectors};
+use crate::write::indexer::tree::{IndexerOpts, validator, vector::WriteVectors};
 use common::storage::in_memory::InMemoryStorage;
 use common::{SequenceAllocator, Storage, StorageRead};
 use std::collections::HashMap;
@@ -270,8 +270,6 @@ impl IndexerOpTestHarnessBuilder {
 pub struct IndexerOpTestHarness {
     pub storage: Arc<dyn Storage>,
     pub state: VectorIndexState,
-    // TODO: clean me up
-    #[allow(dead_code)]
     dimensions: usize,
     vector_schema: Vec<MetadataFieldSpec>,
 }
@@ -299,13 +297,10 @@ impl IndexerOpTestHarness {
     }
 
     pub async fn validate(&self) {
-        // TODO: clean me up
-        /*
         let snapshot = self.storage.snapshot().await.unwrap();
         validator::validate(snapshot, &self.state, self.dimensions)
             .await
             .unwrap();
-         */
     }
 }
 
@@ -339,9 +334,7 @@ fn assert_attributes_conform_to_schema(
 }
 
 #[allow(dead_code)]
-pub async fn validate_harness(_harness: &IndexerOpTestHarness) -> Result<()> {
-    // TODO: clean me up
-    /*let snapshot = harness.storage.snapshot().await.unwrap();
-    validator::validate(snapshot, &harness.state, harness.dimensions).await*/
-    Ok(())
+pub async fn validate_harness(harness: &IndexerOpTestHarness) -> Result<()> {
+    let snapshot = harness.storage.snapshot().await.unwrap();
+    validator::validate(snapshot, &harness.state, harness.dimensions).await
 }

--- a/vector/src/write/indexer/tree/validator.rs
+++ b/vector/src/write/indexer/tree/validator.rs
@@ -1,0 +1,922 @@
+use crate::Error;
+use crate::Result;
+use crate::db::LastAppliedSnapshot;
+use crate::serde::centroid_info::CentroidInfoValue;
+use crate::serde::centroids::CentroidsValue;
+use crate::serde::vector_id::{LEAF_LEVEL, ROOT_VECTOR_ID, VectorId};
+use crate::storage::VectorDbStorageReadExt;
+use crate::write::indexer::tree::centroids::{CentroidCache, TreeDepth, TreeLevel};
+use crate::write::indexer::tree::posting_list::PostingList;
+use crate::write::indexer::tree::state::VectorIndexState;
+use common::StorageRead;
+use common::storage::StorageSnapshot;
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Instant;
+use tracing::debug;
+
+pub(crate) async fn validate(
+    snapshot: Arc<dyn StorageSnapshot>,
+    state: &VectorIndexState,
+    dimensions: usize,
+) -> Result<()> {
+    let validate_start = Instant::now();
+    let centroids_meta = snapshot
+        .get_centroids_meta()
+        .await?
+        .ok_or_else(|| Error::Internal("missing centroid tree metadata".to_string()))?;
+    if centroids_meta.depth == 0 {
+        return Err(Error::Internal(
+            "centroid tree depth must be at least 1".to_string(),
+        ));
+    }
+
+    let root_posting_list =
+        PostingList::from_value(snapshot.get_root_posting_list(dimensions).await?);
+    let centroid_info: HashMap<VectorId, CentroidInfoValue> = snapshot
+        .scan_all_centroid_info()
+        .await?
+        .into_iter()
+        .collect();
+    let centroid_counts = load_centroid_counts(snapshot.as_ref()).await?;
+    let centroid_postings = load_centroid_postings(snapshot.as_ref(), dimensions).await?;
+
+    let mut reachable_centroids = HashSet::new();
+    let mut reachable_counts = HashMap::new();
+    validate_root(
+        &centroids_meta,
+        &root_posting_list,
+        &centroid_info,
+        &centroid_counts,
+        &centroid_postings,
+        &mut reachable_centroids,
+        &mut reachable_counts,
+    )?;
+    validate_reachability(
+        &centroid_info,
+        &centroid_counts,
+        &centroid_postings,
+        &reachable_centroids,
+        &reachable_counts,
+    )?;
+    validate_state_matches_storage(
+        state,
+        &centroids_meta,
+        &root_posting_list,
+        &centroid_info,
+        &centroid_counts,
+        &centroid_postings,
+    )?;
+
+    debug!(
+        op = "validate_tree_index",
+        elapsed_ms = validate_start.elapsed().as_millis() as u64,
+        centroid_count = centroid_info.len(),
+        stats_count = centroid_counts.len(),
+        "completed"
+    );
+    Ok(())
+}
+
+pub(crate) async fn validate_state_and_storage_consistent(
+    last_applied_snapshot: &LastAppliedSnapshot,
+    dimensions: usize,
+) -> Result<()> {
+    let snapshot = last_applied_snapshot.snapshot.clone();
+    let _centroids_meta = snapshot
+        .get_centroids_meta()
+        .await?
+        .ok_or_else(|| Error::Internal("missing centroid tree metadata".to_string()))?;
+    let storage_root = PostingList::from_value(snapshot.get_root_posting_list(dimensions).await?);
+    let cached_root = last_applied_snapshot
+        .centroid_cache
+        .root(u64::MAX)
+        .ok_or_else(|| {
+            Error::Internal("centroid cache is missing the root posting list".to_string())
+        })?;
+    validate_exact_posting_list_match(ROOT_VECTOR_ID, &storage_root, cached_root.as_ref())?;
+
+    let centroid_postings = load_centroid_postings(snapshot.as_ref(), dimensions).await?;
+    validate_cached_subtree(
+        last_applied_snapshot.centroid_cache.as_ref(),
+        &centroid_postings,
+        &storage_root,
+    )?;
+    Ok(())
+}
+
+fn validate_root(
+    centroids_meta: &CentroidsValue,
+    root_posting_list: &PostingList,
+    centroid_info: &HashMap<VectorId, CentroidInfoValue>,
+    centroid_counts: &HashMap<(u8, VectorId), u64>,
+    centroid_postings: &HashMap<VectorId, PostingList>,
+    reachable_centroids: &mut HashSet<VectorId>,
+    reachable_counts: &mut HashMap<(u8, VectorId), u64>,
+) -> Result<()> {
+    debug!("validate root");
+    let depth = TreeDepth::of(centroids_meta.depth);
+    let root_level = TreeLevel::root(depth);
+    let mut root_children = HashSet::new();
+    for posting in root_posting_list.iter() {
+        if !root_children.insert(posting.id()) {
+            return Err(Error::Internal(format!(
+                "duplicate centroid {} in root posting list",
+                posting.id()
+            )));
+        }
+        let centroid = centroid_info.get(&posting.id()).ok_or_else(|| {
+            Error::Internal(format!(
+                "root references centroid {} that has no centroid info",
+                posting.id()
+            ))
+        })?;
+        validate_centroid_reference(
+            posting.id(),
+            centroid,
+            posting.vector(),
+            root_level.next_level_down(),
+            ROOT_VECTOR_ID,
+            reachable_centroids,
+        )?;
+        validate_centroid_subtree(
+            root_level.next_level_down(),
+            posting.id(),
+            centroid,
+            centroid_info,
+            centroid_counts,
+            centroid_postings,
+            reachable_centroids,
+            reachable_counts,
+        )?;
+    }
+    debug!("validated root successfully");
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn validate_centroid_subtree(
+    level: TreeLevel,
+    centroid_id: VectorId,
+    centroid: &CentroidInfoValue,
+    centroid_info: &HashMap<VectorId, CentroidInfoValue>,
+    centroid_counts: &HashMap<(u8, VectorId), u64>,
+    centroid_postings: &HashMap<VectorId, PostingList>,
+    reachable_centroids: &mut HashSet<VectorId>,
+    reachable_counts: &mut HashMap<(u8, VectorId), u64>,
+) -> Result<()> {
+    debug!("validate centroid {} subtree", centroid_id);
+    assert_eq!(level.level(), centroid_id.level());
+    let posting_list = centroid_postings
+        .get(&centroid_id)
+        .cloned()
+        .unwrap_or_else(PostingList::empty);
+    let actual_count = posting_list.len() as u64;
+    let Some(stored_count) = centroid_counts.get(&(centroid.level, centroid_id)) else {
+        return Err(Error::Internal(format!(
+            "missing centroid stats for level {}/{}",
+            centroid.level, centroid_id
+        )));
+    };
+    if *stored_count != actual_count {
+        return Err(Error::Internal(format!(
+            "centroid stats mismatch for level {}/{}: stats={}, postings={}",
+            centroid.level, centroid_id, stored_count, actual_count
+        )));
+    }
+    if reachable_counts
+        .insert((centroid.level, centroid_id), actual_count)
+        .is_some()
+    {
+        return Err(Error::Internal(format!(
+            "centroid stats visited multiple times for level {}/{}",
+            centroid.level, centroid_id
+        )));
+    }
+
+    if centroid.level == LEAF_LEVEL {
+        return Ok(());
+    }
+
+    let expected_child_level = level.next_level_down();
+    let mut child_ids = HashSet::new();
+    for child in posting_list.iter() {
+        if !child_ids.insert(child.id()) {
+            return Err(Error::Internal(format!(
+                "duplicate child centroid {} in posting list for {}/{}",
+                child.id(),
+                centroid.level,
+                centroid_id
+            )));
+        }
+        let child_info = centroid_info.get(&child.id()).ok_or_else(|| {
+            Error::Internal(format!(
+                "centroid {}/{} references child {} with no centroid info",
+                centroid.level,
+                centroid_id,
+                child.id()
+            ))
+        })?;
+        validate_centroid_reference(
+            child.id(),
+            child_info,
+            child.vector(),
+            expected_child_level,
+            centroid_id,
+            reachable_centroids,
+        )?;
+        validate_centroid_subtree(
+            expected_child_level,
+            child.id(),
+            child_info,
+            centroid_info,
+            centroid_counts,
+            centroid_postings,
+            reachable_centroids,
+            reachable_counts,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_centroid_reference(
+    centroid_id: VectorId,
+    centroid: &CentroidInfoValue,
+    vector: &[f32],
+    expected_level: TreeLevel,
+    expected_parent: VectorId,
+    reachable_centroids: &mut HashSet<VectorId>,
+) -> Result<()> {
+    if centroid.level != expected_level.level() {
+        return Err(Error::Internal(format!(
+            "centroid {} has level {}, expected {}",
+            centroid_id, centroid.level, expected_level
+        )));
+    }
+    if centroid.parent_vector_id != expected_parent {
+        return Err(Error::Internal(format!(
+            "centroid {}/{} has parent {:?}, expected {:?}",
+            centroid.level, centroid_id, centroid.parent_vector_id, expected_parent
+        )));
+    }
+    if centroid.vector.as_slice() != vector {
+        return Err(Error::Internal(format!(
+            "centroid {}/{} vector does not match parent posting entry",
+            centroid.level, centroid_id
+        )));
+    }
+    if !reachable_centroids.insert(centroid_id) {
+        return Err(Error::Internal(format!(
+            "centroid {}/{} is reachable multiple times",
+            centroid.level, centroid_id
+        )));
+    }
+    Ok(())
+}
+
+fn validate_reachability(
+    centroid_info: &HashMap<VectorId, CentroidInfoValue>,
+    centroid_counts: &HashMap<(u8, VectorId), u64>,
+    centroid_postings: &HashMap<VectorId, PostingList>,
+    reachable_centroids: &HashSet<VectorId>,
+    reachable_counts: &HashMap<(u8, VectorId), u64>,
+) -> Result<()> {
+    let stale_centroids = centroid_info
+        .keys()
+        .filter(|centroid_id| !reachable_centroids.contains(centroid_id))
+        .copied()
+        .collect::<BTreeSet<_>>();
+    if !stale_centroids.is_empty() {
+        return Err(Error::Internal(format!(
+            "stale centroid info entries found: {:?}",
+            stale_centroids
+        )));
+    }
+
+    let stale_counts = centroid_counts
+        .keys()
+        .filter(|key| !reachable_counts.contains_key(key))
+        .copied()
+        .collect::<BTreeSet<_>>();
+    if !stale_counts.is_empty() {
+        return Err(Error::Internal(format!(
+            "stale centroid stats entries found: {:?}",
+            stale_counts
+        )));
+    }
+
+    let stale_postings = centroid_postings
+        .keys()
+        .filter(|centroid_id| {
+            **centroid_id != ROOT_VECTOR_ID && !reachable_centroids.contains(centroid_id)
+        })
+        .copied()
+        .collect::<BTreeSet<_>>();
+    if !stale_postings.is_empty() {
+        return Err(Error::Internal(format!(
+            "stale centroid posting lists found: {:?}",
+            stale_postings
+        )));
+    }
+
+    Ok(())
+}
+
+fn validate_state_matches_storage(
+    state: &VectorIndexState,
+    centroids_meta: &CentroidsValue,
+    root_posting_list: &PostingList,
+    centroid_info: &HashMap<VectorId, CentroidInfoValue>,
+    centroid_counts: &HashMap<(u8, VectorId), u64>,
+    centroid_postings: &HashMap<VectorId, PostingList>,
+) -> Result<()> {
+    if state.centroids_meta() != centroids_meta {
+        return Err(Error::Internal(format!(
+            "in-memory centroid metadata {:?} does not match storage {:?}",
+            state.centroids_meta(),
+            centroids_meta
+        )));
+    }
+    if state.root_centroid_count() != root_posting_list.len() as u64 {
+        return Err(Error::Internal(format!(
+            "in-memory root centroid count {} does not match storage {}",
+            state.root_centroid_count(),
+            root_posting_list.len()
+        )));
+    }
+    if state.centroids() != centroid_info {
+        return Err(Error::Internal(
+            "in-memory centroid info map does not match storage".to_string(),
+        ));
+    }
+
+    let state_counts = flatten_state_counts(state.centroid_counts());
+    if state_counts != *centroid_counts {
+        return Err(Error::Internal(format!(
+            "in-memory centroid stats do not match storage: state={:?}, storage={:?}",
+            state_counts, centroid_counts
+        )));
+    }
+
+    let centroid_cache = state.centroid_cache();
+    let Some(cached_root) = centroid_cache.root(u64::MAX) else {
+        return Err(Error::Internal(
+            "centroid cache is missing the root posting list".to_string(),
+        ));
+    };
+    if cached_root.as_ref() != root_posting_list {
+        return Err(Error::Internal(
+            "cached root posting list does not match storage".to_string(),
+        ));
+    }
+
+    for (&centroid_id, centroid) in centroid_info {
+        let storage_posting = centroid_postings
+            .get(&centroid_id)
+            .cloned()
+            .unwrap_or_else(PostingList::empty);
+        if centroid.level == 0 {
+            if centroid_cache.posting(centroid_id, u64::MAX).is_some() {
+                return Err(Error::Internal(format!(
+                    "leaf centroid {}/{} should not be present in centroid cache",
+                    centroid.level, centroid_id
+                )));
+            }
+            continue;
+        }
+
+        match centroid_cache.posting(centroid_id, u64::MAX) {
+            Some(cached_posting) => {
+                assert!(centroid_id.level() > 1);
+                let cached_posting = cached_posting
+                    .iter()
+                    .map(|p| p.id())
+                    .collect::<HashSet<_>>();
+                let storage_posting = storage_posting
+                    .iter()
+                    .map(|p| p.id())
+                    .collect::<HashSet<_>>();
+                if cached_posting != storage_posting {
+                    return Err(Error::Internal(format!(
+                        "cached posting list for centroid {}/{} does not match storage {:?} {:?}",
+                        centroid.level, centroid_id, storage_posting, cached_posting
+                    )));
+                }
+            }
+            None if storage_posting.is_empty() => {}
+            None => {
+                if centroid_id.level() > 1 {
+                    return Err(Error::Internal(format!(
+                        "centroid cache is missing internal centroid {}/{}",
+                        centroid.level, centroid_id
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_cached_subtree(
+    centroid_cache: &dyn CentroidCache,
+    centroid_postings: &HashMap<VectorId, PostingList>,
+    posting_list: &PostingList,
+) -> Result<()> {
+    for posting in posting_list.iter() {
+        let centroid_id = posting.id();
+        if centroid_id.level() == LEAF_LEVEL {
+            if centroid_cache.posting(centroid_id, u64::MAX).is_some() {
+                return Err(Error::Internal(format!(
+                    "leaf centroid {} should not be present in centroid cache",
+                    centroid_id
+                )));
+            }
+            continue;
+        }
+
+        let storage_posting = centroid_postings.get(&centroid_id).ok_or_else(|| {
+            Error::Internal(format!(
+                "storage is missing posting list for cached centroid {}",
+                centroid_id
+            ))
+        })?;
+        let cached_posting = centroid_cache
+            .posting(centroid_id, u64::MAX)
+            .ok_or_else(|| {
+                Error::Internal(format!(
+                    "centroid cache is missing internal centroid {}",
+                    centroid_id
+                ))
+            })?;
+        validate_exact_posting_list_match(centroid_id, storage_posting, cached_posting.as_ref())?;
+        validate_cached_subtree(centroid_cache, centroid_postings, storage_posting)?;
+    }
+    Ok(())
+}
+
+fn validate_exact_posting_list_match(
+    centroid_id: VectorId,
+    storage_posting: &PostingList,
+    cached_posting: &PostingList,
+) -> Result<()> {
+    debug!(
+        "cached: {:?}",
+        cached_posting.iter().map(|p| p.id()).collect::<Vec<_>>()
+    );
+    debug!(
+        "root: {:?}",
+        storage_posting.iter().map(|p| p.id()).collect::<Vec<_>>()
+    );
+    if storage_posting.len() != cached_posting.len() {
+        return Err(Error::Internal(format!(
+            "posting list length mismatch for {}: storage={}, cache={}",
+            centroid_id,
+            storage_posting.len(),
+            cached_posting.len()
+        )));
+    }
+
+    let mut storage_posting = storage_posting.iter().cloned().collect::<Vec<_>>();
+    storage_posting.sort_by_key(|a| a.id());
+    let mut cached_posting = cached_posting.iter().cloned().collect::<Vec<_>>();
+    cached_posting.sort_by_key(|a| a.id());
+
+    for (storage, cached) in storage_posting.iter().zip(cached_posting.iter()) {
+        if storage != cached {
+            return Err(Error::Internal(format!(
+                "posting list mismatch for {}: storage={:?}, cache={:?}",
+                centroid_id, storage, cached
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+async fn load_centroid_counts(snapshot: &dyn StorageRead) -> Result<HashMap<(u8, VectorId), u64>> {
+    let mut counts = HashMap::new();
+    for (centroid_id, value) in snapshot.scan_all_centroid_stats().await? {
+        if value.num_vectors < 0 {
+            return Err(Error::Internal(format!(
+                "negative centroid count for level {}: {}",
+                centroid_id, value.num_vectors
+            )));
+        }
+        counts.insert((centroid_id.level(), centroid_id), value.num_vectors as u64);
+    }
+    Ok(counts)
+}
+
+async fn load_centroid_postings(
+    snapshot: &dyn StorageRead,
+    dimensions: usize,
+) -> Result<HashMap<VectorId, PostingList>> {
+    Ok(snapshot
+        .scan_all_posting_lists(dimensions)
+        .await?
+        .into_iter()
+        .map(|(centroid_id, posting_list)| (centroid_id, PostingList::from_value(posting_list)))
+        .collect())
+}
+
+fn flatten_state_counts(
+    centroid_counts: &HashMap<u8, HashMap<VectorId, u64>>,
+) -> HashMap<(u8, VectorId), u64> {
+    centroid_counts
+        .iter()
+        .flat_map(|(&level, counts)| {
+            counts
+                .iter()
+                .map(move |(&centroid_id, &count)| (level, centroid_id, count))
+        })
+        .map(|(level, centroid_id, count)| ((level, centroid_id), count))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::LastAppliedSnapshot;
+    use crate::serde::centroid_stats::CentroidStatsValue;
+    use crate::serde::collection_meta::DistanceMetric;
+    use crate::serde::key::{CentroidInfoKey, CentroidStatsKey, CentroidsKey, PostingListKey};
+    use crate::serde::posting_list::{PostingListValue, PostingUpdate};
+    use crate::serde::vector_id::{ROOT_VECTOR_ID, VectorId};
+    use crate::storage::merge_operator::VectorDbMergeOperator;
+    use crate::write::indexer::tree::centroids::{
+        AllCentroidsCacheWriter, CachedCentroidReader, CentroidCache, LeveledCentroidIndex,
+        StoredCentroidReader,
+    };
+    use crate::write::indexer::tree::posting_list::Posting;
+    use bytes::Bytes;
+    use common::storage::in_memory::InMemoryStorage;
+    use common::{Record, SequenceAllocator, Storage};
+
+    const DIMS: usize = 2;
+
+    fn centroid_id(level: u8, id: u64) -> VectorId {
+        VectorId::centroid_id(level, id)
+    }
+
+    fn root_posting_id(depth: u8, id: u64) -> VectorId {
+        centroid_id(TreeDepth::of(depth).max_inner_level(), id)
+    }
+
+    #[tokio::test]
+    async fn should_validate_consistent_root_only_tree() {
+        let storage = create_storage();
+        let root = vec![(1, vec![1.0, 0.0]), (2, vec![0.0, 1.0])];
+        write_tree(
+            &storage,
+            3,
+            root.clone(),
+            vec![
+                (1, CentroidInfoValue::new(1, vec![1.0, 0.0], ROOT_VECTOR_ID)),
+                (2, CentroidInfoValue::new(1, vec![0.0, 1.0], ROOT_VECTOR_ID)),
+            ],
+            vec![((1, 1), 0), ((1, 2), 0)],
+            vec![],
+        )
+        .await;
+        let snapshot = storage.snapshot().await.unwrap();
+        let state = create_state(storage.clone(), snapshot.clone(), 3, root, vec![]).await;
+
+        let result = validate(snapshot, &state, DIMS).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn should_reject_stale_centroid_info_entries() {
+        let storage = create_storage();
+        let root = vec![(1, vec![1.0, 0.0]), (2, vec![0.0, 1.0])];
+        write_tree(
+            &storage,
+            3,
+            root.clone(),
+            vec![
+                (1, CentroidInfoValue::new(1, vec![1.0, 0.0], ROOT_VECTOR_ID)),
+                (2, CentroidInfoValue::new(1, vec![0.0, 1.0], ROOT_VECTOR_ID)),
+                (3, CentroidInfoValue::new(1, vec![2.0, 2.0], ROOT_VECTOR_ID)),
+            ],
+            vec![((1, 1), 0), ((1, 2), 0), ((1, 3), 0)],
+            vec![],
+        )
+        .await;
+        let snapshot = storage.snapshot().await.unwrap();
+        let state = create_state(storage.clone(), snapshot.clone(), 3, root, vec![]).await;
+
+        let result = validate(snapshot, &state, DIMS).await;
+
+        assert_eq!(
+            result,
+            Err(Error::Internal(
+                "stale centroid info entries found: {1:3}".to_string()
+            ))
+        );
+    }
+
+    #[tokio::test]
+    async fn should_validate_cached_root_and_internal_centroids_against_storage() {
+        let storage = create_storage();
+        let root = vec![(10, vec![1.0, 0.0]), (11, vec![0.0, 1.0])];
+        write_tree(
+            &storage,
+            4,
+            root.clone(),
+            vec![
+                (
+                    10,
+                    CentroidInfoValue::new(2, vec![1.0, 0.0], ROOT_VECTOR_ID),
+                ),
+                (
+                    11,
+                    CentroidInfoValue::new(2, vec![0.0, 1.0], ROOT_VECTOR_ID),
+                ),
+                (
+                    20,
+                    CentroidInfoValue::new(1, vec![1.0, 1.0], centroid_id(2, 10)),
+                ),
+                (
+                    21,
+                    CentroidInfoValue::new(1, vec![1.0, 2.0], centroid_id(2, 10)),
+                ),
+                (
+                    22,
+                    CentroidInfoValue::new(1, vec![2.0, 1.0], centroid_id(2, 11)),
+                ),
+            ],
+            vec![
+                ((2, 10), 2),
+                ((2, 11), 1),
+                ((1, 20), 0),
+                ((1, 21), 0),
+                ((1, 22), 0),
+            ],
+            vec![
+                (10, vec![(20, vec![1.0, 1.0]), (21, vec![1.0, 2.0])]),
+                (11, vec![(22, vec![2.0, 1.0])]),
+            ],
+        )
+        .await;
+        let snapshot = storage.snapshot().await.unwrap();
+        let cache = build_last_applied_snapshot(
+            storage.clone(),
+            snapshot.clone(),
+            4,
+            root,
+            vec![
+                (10, vec![(20, vec![1.0, 1.0]), (21, vec![1.0, 2.0])]),
+                (11, vec![(22, vec![2.0, 1.0])]),
+            ],
+        )
+        .await;
+
+        let result = validate_state_and_storage_consistent(&cache, DIMS).await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn should_reject_when_cached_internal_posting_differs_from_storage() {
+        let storage = create_storage();
+        let root = vec![(10, vec![1.0, 0.0])];
+        write_tree(
+            &storage,
+            4,
+            root.clone(),
+            vec![
+                (
+                    10,
+                    CentroidInfoValue::new(2, vec![1.0, 0.0], ROOT_VECTOR_ID),
+                ),
+                (
+                    20,
+                    CentroidInfoValue::new(1, vec![1.0, 1.0], centroid_id(2, 10)),
+                ),
+            ],
+            vec![((2, 10), 1), ((1, 20), 0)],
+            vec![(10, vec![(20, vec![1.0, 1.0])])],
+        )
+        .await;
+        let snapshot = storage.snapshot().await.unwrap();
+        let cache = build_last_applied_snapshot(
+            storage.clone(),
+            snapshot.clone(),
+            4,
+            root,
+            vec![(10, vec![(21, vec![9.0, 9.0])])],
+        )
+        .await;
+
+        let result = validate_state_and_storage_consistent(&cache, DIMS).await;
+
+        assert_eq!(
+            result,
+            Err(Error::Internal(
+                "posting list mismatch for 2:10: storage=Posting { id: 1:20, vector: [1.0, 1.0] }, cache=Posting { id: 1:21, vector: [9.0, 9.0] }".to_string()
+            ))
+        );
+    }
+
+    fn create_storage() -> Arc<dyn Storage> {
+        Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
+            VectorDbMergeOperator::new(DIMS),
+        )))
+    }
+
+    #[allow(clippy::type_complexity)]
+    async fn create_state(
+        storage: Arc<dyn Storage>,
+        snapshot: Arc<dyn StorageSnapshot>,
+        depth: u8,
+        root: Vec<(u64, Vec<f32>)>,
+        centroid_postings: Vec<(u64, Vec<(u64, Vec<f32>)>)>,
+    ) -> VectorIndexState {
+        let seq_key = Bytes::from_static(&[0x01, 0x02]);
+        let id_allocator = SequenceAllocator::load(storage.as_ref(), seq_key)
+            .await
+            .unwrap();
+        let centroid_seq_key = Bytes::from_static(&[0x01, 0x03]);
+        let centroid_id_allocator = SequenceAllocator::load(storage.as_ref(), centroid_seq_key)
+            .await
+            .unwrap();
+        let (seq_block_key, seq_block) = id_allocator.freeze();
+        let (centroid_seq_block_key, centroid_seq_block) = centroid_id_allocator.freeze();
+
+        let centroids: HashMap<VectorId, CentroidInfoValue> = snapshot
+            .scan_all_centroid_info()
+            .await
+            .unwrap()
+            .into_iter()
+            .collect();
+        let centroid_counts = snapshot
+            .scan_all_centroid_stats()
+            .await
+            .unwrap()
+            .into_iter()
+            .fold(HashMap::new(), |mut counts, (centroid_id, value)| {
+                counts
+                    .entry(centroid_id.level())
+                    .or_insert_with(HashMap::new)
+                    .insert(centroid_id, value.num_vectors as u64);
+                counts
+            });
+        let centroid_cache = AllCentroidsCacheWriter::new(
+            Arc::new(
+                root.into_iter()
+                    .map(|(id, vector)| Posting::new(root_posting_id(depth, id), vector))
+                    .collect::<PostingList>(),
+            ),
+            centroid_postings
+                .into_iter()
+                .map(|(centroid_num, postings)| {
+                    (
+                        root_posting_id(depth, centroid_num),
+                        Arc::new(
+                            postings
+                                .into_iter()
+                                .map(|(id, vector)| {
+                                    Posting::new(VectorId::data_vector_id(id), vector)
+                                })
+                                .collect::<PostingList>(),
+                        ),
+                    )
+                })
+                .collect(),
+        );
+
+        let _opts = DistanceMetric::L2;
+        VectorIndexState::new(
+            HashMap::new(),
+            CentroidsValue::new(depth),
+            snapshot
+                .get_root_posting_list(DIMS)
+                .await
+                .unwrap()
+                .postings
+                .len() as u64,
+            centroids,
+            centroid_counts,
+            seq_block_key,
+            seq_block,
+            centroid_seq_block_key,
+            centroid_seq_block,
+            centroid_cache,
+        )
+    }
+
+    #[allow(clippy::type_complexity)]
+    async fn build_last_applied_snapshot(
+        _storage: Arc<dyn Storage>,
+        snapshot: Arc<dyn StorageSnapshot>,
+        depth: u8,
+        root: Vec<(u64, Vec<f32>)>,
+        centroid_postings: Vec<(u64, Vec<(u64, Vec<f32>)>)>,
+    ) -> LastAppliedSnapshot {
+        let centroid_cache = AllCentroidsCacheWriter::new(
+            Arc::new(
+                root.clone()
+                    .into_iter()
+                    .map(|(id, vector)| Posting::new(root_posting_id(depth, id), vector))
+                    .collect::<PostingList>(),
+            ),
+            centroid_postings
+                .into_iter()
+                .map(|(centroid_num, postings)| {
+                    (
+                        root_posting_id(depth, centroid_num),
+                        Arc::new(
+                            postings
+                                .into_iter()
+                                .map(|(id, vector)| Posting::new(centroid_id(1, id), vector))
+                                .collect::<PostingList>(),
+                        ),
+                    )
+                })
+                .collect(),
+        );
+        let query_cache = Arc::new(centroid_cache.cache());
+        let stored_reader = StoredCentroidReader::new(DIMS, snapshot.clone(), 0);
+        let cached_reader = CachedCentroidReader::new(
+            &(query_cache.clone() as Arc<dyn CentroidCache>),
+            stored_reader,
+        );
+        let centroid_index = LeveledCentroidIndex::new(
+            TreeDepth::of(depth),
+            DistanceMetric::L2,
+            Arc::new(cached_reader),
+        );
+        LastAppliedSnapshot {
+            snapshot,
+            centroid_cache: query_cache,
+            centroid_index: Arc::new(centroid_index),
+            centroid_count: 0,
+        }
+    }
+
+    #[allow(clippy::type_complexity)]
+    async fn write_tree(
+        storage: &Arc<dyn Storage>,
+        depth: u8,
+        root: Vec<(u64, Vec<f32>)>,
+        centroid_info: Vec<(u64, CentroidInfoValue)>,
+        centroid_stats: Vec<((u8, u64), i32)>,
+        centroid_postings: Vec<(u64, Vec<(u64, Vec<f32>)>)>,
+    ) {
+        let mut ops = Vec::new();
+        ops.push(
+            Record::new(
+                CentroidsKey::new().encode(),
+                CentroidsValue::new(depth).encode_to_bytes(),
+            )
+            .into(),
+        );
+        ops.push(
+            Record::new(
+                PostingListKey::new(ROOT_VECTOR_ID).encode(),
+                posting_list_value(TreeDepth::of(depth).max_inner_level(), root).encode_to_bytes(),
+            )
+            .into(),
+        );
+        for (centroid_num, value) in centroid_info {
+            ops.push(
+                Record::new(
+                    CentroidInfoKey::new(centroid_id(value.level, centroid_num)).encode(),
+                    value.encode_to_bytes(),
+                )
+                .into(),
+            );
+        }
+        for ((level, centroid_num), count) in centroid_stats {
+            ops.push(
+                Record::new(
+                    CentroidStatsKey::new(centroid_id(level, centroid_num)).encode(),
+                    CentroidStatsValue::new(count).encode_to_bytes(),
+                )
+                .into(),
+            );
+        }
+        for (centroid_id, postings) in centroid_postings {
+            ops.push(
+                Record::new(
+                    PostingListKey::new(root_posting_id(depth, centroid_id)).encode(),
+                    posting_list_value(1, postings).encode_to_bytes(),
+                )
+                .into(),
+            );
+        }
+        storage.put(ops).await.unwrap();
+    }
+
+    fn posting_list_value(level: u8, postings: Vec<(u64, Vec<f32>)>) -> PostingListValue {
+        PostingListValue::from_posting_updates(
+            postings
+                .into_iter()
+                .map(|(id, vector)| PostingUpdate::append(centroid_id(level, id), vector))
+                .collect(),
+        )
+        .unwrap()
+    }
+}

--- a/vector/tests/sift1m.rs
+++ b/vector/tests/sift1m.rs
@@ -224,8 +224,7 @@ async fn sift100k_recall() {
     db.flush().await.expect("failed to flush");
     println!("Ingested all base vectors");
 
-    // TODO: clean me up
-    // db.validate_cache().await;
+    db.validate_cache().await;
     println!("validated cache");
 
     // Query and measure recall using first 1000 queries


### PR DESCRIPTION
## Summary

This patch adds a validator module that runs bulk validation of the on-disk index to check that its internally consistent. Validation is run by tests and via a newly added admin tool

Also adds a README for running the different dataset benchmarks

## Test Plan

This is mostly test code 

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
