### PR TITLE
revert change to setup LimitStore ObjectStore

### DIFF
--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -15,7 +15,6 @@ pub use slatedb::db_cache::CachedEntry;
 use slatedb::db_cache::DbCache;
 pub use slatedb::db_cache::foyer::{FoyerCache, FoyerCacheOptions};
 pub use slatedb::db_cache::foyer_hybrid::FoyerHybridCache;
-use slatedb::object_store::limit::LimitStore;
 use slatedb::object_store::{self, ObjectStore};
 pub use slatedb::{CompactorBuilder, DbBuilder};
 use tracing::info;
@@ -241,8 +240,6 @@ pub fn create_object_store(config: &ObjectStoreConfig) -> StorageResult<Arc<dyn 
                 .map_err(|e| {
                     StorageError::Storage(format!("Failed to create AWS S3 store: {}", e))
                 })?;
-            println!("CREATE OBJECT STORE WITH IO LIMIT");
-            let store = LimitStore::new(store, 100);
             Ok(Arc::new(store))
         }
         ObjectStoreConfig::Local(local_config) => {


### PR DESCRIPTION
I accidentally included a change to create a `LimitStore` whenever creating `ObjectStore` which internally uses a semaphore to limit parallel object store requests. Reverting in this patch.