### PR TITLE
Bump Rust to 1.94 and runtime to Debian trixie in Docker builds

### DIFF
--- a/log/Dockerfile
+++ b/log/Dockerfile
@@ -1,7 +1,7 @@
 # Use cargo-chef for dependency caching
 # Pin to multi-arch manifest list digest for reproducible builds (supports amd64/arm64)
-# To update: docker manifest inspect lukemathwalker/cargo-chef:latest-rust-1.89
-FROM lukemathwalker/cargo-chef:latest-rust-1.89@sha256:abbe80c8000f4e1b6969b4d84d5ec7ad86616be7e6322ba0e3b451c2eee6f280 AS chef
+# To update: docker manifest inspect lukemathwalker/cargo-chef:latest-rust-1.94
+FROM lukemathwalker/cargo-chef:latest-rust-1.94@sha256:d5a1cca12f21de999e5b221b5c6ff5635080f4b8d5e58053241ff169e0fc60f6 AS chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/log/Dockerfile
+++ b/log/Dockerfile
@@ -25,8 +25,8 @@ RUN cargo build --release --locked --manifest-path log/Cargo.toml --features htt
 
 # Runtime stage
 # Pin to multi-arch manifest list digest for reproducible builds (supports amd64/arm64)
-# To update: docker manifest inspect debian:bookworm-slim
-FROM debian:bookworm-slim@sha256:56ff6d36d4eb3db13a741b342ec466f121480b5edded42e4b7ee850ce7a418ee
+# To update: docker buildx imagetools inspect debian:trixie-slim
+FROM debian:trixie-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a
 
 WORKDIR /app
 

--- a/timeseries/Dockerfile
+++ b/timeseries/Dockerfile
@@ -1,7 +1,7 @@
 # Use cargo-chef for dependency caching
 # Pin to multi-arch manifest list digest for reproducible builds (supports amd64/arm64)
-# To update: docker manifest inspect lukemathwalker/cargo-chef:latest-rust-1.89
-FROM lukemathwalker/cargo-chef:latest-rust-1.89@sha256:abbe80c8000f4e1b6969b4d84d5ec7ad86616be7e6322ba0e3b451c2eee6f280 AS chef
+# To update: docker manifest inspect lukemathwalker/cargo-chef:latest-rust-1.94
+FROM lukemathwalker/cargo-chef:latest-rust-1.94@sha256:d5a1cca12f21de999e5b221b5c6ff5635080f4b8d5e58053241ff169e0fc60f6 AS chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/timeseries/Dockerfile
+++ b/timeseries/Dockerfile
@@ -24,8 +24,8 @@ RUN cargo build --release --locked --manifest-path timeseries/Cargo.toml --featu
 
 # Runtime stage
 # Pin to multi-arch manifest list digest for reproducible builds (supports amd64/arm64)
-# To update: docker manifest inspect debian:bookworm-slim
-FROM debian:bookworm-slim@sha256:56ff6d36d4eb3db13a741b342ec466f121480b5edded42e4b7ee850ce7a418ee
+# To update: docker buildx imagetools inspect debian:trixie-slim
+FROM debian:trixie-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a
 
 WORKDIR /app
 

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -1,7 +1,7 @@
 # Use cargo-chef for dependency caching
 # Pin to multi-arch manifest list digest for reproducible builds (supports amd64/arm64)
-# To update: docker manifest inspect lukemathwalker/cargo-chef:latest-rust-1.89
-FROM lukemathwalker/cargo-chef:latest-rust-1.89@sha256:abbe80c8000f4e1b6969b4d84d5ec7ad86616be7e6322ba0e3b451c2eee6f280 AS chef
+# To update: docker manifest inspect lukemathwalker/cargo-chef:latest-rust-1.94
+FROM lukemathwalker/cargo-chef:latest-rust-1.94@sha256:d5a1cca12f21de999e5b221b5c6ff5635080f4b8d5e58053241ff169e0fc60f6 AS chef
 WORKDIR /app
 
 FROM chef AS planner

--- a/vector/Dockerfile
+++ b/vector/Dockerfile
@@ -24,8 +24,8 @@ RUN cargo build --release --locked --manifest-path vector/Cargo.toml --features 
 
 # Runtime stage
 # Pin to multi-arch manifest list digest for reproducible builds (supports amd64/arm64)
-# To update: docker manifest inspect debian:bookworm-slim
-FROM debian:bookworm-slim@sha256:56ff6d36d4eb3db13a741b342ec466f121480b5edded42e4b7ee850ce7a418ee
+# To update: docker buildx imagetools inspect debian:trixie-slim
+FROM debian:trixie-slim@sha256:4ffb3a1511099754cddc70eb1b12e50ffdb67619aa0ab6c13fcd800a78ef7c7a
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

- Bump cargo-chef build image from Rust 1.89 to 1.94 across all three Dockerfiles (timeseries, log, vector)
- Update runtime image from `debian:bookworm-slim` to `debian:trixie-slim` to match glibc 2.38

## Problem

After #382 (add garbage collection to opendata ingest) landed, `opendata-ingest` uses `Duration::from_mins()` and `Duration::from_hours()` which require the `duration_constructors_lite` feature (stabilized in Rust 1.84). The `cargo-chef:latest-rust-1.89` image pinned by digest didn't support this, causing Docker builds to fail:

```
error[E0658]: use of unstable library feature `duration_constructors_lite`
```

Bumping to `cargo-chef:latest-rust-1.94` fixes compilation, but the new image links against glibc 2.38 (Debian trixie). The old `bookworm-slim` runtime image only has glibc 2.36, causing:

```
/app/opendata-timeseries: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
```

Updating the runtime to `trixie-slim` resolves both issues.

## Test plan

- [x] Built timeseries image via `build-test-image.yml` — compiles and starts successfully
- [x] Deployed to prod and verified pod is healthy and serving queries
- [ ] Build log and vector images to verify they also work

🤖 Generated with [Claude Code](https://claude.com/claude-code)