### PR TITLE
[common] configure foyer hybrid cache

### DIFF
--- a/common/src/storage/config.rs
+++ b/common/src/storage/config.rs
@@ -62,6 +62,20 @@ pub enum BlockCacheConfig {
     FoyerHybrid(FoyerHybridCacheConfig),
 }
 
+/// Write policy for foyer's hybrid cache.
+///
+/// Controls when entries are written to the disk tier.
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum FoyerWritePolicy {
+    /// Write to disk when an entry is inserted into the memory cache.
+    /// Ensures every cached block is also persisted to the disk tier.
+    #[default]
+    WriteOnInsertion,
+    /// Write to disk only when an entry is evicted from the memory cache.
+    /// This is foyer's default policy.
+    WriteOnEviction,
+}
+
 /// Configuration for foyer's hybrid (memory + disk) block cache.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct FoyerHybridCacheConfig {
@@ -71,6 +85,37 @@ pub struct FoyerHybridCacheConfig {
     pub disk_capacity: u64,
     /// Path for the on-disk cache directory.
     pub disk_path: String,
+    /// Write policy for the hybrid cache. Default: `WriteOnInsertion`.
+    #[serde(default)]
+    pub write_policy: FoyerWritePolicy,
+    /// Number of flush threads for the large engine. Default: 4.
+    #[serde(default = "default_flushers")]
+    pub flushers: usize,
+    /// Buffer pool size in bytes for the large engine flush pipeline.
+    /// Each flusher double-buffers, so actual allocation is ~2x this value.
+    /// Default: `memory_capacity / 32` (computed at build time when absent).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub buffer_pool_size: Option<u64>,
+    /// Submit queue size threshold in bytes. Entries are dropped when
+    /// the queue exceeds this limit. Default: 1 GiB.
+    #[serde(default = "default_submit_queue_size_threshold")]
+    pub submit_queue_size_threshold: u64,
+}
+
+fn default_flushers() -> usize {
+    4
+}
+
+fn default_submit_queue_size_threshold() -> u64 {
+    1024 * 1024 * 1024 // 1 GiB
+}
+
+impl FoyerHybridCacheConfig {
+    /// Returns the effective buffer pool size: explicit value if set,
+    /// otherwise `memory_capacity / 32`.
+    pub fn effective_buffer_pool_size(&self) -> u64 {
+        self.buffer_pool_size.unwrap_or(self.memory_capacity / 32)
+    }
 }
 
 impl Default for SlateDbStorageConfig {
@@ -302,11 +347,79 @@ block_cache:
                         assert_eq!(foyer.memory_capacity, 8589934592);
                         assert_eq!(foyer.disk_capacity, 150323855360);
                         assert_eq!(foyer.disk_path, "/mnt/nvme/block-cache");
+                        // new fields should get defaults
+                        assert_eq!(foyer.write_policy, FoyerWritePolicy::WriteOnInsertion);
+                        assert_eq!(foyer.flushers, 4);
+                        assert!(foyer.buffer_pool_size.is_none());
+                        assert_eq!(foyer.submit_queue_size_threshold, 1024 * 1024 * 1024);
+                        // effective buffer pool = memory_capacity / 32
+                        assert_eq!(foyer.effective_buffer_pool_size(), 8589934592 / 32);
                     }
                 }
             }
             _ => panic!("Expected SlateDb config"),
         }
+    }
+
+    #[test]
+    fn should_deserialize_block_cache_with_explicit_engine_options() {
+        // given
+        let yaml = r#"
+type: SlateDb
+path: data
+object_store:
+  type: InMemory
+block_cache:
+  type: FoyerHybrid
+  memory_capacity: 4294967296
+  disk_capacity: 10737418240
+  disk_path: /mnt/nvme/cache
+  write_policy: WriteOnEviction
+  flushers: 2
+  buffer_pool_size: 134217728
+  submit_queue_size_threshold: 536870912
+"#;
+
+        // when
+        let config: StorageConfig = serde_yaml::from_str(yaml).unwrap();
+
+        // then
+        match config {
+            StorageConfig::SlateDb(slate_config) => {
+                let cache = slate_config.block_cache.expect("block_cache should be set");
+                match cache {
+                    BlockCacheConfig::FoyerHybrid(foyer) => {
+                        assert_eq!(foyer.write_policy, FoyerWritePolicy::WriteOnEviction);
+                        assert_eq!(foyer.flushers, 2);
+                        assert_eq!(foyer.buffer_pool_size, Some(134217728));
+                        assert_eq!(foyer.submit_queue_size_threshold, 536870912);
+                        // explicit value overrides derivation
+                        assert_eq!(foyer.effective_buffer_pool_size(), 134217728);
+                    }
+                }
+            }
+            _ => panic!("Expected SlateDb config"),
+        }
+    }
+
+    #[test]
+    fn should_derive_buffer_pool_size_from_memory_capacity() {
+        // given
+        let config = FoyerHybridCacheConfig {
+            memory_capacity: 8 * 1024 * 1024 * 1024, // 8 GiB
+            disk_capacity: 100 * 1024 * 1024 * 1024,
+            disk_path: "/tmp/cache".to_string(),
+            write_policy: FoyerWritePolicy::default(),
+            flushers: 4,
+            buffer_pool_size: None,
+            submit_queue_size_threshold: 1024 * 1024 * 1024,
+        };
+
+        // when/then
+        assert_eq!(
+            config.effective_buffer_pool_size(),
+            256 * 1024 * 1024 // 256 MiB = 8 GiB / 32
+        );
     }
 
     #[test]

--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -331,7 +331,10 @@ async fn create_block_cache_from_config(
     };
     match config {
         BlockCacheConfig::FoyerHybrid(foyer_config) => {
-            use foyer::{DirectFsDeviceOptions, Engine, HybridCacheBuilder};
+            use foyer::{
+                DirectFsDeviceOptions, Engine, HybridCacheBuilder, HybridCachePolicy,
+                LargeEngineOptions,
+            };
 
             let memory_capacity = usize::try_from(foyer_config.memory_capacity).map_err(|_| {
                 StorageError::Storage(format!(
@@ -346,12 +349,42 @@ async fn create_block_cache_from_config(
                 ))
             })?;
 
+            let buffer_pool_size = usize::try_from(foyer_config.effective_buffer_pool_size())
+                .map_err(|_| {
+                    StorageError::Storage(format!(
+                        "buffer_pool_size {} exceeds usize::MAX on this platform",
+                        foyer_config.effective_buffer_pool_size()
+                    ))
+                })?;
+            let submit_queue_size_threshold =
+                usize::try_from(foyer_config.submit_queue_size_threshold).map_err(|_| {
+                    StorageError::Storage(format!(
+                        "submit_queue_size_threshold {} exceeds usize::MAX on this platform",
+                        foyer_config.submit_queue_size_threshold
+                    ))
+                })?;
+
+            let policy = match foyer_config.write_policy {
+                super::config::FoyerWritePolicy::WriteOnInsertion => {
+                    HybridCachePolicy::WriteOnInsertion
+                }
+                super::config::FoyerWritePolicy::WriteOnEviction => {
+                    HybridCachePolicy::WriteOnEviction
+                }
+            };
+
             let cache = HybridCacheBuilder::new()
                 .with_name("slatedb_block_cache")
                 .with_metrics_registry(Box::new(MetricsRsRegistry))
+                .with_policy(policy)
                 .memory(memory_capacity)
                 .with_weighter(|_, v: &CachedEntry| v.size())
-                .storage(Engine::large())
+                .storage(Engine::Large(
+                    LargeEngineOptions::new()
+                        .with_flushers(foyer_config.flushers)
+                        .with_buffer_pool_size(buffer_pool_size)
+                        .with_submit_queue_size_threshold(submit_queue_size_threshold),
+                ))
                 .with_device_options(
                     DirectFsDeviceOptions::new(&foyer_config.disk_path)
                         .with_capacity(disk_capacity),
@@ -366,6 +399,11 @@ async fn create_block_cache_from_config(
                 memory_mb = foyer_config.memory_capacity / (1024 * 1024),
                 disk_mb = foyer_config.disk_capacity / (1024 * 1024),
                 disk_path = %foyer_config.disk_path,
+                write_policy = ?foyer_config.write_policy,
+                flushers = foyer_config.flushers,
+                buffer_pool_mb = foyer_config.effective_buffer_pool_size() / (1024 * 1024),
+                submit_queue_threshold_mb =
+                    foyer_config.submit_queue_size_threshold / (1024 * 1024),
                 "hybrid block cache enabled"
             );
 
@@ -382,6 +420,22 @@ mod tests {
     use crate::storage::config::{
         FoyerHybridCacheConfig, LocalObjectStoreConfig, SlateDbStorageConfig,
     };
+
+    fn foyer_cache_config(
+        memory_capacity: u64,
+        disk_capacity: u64,
+        disk_path: String,
+    ) -> FoyerHybridCacheConfig {
+        FoyerHybridCacheConfig {
+            memory_capacity,
+            disk_capacity,
+            disk_path,
+            write_policy: Default::default(),
+            flushers: 4,
+            buffer_pool_size: None,
+            submit_queue_size_threshold: 1024 * 1024 * 1024,
+        }
+    }
 
     fn slatedb_config_with_local_dir(dir: &std::path::Path) -> StorageConfig {
         StorageConfig::SlateDb(SlateDbStorageConfig {
@@ -406,11 +460,11 @@ mod tests {
                 path: tmp.path().join("obj").to_str().unwrap().to_string(),
             }),
             settings_path: None,
-            block_cache: Some(BlockCacheConfig::FoyerHybrid(FoyerHybridCacheConfig {
-                memory_capacity: 1024 * 1024,
-                disk_capacity: 4 * 1024 * 1024,
-                disk_path: cache_dir.to_str().unwrap().to_string(),
-            })),
+            block_cache: Some(BlockCacheConfig::FoyerHybrid(foyer_cache_config(
+                1024 * 1024,
+                4 * 1024 * 1024,
+                cache_dir.to_str().unwrap().to_string(),
+            ))),
         });
 
         let storage = StorageBuilder::new(&config).await.unwrap().build().await;
@@ -433,11 +487,11 @@ mod tests {
                 path: tmp.path().join("obj").to_str().unwrap().to_string(),
             }),
             settings_path: None,
-            block_cache: Some(BlockCacheConfig::FoyerHybrid(FoyerHybridCacheConfig {
-                memory_capacity: 1024 * 1024,
-                disk_capacity: 4 * 1024 * 1024,
-                disk_path: cache_dir.to_str().unwrap().to_string(),
-            })),
+            block_cache: Some(BlockCacheConfig::FoyerHybrid(foyer_cache_config(
+                1024 * 1024,
+                4 * 1024 * 1024,
+                cache_dir.to_str().unwrap().to_string(),
+            ))),
         };
 
         // First open a writer so the reader has a manifest to read
@@ -469,11 +523,11 @@ mod tests {
     async fn should_error_when_capacity_exceeds_usize() {
         // On 32-bit platforms, u64::MAX > usize::MAX triggers our overflow check.
         // On 64-bit this is a no-op, so gate on 32-bit.
-        let config = BlockCacheConfig::FoyerHybrid(FoyerHybridCacheConfig {
-            memory_capacity: u64::MAX,
-            disk_capacity: 4 * 1024 * 1024,
-            disk_path: "/tmp/unused".to_string(),
-        });
+        let config = BlockCacheConfig::FoyerHybrid(foyer_cache_config(
+            u64::MAX,
+            4 * 1024 * 1024,
+            "/tmp/unused".to_string(),
+        ));
 
         let result = create_block_cache_from_config(&Some(config)).await;
         assert!(result.is_err());
@@ -491,11 +545,11 @@ mod tests {
                 path: obj_dir.to_str().unwrap().to_string(),
             }),
             settings_path: None,
-            block_cache: Some(BlockCacheConfig::FoyerHybrid(FoyerHybridCacheConfig {
-                memory_capacity: 1024 * 1024,
-                disk_capacity: 4 * 1024 * 1024,
-                disk_path: bad_disk_path.to_string(),
-            })),
+            block_cache: Some(BlockCacheConfig::FoyerHybrid(foyer_cache_config(
+                1024 * 1024,
+                4 * 1024 * 1024,
+                bad_disk_path.to_string(),
+            ))),
         })
     }
 
@@ -537,11 +591,11 @@ mod tests {
                 path: tmp.path().join("obj").to_str().unwrap().to_string(),
             }),
             settings_path: None,
-            block_cache: Some(BlockCacheConfig::FoyerHybrid(FoyerHybridCacheConfig {
-                memory_capacity: 1024 * 1024,
-                disk_capacity: 4 * 1024 * 1024,
-                disk_path: bad_path.to_str().unwrap().to_string(),
-            })),
+            block_cache: Some(BlockCacheConfig::FoyerHybrid(foyer_cache_config(
+                1024 * 1024,
+                4 * 1024 * 1024,
+                bad_path.to_str().unwrap().to_string(),
+            ))),
         };
 
         // First open a writer (without cache) so the reader has a manifest
@@ -585,11 +639,11 @@ mod tests {
                 path: tmp.path().join("obj").to_str().unwrap().to_string(),
             }),
             settings_path: None,
-            block_cache: Some(BlockCacheConfig::FoyerHybrid(FoyerHybridCacheConfig {
-                memory_capacity: 1024 * 1024,
-                disk_capacity: 4 * 1024 * 1024,
-                disk_path: bad_path.to_str().unwrap().to_string(),
-            })),
+            block_cache: Some(BlockCacheConfig::FoyerHybrid(foyer_cache_config(
+                1024 * 1024,
+                4 * 1024 * 1024,
+                bad_path.to_str().unwrap().to_string(),
+            ))),
         };
 
         // First open a writer (without cache) so the reader has a manifest

--- a/timeseries/src/promql/pipeline.rs
+++ b/timeseries/src/promql/pipeline.rs
@@ -162,7 +162,7 @@ impl QueryPlan {
     ) -> Self {
         let end_ms = adjusted_eval_ts_ms;
         let start_ms = end_ms - lookback_delta_ms;
-        buckets.sort_by(|a, b| b.start.cmp(&a.start)); // newest first
+        buckets.sort_by_key(|b| std::cmp::Reverse(b.start)); // newest first
         QueryPlan {
             sample_start_ms: start_ms,
             sample_end_ms: end_ms,
@@ -182,7 +182,7 @@ impl QueryPlan {
     ) -> Self {
         let end_ms = adjusted_eval_ts_ms;
         let start_ms = end_ms - range_ms;
-        buckets.sort_by(|a, b| a.start.cmp(&b.start)); // chronological
+        buckets.sort_by_key(|a| a.start); // chronological
         buckets.retain(|bucket| {
             let bucket_start_ms = (bucket.start as i64) * 60 * 1000;
             let bucket_end_ms = bucket_start_ms + (bucket.size_in_mins() as i64) * 60 * 1000;
@@ -216,7 +216,7 @@ impl QueryPlan {
                 lookback_delta_ms,
             );
         let range_ms = subquery_end_ms - subquery_start_ms;
-        buckets.sort_by(|a, b| b.start.cmp(&a.start)); // newest first
+        buckets.sort_by_key(|b| std::cmp::Reverse(b.start)); // newest first
         QueryPlan {
             sample_start_ms: range_start_ms,
             sample_end_ms: range_end_ms,

--- a/timeseries/src/promql/selector.rs
+++ b/timeseries/src/promql/selector.rs
@@ -79,16 +79,17 @@ async fn find_candidates_with_reader<'reader, R: QueryReader>(
 
     for matcher in &selector.matchers.matchers {
         match &matcher.op {
-            MatchOp::Equal => {
+            MatchOp::Equal
                 // For empty string matchers, we skip adding them to and_terms
                 // and handle them later with post-filtering
-                if !matcher.value.is_empty() {
-                    and_terms.push(Label {
-                        name: matcher.name.clone(),
-                        value: matcher.value.clone(),
-                    });
-                }
+                if !matcher.value.is_empty() =>
+            {
+                and_terms.push(Label {
+                    name: matcher.name.clone(),
+                    value: matcher.value.clone(),
+                });
             }
+            MatchOp::Equal => {}
             MatchOp::Re(_) => {
                 let values = parse_limited_regex(&matcher.value)
                     .map_err(crate::error::Error::InvalidInput)?;
@@ -260,16 +261,17 @@ fn find_candidates_with_regex_support(
     // Process matchers
     for matcher in &selector.matchers.matchers {
         match &matcher.op {
-            MatchOp::Equal => {
+            MatchOp::Equal
                 // For empty string matchers, we skip adding them to and_terms
                 // and handle them later with post-filtering
-                if !matcher.value.is_empty() {
-                    and_terms.push(Label {
-                        name: matcher.name.clone(),
-                        value: matcher.value.clone(),
-                    });
-                }
+                if !matcher.value.is_empty() =>
+            {
+                and_terms.push(Label {
+                    name: matcher.name.clone(),
+                    value: matcher.value.clone(),
+                });
             }
+            MatchOp::Equal => {}
             MatchOp::Re(_) => {
                 // Validate and expand regex pattern
                 let values = parse_limited_regex(&matcher.value)?;
@@ -347,16 +349,18 @@ fn extract_equality_terms(selector: &VectorSelector) -> std::result::Result<Vec<
 
     for matcher in &selector.matchers.matchers {
         match &matcher.op {
-            MatchOp::Equal => {
+            MatchOp::Equal
                 // For empty string matchers, we skip adding them to terms
                 // and handle them later with post-filtering
-                if !matcher.value.is_empty() {
-                    terms.push(Label {
-                        name: matcher.name.clone(),
-                        value: matcher.value.clone(),
-                    });
-                }
+                if !matcher.value.is_empty() =>
+            {
+                terms.push(Label {
+                    name: matcher.name.clone(),
+                    value: matcher.value.clone(),
+                });
             }
+            MatchOp::Equal => {}
+
             MatchOp::Re(_) => {
                 // Regex validation only - actual handling done in find_candidates_with_regex_support
                 let _values = parse_limited_regex(&matcher.value)?;

--- a/vector/src/query_engine.rs
+++ b/vector/src/query_engine.rs
@@ -294,7 +294,7 @@ impl QueryEngine {
                         }
                     })
                     .collect();
-                scored.sort_unstable_by(|a, b| a.distance.cmp(&b.distance));
+                scored.sort_unstable_by_key(|a| a.distance);
                 Ok::<_, Error>(scored)
             }));
         }

--- a/vector/src/write/indexer/tree/split.rs
+++ b/vector/src/write/indexer/tree/split.rs
@@ -158,7 +158,7 @@ impl SplitCentroids {
                 .into_iter()
                 .filter(|(_k, v)| *v >= self.opts.split_threshold_vectors as u64)
                 .collect();
-            to_split.sort_by(|a, b| b.1.cmp(&a.1));
+            to_split.sort_by_key(|b| std::cmp::Reverse(b.1));
             to_split.truncate(self.max_splits);
             if to_split.is_empty() {
                 return Ok(SplitCentroidsResult {


### PR DESCRIPTION
Expose write policy, flushers, buffer pool size, and submit queue threshold as configurable fields on FoyerHybridCacheConfig. Defaults to WriteOnInsertion with 4 flushers and buffer pool derived from memory_capacity / 32.

fixes #405 