### PR TITLE
[timeseries] Implement PromQL `delta` function

### DIFF
--- a/timeseries/src/promql/promqltest/testdata/functions.test
+++ b/timeseries/src/promql/promqltest/testdata/functions.test
@@ -337,18 +337,27 @@ eval instant at 20m irate(http_requests_histogram{path="/g"}[20m])
 
 clear
 
-# Tests for delta().
+resume
+
+# Tests for delta() (non-histogram).
 load 5m
 	http_requests{path="/foo"}	0 50 100 150 200
 	http_requests{path="/bar"}	200 150 100 50 0
-	http_requests_gauge{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}}+{{schema:0 sum:1 count:2 buckets:[1 1 1] counter_reset_hint:gauge}}x5
-	http_requests_counter{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0]}}+{{schema:0 sum:1 count:2 buckets:[1 1 1]}}x5
-	http_requests_mix{path="/foo"} 0 50 100 {{schema:0 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}} {{schema:0 sum:1 count:2 buckets:[1 1 1] counter_reset_hint:gauge}}
 
 eval instant at 20m delta(http_requests[20m])
 	expect no_warn
 	{path="/foo"} 200
 	{path="/bar"} -200
+
+clear
+
+ignore
+
+# Tests for delta() (histogram).
+load 5m
+	http_requests_gauge{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}}+{{schema:0 sum:1 count:2 buckets:[1 1 1] counter_reset_hint:gauge}}x5
+	http_requests_counter{path="/foo"} {{schema:0 sum:0 count:0 buckets:[0 0 0]}}+{{schema:0 sum:1 count:2 buckets:[1 1 1]}}x5
+	http_requests_mix{path="/foo"} 0 50 100 {{schema:0 sum:0 count:0 buckets:[0 0 0] counter_reset_hint:gauge}} {{schema:0 sum:1 count:2 buckets:[1 1 1] counter_reset_hint:gauge}}
 
 eval instant at 20m delta(http_requests_gauge[20m])
 	expect no_warn


### PR DESCRIPTION
## Summary

This builds on the work from #394 and #409 to implement the PromQL `delta` function, which is similar to `increase` with the following differences:
- no counter reset handling (`delta` should be applied to gauges)
- extrapolated values can be negative

## Related Issues

No specific issue but this is a natural follow-up to the PRs mentioned above.

## Test Plan

Unit tests added.
Those existing PromQL tests for `delta` that are non-histogram have been un-ignored.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
