### PR TITLE
upgrade slatedb to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2574,8 +2574,8 @@ dependencies = [
  "criterion",
  "foyer",
  "futures",
+ "metrics",
  "opendata-macros",
- "prometheus-client",
  "proptest",
  "serde",
  "serde_yaml",
@@ -2629,6 +2629,8 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "clap",
+ "metrics",
+ "metrics-exporter-prometheus",
  "opendata-common",
  "opendata-macros",
  "prometheus-client",
@@ -2694,7 +2696,6 @@ dependencies = [
  "opendata-ingest",
  "opendata-macros",
  "opentelemetry-proto",
- "prometheus-client",
  "promql-parser",
  "proptest",
  "prost",
@@ -4044,11 +4045,12 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slatedb"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d945c6cd6f239873e640c5b7bb204f5638ed5681b02145cdcc2e80b2d3882b8a"
+checksum = "8c5a80caa3ae5d5ca404b3c22a4d7ba235798a011641eda24b629d1b7fc203dc"
 dependencies = [
  "anyhow",
+ "async-channel",
  "async-trait",
  "atomic",
  "backon",
@@ -4091,19 +4093,21 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2893ff22bb9a1013af0fb5e85380307ccd9d0a4fa8a111e187a48750e14b9a47"
+checksum = "d6f4df716813038071acf5a21046494493dcce21e8d1b90d04035d01a23e45c2"
 dependencies = [
  "chrono",
+ "log",
+ "serde",
  "tokio",
 ]
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c33d5597404e23b9706aa32a1723399f022f0513a289d1059df8810a282dcc4"
+checksum = "be31b387569b0d71ea08b0ad94ed8cb0c2e8cb8b31e737086c79bbe90c978249"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ serde_json = "1.0"
 serde_with = { version = "3", features = ["base64"] }
 serde_yaml = "0.9"
 foyer = "0.18"
-slatedb = "0.11.2"
-slatedb-common = "0.11.1"
+slatedb = "0.12.0"
+slatedb-common = "0.12.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full", "test-util"] }
 tokio-util = "0.7"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -15,21 +15,21 @@ path = "src/lib.rs"
 
 [features]
 default = []
-metrics = ["dep:prometheus-client"]
 test-utils = ["dep:arc-swap"]
 
 [dependencies]
 slatedb.workspace = true
+slatedb-common.workspace = true
 foyer.workspace = true
 bytes.workspace = true
 futures.workspace = true
 async-trait.workspace = true
+metrics.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 uuid.workspace = true
 serde.workspace = true
-prometheus-client = { version = "0.22", optional = true }
 arc-swap = { version = "1", optional = true }
 
 [dev-dependencies]

--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use super::config::{BlockCacheConfig, ObjectStoreConfig, StorageConfig};
 use super::in_memory::InMemoryStorage;
+use super::metrics_recorder::MetricsRsRecorder;
 use super::slate::{SlateDbStorage, SlateDbStorageReader};
 use super::{MergeOperator, Storage, StorageError, StorageRead, StorageResult};
 use slatedb::DbReader;
@@ -135,6 +136,7 @@ impl StorageBuilder {
             }
             StorageBuilderInner::SlateDb(db_builder) => {
                 let mut db_builder = *db_builder;
+                db_builder = db_builder.with_metrics_recorder(Arc::new(MetricsRsRecorder));
                 if let Some(op) = self.semantics.merge_operator {
                     let adapter = SlateDbStorage::merge_operator_adapter(op);
                     db_builder = db_builder.with_merge_operator(Arc::new(adapter));
@@ -300,27 +302,22 @@ pub async fn create_storage_read(
                 create_object_store(&slate_config.object_store)?
             };
 
-            let mut options = reader_options;
+            let mut builder = DbReader::builder(slate_config.path.clone(), object_store)
+                .with_options(reader_options)
+                .with_metrics_recorder(Arc::new(MetricsRsRecorder));
             if let Some(op) = semantics.merge_operator {
                 let adapter = SlateDbStorage::merge_operator_adapter(op);
-                options.merge_operator = Some(Arc::new(adapter));
+                builder = builder.with_merge_operator(Arc::new(adapter));
             }
             // Prefer runtime-provided cache, fall back to config
             if let Some(cache) = runtime.block_cache {
-                options.block_cache = Some(cache);
+                builder = builder.with_db_cache(cache);
             } else if let Some(cache) =
                 create_block_cache_from_config(&slate_config.block_cache).await?
             {
-                options.block_cache = Some(cache);
+                builder = builder.with_db_cache(cache);
             }
-            let reader = DbReader::open(
-                slate_config.path.clone(),
-                object_store,
-                None, // checkpoint_id - use latest state
-                options,
-            )
-            .await
-            .map_err(|e| {
+            let reader = builder.build().await.map_err(|e| {
                 StorageError::Storage(format!("Failed to create SlateDB reader: {}", e))
             })?;
             Ok(Arc::new(SlateDbStorageReader::new(Arc::new(reader))))

--- a/common/src/storage/metrics_recorder.rs
+++ b/common/src/storage/metrics_recorder.rs
@@ -1,0 +1,109 @@
+//! Bridge from slatedb's [`MetricsRecorder`] trait to the `metrics` crate.
+//!
+//! Slatedb calls `register_*` during DB construction; each call is forwarded
+//! to the `metrics` global recorder so that slatedb metrics appear alongside
+//! application metrics on the Prometheus `/metrics` endpoint.
+
+use slatedb_common::metrics::{CounterFn, GaugeFn, HistogramFn, MetricsRecorder, UpDownCounterFn};
+use std::sync::Arc;
+
+/// [`MetricsRecorder`] implementation that forwards to the `metrics` crate.
+///
+/// Metric names are forwarded as-is (dot-separated, e.g.
+/// `slatedb.db.write_ops`). Labels become `metrics::Label`s. Descriptions
+/// are registered via `metrics::describe_*`.
+pub struct MetricsRsRecorder;
+
+impl MetricsRecorder for MetricsRsRecorder {
+    fn register_counter(
+        &self,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+    ) -> Arc<dyn CounterFn> {
+        let name = name.to_string();
+        let labels = to_labels(labels);
+        metrics::describe_counter!(name.clone(), description.to_string());
+        Arc::new(CounterHandle(metrics::counter!(name, labels)))
+    }
+
+    fn register_gauge(
+        &self,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+    ) -> Arc<dyn GaugeFn> {
+        let name = name.to_string();
+        let labels = to_labels(labels);
+        metrics::describe_gauge!(name.clone(), description.to_string());
+        Arc::new(GaugeHandle(metrics::gauge!(name, labels)))
+    }
+
+    fn register_up_down_counter(
+        &self,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+    ) -> Arc<dyn UpDownCounterFn> {
+        // metrics-rs has no up-down counter; map to a gauge with increment.
+        let name = name.to_string();
+        let labels = to_labels(labels);
+        metrics::describe_gauge!(name.clone(), description.to_string());
+        Arc::new(UpDownCounterHandle(metrics::gauge!(name, labels)))
+    }
+
+    fn register_histogram(
+        &self,
+        name: &str,
+        description: &str,
+        labels: &[(&str, &str)],
+        _boundaries: &[f64],
+    ) -> Arc<dyn HistogramFn> {
+        // Bucket boundaries are configured on the PrometheusBuilder, not here.
+        let name = name.to_string();
+        let labels = to_labels(labels);
+        metrics::describe_histogram!(name.clone(), description.to_string());
+        Arc::new(HistogramHandle(metrics::histogram!(name, labels)))
+    }
+}
+
+fn to_labels(labels: &[(&str, &str)]) -> Vec<metrics::Label> {
+    labels
+        .iter()
+        .map(|(k, v)| metrics::Label::new(k.to_string(), v.to_string()))
+        .collect()
+}
+
+// -- Handle wrappers --
+
+struct CounterHandle(metrics::Counter);
+
+impl CounterFn for CounterHandle {
+    fn increment(&self, value: u64) {
+        self.0.increment(value);
+    }
+}
+
+struct GaugeHandle(metrics::Gauge);
+
+impl GaugeFn for GaugeHandle {
+    fn set(&self, value: i64) {
+        self.0.set(value as f64);
+    }
+}
+
+struct UpDownCounterHandle(metrics::Gauge);
+
+impl UpDownCounterFn for UpDownCounterHandle {
+    fn increment(&self, value: i64) {
+        self.0.increment(value as f64);
+    }
+}
+
+struct HistogramHandle(metrics::Histogram);
+
+impl HistogramFn for HistogramHandle {
+    fn record(&self, value: f64) {
+        self.0.record(value);
+    }
+}

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -2,6 +2,7 @@ pub mod config;
 pub mod factory;
 pub mod in_memory;
 pub mod loader;
+pub mod metrics_recorder;
 pub mod slate;
 pub mod util;
 
@@ -365,12 +366,4 @@ pub trait Storage: StorageRead {
     /// `DbStatus::durable_seq`. For in-memory storage, writes are immediately
     /// "durable" so the watermark matches the latest written seqnum.
     fn subscribe_durable(&self) -> tokio::sync::watch::Receiver<u64>;
-
-    /// Registers storage engine metrics into the given Prometheus registry.
-    ///
-    /// The default implementation is a no-op. Storage backends that expose
-    /// internal metrics (e.g., SlateDB) override this to register gauges
-    /// that read live values on each scrape.
-    #[cfg(feature = "metrics")]
-    fn register_metrics(&self, _registry: &mut prometheus_client::registry::Registry) {}
 }

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -10,37 +10,13 @@ use crate::{
 };
 use async_trait::async_trait;
 use bytes::Bytes;
+use slatedb::IterationOrder;
 use slatedb::config::ScanOptions;
 use slatedb::{
     Db, DbIterator, DbReader, DbSnapshot, MergeOperator as SlateDbMergeOperator,
     MergeOperatorError, WriteBatch, config::WriteOptions as SlateDbWriteOptions,
 };
 use tokio::sync::watch;
-
-/// Thin wrapper that exposes a SlateDB [`ReadableStat`] as a Prometheus gauge.
-///
-/// Instead of snapshotting stats into an intermediate representation and
-/// refreshing gauges, this reads the live atomic value on each encode/scrape.
-#[cfg(feature = "metrics")]
-#[derive(Debug)]
-struct ReadableStatGauge(std::sync::Arc<dyn slatedb::stats::ReadableStat>);
-
-#[cfg(feature = "metrics")]
-impl prometheus_client::encoding::EncodeMetric for ReadableStatGauge {
-    fn encode(
-        &self,
-        mut encoder: prometheus_client::encoding::MetricEncoder,
-    ) -> Result<(), std::fmt::Error> {
-        encoder.encode_gauge(&self.0.get())
-    }
-
-    fn metric_type(&self) -> prometheus_client::metrics::MetricType {
-        match self.0.metric_type() {
-            slatedb::stats::MetricType::Counter => prometheus_client::metrics::MetricType::Counter,
-            slatedb::stats::MetricType::Gauge => prometheus_client::metrics::MetricType::Gauge,
-        }
-    }
-}
 
 /// Adapter that wraps our `MergeOperator` trait to implement SlateDB's `MergeOperator` trait.
 ///
@@ -86,6 +62,7 @@ fn default_scan_options() -> ScanOptions {
         read_ahead_bytes: 1024 * 1024,
         cache_blocks: true,
         max_fetch_tasks: 4,
+        order: IterationOrder::Ascending,
     }
 }
 
@@ -341,38 +318,6 @@ impl Storage for SlateDbStorage {
         self.db.close().await.map_err(StorageError::from_storage)?;
         Ok(())
     }
-
-    #[cfg(feature = "metrics")]
-    fn register_metrics(&self, registry: &mut prometheus_client::registry::Registry) {
-        let stat_registry = self.db.metrics();
-        let mut seen = std::collections::HashSet::new();
-        for name in stat_registry.names() {
-            if let Some(stat) = stat_registry.lookup(name) {
-                let sanitized: String = name
-                    .chars()
-                    .map(|c| {
-                        if c.is_ascii_alphanumeric() || c == '_' {
-                            c
-                        } else {
-                            '_'
-                        }
-                    })
-                    .collect();
-                let prom_name = format!("slatedb_{sanitized}");
-                if !seen.insert(prom_name.clone()) {
-                    tracing::warn!(
-                        "Duplicate metric name after sanitization: {prom_name:?} (from {name:?}, skipped)"
-                    );
-                    continue;
-                }
-                registry.register(
-                    &prom_name,
-                    format!("SlateDB {name}"),
-                    ReadableStatGauge(stat),
-                );
-            }
-        }
-    }
 }
 
 impl From<Ttl> for slatedb::config::Ttl {
@@ -451,7 +396,7 @@ mod tests {
     use super::*;
     use crate::BytesRange;
     use slatedb::DbBuilder;
-    use slatedb::config::{DbReaderOptions, Settings};
+    use slatedb::config::Settings;
     use slatedb::object_store::memory::InMemory;
     use slatedb_common::clock::MockSystemClock;
 
@@ -477,9 +422,7 @@ mod tests {
         storage.flush().await.unwrap();
 
         // Create reader and verify data
-        let reader = DbReader::open(path, object_store, None, Default::default())
-            .await
-            .unwrap();
+        let reader = DbReader::builder(path, object_store).build().await.unwrap();
         let storage_reader = SlateDbStorageReader::new(Arc::new(reader));
 
         let record = storage_reader.get(Bytes::from("key1")).await.unwrap();
@@ -519,9 +462,7 @@ mod tests {
         storage.flush().await.unwrap();
 
         // Create reader and scan data
-        let reader = DbReader::open(path, object_store, None, Default::default())
-            .await
-            .unwrap();
+        let reader = DbReader::builder(path, object_store).build().await.unwrap();
         let storage_reader = SlateDbStorageReader::new(Arc::new(reader));
 
         let mut iter = storage_reader
@@ -563,9 +504,7 @@ mod tests {
         storage.flush().await.unwrap();
 
         // Create reader while writer is still open - this should NOT cause fencing error
-        let reader = DbReader::open(path, object_store, None, Default::default())
-            .await
-            .unwrap();
+        let reader = DbReader::builder(path, object_store).build().await.unwrap();
         let storage_reader = SlateDbStorageReader::new(Arc::new(reader));
 
         // Reader can read the data
@@ -586,7 +525,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_expire_records_based_on_ttl() {
+    async fn should_set_expire_ts_based_on_ttl() {
         // given - storage configured with a 30 second default TTL
         let object_store = Arc::new(InMemory::new());
         let path = "/test/ttl_db";
@@ -627,28 +566,17 @@ mod tests {
             .await
             .unwrap();
 
-        // then - all three keys are present at time=0
-        assert!(storage.get(Bytes::from("key1")).await.unwrap().is_some());
-        assert!(storage.get(Bytes::from("key2")).await.unwrap().is_some());
-        assert!(storage.get(Bytes::from("key3")).await.unwrap().is_some());
+        // then - key1 has expire_ts = 20_000 (time=0 + 20s TTL)
+        let kv1 = storage.db.get_key_value(b"key1").await.unwrap().unwrap();
+        assert_eq!(kv1.expire_ts, Some(20_000));
 
-        // when - advance to 25 seconds
-        clock.set(25_000);
+        // then - key2 has expire_ts = 30_000 (time=0 + 30s default TTL)
+        let kv2 = storage.db.get_key_value(b"key2").await.unwrap().unwrap();
+        assert_eq!(kv2.expire_ts, Some(30_000));
 
-        // then - key1 (20s TTL) expired; key2 (30s default) and key3 (no expiry) still present
-        assert!(storage.get(Bytes::from("key1")).await.unwrap().is_none());
-        assert!(storage.get(Bytes::from("key2")).await.unwrap().is_some());
-        assert!(storage.get(Bytes::from("key3")).await.unwrap().is_some());
-
-        // when - advance to 35 seconds
-        clock.set(35_000);
-
-        // then - key1 and key2 expired; key3 (no expiry) still present with correct value
-        assert!(storage.get(Bytes::from("key1")).await.unwrap().is_none());
-        assert!(storage.get(Bytes::from("key2")).await.unwrap().is_none());
-        let record = storage.get(Bytes::from("key3")).await.unwrap();
-        assert!(record.is_some());
-        assert_eq!(record.unwrap().value, Bytes::from("value3"));
+        // then - key3 has no expire_ts (NoExpiry)
+        let kv3 = storage.db.get_key_value(b"key3").await.unwrap().unwrap();
+        assert_eq!(kv3.expire_ts, None);
 
         storage.close().await.unwrap();
     }
@@ -672,7 +600,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_expire_merge_records_based_on_ttl() {
+    async fn should_set_expire_ts_on_merge_records_based_on_ttl() {
         // given - storage configured with a 30 second default TTL and a merge operator
         let object_store = Arc::new(InMemory::new());
         let path = "/test/merge_ttl_db";
@@ -716,52 +644,20 @@ mod tests {
             .await
             .unwrap();
 
-        // then - all three keys are present at time=0
-        assert_eq!(
-            storage
-                .get(Bytes::from("key1"))
-                .await
-                .unwrap()
-                .unwrap()
-                .value,
-            Bytes::from("v1")
-        );
-        assert_eq!(
-            storage
-                .get(Bytes::from("key2"))
-                .await
-                .unwrap()
-                .unwrap()
-                .value,
-            Bytes::from("v2")
-        );
-        assert_eq!(
-            storage
-                .get(Bytes::from("key3"))
-                .await
-                .unwrap()
-                .unwrap()
-                .value,
-            Bytes::from("v3")
-        );
+        // then - key1 has expire_ts = 20_000 (time=0 + 20s TTL)
+        let kv1 = storage.db.get_key_value(b"key1").await.unwrap().unwrap();
+        assert_eq!(kv1.value, Bytes::from("v1"));
+        assert_eq!(kv1.expire_ts, Some(20_000));
 
-        // when - advance to 25 seconds
-        clock.set(25_000);
+        // then - key2 has expire_ts = 30_000 (time=0 + 30s default TTL)
+        let kv2 = storage.db.get_key_value(b"key2").await.unwrap().unwrap();
+        assert_eq!(kv2.value, Bytes::from("v2"));
+        assert_eq!(kv2.expire_ts, Some(30_000));
 
-        // then - key1 (20s TTL) expired; key2 (30s default) and key3 (no expiry) still present
-        assert!(storage.get(Bytes::from("key1")).await.unwrap().is_none());
-        assert!(storage.get(Bytes::from("key2")).await.unwrap().is_some());
-        assert!(storage.get(Bytes::from("key3")).await.unwrap().is_some());
-
-        // when - advance to 35 seconds
-        clock.set(35_000);
-
-        // then - key1 and key2 expired; key3 (no expiry) still present with correct value
-        assert!(storage.get(Bytes::from("key1")).await.unwrap().is_none());
-        assert!(storage.get(Bytes::from("key2")).await.unwrap().is_none());
-        let record = storage.get(Bytes::from("key3")).await.unwrap();
-        assert!(record.is_some());
-        assert_eq!(record.unwrap().value, Bytes::from("v3"));
+        // then - key3 has no expire_ts (NoExpiry)
+        let kv3 = storage.db.get_key_value(b"key3").await.unwrap().unwrap();
+        assert_eq!(kv3.value, Bytes::from("v3"));
+        assert_eq!(kv3.expire_ts, None);
 
         storage.close().await.unwrap();
     }
@@ -778,13 +674,11 @@ mod tests {
         key: &str,
         merge_op: Option<Arc<dyn SlateDbMergeOperator + Send + Sync>>,
     ) -> bool {
-        let options = DbReaderOptions {
-            merge_operator: merge_op,
-            ..Default::default()
-        };
-        let reader = DbReader::open(path, object_store, None, options)
-            .await
-            .unwrap();
+        let mut builder = DbReader::builder(path, object_store);
+        if let Some(op) = merge_op {
+            builder = builder.with_merge_operator(op);
+        }
+        let reader = builder.build().await.unwrap();
         let storage_reader = SlateDbStorageReader::new(Arc::new(reader));
         storage_reader
             .get(Bytes::from(key.to_owned()))
@@ -980,64 +874,5 @@ mod tests {
         );
 
         storage.close().await.unwrap();
-    }
-}
-
-#[cfg(all(test, feature = "metrics"))]
-mod metrics_tests {
-    use super::ReadableStatGauge;
-    use prometheus_client::encoding::EncodeMetric;
-    use slatedb::stats::{MetricType as SlateMetricType, ReadableStat};
-    use std::sync::Arc;
-
-    #[derive(Debug)]
-    struct MockStat {
-        metric_type: SlateMetricType,
-    }
-
-    impl ReadableStat for MockStat {
-        fn get(&self) -> i64 {
-            0
-        }
-
-        fn metric_type(&self) -> SlateMetricType {
-            self.metric_type
-        }
-    }
-
-    #[test]
-    fn should_return_counter_when_slate_metric_type_is_counter() {
-        // given
-        let stat = Arc::new(MockStat {
-            metric_type: SlateMetricType::Counter,
-        });
-        let gauge = ReadableStatGauge(stat);
-
-        // when
-        let result = gauge.metric_type();
-
-        // then
-        assert!(matches!(
-            result,
-            prometheus_client::metrics::MetricType::Counter,
-        ));
-    }
-
-    #[test]
-    fn should_return_gauge_when_slate_metric_type_is_gauge() {
-        // given
-        let stat = Arc::new(MockStat {
-            metric_type: SlateMetricType::Gauge,
-        });
-        let gauge = ReadableStatGauge(stat);
-
-        // when
-        let result = gauge.metric_type();
-
-        // then
-        assert!(matches!(
-            result,
-            prometheus_client::metrics::MetricType::Gauge,
-        ));
     }
 }

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -20,12 +20,13 @@ required-features = ["http-server"]
 
 [features]
 default = []
-http-server = ["dep:axum", "dep:tower", "dep:clap", "dep:prometheus-client", "common/metrics"]
+http-server = ["dep:axum", "dep:tower", "dep:clap", "dep:prometheus-client", "dep:metrics-exporter-prometheus"]
 
 [dependencies]
 async-trait.workspace = true
 bytes.workspace = true
 common.workspace = true
+metrics.workspace = true
 prost.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -40,10 +41,12 @@ axum = { workspace = true, optional = true }
 tower = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 prometheus-client = { version = "0.22", optional = true }
+metrics-exporter-prometheus = { workspace = true, optional = true }
 
 [dev-dependencies]
 base64.workspace = true
 common = { workspace = true, features = ["test-utils"] }
+metrics-exporter-prometheus.workspace = true
 proptest.workspace = true
 reqwest.workspace = true
 tempfile.workspace = true

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -130,12 +130,6 @@ impl LogDb {
         LogDbBuilder::new(config).build().await
     }
 
-    /// Registers storage engine metrics into the given Prometheus registry.
-    #[cfg(feature = "http-server")]
-    pub fn register_metrics(&self, registry: &mut prometheus_client::registry::Registry) {
-        self.storage.register_metrics(registry);
-    }
-
     /// Appends records to the log without blocking.
     ///
     /// Records are assigned sequence numbers in the order they appear in the

--- a/log/src/main.rs
+++ b/log/src/main.rs
@@ -24,12 +24,18 @@ async fn main() {
     let log_config = args.to_log_config();
     let server_config = LogServerConfig::from(&args);
 
+    // Install the metrics-rs recorder early so that slatedb metrics registered
+    // during LogDb::open() are captured by the prometheus exporter.
+    let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+    let metrics_handle = recorder.handle();
+    let _ = metrics::set_global_recorder(recorder);
+
     tracing::info!("Opening log with config: {:?}", log_config);
 
     // Open the log
     let log = LogDb::open(log_config).await.expect("Failed to open log");
 
     // Create and run the server
-    let server = LogServer::new(Arc::new(log), server_config);
+    let server = LogServer::new(Arc::new(log), server_config, metrics_handle);
     server.run().await;
 }

--- a/log/src/server/http.rs
+++ b/log/src/server/http.rs
@@ -20,22 +20,26 @@ use crate::LogDb;
 pub struct LogServer {
     log: Arc<LogDb>,
     config: LogServerConfig,
+    metrics_handle: metrics_exporter_prometheus::PrometheusHandle,
 }
 
 impl LogServer {
     /// Create a new log server.
-    pub fn new(log: Arc<LogDb>, config: LogServerConfig) -> Self {
-        Self { log, config }
+    pub fn new(
+        log: Arc<LogDb>,
+        config: LogServerConfig,
+        metrics_handle: metrics_exporter_prometheus::PrometheusHandle,
+    ) -> Self {
+        Self {
+            log,
+            config,
+            metrics_handle,
+        }
     }
 
     /// Run the HTTP server.
     pub async fn run(self) {
-        // Install the metrics-rs recorder for slatedb metrics
-        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
-        let handle = recorder.handle();
-        let _ = metrics::set_global_recorder(recorder);
-
-        let metrics = Arc::new(Metrics::with_metrics_rs_handle(Some(handle)));
+        let metrics = Arc::new(Metrics::with_metrics_rs_handle(Some(self.metrics_handle)));
 
         // Create app state
         let state = AppState {

--- a/log/src/server/http.rs
+++ b/log/src/server/http.rs
@@ -30,10 +30,12 @@ impl LogServer {
 
     /// Run the HTTP server.
     pub async fn run(self) {
-        // Create metrics registry and register storage engine metrics
-        let mut metrics = Metrics::new();
-        self.log.register_metrics(metrics.registry_mut());
-        let metrics = Arc::new(metrics);
+        // Install the metrics-rs recorder for slatedb metrics
+        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        let _ = metrics::set_global_recorder(recorder);
+
+        let metrics = Arc::new(Metrics::with_metrics_rs_handle(Some(handle)));
 
         // Create app state
         let state = AppState {

--- a/log/src/server/metrics.rs
+++ b/log/src/server/metrics.rs
@@ -1,6 +1,7 @@
 //! Prometheus metrics for the log server.
 
 use axum::http::Method;
+use metrics_exporter_prometheus::PrometheusHandle;
 use prometheus_client::encoding::{EncodeLabelSet, EncodeLabelValue};
 use prometheus_client::metrics::counter::Counter;
 use prometheus_client::metrics::family::Family;
@@ -52,8 +53,12 @@ pub struct HttpLabels {
 }
 
 /// Container for all Prometheus metrics.
+///
+/// Combines `prometheus_client`-based log metrics with `metrics-rs` output
+/// (used by slatedb via the `MetricsRsRecorder` bridge).
 pub struct Metrics {
     registry: Registry,
+    metrics_rs_handle: Option<PrometheusHandle>,
 
     /// Counter of records successfully appended.
     pub log_append_records_total: Counter,
@@ -86,6 +91,12 @@ impl Default for Metrics {
 impl Metrics {
     /// Create a new metrics registry with all metrics registered.
     pub fn new() -> Self {
+        Self::with_metrics_rs_handle(None)
+    }
+
+    /// Create a new metrics registry with a `metrics-rs` handle for
+    /// rendering slatedb metrics alongside log-server metrics.
+    pub fn with_metrics_rs_handle(handle: Option<PrometheusHandle>) -> Self {
         let mut registry = Registry::default();
 
         // Log append records counter
@@ -149,6 +160,7 @@ impl Metrics {
 
         Self {
             registry,
+            metrics_rs_handle: handle,
             log_append_records_total,
             log_append_bytes_total,
             log_records_scanned_total,
@@ -159,19 +171,17 @@ impl Metrics {
         }
     }
 
-    /// Returns a mutable reference to the underlying Prometheus registry.
-    ///
-    /// Use this to register additional metrics (e.g. storage engine metrics)
-    /// before wrapping `Metrics` in an `Arc`.
-    pub fn registry_mut(&mut self) -> &mut Registry {
-        &mut self.registry
-    }
-
     /// Encode all metrics to Prometheus text format.
+    ///
+    /// Combines `prometheus_client` log metrics with `metrics-rs` output
+    /// (slatedb metrics registered via `MetricsRsRecorder`).
     pub fn encode(&self) -> String {
         let mut buffer = String::new();
         prometheus_client::encoding::text::encode(&mut buffer, &self.registry)
             .expect("encoding metrics should not fail");
+        if let Some(handle) = &self.metrics_rs_handle {
+            buffer.push_str(&handle.render());
+        }
         buffer
     }
 }

--- a/log/tests/http_api_formats.rs
+++ b/log/tests/http_api_formats.rs
@@ -749,8 +749,22 @@ async fn test_scan_follow_at_poll_boundary_returns_empty() {
 // SlateDB Metrics Tests
 // ============================================================================
 
+/// Install a global metrics-rs recorder once for the entire test process.
+fn global_prometheus_handle() -> metrics_exporter_prometheus::PrometheusHandle {
+    use std::sync::OnceLock;
+    static HANDLE: OnceLock<metrics_exporter_prometheus::PrometheusHandle> = OnceLock::new();
+    HANDLE
+        .get_or_init(|| {
+            let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+            let handle = recorder.handle();
+            let _ = metrics::set_global_recorder(recorder);
+            handle
+        })
+        .clone()
+}
+
 /// Setup a test app backed by SlateDB (in-memory object store) so that
-/// the StatRegistry is populated with real metrics.
+/// slatedb metrics are populated via the MetricsRsRecorder bridge.
 async fn setup_slatedb_test_app() -> Router {
     use common::storage::config::{ObjectStoreConfig, SlateDbStorageConfig};
 
@@ -764,10 +778,9 @@ async fn setup_slatedb_test_app() -> Router {
         ..Default::default()
     };
 
+    let handle = global_prometheus_handle();
     let log = Arc::new(LogDb::open(config).await.expect("Failed to open log"));
-    let mut metrics = Metrics::new();
-    log.register_metrics(metrics.registry_mut());
-    let metrics = Arc::new(metrics);
+    let metrics = Arc::new(Metrics::with_metrics_rs_handle(Some(handle)));
 
     let state = AppState {
         log: log.clone(),
@@ -813,7 +826,17 @@ fn parse_metric_value(metrics_text: &str, metric_name: &str) -> i64 {
     let line = metrics_text
         .lines()
         .find(|line| line.starts_with(&format!("{metric_name} ")))
-        .unwrap_or_else(|| panic!("{metric_name} metric line not found"));
+        .unwrap_or_else(|| {
+            let relevant: Vec<&str> = metrics_text
+                .lines()
+                .filter(|l| l.contains(metric_name))
+                .collect();
+            panic!(
+                "{metric_name} metric line not found. \
+                 Lines containing the name:\n{}",
+                relevant.join("\n")
+            )
+        });
     line.split_whitespace()
         .last()
         .unwrap()

--- a/timeseries/Cargo.toml
+++ b/timeseries/Cargo.toml
@@ -26,7 +26,6 @@ http-server = [
     "dep:tower",
     "dep:tower-http",
     "dep:clap",
-    "dep:prometheus-client",
     "dep:metrics-exporter-prometheus",
 ]
 testing = []
@@ -45,7 +44,7 @@ config.workspace = true
 dashmap.workspace = true
 futures.workspace = true
 moka.workspace = true
-common = { workspace = true, features = ["metrics"] }
+common.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
@@ -65,7 +64,6 @@ blake3 = "1.8.2"
 metrics.workspace = true
 metrics-exporter-prometheus = { workspace = true, optional = true }
 mime_guess = "2"
-prometheus-client = { version = "0.22", optional = true }
 promql-parser = "0.8"
 regex = "1.0"
 ryu = "1"

--- a/timeseries/src/main.rs
+++ b/timeseries/src/main.rs
@@ -67,6 +67,12 @@ async fn main() {
         PrometheusConfig::default()
     };
 
+    // Install the metrics-rs recorder early so that slatedb metrics registered
+    // during StorageBuilder::build() are captured by the prometheus exporter.
+    let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+    let metrics_handle = recorder.handle();
+    let _ = metrics::set_global_recorder(recorder);
+
     // Create storage based on configuration
     tracing::info!(
         "Creating storage with config: {:?}",
@@ -74,7 +80,7 @@ async fn main() {
     );
 
     let read_only = prometheus_config.read_only;
-    let (tsdb, storage) = if read_only {
+    let tsdb = if read_only {
         // Read-only mode: open a non-fencing reader.
         let reader = TimeSeriesDbReader::open(
             prometheus_config.storage.clone(),
@@ -88,7 +94,7 @@ async fn main() {
         });
         let engine: Arc<TsdbEngine> = Arc::new(Arc::new(reader).into());
         tracing::info!("Opened storage in read-only mode");
-        (engine, None)
+        engine
     } else {
         // Read-write mode: open full storage + Tsdb
         let merge_operator = Arc::new(OpenTsdbMergeOperator);
@@ -106,8 +112,7 @@ async fn main() {
                 std::process::exit(1);
             });
         tracing::info!("Storage created successfully");
-        let engine: Arc<TsdbEngine> = Arc::new(Arc::new(Tsdb::new(storage.clone())).into());
-        (engine, Some(storage))
+        Arc::new(Arc::new(Tsdb::new(storage)).into())
     };
 
     // Create server configuration
@@ -117,7 +122,7 @@ async fn main() {
     };
 
     // Create and run server
-    let server = TimeSeriesHttpServer::new(tsdb, config, storage);
+    let server = TimeSeriesHttpServer::new(tsdb, config, metrics_handle);
 
     tracing::info!(
         "Starting timeseries {} server on port {}...",

--- a/timeseries/src/server/http.rs
+++ b/timeseries/src/server/http.rs
@@ -113,31 +113,25 @@ pub(crate) fn build_router(
 pub(crate) struct TimeSeriesHttpServer {
     tsdb: Arc<TsdbEngine>,
     config: ServerConfig,
-    storage: Option<Arc<dyn common::Storage>>,
+    metrics_handle: metrics_exporter_prometheus::PrometheusHandle,
 }
 
 impl TimeSeriesHttpServer {
     pub(crate) fn new(
         tsdb: Arc<TsdbEngine>,
         config: ServerConfig,
-        storage: Option<Arc<dyn common::Storage>>,
+        metrics_handle: metrics_exporter_prometheus::PrometheusHandle,
     ) -> Self {
         Self {
             tsdb,
             config,
-            storage,
+            metrics_handle,
         }
     }
 
     /// Run the HTTP server
     pub(crate) async fn run(self) {
-        // Install the metrics-rs recorder and create the rendering handle
-        let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
-        let handle = recorder.handle();
-        // Install globally — if a recorder is already installed (e.g. tests), this is a no-op
-        let _ = metrics::set_global_recorder(recorder);
-
-        let metrics = Arc::new(Metrics::new(handle));
+        let metrics = Arc::new(Metrics::new(self.metrics_handle));
 
         // Start the scraper if there are scrape configs (requires read-write mode)
         if !self.config.prometheus_config.scrape_configs.is_empty() {

--- a/timeseries/src/server/http.rs
+++ b/timeseries/src/server/http.rs
@@ -137,12 +137,7 @@ impl TimeSeriesHttpServer {
         // Install globally — if a recorder is already installed (e.g. tests), this is a no-op
         let _ = metrics::set_global_recorder(recorder);
 
-        // Create metrics container with optional storage engine metrics
-        let mut metrics = Metrics::new(handle);
-        if let Some(storage) = &self.storage {
-            storage.register_metrics(metrics.storage_registry_mut());
-        }
-        let metrics = Arc::new(metrics);
+        let metrics = Arc::new(Metrics::new(handle));
 
         // Start the scraper if there are scrape configs (requires read-write mode)
         if !self.config.prometheus_config.scrape_configs.is_empty() {

--- a/timeseries/src/server/metrics.rs
+++ b/timeseries/src/server/metrics.rs
@@ -1,7 +1,6 @@
 //! Prometheus metrics for the timeseries server.
 
 use metrics_exporter_prometheus::PrometheusHandle;
-use prometheus_client::registry::Registry;
 
 // ── Metric name constants ──
 
@@ -42,12 +41,10 @@ fn describe_metrics() {
 /// Container for metrics rendering.
 ///
 /// Uses `metrics-rs` for recording (callers use `metrics::counter!()` etc.)
-/// and `metrics-exporter-prometheus` for rendering. A separate
-/// `prometheus_client::Registry` is kept for storage engine metrics that are
-/// registered via the `common::StorageRead::register_metrics` bridge.
+/// and `metrics-exporter-prometheus` for rendering. SlateDB metrics are
+/// also routed through `metrics-rs` via the `MetricsRsRecorder`.
 pub struct Metrics {
     handle: PrometheusHandle,
-    storage_registry: Registry,
 }
 
 impl Metrics {
@@ -57,31 +54,12 @@ impl Metrics {
     /// (e.g. in tests) reuse the existing one but get their own handle.
     pub fn new(handle: PrometheusHandle) -> Self {
         describe_metrics();
-        Self {
-            handle,
-            storage_registry: Registry::default(),
-        }
-    }
-
-    /// Returns a mutable reference to the storage engine Prometheus registry.
-    ///
-    /// Use this to register SlateDB / storage-level metrics before wrapping
-    /// `Metrics` in an `Arc`.
-    pub fn storage_registry_mut(&mut self) -> &mut Registry {
-        &mut self.storage_registry
+        Self { handle }
     }
 
     /// Encode all metrics to Prometheus text format.
-    ///
-    /// Combines `metrics-rs` output (via the exporter handle) with any
-    /// storage engine metrics registered in the `prometheus_client` registry.
     pub fn encode(&self) -> String {
-        let mut output = self.handle.render();
-        let mut storage_buf = String::new();
-        prometheus_client::encoding::text::encode(&mut storage_buf, &self.storage_registry)
-            .expect("encoding storage metrics should not fail");
-        output.push_str(&storage_buf);
-        output
+        self.handle.render()
     }
 }
 

--- a/timeseries/src/testing/http.rs
+++ b/timeseries/src/testing/http.rs
@@ -3,10 +3,9 @@
 //! Provides the production Axum router wired to a [`TestTsdb`] for
 //! integration tests that exercise HTTP endpoints via `oneshot()`.
 
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use axum::Router;
-use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
 
 use crate::promql::config::OtelServerConfig;
 use crate::server::{Metrics, build_router};
@@ -14,28 +13,12 @@ use crate::tsdb::TsdbEngine;
 
 use super::TestTsdb;
 
-/// Install a global metrics-rs recorder once for the entire test process.
-/// Returns a handle that can render the recorded metrics.
-fn global_prometheus_handle() -> PrometheusHandle {
-    static HANDLE: OnceLock<PrometheusHandle> = OnceLock::new();
-    HANDLE
-        .get_or_init(|| {
-            let recorder = PrometheusBuilder::new().build_recorder();
-            let handle = recorder.handle();
-            let _ = metrics::set_global_recorder(recorder);
-            handle
-        })
-        .clone()
-}
-
 /// Build the production Axum router — same routes, middleware, and state
 /// as `crate::server::TimeSeriesHttpServer::run()` but without binding
 /// to a TCP port.
 pub fn build_app(tsdb: &TestTsdb) -> Router {
-    let handle = global_prometheus_handle();
-    let mut metrics = Metrics::new(handle);
-    tsdb.storage
-        .register_metrics(metrics.storage_registry_mut());
+    let handle = super::ensure_metrics_recorder();
+    let metrics = Metrics::new(handle);
     let engine: Arc<TsdbEngine> = Arc::new(tsdb.inner.clone().into());
     build_router(engine, Arc::new(metrics), OtelServerConfig::default())
 }

--- a/timeseries/src/testing/mod.rs
+++ b/timeseries/src/testing/mod.rs
@@ -15,6 +15,24 @@ use common::{StorageBuilder, StorageConfig, StorageSemantics};
 
 use common::Storage;
 
+/// Install a global metrics-rs recorder once for the test process.
+///
+/// Must be called before constructing any SlateDB instances so that
+/// metrics registered via `MetricsRsRecorder` are captured.
+#[cfg(feature = "http-server")]
+pub fn ensure_metrics_recorder() -> metrics_exporter_prometheus::PrometheusHandle {
+    use std::sync::OnceLock;
+    static HANDLE: OnceLock<metrics_exporter_prometheus::PrometheusHandle> = OnceLock::new();
+    HANDLE
+        .get_or_init(|| {
+            let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+            let handle = recorder.handle();
+            let _ = metrics::set_global_recorder(recorder);
+            handle
+        })
+        .clone()
+}
+
 use crate::model::Series;
 use crate::storage::merge_operator::OpenTsdbMergeOperator;
 use crate::tsdb::Tsdb;
@@ -66,6 +84,11 @@ pub async fn create_test_tsdb() -> TestTsdb {
 /// This allows benchmarks to use production-like storage backends
 /// such as local filesystem or S3 instead of in-memory.
 pub async fn create_test_tsdb_with_config(object_store: ObjectStoreConfig) -> TestTsdb {
+    // Ensure the metrics-rs recorder is installed before building the DB
+    // so that slatedb metrics registered via MetricsRsRecorder are captured.
+    #[cfg(feature = "http-server")]
+    ensure_metrics_recorder();
+
     let config = StorageConfig::SlateDb(SlateDbStorageConfig {
         path: "bench-data".to_string(),
         object_store,


### PR DESCRIPTION
Replace the old ReadableStatGauge/register_metrics pattern (which scraped slatedb's StatRegistry into a prometheus_client::Registry) with a MetricsRsRecorder that implements slatedb 0.12.0's MetricsRecorder trait, forwarding metrics into the metrics-rs global recorder.

Key changes:
- slatedb 0.11.2 -> 0.12.0, slatedb-common 0.11.1 -> 0.12.0
- Add MetricsRsRecorder bridge (common/src/storage/metrics_recorder.rs)
- Wire MetricsRsRecorder into StorageBuilder and create_storage_read
- Remove register_metrics from Storage trait and all call sites
- DbReader switched to builder pattern (DbReader::builder().build())
- ScanOptions gains order field (IterationOrder)
- TTL tests assert expire_ts via get_key_value instead of read-path filtering
- Remove prometheus-client dependency from common and timeseries crates