### PR TITLE
add startup cache warmer to pre-populate block cache

### DIFF
--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -13,12 +13,29 @@ use super::{MergeOperator, Storage, StorageError, StorageRead, StorageResult};
 use slatedb::DbReader;
 use slatedb::config::Settings;
 pub use slatedb::db_cache::CachedEntry;
-use slatedb::db_cache::DbCache;
 pub use slatedb::db_cache::foyer::{FoyerCache, FoyerCacheOptions};
 pub use slatedb::db_cache::foyer_hybrid::FoyerHybridCache;
+use slatedb::db_cache::{CachedKey, DbCache};
 use slatedb::object_store::{self, ObjectStore};
 pub use slatedb::{CompactorBuilder, DbBuilder};
 use tracing::info;
+
+/// Handle to a foyer hybrid cache that we own and must close explicitly on
+/// shutdown. Cloneable because foyer's `HybridCache` is Arc-backed.
+///
+/// TODO(slatedb 0.13): remove this and the surrounding plumbing. SlateDB 0.13
+/// adds a `close()` hook to the `DbCache` trait and drives cache shutdown from
+/// `Db::close()` / `DbReader::close()`, so callers won't need to hold a side
+/// handle to the hybrid cache just to close it deterministically.
+pub(crate) type OwnedHybridCache = foyer::HybridCache<CachedKey, CachedEntry>;
+
+/// Block cache we constructed internally — keep the `HybridCache` handle so
+/// we can call `close().await` from `StorageRead::close()` instead of relying
+/// on foyer's Drop-based close, which races the runtime shutdown.
+struct ManagedBlockCache {
+    db_cache: Arc<dyn DbCache>,
+    hybrid: OwnedHybridCache,
+}
 
 /// Builder for creating storage instances from configuration.
 ///
@@ -52,6 +69,7 @@ use tracing::info;
 pub struct StorageBuilder {
     inner: StorageBuilderInner,
     semantics: StorageSemantics,
+    managed_cache: Option<OwnedHybridCache>,
 }
 
 enum StorageBuilderInner {
@@ -67,6 +85,7 @@ impl StorageBuilder {
     /// InMemory configs it stores a sentinel so that `build()` returns an
     /// `InMemoryStorage`.
     pub async fn new(config: &StorageConfig) -> StorageResult<Self> {
+        let mut managed_cache: Option<OwnedHybridCache> = None;
         let inner = match config {
             StorageConfig::InMemory => StorageBuilderInner::InMemory,
             StorageConfig::SlateDb(slate_config) => {
@@ -86,10 +105,11 @@ impl StorageBuilder {
                 );
                 let mut db_builder =
                     DbBuilder::new(slate_config.path.clone(), object_store).with_settings(settings);
-                if let Some(cache) =
+                if let Some(managed) =
                     create_block_cache_from_config(&slate_config.block_cache).await?
                 {
-                    db_builder = db_builder.with_db_cache(cache);
+                    db_builder = db_builder.with_db_cache(managed.db_cache);
+                    managed_cache = Some(managed.hybrid);
                 }
                 StorageBuilderInner::SlateDb(Box::new(db_builder))
             }
@@ -97,6 +117,7 @@ impl StorageBuilder {
         Ok(Self {
             inner,
             semantics: StorageSemantics::default(),
+            managed_cache,
         })
     }
 
@@ -143,7 +164,10 @@ impl StorageBuilder {
                 let db = db_builder.build().await.map_err(|e| {
                     StorageError::Storage(format!("Failed to create SlateDB: {}", e))
                 })?;
-                Ok(Arc::new(SlateDbStorage::new(Arc::new(db))))
+                Ok(Arc::new(SlateDbStorage::new_with_managed_cache(
+                    Arc::new(db),
+                    self.managed_cache,
+                )))
             }
         }
     }
@@ -306,26 +330,36 @@ pub async fn create_storage_read(
                 let adapter = SlateDbStorage::merge_operator_adapter(op);
                 builder = builder.with_merge_operator(Arc::new(adapter));
             }
-            // Prefer runtime-provided cache, fall back to config
+            // Prefer runtime-provided cache, fall back to config. The
+            // runtime-provided cache is owned by the caller, so we don't hold
+            // a handle to close it on shutdown.
+            let mut managed_cache: Option<OwnedHybridCache> = None;
             if let Some(cache) = runtime.block_cache {
                 builder = builder.with_db_cache(cache);
-            } else if let Some(cache) =
+            } else if let Some(managed) =
                 create_block_cache_from_config(&slate_config.block_cache).await?
             {
-                builder = builder.with_db_cache(cache);
+                builder = builder.with_db_cache(managed.db_cache);
+                managed_cache = Some(managed.hybrid);
             }
             let reader = builder.build().await.map_err(|e| {
                 StorageError::Storage(format!("Failed to create SlateDB reader: {}", e))
             })?;
-            Ok(Arc::new(SlateDbStorageReader::new(Arc::new(reader))))
+            Ok(Arc::new(SlateDbStorageReader::new_with_managed_cache(
+                Arc::new(reader),
+                managed_cache,
+            )))
         }
     }
 }
 
-/// Creates a block cache from the serializable config, if present.
+/// Creates a block cache from the serializable config, if present. Returns
+/// both the `DbCache` trait object handed to SlateDB and a `HybridCache`
+/// handle the caller keeps so it can close the cache deterministically on
+/// shutdown.
 async fn create_block_cache_from_config(
     config: &Option<BlockCacheConfig>,
-) -> StorageResult<Option<Arc<dyn DbCache>>> {
+) -> StorageResult<Option<ManagedBlockCache>> {
     let Some(config) = config else {
         return Ok(None);
     };
@@ -407,9 +441,12 @@ async fn create_block_cache_from_config(
                 "hybrid block cache enabled"
             );
 
-            Ok(Some(
-                Arc::new(FoyerHybridCache::new_with_cache(cache)) as Arc<dyn DbCache>
-            ))
+            let db_cache =
+                Arc::new(FoyerHybridCache::new_with_cache(cache.clone())) as Arc<dyn DbCache>;
+            Ok(Some(ManagedBlockCache {
+                db_cache,
+                hybrid: cache,
+            }))
         }
     }
 }

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::storage::factory::OwnedHybridCache;
 use crate::storage::{MergeOptions, PutOptions};
 use crate::{
     BytesRange, Record, StorageError, StorageIterator, StorageRead, StorageResult, Ttl,
@@ -17,6 +18,7 @@ use slatedb::{
     MergeOperatorError, WriteBatch, config::WriteOptions as SlateDbWriteOptions,
 };
 use tokio::sync::watch;
+use tracing::warn;
 
 /// Adapter that wraps our `MergeOperator` trait to implement SlateDB's `MergeOperator` trait.
 ///
@@ -74,11 +76,24 @@ pub struct SlateDbStorage {
     pub(super) db: Arc<Db>,
     durable_tx: watch::Sender<u64>,
     durable_bridge_abort: tokio::task::AbortHandle,
+    // TODO(slatedb 0.13): remove once DbCache exposes a close() hook and
+    // SlateDb::close() drives cache shutdown itself.
+    managed_cache: Option<OwnedHybridCache>,
 }
 
 impl SlateDbStorage {
     /// Creates a new SlateDbStorage instance wrapping the given SlateDB database.
     pub fn new(db: Arc<Db>) -> Self {
+        Self::new_with_managed_cache(db, None)
+    }
+
+    /// Creates a new SlateDbStorage that will explicitly close the given foyer
+    /// hybrid cache during [`StorageRead::close`]. See [`OwnedHybridCache`] for
+    /// why this exists.
+    pub(crate) fn new_with_managed_cache(
+        db: Arc<Db>,
+        managed_cache: Option<OwnedHybridCache>,
+    ) -> Self {
         let slate_rx = db.subscribe();
         let (durable_tx, _) = watch::channel(slate_rx.borrow().durable_seq);
         let task = tokio::spawn({
@@ -98,6 +113,7 @@ impl SlateDbStorage {
             db,
             durable_tx,
             durable_bridge_abort: task.abort_handle(),
+            managed_cache,
         }
     }
 
@@ -157,6 +173,15 @@ impl StorageRead for SlateDbStorage {
         // Stop durable bridge first so no status subscriber outlives DB close.
         self.durable_bridge_abort.abort();
         self.db.close().await.map_err(StorageError::from_storage)?;
+        // Close the cache after SlateDB so no inserts race the flushers. Log
+        // and swallow errors: cache flush failures only cost cache warmth, not
+        // durability, and we'd rather not fail shutdown over it.
+        // TODO(slatedb 0.13): remove once DbCache owns its close lifecycle.
+        if let Some(cache) = &self.managed_cache
+            && let Err(e) = cache.close().await
+        {
+            warn!(error = ?e, "foyer hybrid cache close failed");
+        }
         Ok(())
     }
 }
@@ -352,12 +377,27 @@ impl From<MergeOptions> for slatedb::config::MergeOptions {
 /// allowing multiple readers to coexist with a single writer.
 pub struct SlateDbStorageReader {
     reader: Arc<DbReader>,
+    // TODO(slatedb 0.13): remove once DbCache exposes a close() hook and
+    // DbReader::close() drives cache shutdown itself.
+    managed_cache: Option<OwnedHybridCache>,
 }
 
 impl SlateDbStorageReader {
     /// Creates a new SlateDbStorageReader wrapping the given DbReader.
     pub fn new(reader: Arc<DbReader>) -> Self {
-        Self { reader }
+        Self::new_with_managed_cache(reader, None)
+    }
+
+    /// Creates a reader that will explicitly close the given foyer hybrid
+    /// cache during [`StorageRead::close`].
+    pub(crate) fn new_with_managed_cache(
+        reader: Arc<DbReader>,
+        managed_cache: Option<OwnedHybridCache>,
+    ) -> Self {
+        Self {
+            reader,
+            managed_cache,
+        }
     }
 }
 
@@ -394,7 +434,15 @@ impl StorageRead for SlateDbStorageReader {
         self.reader
             .close()
             .await
-            .map_err(StorageError::from_storage)
+            .map_err(StorageError::from_storage)?;
+        // Close the cache after the reader so no inserts race the flushers.
+        // TODO(slatedb 0.13): remove once DbCache owns its close lifecycle.
+        if let Some(cache) = &self.managed_cache
+            && let Err(e) = cache.close().await
+        {
+            warn!(error = ?e, "foyer hybrid cache close failed");
+        }
+        Ok(())
     }
 }
 

--- a/timeseries/src/promql/config.rs
+++ b/timeseries/src/promql/config.rs
@@ -59,6 +59,10 @@ pub struct PrometheusConfig {
     /// Maximum number of bucket readers to cache in memory.
     #[serde(default = "default_cache_capacity")]
     pub cache_capacity: u64,
+    /// Startup cache warmer configuration. Scans recent buckets on startup
+    /// to pre-populate the block cache. Enabled by default (24h, with samples).
+    #[serde(default = "default_cache_warmer")]
+    pub cache_warmer: Option<CacheWarmerConfig>,
 }
 
 fn default_flush_interval_secs() -> u64 {
@@ -118,6 +122,7 @@ impl Default for PrometheusConfig {
             read_only: false,
             reader: default_reader_options(),
             cache_capacity: default_cache_capacity(),
+            cache_warmer: default_cache_warmer(),
         }
     }
 }
@@ -206,13 +211,43 @@ fn default_gc_grace_period() -> Duration {
     Duration::from_secs(600)
 }
 
-#[cfg(feature = "otel")]
 fn deserialize_duration<'de, D>(deserializer: D) -> std::result::Result<Duration, D::Error>
 where
     D: Deserializer<'de>,
 {
     let s = String::deserialize(deserializer)?;
     parse_duration(&s).map_err(serde::de::Error::custom)
+}
+
+/// Configuration for the startup cache warmer.
+///
+/// When present, the server scans recent time bucket key ranges on startup
+/// to pre-populate the block cache. This is a temporary workaround until
+/// SlateDB's CacheManager is available.
+#[derive(Debug, Clone, Deserialize)]
+pub struct CacheWarmerConfig {
+    /// How far back to warm (e.g., "6h", "24h"). Defaults to 24h.
+    #[serde(
+        default = "default_warm_range",
+        deserialize_with = "deserialize_duration"
+    )]
+    pub warm_range: Duration,
+
+    /// Whether to warm timeseries sample data in addition to metadata.
+    /// Defaults to true.
+    #[serde(default = "default_true")]
+    pub include_samples: bool,
+}
+
+fn default_warm_range() -> Duration {
+    Duration::from_hours(24)
+}
+
+fn default_cache_warmer() -> Option<CacheWarmerConfig> {
+    Some(CacheWarmerConfig {
+        warm_range: default_warm_range(),
+        include_samples: true,
+    })
 }
 
 /// Global configuration defaults.

--- a/timeseries/src/reader.rs
+++ b/timeseries/src/reader.rs
@@ -144,7 +144,7 @@ impl QueryReader for ReaderQueryReader {
 /// let result = reader.query("rate(http_requests_total[5m])", None).await?;
 /// ```
 pub struct TimeSeriesDbReader {
-    pub(crate) storage: Arc<dyn StorageRead>,
+    storage: Arc<dyn StorageRead>,
     /// LRU cache for read-only query buckets.
     query_cache: Cache<TimeBucket, Arc<MiniQueryReader>>,
 }
@@ -184,6 +184,12 @@ impl TimeSeriesDbReader {
             storage,
             query_cache,
         }
+    }
+
+    /// Returns a read handle to the underlying storage, for background tasks
+    /// like the cache warmer.
+    pub(crate) fn storage_read(&self) -> Arc<dyn StorageRead> {
+        self.storage.clone()
     }
 
     /// Get a cached bucket reader, loading from storage if needed.

--- a/timeseries/src/reader.rs
+++ b/timeseries/src/reader.rs
@@ -144,7 +144,7 @@ impl QueryReader for ReaderQueryReader {
 /// let result = reader.query("rate(http_requests_total[5m])", None).await?;
 /// ```
 pub struct TimeSeriesDbReader {
-    storage: Arc<dyn StorageRead>,
+    pub(crate) storage: Arc<dyn StorageRead>,
     /// LRU cache for read-only query buckets.
     query_cache: Cache<TimeBucket, Arc<MiniQueryReader>>,
 }

--- a/timeseries/src/server/cache_warmer.rs
+++ b/timeseries/src/server/cache_warmer.rs
@@ -1,0 +1,237 @@
+//! Startup cache warmer that pre-populates the block cache by scanning
+//! recent time bucket key ranges through the normal StorageRead API.
+//!
+//! This is a temporary workaround until SlateDB's CacheManager
+//! (`set_warm_prefixes()` + `warm_current()`) is available. Delete this
+//! module when that lands.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use common::{BytesRange, StorageRead};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::promql::config::CacheWarmerConfig;
+use crate::serde::TimeBucketScoped;
+use crate::serde::key::{
+    BucketListKey, ForwardIndexKey, InvertedIndexKey, SeriesDictionaryKey, TimeSeriesKey,
+};
+use crate::storage::OpenTsdbStorageReadExt;
+
+const LOG_INTERVAL: Duration = Duration::from_secs(30);
+
+pub(crate) struct CacheWarmerHandle {
+    cancel: CancellationToken,
+    join: JoinHandle<()>,
+}
+
+impl CacheWarmerHandle {
+    pub async fn shutdown(self) {
+        self.cancel.cancel();
+        if let Err(e) = self.join.await {
+            tracing::error!("Cache warmer task panicked: {e}");
+        }
+    }
+}
+
+/// Spawns a one-off cache warming task. Returns a handle that must be
+/// shut down before closing the database.
+pub(crate) fn start(storage: Arc<dyn StorageRead>, config: CacheWarmerConfig) -> CacheWarmerHandle {
+    let cancel = CancellationToken::new();
+    let join = tokio::spawn({
+        let cancel = cancel.clone();
+        async move {
+            match warm(&storage, &config, &cancel).await {
+                Ok(stats) => tracing::info!(
+                    buckets = stats.buckets,
+                    records = stats.records,
+                    elapsed = ?stats.elapsed,
+                    "Cache warming complete"
+                ),
+                Err(e) => tracing::warn!("Cache warming failed: {e}"),
+            }
+        }
+    });
+    CacheWarmerHandle { cancel, join }
+}
+
+struct WarmStats {
+    buckets: usize,
+    records: u64,
+    elapsed: Duration,
+}
+
+async fn warm(
+    storage: &Arc<dyn StorageRead>,
+    config: &CacheWarmerConfig,
+    cancel: &CancellationToken,
+) -> crate::util::Result<WarmStats> {
+    let start = Instant::now();
+    let now_secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+    let range_start = now_secs - config.warm_range.as_secs() as i64;
+
+    // Warm the bucket list key
+    let _ = storage.get(BucketListKey.encode()).await?;
+
+    let buckets = storage
+        .get_buckets_in_range(Some(range_start), Some(now_secs))
+        .await?;
+    let total = buckets.len();
+
+    let mut records: u64 = 0;
+    let mut last_log = Instant::now();
+
+    for (i, bucket) in buckets.iter().enumerate() {
+        if cancel.is_cancelled() {
+            tracing::info!("Cache warming cancelled");
+            break;
+        }
+
+        records += drain_scan(storage, ForwardIndexKey::bucket_range(bucket)).await?;
+        records += drain_scan(storage, InvertedIndexKey::bucket_range(bucket)).await?;
+        records += drain_scan(storage, SeriesDictionaryKey::bucket_range(bucket)).await?;
+
+        if config.include_samples {
+            records += drain_scan(storage, TimeSeriesKey::bucket_range(bucket)).await?;
+        }
+
+        if last_log.elapsed() >= LOG_INTERVAL {
+            tracing::info!(
+                bucket = i + 1,
+                total,
+                records,
+                elapsed = ?start.elapsed(),
+                "Cache warming progress"
+            );
+            last_log = Instant::now();
+        }
+    }
+
+    Ok(WarmStats {
+        buckets: total,
+        records,
+        elapsed: start.elapsed(),
+    })
+}
+
+/// Scan a key range, consuming all records to populate the block cache.
+/// Returns the number of records touched.
+async fn drain_scan(storage: &Arc<dyn StorageRead>, range: BytesRange) -> crate::util::Result<u64> {
+    let mut iter = storage.scan_iter(range).await?;
+    let mut count = 0u64;
+    while iter.next().await?.is_some() {
+        count += 1;
+    }
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Series;
+    use crate::storage::merge_operator::OpenTsdbMergeOperator;
+    use crate::tsdb::Tsdb;
+    use common::storage::in_memory::InMemoryStorage;
+
+    fn create_storage() -> Arc<InMemoryStorage> {
+        Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
+            OpenTsdbMergeOperator,
+        )))
+    }
+
+    #[tokio::test]
+    async fn should_warm_with_data() {
+        // given
+        let storage = create_storage();
+        let tsdb = Tsdb::new(storage.clone());
+        let series = vec![
+            Series::builder("http_requests_total")
+                .label("method", "GET")
+                .sample(
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_millis() as i64,
+                    100.0,
+                )
+                .build(),
+        ];
+        tsdb.ingest_samples(series, None).await.unwrap();
+        tsdb.flush().await.unwrap();
+
+        let config = CacheWarmerConfig {
+            warm_range: Duration::from_secs(3600),
+            include_samples: true,
+        };
+
+        // when
+        let cancel = CancellationToken::new();
+        let stats = warm(&(storage as Arc<dyn StorageRead>), &config, &cancel)
+            .await
+            .unwrap();
+
+        // then
+        assert!(stats.buckets > 0);
+        assert!(stats.records > 0);
+    }
+
+    #[tokio::test]
+    async fn should_warm_empty_storage() {
+        // given
+        let storage = create_storage();
+        let config = CacheWarmerConfig {
+            warm_range: Duration::from_secs(3600),
+            include_samples: true,
+        };
+
+        // when
+        let cancel = CancellationToken::new();
+        let stats = warm(&(storage as Arc<dyn StorageRead>), &config, &cancel)
+            .await
+            .unwrap();
+
+        // then
+        assert_eq!(stats.buckets, 0);
+        assert_eq!(stats.records, 0);
+    }
+
+    #[tokio::test]
+    async fn should_stop_on_cancellation() {
+        // given
+        let storage = create_storage();
+        let tsdb = Tsdb::new(storage.clone());
+        let series = vec![
+            Series::builder("metric_a")
+                .label("env", "test")
+                .sample(
+                    SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .unwrap()
+                        .as_millis() as i64,
+                    1.0,
+                )
+                .build(),
+        ];
+        tsdb.ingest_samples(series, None).await.unwrap();
+        tsdb.flush().await.unwrap();
+
+        let config = CacheWarmerConfig {
+            warm_range: Duration::from_secs(3600),
+            include_samples: true,
+        };
+
+        // when — cancel before starting
+        let cancel = CancellationToken::new();
+        cancel.cancel();
+        let stats = warm(&(storage as Arc<dyn StorageRead>), &config, &cancel)
+            .await
+            .unwrap();
+
+        // then — should have found buckets but processed none
+        assert_eq!(stats.records, 0);
+    }
+}

--- a/timeseries/src/server/http.rs
+++ b/timeseries/src/server/http.rs
@@ -187,6 +187,22 @@ impl TimeSeriesHttpServer {
             handle
         };
 
+        // Start the cache warmer if configured
+        let warmer_handle =
+            self.config
+                .prometheus_config
+                .cache_warmer
+                .as_ref()
+                .map(|warmer_config| {
+                    let storage = self.tsdb.storage_read();
+                    tracing::info!(
+                        warm_range = ?warmer_config.warm_range,
+                        include_samples = warmer_config.include_samples,
+                        "Starting cache warmer"
+                    );
+                    super::cache_warmer::start(storage, warmer_config.clone())
+                });
+
         // Build router with metrics middleware
         let app = build_router(
             self.tsdb.clone(),
@@ -207,6 +223,12 @@ impl TimeSeriesHttpServer {
         #[cfg(feature = "otel")]
         if let Some(handle) = consumer_handle {
             tracing::info!("Shutting down ingest consumer...");
+            handle.shutdown().await;
+        }
+
+        // Stop the cache warmer before closing storage
+        if let Some(handle) = warmer_handle {
+            tracing::info!("Shutting down cache warmer...");
             handle.shutdown().await;
         }
 

--- a/timeseries/src/server/mod.rs
+++ b/timeseries/src/server/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod cache_warmer;
 mod http;
 #[cfg(feature = "otel")]
 pub(crate) mod ingest_consumer;

--- a/timeseries/src/tsdb.rs
+++ b/timeseries/src/tsdb.rs
@@ -515,7 +515,7 @@ pub(crate) async fn discover_label_values<R: QueryReader>(
 /// Tsdb manages multiple MiniTsdb instances (one per time bucket) and provides
 /// a unified QueryReader interface that merges results across buckets.
 pub(crate) struct Tsdb {
-    pub(crate) storage: Arc<dyn Storage>,
+    storage: Arc<dyn Storage>,
 
     /// TTI cache (15 min idle) for buckets being actively ingested into.
     /// Also used during queries so that unflushed data is visible.
@@ -537,6 +537,12 @@ impl Tsdb {
             ingest_cache,
             metadata_catalog: RwLock::new(HashMap::new()),
         }
+    }
+
+    /// Returns a read handle to the underlying storage, for background tasks
+    /// like the cache warmer.
+    pub(crate) fn storage_read(&self) -> Arc<dyn StorageRead> {
+        self.storage.clone() as Arc<dyn StorageRead>
     }
 
     /// Get or create a MiniTsdb for ingestion into a specific bucket.
@@ -812,8 +818,8 @@ impl TsdbEngine {
     /// like the cache warmer.
     pub(crate) fn storage_read(&self) -> Arc<dyn StorageRead> {
         match self {
-            Self::ReadWrite(tsdb) => tsdb.storage.clone() as Arc<dyn StorageRead>,
-            Self::ReadOnly(reader) => reader.storage.clone(),
+            Self::ReadWrite(tsdb) => tsdb.storage_read(),
+            Self::ReadOnly(reader) => reader.storage_read(),
         }
     }
 

--- a/timeseries/src/tsdb.rs
+++ b/timeseries/src/tsdb.rs
@@ -515,7 +515,7 @@ pub(crate) async fn discover_label_values<R: QueryReader>(
 /// Tsdb manages multiple MiniTsdb instances (one per time bucket) and provides
 /// a unified QueryReader interface that merges results across buckets.
 pub(crate) struct Tsdb {
-    storage: Arc<dyn Storage>,
+    pub(crate) storage: Arc<dyn Storage>,
 
     /// TTI cache (15 min idle) for buckets being actively ingested into.
     /// Also used during queries so that unflushed data is visible.
@@ -806,6 +806,15 @@ impl TsdbEngine {
     /// Returns `true` when the engine is read-only.
     pub(crate) fn is_read_only(&self) -> bool {
         matches!(self, Self::ReadOnly(_))
+    }
+
+    /// Returns a read handle to the underlying storage, for background tasks
+    /// like the cache warmer.
+    pub(crate) fn storage_read(&self) -> Arc<dyn StorageRead> {
+        match self {
+            Self::ReadWrite(tsdb) => tsdb.storage.clone() as Arc<dyn StorageRead>,
+            Self::ReadOnly(reader) => reader.storage.clone(),
+        }
     }
 
     /// Returns a clone of the inner `Arc<Tsdb>` if this is a read-write engine.


### PR DESCRIPTION
Temporary workaround until SlateDB's CacheManager is available (see https://github.com/slatedb/slatedb/pull/1520). Spawns a one-off task at startup that scans recent time bucket key ranges through StorageRead, populating the block cache as a side effect.
