### PR TITLE
docs(timeseries): clarify promqltest ignore semantics

### DIFF
--- a/timeseries/src/promql/promqltest/README.md
+++ b/timeseries/src/promql/promqltest/README.md
@@ -72,7 +72,7 @@ The test format follows [Prometheus's promqltest specification](https://promethe
 
 ### Ignore and Resume Directives
 
-The `ignore` directive skips all subsequent commands until `resume` or `clear`. This allows copying test files directly from Prometheus's test suite while marking unimplemented features.
+The `ignore` directive skips all subsequent commands until `resume`. This allows copying test files directly from Prometheus's test suite while marking unimplemented features.
 
 ```
 # Working features


### PR DESCRIPTION

Clarifies the promqltest README for ignore semantics. The previous wording said ignore lasted until resume or clear, but the implementation actually keeps ignore mode active until resume.

## Test Plan
Verified by inspecting the promqltest parser and runner logic.

## Checklist

- [ ] Tests added/updated
- [ ] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
