### PR TITLE
common: add status method in Storage trait for health checks, #165

### DIFF
--- a/common/src/storage/in_memory.rs
+++ b/common/src/storage/in_memory.rs
@@ -442,6 +442,11 @@ impl Storage for InMemoryStorage {
         }
         Ok(())
     }
+
+    async fn status(&self) -> StorageResult<()> {
+        // No-op for in-memory storage
+        Ok(())
+    }
 }
 
 /// Injected failure that fires either once or on every call.
@@ -629,6 +634,11 @@ impl super::Storage for FailingStorage {
     async fn flush(&self) -> super::StorageResult<()> {
         check_failure(&self.fail_flush)?;
         self.inner.flush().await
+    }
+
+    async fn status(&self) -> super::StorageResult<()> {
+        // No-op for in-memory storage
+        self.inner.status().await
     }
 }
 

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -368,4 +368,7 @@ pub trait Storage: StorageRead {
     /// `DbStatus::durable_seq`. For in-memory storage, writes are immediately
     /// "durable" so the watermark matches the latest written seqnum.
     fn subscribe_durable(&self) -> tokio::sync::watch::Receiver<u64>;
+
+    /// Returns the status of the storage engine.
+    async fn status(&self) -> StorageResult<()>;
 }

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -343,6 +343,15 @@ impl Storage for SlateDbStorage {
         self.db.flush().await.map_err(StorageError::from_storage)?;
         Ok(())
     }
+
+    async fn status(&self) -> StorageResult<()> {
+        // fetch status from slatedb
+        let mut status = self.db.as_ref().subscribe();
+        status
+            .changed()
+            .await
+            .map_err(|e| StorageError::Storage(e.to_string()))
+    }
 }
 
 impl From<Ttl> for slatedb::config::Ttl {

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -311,6 +311,14 @@ impl LogDb {
         Ok(())
     }
 
+    /// Fetch status from the underlying storage.
+    pub async fn status(&self) -> Result<()> {
+        self.storage
+            .status()
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))
+    }
+
     /// Creates a LogDb from an existing storage implementation.
     #[cfg(test)]
     pub(crate) async fn new(storage: Arc<dyn common::Storage>) -> Result<Self> {

--- a/log/src/server/handlers.rs
+++ b/log/src/server/handlers.rs
@@ -231,8 +231,13 @@ pub async fn handle_metrics(State(state): State<AppState>) -> String {
 /// Handle GET /-/healthy
 ///
 /// Returns 200 OK if the service is running.
-pub async fn handle_healthy() -> (axum::http::StatusCode, &'static str) {
-    (axum::http::StatusCode::OK, "OK")
+pub async fn handle_healthy(
+    State(state): State<AppState>,
+) -> (axum::http::StatusCode, &'static str) {
+    match state.log.as_ref().status().await {
+        Ok(_) => (axum::http::StatusCode::OK, "OK"),
+        Err(_) => (axum::http::StatusCode::SERVICE_UNAVAILABLE, "Not Ready"),
+    }
 }
 
 /// Handle GET /-/ready
@@ -265,10 +270,14 @@ mod tests {
 
     #[tokio::test]
     async fn should_return_ok_for_healthy() {
+        let log = Arc::new(LogDb::open(test_config()).await.unwrap());
+        let metrics = Arc::new(Metrics::new());
+        let state = AppState { log, metrics };
         // given/when
-        let (status, body) = handle_healthy().await;
+        let (status, body) = handle_healthy(State(state)).await;
 
         // then
+        // should return OK in case of InMemory Log backend
         assert_eq!(status, StatusCode::OK);
         assert_eq!(body, "OK");
     }
@@ -388,6 +397,10 @@ mod tests {
             }
 
             async fn flush(&self) -> common::StorageResult<()> {
+                self.check_failure()
+            }
+
+            async fn status(&self) -> common::StorageResult<()> {
                 self.check_failure()
             }
         }

--- a/timeseries/src/server/http.rs
+++ b/timeseries/src/server/http.rs
@@ -659,9 +659,19 @@ async fn handle_healthy() -> (StatusCode, &'static str) {
 }
 
 /// Handle /-/ready endpoint - returns 200 OK if service is ready to serve requests
-async fn handle_ready(State(_state): State<AppState>) -> (StatusCode, &'static str) {
+async fn handle_ready(State(state): State<AppState>) -> (StatusCode, String) {
     // Service is ready if it's running (TSDB is initialized in AppState)
-    (StatusCode::OK, "OK")
+    if let Some(tsdb) = state.tsdb.as_tsdb() {
+        match tsdb.as_ref().status().await {
+            Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+            Ok(_) => (StatusCode::OK, "OK".to_string()),
+        }
+    } else {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Tsdb not initialized".to_string(),
+        )
+    }
 }
 
 /// Handle /-/flush endpoint - flushes buffered data to durable storage

--- a/timeseries/src/tsdb.rs
+++ b/timeseries/src/tsdb.rs
@@ -1233,6 +1233,14 @@ impl Tsdb {
 
         Ok(entries)
     }
+
+    pub(crate) async fn status(&self) -> Result<()> {
+        self.storage
+            .as_ref()
+            .status()
+            .await
+            .map_err(|e| crate::error::Error::Storage(e.to_string()))
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary

What does this PR do?
Added status method in [Storage](https://github.com/opendata-oss/opendata/blob/30d8bad7385e147aff50ae9fda2f535fdce6f817/common/src/storage/mod.rs#L250).

Implement status for Inmemory & SlateDB storage backend, update the `/health` endpoint in `opendata-log` and `opendata-timeseries` to delegate to the storage status.

## Related Issues

Fixes: #165 

## Test Plan

How was this tested? Existing Unit tests.

## Checklist

- [X] Tests added/updated
- [X] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
