### PR TITLE
side-channel for collection of traces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2587,6 +2587,9 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "tracing-chrome",
+ "tracing-subscriber",
+ "ulid",
  "uuid",
 ]
 
@@ -2763,6 +2766,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "ulid",
  "usearch",
 ]
 
@@ -4700,6 +4704,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "tracing-chrome"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0a738ed5d6450a9fb96e86a23ad808de2b727fd1394585da5cdd6788ffe724"
+dependencies = [
+ "serde_json",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,8 @@ toml = "0.8"
 tower = "0.5"
 tower-http = { version = "0.5", features = ["cors"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
+tracing-chrome = "0.7"
 ulid = "1"
 uuid = "1.14.0"
 opentelemetry-proto = { version = "0.28", default-features = false, features = ["metrics", "gen-tonic-messages"] }

--- a/common/AGENTS.md
+++ b/common/AGENTS.md
@@ -41,6 +41,17 @@ Block-based sequence allocator for crash-safe ID generation:
 
 Used by: `vector` (internal vector IDs), `log` (sequence numbers)
 
+### `src/tracing/` - Query Tracing Framework
+
+Shared tracing setup for all OpenData databases. Writes Chrome Trace Format
+JSON files viewable in [Perfetto](https://ui.perfetto.dev). See
+[src/tracing/README.md](src/tracing/README.md) for full usage.
+
+Key surface:
+- `init(TracingConfig) -> TracingGuard` — call once from `main()`
+- `TRACE_TARGET` — constant; all instrumented spans must use this target
+- `request_trace_span(trace_id)` — root span for per-request opt-in tracing
+
 ### Other Modules
 
 - `src/bytes.rs` - BytesRange utilities

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -29,6 +29,10 @@ mixtrics.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
+tracing-chrome.workspace = true
+opendata-macros.workspace = true
+ulid.workspace = true
 uuid.workspace = true
 serde.workspace = true
 arc-swap = { version = "1", optional = true }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -5,7 +5,9 @@ pub mod display;
 pub mod sequence;
 pub mod serde;
 pub mod storage;
+pub mod tracing;
 
+pub use crate::tracing::TracingConfig;
 pub use bytes::BytesRange;
 pub use clock::Clock;
 pub use sequence::{DEFAULT_BLOCK_SIZE, SequenceAllocator, SequenceError, SequenceResult};

--- a/common/src/tracing/README.md
+++ b/common/src/tracing/README.md
@@ -1,0 +1,244 @@
+# Query Tracing
+
+The `common::tracing` module provides a shared framework for capturing
+performance traces of query operations across all OpenData databases. Traces
+are written in Chrome Trace Format and viewable in
+[Perfetto UI](https://ui.perfetto.dev) (preferred) or `chrome://tracing`.
+
+## Two streams, asymmetric membership
+
+OpenData has two observability streams:
+
+| Stream | What's in it | Destination | Gate |
+|---|---|---|---|
+| **Logs** | Every `tracing` callsite at or above the configured level | stderr via fmt layer | `RUST_LOG` |
+| **Traces** | Only callsites emitted via `trace_span!` / `#[trace_instrument]` / `request_trace_span` | Chrome JSON file | `OPENDATA_TRACE` + ancestor root |
+
+Trace callsites are emitted at **`debug`** level (not `info`). That keeps
+them out of the default `RUST_LOG=info` console stream — ordinary
+operators reading logs don't see `traced_op` scroll past — but they still
+flow into the Chrome file because `OPENDATA_TRACE` defaults to `debug`.
+
+Consequences:
+
+- `RUST_LOG=info` → trace spans are **absent** from logs (desired default).
+- `RUST_LOG=debug` → trace spans **appear** in logs alongside ordinary
+  debug output.
+- Chrome trace file (when enabled) always captures the trace-marked
+  callsites that `OPENDATA_TRACE` admits.
+- Plain `info!()` / `info_span!()` are *never* in the Chrome file no
+  matter what `OPENDATA_TRACE` is set to.
+
+### How the discrimination works (Chrome side only)
+
+The Chrome layer's filter requires every span or event to declare a
+well-known marker field (`_otrace`) on its metadata before it's captured.
+The trace macros inject that field automatically; ordinary `tracing` macros
+don't. The fmt layer does NOT check this marker — it's the Chrome filter's
+job to decide who gets into the trace file, and the trace file's job alone.
+
+## Every captured span carries a `trace_id`
+
+The framework auto-attaches a `trace_id` field to every span it captures:
+
+- If the span is a [`request_trace_span`] (or a span otherwise explicitly
+  declaring `trace_id = %...`), the caller-supplied id is used.
+- Else if any ancestor span already has a stored trace id, this span
+  inherits it.
+- Else a fresh [ULID](https://github.com/ulid/spec) is minted; this span
+  becomes the implicit root of a new trace.
+
+The value appears in the Chrome trace JSON under each span's `args`, so you
+can filter/search by `trace_id` in Perfetto to isolate a specific logical
+operation. Root-span begin events include the id directly; descendant
+spans record it after creation (via the tracing dispatcher), so it shows
+up on their end events in async mode and on both begin and end in
+threaded mode.
+
+## Trace style (async vs. threaded)
+
+`TracingConfig::trace_style` picks how the Chrome layer emits events. See
+the `TraceStyle` docs for detail; the short version:
+
+| Style | Phase codes | Rendering in Perfetto |
+|---|---|---|
+| `Async` (default) | `ph: "b"`/`"e"` + `id` | One row per unique span name under a shared async track; visually flat even when spans nest in time. |
+| `Threaded` | `ph: "B"`/`"E"` (no id) | Flamegraph stacking of nested spans on each thread; ideal for profiling a sequential pipeline. Spawned work appears on its own thread row. |
+
+The default stays `Async` because it preserves logical span grouping
+across threads via the shared `id`. Flip to `Threaded` when you want the
+flamegraph view of a single-task pipeline.
+
+## Environment variables
+
+| Env var | Controls | Default |
+|---|---|---|
+| `RUST_LOG` | fmt (console) layer | `info` |
+| `OPENDATA_TRACE` | Chrome trace layer | `debug` |
+
+`OPENDATA_TRACE` uses the same `EnvFilter` directive syntax as `RUST_LOG`.
+Because trace spans are debug-level, directives need to admit `debug`:
+
+```sh
+OPENDATA_TRACE=debug                                  # capture every trace span (default)
+OPENDATA_TRACE=vector::query_engine=debug             # just that module
+OPENDATA_TRACE=debug,vector::write=off                # everything except vector::write
+OPENDATA_TRACE=off                                    # disable capture entirely
+OPENDATA_TRACE=off,vector::query_engine=debug         # opt in to exactly one module
+```
+
+## Activation modes
+
+### Process-wide
+
+Set `output_dir` and `always_on = true` on the [`TracingConfig`] passed to
+`common::tracing::init`. Every trace-marked span permitted by
+`OPENDATA_TRACE` is captured for the life of the process. A single JSON file
+is produced per process: `opendata-trace-<pid>-<epoch_secs>.json`.
+
+### Per-request (HTTP)
+
+Set `output_dir` but leave `always_on = false`. Send the header
+`X-Opendata-Trace: true` (or `?trace=1` as a query parameter) with the
+request. The server wraps the handler in a `request_trace_span` which opts
+that request into tracing. The response includes an `X-Opendata-Trace-Id`
+header with the assigned ID. Search for the ID inside the trace JSON (or
+filter in Perfetto) to isolate the request's spans. `OPENDATA_TRACE` still
+scopes what's captured inside the traced request.
+
+### Per-request with a custom level filter
+
+Sometimes you want a single request captured at `debug` while the rest of
+the process stays at `info`. Send a directive string via
+`X-Opendata-Trace-Filter` (or `?trace_filter=...`):
+
+```sh
+curl -H 'X-Opendata-Trace-Filter: vector::query_engine=debug' \
+     -X POST 'https://.../api/v1/vector/search' ...
+```
+
+The directive is parsed as an `EnvFilter` and *replaces* `OPENDATA_TRACE`
+for the lifetime of that request's root span. The header implicitly opts
+into tracing, so `X-Opendata-Trace: true` is redundant when the filter
+header is present. A malformed directive is logged at `warn!` and ignored
+(the request is still traced with `OPENDATA_TRACE`).
+
+Programmatically, call `request_trace_span_with_filter(trace_id, filter)`
+to open such a root span in non-HTTP contexts.
+
+## How to view a trace
+
+1. Locate the JSON file in `output_dir`.
+2. Open <https://ui.perfetto.dev>.
+3. Click "Open trace file" and select the JSON. Perfetto loads it locally —
+   no account, no upload.
+4. Use the search bar to find a span by name or trace_id, or drag-select a
+   region to see per-span aggregate statistics.
+5. For aggregate analysis (averages / percentiles across many requests),
+   open the "Query (SQL)" panel and query the `slice` table.
+
+## How to instrument code
+
+### Functions — `#[trace_instrument]`
+
+Use the proc-macro attribute from `opendata_macros`. It takes the same
+arguments as `#[tracing::instrument]` and additionally injects the marker
+field so the Chrome layer picks up the span. Use `skip_all` and list useful
+fields explicitly — cloning whole payloads into the trace file is expensive.
+
+```rust
+use opendata_macros::trace_instrument;
+
+#[trace_instrument(skip_all, fields(limit = query.limit))]
+pub async fn search(query: &Query) -> Result<Vec<Hit>> {
+    // ...
+}
+```
+
+### Inline spans — `trace_span!`
+
+For spans created outside a function boundary (around a block of work):
+
+```rust
+use common::tracing::trace_span;
+
+let span = trace_span!("load_posting_list", centroid_id = 42);
+let posting = span.in_scope(|| load(42))?;
+```
+
+`trace_span!` accepts the same `"name", key = value, ...` syntax as
+`tracing::info_span!`. For the more exotic `parent: ...` / `target: ...`
+forms, use `tracing::info_span!` directly and add `_otrace =
+tracing::field::Empty` manually.
+
+### Propagating spans across `tokio::spawn`
+
+`tokio::spawn` creates a new task, and that task does **not** inherit the
+caller's current span by default. If you spawn a future whose work should
+appear under the current span in the trace, attach the span explicitly:
+
+```rust
+use tracing::Instrument;
+
+let span = tracing::Span::current();
+tokio::spawn(async move {
+    // work
+}.instrument(span));
+```
+
+### Choosing what to instrument
+
+- **Do instrument**: high-level phases (search, load-and-score, filter apply),
+  IO-bound operations (storage reads, network calls), per-batch loops.
+- **Don't instrument**: tight CPU loops, trivial accessors, very hot paths
+  where the span overhead would distort the measurement.
+
+Rule of thumb: if you'd want to see it as a bar on a timeline, instrument it.
+
+## Behavior details
+
+- The Chrome layer always captures the synthetic root span created by
+  `request_trace_span` (recognized by its fixed name `opendata_trace_root`)
+  — regardless of `OPENDATA_TRACE`, so we always have a record that a
+  request was traced.
+- Non-root spans must (a) carry the `_otrace` marker field, (b) satisfy
+  `OPENDATA_TRACE`, and (c) when `always_on = false`, have an
+  `opendata_trace_root` ancestor.
+- `init` must be called exactly once per process. The returned `TracingGuard`
+  must be held for the life of the process — dropping it flushes and closes
+  the JSON file.
+
+### Implementation: per-layer filters, not global
+
+The fmt layer and the Chrome layer each get their own filter attached via
+`Layer::with_filter`. If `EnvFilter` were instead attached to the registry
+as a *global* layer (`registry.with(env_filter)`), its decision would
+propagate to every downstream layer, re-coupling the two axes. Using
+per-layer filters is what lets `RUST_LOG` and `OPENDATA_TRACE` be truly
+independent.
+
+## Attaching additional layers
+
+`init_with_layers(config, Vec<BoxedLayer>)` accepts extra layers that are
+attached to the same registry as the built-in fmt and Chrome layers.
+Typical uses: a JSON file logger for structured events, an OTEL exporter,
+a metrics bridge. Construct your layer, attach whatever per-layer filter
+it needs, then `.boxed()` and pass it in:
+
+```rust
+use common::tracing::{BoxedLayer, TracingConfig, init_with_layers};
+use tracing_subscriber::{EnvFilter, Layer, fmt};
+
+let file = std::fs::File::create("/var/log/opendata-debug.log").unwrap();
+let file_layer: BoxedLayer = fmt::layer()
+    .with_writer(std::sync::Arc::new(file))
+    .with_filter(EnvFilter::new("opendata_vector=debug"))
+    .boxed();
+
+let _guard = init_with_layers(config, vec![file_layer]);
+```
+
+Extras are attached to the registry *before* the built-in layers so their
+boxed trait objects (`Box<dyn Layer<Registry>>`) type-check. This does not
+affect their visibility into events — every layer in the stack sees every
+span/event it's interested in.

--- a/common/src/tracing/mod.rs
+++ b/common/src/tracing/mod.rs
@@ -1,0 +1,647 @@
+//! Tracing framework for OpenData databases.
+//!
+//! Provides a standard way to initialize tracing with both normal log output
+//! and Chrome-format trace file output for performance analysis.
+//!
+//! # Two independent axes
+//!
+//! - **`RUST_LOG`** controls the fmt (console) layer only. It does not gate
+//!   trace capture.
+//! - **`OPENDATA_TRACE`** controls what lands in the Chrome trace file. It is
+//!   parsed as an [`EnvFilter`] directive string (same syntax as `RUST_LOG`)
+//!   and applied as a per-layer filter on the Chrome layer. Default: `debug`
+//!   — because the trace macros emit spans at `debug` level so they don't
+//!   pollute ordinary `RUST_LOG=info` output.
+//!
+//! # Discrimination: the `_otrace` marker field
+//!
+//! Ordinary `tracing::info!` / `info_span!` calls do **not** land in the
+//! Chrome trace file, even if `OPENDATA_TRACE` would accept their target and
+//! level. The Chrome filter additionally requires a well-known marker field
+//! ([`TRACE_MARKER_FIELD`]) to be declared on the span or event's metadata.
+//! That marker is injected automatically by the [`trace_instrument`] proc
+//! macro and the [`trace_span!`] declarative macro — use those to instrument
+//! code you want to appear in traces.
+//!
+//! # Per-root dynamic filter
+//!
+//! For per-operation tracing you can open a root span whose
+//! [`LEVEL_FILTER_FIELD`] field holds an `EnvFilter` directive string. That
+//! filter is parsed, stored in the root span's extensions, and replaces the
+//! process-wide `OPENDATA_TRACE` decision for every descendant span.
+//! Useful for e.g. opting a single request into `debug`-level query tracing
+//! while the rest of the process stays at `info`. See
+//! [`request_trace_span_with_filter`].
+//!
+//! # Extensibility
+//!
+//! [`init`] takes optional extra [`BoxedLayer`]s — attach file loggers,
+//! OTEL exporters, metrics bridges, etc. alongside the console and Chrome
+//! layers without forking this module.
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tracing::field::{Field, Visit};
+use tracing::span::{Attributes, Id, Record};
+use tracing::{Metadata, Subscriber};
+use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
+use tracing_subscriber::layer::{Context, Filter, Layer, SubscriberExt};
+use tracing_subscriber::registry::{LookupSpan, Registry};
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::{EnvFilter, fmt};
+
+pub use opendata_macros::trace_instrument;
+
+/// Environment variable that controls which spans land in the Chrome trace
+/// file. Parsed as an [`EnvFilter`] directive string (same syntax as
+/// `RUST_LOG`). When unset, defaults to [`DEFAULT_TRACE_FILTER`].
+pub const TRACE_ENV_VAR: &str = "OPENDATA_TRACE";
+
+/// Default directive when `OPENDATA_TRACE` is unset. Trace spans are emitted
+/// at `debug` level (so they don't pollute ordinary info-level console logs),
+/// so the default trace filter must admit debug to capture them.
+pub const DEFAULT_TRACE_FILTER: &str = "debug";
+
+/// Name of the synthetic root span created by [`request_trace_span`]. The
+/// Chrome layer filter looks for an ancestor span with this name to decide
+/// whether a given span should be emitted when per-request mode is active.
+pub const TRACE_ROOT_SPAN_NAME: &str = "opendata_trace_root";
+
+/// Name of the marker field that identifies a span or event as participating
+/// in OpenData query tracing. Injected automatically by [`trace_instrument`]
+/// and [`trace_span!`]. Kept in sync with the same constant in
+/// `opendata-macros`.
+pub const TRACE_MARKER_FIELD: &str = "_otrace";
+
+/// Name of the optional field on a root span whose string value is parsed
+/// as an [`EnvFilter`] directive and applied to all descendant spans. See
+/// [`request_trace_span_with_filter`].
+pub const LEVEL_FILTER_FIELD: &str = "level_filter";
+
+/// Name of the `trace_id` field automatically declared on every span
+/// produced by [`trace_instrument`] / [`trace_span!`] / [`request_trace_span`].
+///
+/// The [`RequestFilterLayer`] populates this field at span creation time,
+/// inheriting from the nearest ancestor's stored trace id or generating a
+/// fresh one. Every span captured in the Chrome trace file therefore
+/// carries a `trace_id` you can group by in Perfetto.
+pub const TRACE_ID_FIELD: &str = "trace_id";
+
+/// Controls how the Chrome trace layer emits events. See
+/// [tracing-chrome docs](https://docs.rs/tracing-chrome) for the full
+/// picture; the short story:
+///
+/// - [`TraceStyle::Async`] (default) uses Chrome's async begin/end events
+///   (`ph: "b"`/`"e"`). All spans that share a root-ancestor get the same
+///   `id`, which keeps their logical grouping intact even across task
+///   boundaries — but Perfetto renders each unique span name as its own
+///   row inside the async track, so sequential nested spans do *not*
+///   visually stack as a flamegraph.
+/// - [`TraceStyle::Threaded`] uses Chrome duration events
+///   (`ph: "B"`/`"E"`) scoped by thread id. Spans that run on the same
+///   thread stack as a flamegraph in Perfetto, which is what you usually
+///   want when profiling a sequential pipeline. Work dispatched to
+///   tokio worker threads naturally appears on separate rows — which is
+///   the accurate picture of parallelism but loses the parent-arrow to
+///   the span that spawned it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TraceStyle {
+    /// Emit Chrome async events (`ph: "b"`/`"e"`). Default.
+    #[default]
+    Async,
+    /// Emit Chrome duration events (`ph: "B"`/`"E"`). Best for flamegraph-
+    /// style visualization of a single-thread pipeline.
+    Threaded,
+}
+
+impl From<TraceStyle> for tracing_chrome::TraceStyle {
+    fn from(s: TraceStyle) -> Self {
+        match s {
+            TraceStyle::Async => tracing_chrome::TraceStyle::Async,
+            TraceStyle::Threaded => tracing_chrome::TraceStyle::Threaded,
+        }
+    }
+}
+
+/// A boxed, type-erased [`Layer`] compatible with the [`Registry`] used by
+/// [`init`]. Accepted by [`init`] via the `extra_layers` argument so callers
+/// can attach their own layers (file loggers, OTEL exporters, etc.)
+/// alongside the built-in console and Chrome layers.
+pub type BoxedLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
+
+/// Create a DEBUG-level span carrying the trace marker field. Convenience
+/// wrapper around [`tracing::debug_span!`] that injects
+/// [`TRACE_MARKER_FIELD`] so the Chrome trace layer picks it up.
+///
+/// Trace spans are `debug` (not `info`) on purpose: at the usual
+/// `RUST_LOG=info` setting they stay out of the console log and only land
+/// in the Chrome trace file.
+///
+/// Accepts the same `"name", key = value, ...` syntax as
+/// [`tracing::debug_span!`]. For more exotic forms (e.g. `parent: ...`,
+/// `target: ...`), use `tracing::debug_span!` directly and add
+/// `_otrace = tracing::field::Empty` manually.
+#[macro_export]
+macro_rules! __opendata_trace_span {
+    ($name:expr $(,)?) => {
+        ::tracing::debug_span!(
+            $name,
+            _otrace = ::tracing::field::Empty,
+            trace_id = ::tracing::field::Empty,
+        )
+    };
+    ($name:expr, $($rest:tt)+) => {
+        ::tracing::debug_span!(
+            $name,
+            _otrace = ::tracing::field::Empty,
+            trace_id = ::tracing::field::Empty,
+            $($rest)+
+        )
+    };
+}
+
+#[doc(inline)]
+pub use crate::__opendata_trace_span as trace_span;
+
+/// Configuration for trace capture.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct TracingConfig {
+    /// Directory where Chrome trace JSON files will be written. `None`
+    /// disables the Chrome layer; only console logging is initialized.
+    #[serde(default)]
+    pub output_dir: Option<PathBuf>,
+
+    /// If `true`, every span that `OPENDATA_TRACE` permits is captured. If
+    /// `false`, spans are only captured when they are descendants of a
+    /// [`request_trace_span`] — the per-request opt-in mode.
+    #[serde(default)]
+    pub always_on: bool,
+
+    /// How the Chrome trace layer emits events. See [`TraceStyle`].
+    #[serde(default)]
+    pub trace_style: TraceStyle,
+}
+
+/// Guard returned by [`init`] that must be held for the lifetime of the
+/// process. Dropping it flushes and closes the Chrome trace file.
+pub struct TracingGuard {
+    _chrome_guard: Option<FlushGuard>,
+    output_path: Option<PathBuf>,
+}
+
+impl TracingGuard {
+    /// Path of the Chrome trace file, if one is being written.
+    pub fn output_path(&self) -> Option<&Path> {
+        self.output_path.as_deref()
+    }
+}
+
+/// Initialize tracing for an OpenData binary with the default set of layers
+/// (fmt console + optional Chrome trace). Callers that want to attach
+/// additional layers should use [`init_with_layers`] instead.
+pub fn init(config: TracingConfig) -> TracingGuard {
+    init_with_layers(config, Vec::new())
+}
+
+/// Like [`init`], but also attaches `extra_layers` to the registry. Each
+/// extra layer is a fully-configured, already-filtered [`BoxedLayer`] —
+/// attach any per-layer filter the caller needs with
+/// [`Layer::with_filter`] / [`Layer::boxed`] before passing it in.
+///
+/// Example: also write a file log filtered with its own env filter.
+///
+/// ```ignore
+/// use common::tracing::{BoxedLayer, TracingConfig, init_with_layers};
+/// use tracing_subscriber::{EnvFilter, Layer, fmt};
+///
+/// let file = std::fs::File::create("/var/log/opendata-debug.log").unwrap();
+/// let extra: BoxedLayer = fmt::layer()
+///     .with_writer(std::sync::Arc::new(file))
+///     .with_filter(EnvFilter::new("opendata_vector=debug"))
+///     .boxed();
+///
+/// let _guard = init_with_layers(config, vec![extra]);
+/// ```
+///
+/// # Panics
+///
+/// Panics if tracing has already been initialized in this process, or if the
+/// output directory cannot be created.
+pub fn init_with_layers(config: TracingConfig, extra_layers: Vec<BoxedLayer>) -> TracingGuard {
+    static INIT: AtomicBool = AtomicBool::new(false);
+    if INIT.swap(true, Ordering::SeqCst) {
+        panic!("common::tracing::init called more than once");
+    }
+
+    // `RUST_LOG` must control ONLY the fmt layer. If attached globally via
+    // `registry.with(env_filter)`, it would also gate the Chrome layer, making
+    // trace capture dependent on log level — exactly what this framework is
+    // designed to avoid. Using a per-layer filter keeps the two axes independent.
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let fmt_layer = fmt::layer()
+        .with_target(true)
+        .with_line_number(true)
+        .with_span_events(fmt::format::FmtSpan::CLOSE)
+        .with_filter(env_filter);
+
+    let mut guard = TracingGuard {
+        _chrome_guard: None,
+        output_path: None,
+    };
+
+    // Extra layers are `Box<dyn Layer<Registry>>`, so they only satisfy
+    // `Layer` against the bare `Registry` type. Attach them FIRST — while the
+    // subscriber is still a plain `Registry` — so subsequent `.with()` calls
+    // wrap them rather than trying to attach them on top of an already-
+    // stacked `Layered<...>` type they couldn't type-check against.
+    let registry = tracing_subscriber::registry()
+        .with(extra_layers)
+        .with(fmt_layer);
+
+    if let Some(dir) = config.output_dir {
+        std::fs::create_dir_all(&dir).expect("failed to create trace output directory");
+        let filename = format!(
+            "opendata-trace-{pid}-{ts}.json",
+            pid = std::process::id(),
+            ts = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs())
+                .unwrap_or_default(),
+        );
+        let path = dir.join(filename);
+        let (chrome_layer, flush_guard) = ChromeLayerBuilder::new()
+            .file(path.clone())
+            .include_args(true)
+            .trace_style(config.trace_style.into())
+            .build();
+        let chrome_layer = chrome_layer.with_filter(build_trace_filter(config.always_on));
+        // Order matters: Chrome must be added before RequestFilterLayer so
+        // Chrome's on_new_span runs first and registers its per-span args
+        // block. RequestFilterLayer.on_new_span then dispatches a record
+        // for the `trace_id` field, and Chrome's on_record updates the
+        // stored args so the id appears in the output JSON.
+        registry.with(chrome_layer).with(RequestFilterLayer).init();
+        guard._chrome_guard = Some(flush_guard);
+        guard.output_path = Some(path);
+    } else {
+        registry.init();
+    }
+
+    guard
+}
+
+/// Build the composite filter used by the Chrome layer:
+///
+/// 1. Root marker spans ([`TRACE_ROOT_SPAN_NAME`]) always pass.
+/// 2. Non-root spans/events must carry the [`TRACE_MARKER_FIELD`] marker,
+///    so ordinary `info!`/`info_span!` callsites never land in the file.
+/// 3. If an ancestor root span carries a stored [`LEVEL_FILTER_FIELD`]
+///    filter, it replaces `OPENDATA_TRACE` for descendants.
+/// 4. Otherwise `OPENDATA_TRACE` (as an [`EnvFilter`]) must admit the span.
+/// 5. If `always_on` is false, additionally require an ancestor named
+///    [`TRACE_ROOT_SPAN_NAME`].
+fn build_trace_filter<S>(always_on: bool) -> ChromeTraceFilter<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let env_filter = EnvFilter::try_from_env(TRACE_ENV_VAR)
+        .unwrap_or_else(|_| EnvFilter::new(DEFAULT_TRACE_FILTER));
+    ChromeTraceFilter {
+        env: env_filter,
+        ancestor_required: !always_on,
+        _phantom: std::marker::PhantomData,
+    }
+}
+
+/// Filter implementation for the Chrome layer. See [`build_trace_filter`].
+struct ChromeTraceFilter<S> {
+    env: EnvFilter,
+    /// If true, non-root spans require an ancestor with
+    /// [`TRACE_ROOT_SPAN_NAME`] to be captured. This is the per-request gate.
+    ancestor_required: bool,
+    _phantom: std::marker::PhantomData<fn(S)>,
+}
+
+impl<S> Filter<S> for ChromeTraceFilter<S>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn enabled(&self, meta: &Metadata<'_>, cx: &Context<'_, S>) -> bool {
+        if meta.name() == TRACE_ROOT_SPAN_NAME {
+            return true;
+        }
+        if !has_trace_marker(meta) {
+            return false;
+        }
+
+        // If any ancestor root carries a stored EnvFilter, it replaces
+        // OPENDATA_TRACE for descendants. Otherwise fall back to the
+        // process-wide filter.
+        let passes_level = match find_ancestor_level_filter(cx) {
+            Some(filter) => <EnvFilter as Filter<S>>::enabled(&filter, meta, cx),
+            None => <EnvFilter as Filter<S>>::enabled(&self.env, meta, cx),
+        };
+        if !passes_level {
+            return false;
+        }
+
+        if !self.ancestor_required {
+            return true;
+        }
+        cx.lookup_current()
+            .map(|span| {
+                span.scope()
+                    .from_root()
+                    .any(|s| s.name() == TRACE_ROOT_SPAN_NAME)
+            })
+            .unwrap_or(false)
+    }
+}
+
+/// True if the callsite declared the trace marker field in its metadata.
+/// `FieldSet::field(name)` returns `Some` only when the field is statically
+/// declared on this span/event's metadata, so ordinary `info!` calls miss.
+fn has_trace_marker(meta: &Metadata<'_>) -> bool {
+    meta.fields().field(TRACE_MARKER_FIELD).is_some()
+}
+
+/// Walk the current span's scope looking for an ancestor with a stored
+/// [`StoredLevelFilter`] extension. Innermost match wins.
+///
+/// Returns a clone of the ancestor's filter because `enabled` calls may
+/// outlive the borrow of the extensions map.
+fn find_ancestor_level_filter<S>(cx: &Context<'_, S>) -> Option<EnvFilter>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let current = cx.lookup_current()?;
+    for span in current.scope() {
+        if let Some(stored) = span.extensions().get::<StoredLevelFilter>() {
+            return Some(stored.0.clone());
+        }
+    }
+    None
+}
+
+/// Layer that enriches every trace span with a [`TRACE_ID_FIELD`] value and
+/// parses any [`LEVEL_FILTER_FIELD`] on root spans.
+///
+/// Trace-id rules:
+/// - If the span is a trace span ([`TRACE_MARKER_FIELD`] is declared in its
+///   metadata) and `trace_id` already has a value in its attributes (e.g.
+///   [`request_trace_span`] set one explicitly), keep that value.
+/// - Else if an ancestor span has a stored trace id, inherit it.
+/// - Else generate a fresh [`ulid::Ulid`] and attach it to this span. That
+///   span becomes the implicit root of a new trace.
+///
+/// The trace id is stored both in the span's extensions (for inheritance)
+/// and recorded as a field value via the tracing dispatcher (so
+/// tracing-chrome picks it up in the span's `args` block).
+pub(crate) struct RequestFilterLayer;
+
+struct StoredLevelFilter(EnvFilter);
+
+#[derive(Clone)]
+struct StoredTraceId(String);
+
+impl<S> Layer<S> for RequestFilterLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, id: &Id, cx: Context<'_, S>) {
+        let meta = attrs.metadata();
+
+        // Only trace-marked spans participate in the trace-id chain.
+        if meta.fields().field(TRACE_MARKER_FIELD).is_some() {
+            resolve_and_store_trace_id(attrs, id, &cx);
+        }
+
+        // Root spans may carry a level_filter directive.
+        if meta.name() == TRACE_ROOT_SPAN_NAME {
+            let mut visitor = LevelFilterVisitor(None);
+            attrs.record(&mut visitor);
+            store_filter_on_span(visitor.0, id, &cx);
+        }
+    }
+
+    fn on_record(&self, id: &Id, record: &Record<'_>, cx: Context<'_, S>) {
+        let Some(span) = cx.span(id) else {
+            return;
+        };
+        if span.metadata().name() != TRACE_ROOT_SPAN_NAME {
+            return;
+        }
+        let mut visitor = LevelFilterVisitor(None);
+        record.record(&mut visitor);
+        store_filter_on_span(visitor.0, id, &cx);
+    }
+}
+
+/// Resolve the `trace_id` for a newly-created trace span and ensure the
+/// field value is both stored in extensions (for descendants) and recorded
+/// on the span (for tracing-chrome args output).
+fn resolve_and_store_trace_id<S>(attrs: &Attributes<'_>, id: &Id, cx: &Context<'_, S>)
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    // Case 1: the span's attrs already supplied a trace_id (e.g. request_trace_span).
+    let mut visitor = TraceIdVisitor(None);
+    attrs.record(&mut visitor);
+    if let Some(existing) = visitor.0 {
+        store_trace_id(id, cx, existing);
+        return;
+    }
+
+    // Case 2: inherit from the nearest ancestor that has a stored trace_id.
+    if let Some(inherited) = find_ancestor_trace_id(cx, id) {
+        store_trace_id(id, cx, inherited.clone());
+        record_trace_id_on_span(id, attrs.metadata(), &inherited);
+        return;
+    }
+
+    // Case 3: this span is an implicit trace root — mint a fresh id.
+    let fresh = ulid::Ulid::new().to_string();
+    store_trace_id(id, cx, fresh.clone());
+    record_trace_id_on_span(id, attrs.metadata(), &fresh);
+}
+
+fn store_trace_id<S>(id: &Id, cx: &Context<'_, S>, trace_id: String)
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    if let Some(span) = cx.span(id) {
+        span.extensions_mut().insert(StoredTraceId(trace_id));
+    }
+}
+
+/// Walk the span's ancestors (not including the span itself) for the
+/// nearest `StoredTraceId`. Returns a clone of the string.
+fn find_ancestor_trace_id<S>(cx: &Context<'_, S>, id: &Id) -> Option<String>
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let span = cx.span(id)?;
+    for ancestor in span.scope().skip(1) {
+        if let Some(stored) = ancestor.extensions().get::<StoredTraceId>() {
+            return Some(stored.0.clone());
+        }
+    }
+    None
+}
+
+/// Record the `trace_id` field value on a span via the current dispatcher.
+/// This fires every layer's `on_record` hook, including tracing-chrome's,
+/// which updates its stored args so the id appears in the Chrome JSON.
+///
+/// We wrap the value in `tracing::field::display` so tracing-chrome's
+/// `record_debug`-only visitor formats it as a clean string (the wrapper's
+/// Debug impl forwards to Display). Passing `&str` directly would produce
+/// `"\"id\""` — the string rendered via Debug of &str, which includes
+/// surrounding quotes.
+fn record_trace_id_on_span(id: &Id, meta: &Metadata<'_>, trace_id: &str) {
+    let Some(field) = meta.fields().field(TRACE_ID_FIELD) else {
+        return;
+    };
+    let display = tracing::field::display(trace_id);
+    let value: &dyn tracing::Value = &display;
+    let values = [(&field, Some(value))];
+    let value_set = meta.fields().value_set(&values);
+    let record = Record::new(&value_set);
+    tracing::dispatcher::get_default(|d| d.record(id, &record));
+}
+
+fn store_filter_on_span<S>(filter_str: Option<String>, id: &Id, cx: &Context<'_, S>)
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    let Some(filter_str) = filter_str else {
+        return;
+    };
+    let filter = match EnvFilter::try_new(&filter_str) {
+        Ok(f) => f,
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                filter = %filter_str,
+                "invalid level_filter on opendata_trace_root; ignoring"
+            );
+            return;
+        }
+    };
+    let Some(span) = cx.span(id) else {
+        return;
+    };
+    span.extensions_mut().insert(StoredLevelFilter(filter));
+}
+
+/// Field visitor that captures the string value of [`LEVEL_FILTER_FIELD`] if
+/// any. We accept both `record_str` and `record_debug` because `EnvFilter`
+/// strings may be passed via `field = %value` / `field = value`.
+struct LevelFilterVisitor(Option<String>);
+
+impl Visit for LevelFilterVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == LEVEL_FILTER_FIELD {
+            self.0 = Some(value.to_string());
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == LEVEL_FILTER_FIELD && self.0.is_none() {
+            self.0 = Some(trim_quotes(format!("{:?}", value)));
+        }
+    }
+}
+
+/// Like [`LevelFilterVisitor`] but scoped to [`TRACE_ID_FIELD`]. Captures the
+/// string value if the span's attrs declared it.
+struct TraceIdVisitor(Option<String>);
+
+impl Visit for TraceIdVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == TRACE_ID_FIELD {
+            self.0 = Some(value.to_string());
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == TRACE_ID_FIELD && self.0.is_none() {
+            self.0 = Some(trim_quotes(format!("{:?}", value)));
+        }
+    }
+}
+
+/// Strip surrounding double-quotes from a Debug-formatted string so
+/// `field = value` and `field = %value` normalize the same way.
+fn trim_quotes(mut s: String) -> String {
+    if s.starts_with('"') && s.ends_with('"') && s.len() >= 2 {
+        s = s[1..s.len() - 1].to_string();
+    }
+    s
+}
+
+/// Create a root span that marks the start of a per-request trace. All
+/// descendant spans permitted by `OPENDATA_TRACE` will be captured in the
+/// Chrome trace output, regardless of [`TracingConfig::always_on`].
+///
+/// The returned span is not entered. Callers typically use `.in_scope(...)`
+/// or `.instrument(span)` on a future.
+pub fn request_trace_span(trace_id: &str) -> tracing::Span {
+    tracing::debug_span!(
+        TRACE_ROOT_SPAN_NAME,
+        trace_id = %trace_id,
+        _otrace = tracing::field::Empty,
+    )
+}
+
+/// Like [`request_trace_span`] but additionally sets the
+/// [`LEVEL_FILTER_FIELD`] to `filter`. The filter is parsed as an
+/// [`EnvFilter`] directive string (same syntax as `RUST_LOG`). When present,
+/// it replaces the process-wide `OPENDATA_TRACE` filter for every descendant
+/// span — useful for opting a single operation into `debug` capture while
+/// the rest of the process stays at `info`.
+///
+/// A malformed filter string emits a `warn!` and is ignored (the span still
+/// acts as a request marker, just without a custom filter).
+pub fn request_trace_span_with_filter(trace_id: &str, filter: &str) -> tracing::Span {
+    tracing::debug_span!(
+        TRACE_ROOT_SPAN_NAME,
+        trace_id = %trace_id,
+        level_filter = filter,
+        _otrace = tracing::field::Empty,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_expose_output_path_on_guard() {
+        // given
+        let guard = TracingGuard {
+            _chrome_guard: None,
+            output_path: Some(PathBuf::from("/tmp/x.json")),
+        };
+
+        // when
+        let path = guard.output_path();
+
+        // then
+        assert_eq!(path, Some(Path::new("/tmp/x.json")));
+    }
+
+    #[test]
+    fn should_return_none_output_path_when_chrome_disabled() {
+        // given
+        let guard = TracingGuard {
+            _chrome_guard: None,
+            output_path: None,
+        };
+
+        // when / then
+        assert!(guard.output_path().is_none());
+    }
+}

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -1,6 +1,7 @@
 //! Procedural macros for OpenData
 
 mod test;
+mod trace;
 
 use proc_macro::TokenStream;
 
@@ -29,4 +30,28 @@ use proc_macro::TokenStream;
 #[proc_macro_attribute]
 pub fn storage_test(args: TokenStream, input: TokenStream) -> TokenStream {
     test::storage::test_impl(args.into(), input.into()).into()
+}
+
+/// Attribute macro for instrumenting functions to participate in OpenData
+/// query tracing.
+///
+/// Expands to `#[tracing::instrument(...)]` with a marker field
+/// (`_otrace = tracing::field::Empty`) injected into `fields(...)`. The
+/// Chrome trace layer in `common::tracing` uses the presence of that field
+/// to discriminate trace spans from ordinary logs — ordinary `info!` /
+/// `info_span!` callsites never land in the trace file.
+///
+/// Accepts all of `#[tracing::instrument]`'s arguments unchanged.
+///
+/// # Example
+///
+/// ```ignore
+/// use opendata_macros::trace_instrument;
+///
+/// #[trace_instrument(skip_all, fields(limit = query.limit))]
+/// async fn search(query: &Query) -> Result<Vec<Hit>> { /* ... */ }
+/// ```
+#[proc_macro_attribute]
+pub fn trace_instrument(args: TokenStream, input: TokenStream) -> TokenStream {
+    trace::trace_instrument_impl(args.into(), input.into()).into()
 }

--- a/macros/src/trace.rs
+++ b/macros/src/trace.rs
@@ -1,0 +1,213 @@
+//! Implementation of the `#[trace_instrument]` attribute macro.
+//!
+//! Expands to `#[tracing::instrument(...)]` with a well-known marker field
+//! (`_otrace = tracing::field::Empty`) injected into the `fields(...)` list.
+//! The Chrome trace filter in `common::tracing` uses the presence of that
+//! field to discriminate trace spans from ordinary `info!`/`info_span!`
+//! callsites, so ordinary logs don't pollute the Chrome trace file.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::parse::Parser;
+use syn::punctuated::Punctuated;
+use syn::{ItemFn, Meta, MetaList, Token, parse_quote, parse2};
+
+/// Name of the marker field that identifies a span or event as participating
+/// in OpenData query tracing. Kept in sync with
+/// `common::tracing::TRACE_MARKER_FIELD`.
+pub const TRACE_MARKER_FIELD: &str = "_otrace";
+
+pub fn trace_instrument_impl(args: TokenStream, input: TokenStream) -> TokenStream {
+    let item_fn: ItemFn = match parse2(input) {
+        Ok(f) => f,
+        Err(e) => return e.to_compile_error(),
+    };
+
+    let new_args = match inject_marker(args) {
+        Ok(ts) => ts,
+        Err(e) => return e.to_compile_error(),
+    };
+
+    quote! {
+        #[::tracing::instrument(#new_args)]
+        #item_fn
+    }
+}
+
+/// Rewrite the attribute args so that
+/// 1. a `fields(...)` list exists and includes the trace marker field, and
+/// 2. `level = "debug"` is set unless the caller specified their own level.
+///
+/// Trace spans default to `debug` rather than `info` so they don't pollute
+/// ordinary `RUST_LOG=info` console output — they appear only when the fmt
+/// layer is at debug+, or when the Chrome trace filter accepts them.
+fn inject_marker(args: TokenStream) -> syn::Result<TokenStream> {
+    let parser = Punctuated::<Meta, Token![,]>::parse_terminated;
+    let metas = parser.parse2(args)?;
+    let marker_ident = proc_macro2::Ident::new(TRACE_MARKER_FIELD, proc_macro2::Span::call_site());
+    let trace_id_ident = proc_macro2::Ident::new("trace_id", proc_macro2::Span::call_site());
+    // Injected trace fields (marker + trace_id, both declared as Empty so
+    // a layer can record real values at span creation time).
+    let auto_fields: TokenStream = quote! {
+        #marker_ident = ::tracing::field::Empty,
+        #trace_id_ident = ::tracing::field::Empty
+    };
+
+    let mut new_metas: Punctuated<Meta, Token![,]> = Punctuated::new();
+    let mut had_fields = false;
+    let mut had_level = false;
+
+    for meta in metas {
+        if let Meta::NameValue(ref nv) = meta
+            && nv.path.is_ident("level")
+        {
+            had_level = true;
+        }
+        match meta {
+            Meta::List(list) if list.path.is_ident("fields") => {
+                had_fields = true;
+                let inner = list.tokens;
+                let new_inner = if inner.is_empty() {
+                    auto_fields.clone()
+                } else {
+                    quote! { #auto_fields, #inner }
+                };
+                new_metas.push(Meta::List(MetaList {
+                    path: list.path,
+                    delimiter: list.delimiter,
+                    tokens: new_inner,
+                }));
+            }
+            other => new_metas.push(other),
+        }
+    }
+
+    if !had_fields {
+        new_metas.push(parse_quote! { fields(#auto_fields) });
+    }
+    if !had_level {
+        new_metas.push(parse_quote! { level = "debug" });
+    }
+
+    Ok(quote! { #new_metas })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_inject_marker_when_fields_absent() {
+        // given
+        let args = quote! { skip_all };
+
+        // when
+        let out = inject_marker(args).unwrap().to_string();
+
+        // then
+        assert!(out.contains("skip_all"), "preserves original args: {}", out);
+        assert!(out.contains("fields"), "adds fields: {}", out);
+        assert!(out.contains(TRACE_MARKER_FIELD), "injects marker: {}", out);
+    }
+
+    #[test]
+    fn should_inject_marker_into_existing_fields() {
+        // given
+        let args = quote! { skip_all, fields(limit = 10, user = "x") };
+
+        // when
+        let out = inject_marker(args).unwrap().to_string();
+
+        // then
+        assert!(out.contains(TRACE_MARKER_FIELD), "marker injected: {}", out);
+        assert!(out.contains("limit"), "original field preserved: {}", out);
+        assert!(out.contains("user"), "original field preserved: {}", out);
+    }
+
+    #[test]
+    fn should_inject_marker_into_empty_fields() {
+        // given
+        let args = quote! { fields() };
+
+        // when
+        let out = inject_marker(args).unwrap().to_string();
+
+        // then
+        assert!(out.contains(TRACE_MARKER_FIELD), "marker injected: {}", out);
+    }
+
+    #[test]
+    fn should_produce_fn_attribute_with_instrument() {
+        // given
+        let args = quote! { skip_all };
+        let body = quote! {
+            async fn do_thing(x: u32) -> u32 { x + 1 }
+        };
+
+        // when
+        let out = trace_instrument_impl(args, body).to_string();
+
+        // then
+        assert!(
+            out.contains("tracing :: instrument"),
+            "emits tracing::instrument: {}",
+            out
+        );
+        assert!(out.contains("_otrace"), "emits marker field name: {}", out);
+        assert!(out.contains("do_thing"), "preserves original fn: {}", out);
+    }
+
+    #[test]
+    fn should_default_level_to_debug_when_caller_omits_it() {
+        // given
+        let args = quote! { skip_all };
+
+        // when
+        let out = inject_marker(args).unwrap().to_string();
+
+        // then
+        assert!(
+            out.contains("level = \"debug\""),
+            "expected level = \"debug\" injected by default, got: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn should_not_override_caller_specified_level() {
+        // given - caller pins the level explicitly
+        let args = quote! { skip_all, level = "info" };
+
+        // when
+        let out = inject_marker(args).unwrap().to_string();
+
+        // then - only the caller-supplied level is present
+        assert!(
+            out.contains("level = \"info\""),
+            "caller's level preserved: {}",
+            out
+        );
+        assert!(
+            !out.contains("level = \"debug\""),
+            "default level must not be injected when one was supplied: {}",
+            out
+        );
+    }
+
+    #[test]
+    fn should_surface_parse_errors_as_compile_error() {
+        // given - garbage in the attribute position
+        let args = quote! { , , fields(x = 1) };
+        let body = quote! { async fn f() {} };
+
+        // when
+        let out = trace_instrument_impl(args, body).to_string();
+
+        // then - a compile_error! macro invocation is emitted
+        assert!(
+            out.contains("compile_error"),
+            "emits compile_error: {}",
+            out
+        );
+    }
+}

--- a/vector/Cargo.toml
+++ b/vector/Cargo.toml
@@ -46,6 +46,7 @@ slatedb.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+ulid.workspace = true
 log = "0.4.29"
 rand = "0.8"
 

--- a/vector/bench/src/main.rs
+++ b/vector/bench/src/main.rs
@@ -7,16 +7,33 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 mod recall;
 
 use bencher::Benchmark;
-use tracing_subscriber::EnvFilter;
+use common::tracing::{TracingConfig, TracingGuard, init as init_tracing};
+
+/// Environment variable: when set, trace JSON files are written under this
+/// directory. When unset, only console logs are emitted. Use
+/// `OPENDATA_TRACE=<filter>` alongside to scope what lands in the file.
+const TRACE_DIR_ENV: &str = "OPENDATA_TRACE_DIR";
 
 fn benchmarks() -> Vec<Box<dyn Benchmark>> {
     vec![Box::new(recall::RecallBenchmark::new())]
 }
 
+fn install_tracing() -> TracingGuard {
+    let output_dir = std::env::var(TRACE_DIR_ENV).ok().map(Into::into);
+    let always_on = output_dir.is_some();
+    let guard = init_tracing(TracingConfig {
+        output_dir,
+        always_on,
+        ..Default::default()
+    });
+    if let Some(path) = guard.output_path() {
+        eprintln!("tracing: chrome trace file → {}", path.display());
+    }
+    guard
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .init();
+    let _trace_guard = install_tracing();
     bencher::run(benchmarks()).await
 }

--- a/vector/bench/src/recall.rs
+++ b/vector/bench/src/recall.rs
@@ -823,6 +823,7 @@ impl Benchmark for RecallBenchmark {
             distance_metric: config.distance_metric,
             query_pruning_factor: config.query_pruning_factor,
             metadata_fields: config.metadata_fields.clone(),
+            tracing: Default::default(),
         };
         let db = VectorDb::open_with_storage(config, sb).await?;
 

--- a/vector/src/bin/server.rs
+++ b/vector/src/bin/server.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use clap::{Parser, Subcommand};
-use tracing_subscriber::EnvFilter;
 
+use common::tracing::{TracingGuard, init as init_tracing};
 use vector::VectorDb;
 use vector::VectorDbReader;
 use vector::server::{
@@ -43,20 +43,14 @@ enum Command {
 
 #[tokio::main]
 async fn main() {
-    // Initialize tracing
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .init();
-
-    // Parse CLI arguments
+    // Parse CLI arguments first so we can read tracing config out of the YAML.
     let args = CliArgs::parse();
     let server_config = VectorServerConfig { port: args.port };
 
     match args.command {
         Command::Vector { config } => {
             let vector_config = load_vector_config(&config);
+            let _trace_guard = init_and_log_tracing(vector_config.tracing.clone());
             tracing::info!("Opening vector database with config: {:?}", vector_config);
             let metadata_fields = vector_config.metadata_fields.clone();
 
@@ -69,6 +63,7 @@ async fn main() {
         }
         Command::Reader { config } => {
             let reader_config = load_reader_config(&config);
+            let _trace_guard = init_and_log_tracing(reader_config.tracing.clone());
             tracing::info!(
                 "Opening vector database reader with config: {:?}",
                 reader_config
@@ -83,6 +78,16 @@ async fn main() {
             server.run().await;
         }
     }
+}
+
+/// Initialize tracing and, if trace capture is enabled, log the output path so
+/// operators can find the file.
+fn init_and_log_tracing(config: common::TracingConfig) -> TracingGuard {
+    let guard = init_tracing(config);
+    if let Some(path) = guard.output_path() {
+        tracing::info!(path = %path.display(), "tracing: chrome trace output enabled");
+    }
+    guard
 }
 
 #[cfg(test)]

--- a/vector/src/model.rs
+++ b/vector/src/model.rs
@@ -7,7 +7,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
-use common::StorageConfig;
+use common::{StorageConfig, TracingConfig};
 use serde::{Deserialize, Serialize};
 
 // Re-export types from serde layer
@@ -245,6 +245,15 @@ pub struct Config {
     /// attribute names or type mismatches will fail. If empty, any attribute
     /// names are accepted with types inferred from the first write.
     pub metadata_fields: Vec<MetadataFieldSpec>,
+
+    /// Tracing / query profiling configuration.
+    ///
+    /// When `output_dir` is set, per-operation timing spans (e.g.
+    /// `search_with_options` and its sub-steps) are written to a Chrome
+    /// Trace Format JSON file for later analysis in Perfetto. See
+    /// `common::tracing` for details.
+    #[serde(default)]
+    pub tracing: TracingConfig,
 }
 
 impl Default for Config {
@@ -263,6 +272,7 @@ impl Default for Config {
             chunk_target: 4096,
             query_pruning_factor: None,
             metadata_fields: Vec::new(),
+            tracing: TracingConfig::default(),
         }
     }
 }
@@ -293,6 +303,10 @@ pub struct ReaderConfig {
 
     /// Metadata field schema.
     pub metadata_fields: Vec<MetadataFieldSpec>,
+
+    /// Tracing / query profiling configuration. See [`Config::tracing`].
+    #[serde(default)]
+    pub tracing: TracingConfig,
 }
 
 /// Metadata field specification for schema definition.

--- a/vector/src/query_engine.rs
+++ b/vector/src/query_engine.rs
@@ -9,12 +9,12 @@ use crate::write::indexer::tree::centroids::{LeveledCentroidIndex, search_centro
 use crate::write::indexer::tree::posting_list::{Posting, PostingList};
 use crate::{Attribute, Vector};
 use common::storage::StorageRead;
+use common::tracing::{trace_instrument, trace_span};
 use roaring::RoaringTreemap;
 use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashSet};
 use std::sync::Arc;
-use std::time::Instant;
-use tracing::debug;
+use tracing::Instrument;
 
 /// The subset of configuration needed by the query engine.
 #[derive(Debug, Clone)]
@@ -144,12 +144,26 @@ impl QueryEngine {
         Ok(results)
     }
 
+    #[trace_instrument(
+        name = "search_with_options",
+        skip_all,
+        fields(
+            limit = query.limit,
+            has_filter = query.filter.is_some(),
+            nprobe = tracing::field::Empty,
+            n_centroids = tracing::field::Empty,
+            n_pruned_centroids = tracing::field::Empty,
+            n_results = tracing::field::Empty,
+        ),
+    )]
     pub(crate) async fn search_with_options(
         &self,
         query: &Query,
         options: SearchOptions,
     ) -> Result<Vec<SearchResult>> {
         let nprobe = options.nprobe.unwrap_or_else(|| query.limit.clamp(10, 100));
+        tracing::Span::current().record("nprobe", nprobe);
+
         // 1. Validate query dimensions
         if query.vector.len() != self.options.dimensions as usize {
             return Err(Error::InvalidInput(format!(
@@ -162,49 +176,35 @@ impl QueryEngine {
         // 2. Normalize query vector if required.
         let query_vector = self.normalize_query_if_needed(&query.vector);
 
-        // 3. Search HNSW for nearest centroids
-        let num_centroids = nprobe;
-        let t = Instant::now();
-        let centroid_candidates = self.search_centroids(&query_vector, num_centroids).await?;
-        debug!(
-            "searched for {} centroids, found: {}, elapsed_ms: {:?}",
-            num_centroids,
-            centroid_candidates.len(),
-            t.elapsed().as_millis()
-        );
+        // 3. Search centroid index for nearest centroids.
+        let centroid_candidates = self.search_centroids(&query_vector, nprobe).await?;
+        tracing::Span::current().record("n_centroids", centroid_candidates.len());
 
         if centroid_candidates.is_empty() {
             return Ok(Vec::new());
         }
 
-        // 3. Dynamic pruning: skip posting lists whose centroids are far from query
-        let original_ncentroids = centroid_candidates.len();
+        // 4. Dynamic pruning: skip posting lists whose centroids are far from query.
         let centroid_ids = self.prune_centroids(&centroid_candidates, &query_vector);
-        debug!(
-            "before pruning: {} centroids, after dynamic pruning: {} centroids",
-            original_ncentroids,
-            centroid_ids.len()
-        );
+        tracing::Span::current().record("n_pruned_centroids", centroid_ids.len());
 
-        // 5. Load posting lists and score candidates
+        // 5. Load posting lists and score candidates.
         let mut sorted_lists = self.load_and_score(&centroid_ids, &query_vector).await?;
 
         if sorted_lists.is_empty() {
             return Ok(Vec::new());
         }
 
-        // 6. Apply metadata filter (if provided)
+        // 6. Apply metadata filter (if provided).
         if let Some(filter) = &query.filter {
             Self::apply_filter(&mut sorted_lists, filter, self.storage.as_ref()).await?;
         }
 
-        // 7. K-way merge and resolve top-k forward index lookups
+        // 7. K-way merge and resolve top-k forward index lookups.
         let mut results = self.resolve_top_k(sorted_lists, query.limit).await?;
         Self::apply_field_selection(&mut results, &query.include_fields);
-        debug!(
-            op = "search_with_options",
-            elapsed_ms = t.elapsed().as_millis()
-        );
+
+        tracing::Span::current().record("n_results", results.len());
         Ok(results)
     }
 
@@ -217,6 +217,11 @@ impl QueryEngine {
     ///
     /// Returns the pruned centroid IDs. If pruning is disabled (`None`), returns
     /// the input unchanged.
+    #[trace_instrument(
+        name = "prune_centroids",
+        skip_all,
+        fields(n_in = centroid_ids.len()),
+    )]
     pub(crate) fn prune_centroids(&self, centroid_ids: &[Posting], query: &[f32]) -> Vec<VectorId> {
         let epsilon = match self.options.query_pruning_factor {
             Some(e) => e,
@@ -261,12 +266,18 @@ impl QueryEngine {
             .collect()
     }
 
+    #[trace_instrument(name = "search_centroids", skip_all, fields(k))]
     async fn search_centroids(&self, query: &[f32], k: usize) -> Result<Vec<Posting>> {
         search_centroids(self.centroid_index.as_ref(), query, k).await
     }
 
     /// Spawn a task per centroid to load its posting list and score all candidates
     /// against the query vector. Returns per-centroid sorted candidate lists.
+    #[trace_instrument(
+        name = "load_and_score",
+        skip_all,
+        fields(n_centroids = centroid_ids.len()),
+    )]
     async fn load_and_score(
         &self,
         centroid_ids: &[VectorId],
@@ -276,35 +287,38 @@ impl QueryEngine {
         let metric = self.options.distance_metric;
         let query_vec: Vec<f32> = query.to_vec();
 
-        let t = Instant::now();
         let mut handles = Vec::with_capacity(centroid_ids.len());
         for &cid in centroid_ids {
             let snap = self.storage.clone();
             let q = query_vec.clone();
-            handles.push(tokio::spawn(async move {
-                let posting_list =
-                    PostingList::from_value(snap.get_posting_list(cid, dimensions).await?);
-                let mut scored: Vec<ScoredCandidate> = posting_list
-                    .iter()
-                    .map(|posting| {
-                        let d = distance::compute_distance(&q, posting.vector(), metric);
-                        ScoredCandidate {
-                            internal_id: posting.id(),
-                            distance: d,
-                        }
-                    })
-                    .collect();
-                scored.sort_unstable_by_key(|a| a.distance);
-                Ok::<_, Error>(scored)
-            }));
+            let per_centroid_span = trace_span!(
+                "load_posting_list_and_score",
+                centroid_id = cid.id(),
+                n_scored = tracing::field::Empty,
+            );
+            handles.push(tokio::spawn(
+                async move {
+                    let posting_list =
+                        PostingList::from_value(snap.get_posting_list(cid, dimensions).await?);
+                    let mut scored: Vec<ScoredCandidate> = posting_list
+                        .iter()
+                        .map(|posting| {
+                            let d = distance::compute_distance(&q, posting.vector(), metric);
+                            ScoredCandidate {
+                                internal_id: posting.id(),
+                                distance: d,
+                            }
+                        })
+                        .collect();
+                    scored.sort_unstable_by_key(|a| a.distance);
+                    tracing::Span::current().record("n_scored", scored.len());
+                    Ok::<_, Error>(scored)
+                }
+                .instrument(per_centroid_span),
+            ));
         }
 
         let results = futures::future::join_all(handles).await;
-        let elapsed = t.elapsed();
-        debug!(
-            op = "search/load_and_score/load",
-            elapsed_ms = elapsed.as_millis()
-        );
         let mut sorted_lists: Vec<Vec<ScoredCandidate>> = Vec::with_capacity(results.len());
         for result in results {
             let scored =
@@ -320,6 +334,13 @@ impl QueryEngine {
     /// K-way merge the per-centroid sorted lists and resolve top-k forward
     /// index lookups. Only merges as far into the lists as needed to produce
     /// k results, deduplicating by `internal_id` along the way.
+    ///
+    /// Instrumentation has three sub-phases inside the top-level span:
+    /// 1. `seed_heap` — build the k-way merge heap from the input lists.
+    /// 2. `merge_candidates` — pop a batch of k unique candidates from the heap
+    ///    (the "final ranking" step — this is what produces the output order).
+    /// 3. `forward_index_read` — resolve the batch's vector data from storage.
+    #[trace_instrument(name = "resolve_top_k", skip_all, fields(k))]
     async fn resolve_top_k(
         &self,
         sorted_lists: Vec<Vec<ScoredCandidate>>,
@@ -328,13 +349,17 @@ impl QueryEngine {
         let dimensions = self.options.dimensions as usize;
 
         // Seed the min-heap with the first element of each sorted list.
-        let mut heap = BinaryHeap::new();
-        for list in sorted_lists {
-            let mut iter = list.into_iter();
-            if let Some(first) = iter.next() {
-                heap.push(Reverse(MergeEntry(first, iter)));
+        let n_lists = sorted_lists.len();
+        let mut heap = trace_span!("seed_heap", n_lists = n_lists).in_scope(|| {
+            let mut heap = BinaryHeap::new();
+            for list in sorted_lists {
+                let mut iter = list.into_iter();
+                if let Some(first) = iter.next() {
+                    heap.push(Reverse(MergeEntry(first, iter)));
+                }
             }
-        }
+            heap
+        });
 
         let mut results = Vec::with_capacity(k);
         let mut seen = HashSet::new();
@@ -342,36 +367,48 @@ impl QueryEngine {
         // Pop candidates from the heap in score order, batch-resolve k at a
         // time, and stop as soon as we have k results.
         loop {
-            // Drain up to k unique candidates from the merge heap.
-            let mut batch = Vec::with_capacity(k - results.len());
-            while batch.len() < k - results.len() {
-                let Some(Reverse(MergeEntry(candidate, mut iter))) = heap.pop() else {
-                    break;
-                };
-                if let Some(next) = iter.next() {
-                    heap.push(Reverse(MergeEntry(next, iter)));
+            // Drain up to k unique candidates from the merge heap — the
+            // "final ranking" phase. This is what decides the returned
+            // order; the forward-index read below just materializes the
+            // result payloads.
+            let need = k - results.len();
+            let merge_span = trace_span!(
+                "merge_candidates",
+                want = need,
+                picked = tracing::field::Empty,
+            );
+            let batch = merge_span.in_scope(|| {
+                let mut batch = Vec::with_capacity(need);
+                while batch.len() < need {
+                    let Some(Reverse(MergeEntry(candidate, mut iter))) = heap.pop() else {
+                        break;
+                    };
+                    if let Some(next) = iter.next() {
+                        heap.push(Reverse(MergeEntry(next, iter)));
+                    }
+                    if seen.insert(candidate.internal_id) {
+                        batch.push(candidate);
+                    }
                 }
-                if seen.insert(candidate.internal_id) {
-                    batch.push(candidate);
-                }
-            }
+                tracing::Span::current().record("picked", batch.len());
+                batch
+            });
 
             if batch.is_empty() {
                 break;
             }
 
             // Resolve forward index lookups for the batch concurrently.
-            let t = Instant::now();
-            let futures: Vec<_> = batch
-                .iter()
-                .map(|sr| self.storage.get_vector_data(sr.internal_id, dimensions))
-                .collect();
-            let loaded = futures::future::join_all(futures).await;
-            let elapsed = t.elapsed();
-            debug!(
-                op = "query/resolve_top_k/load",
-                elapsed_ms = elapsed.as_millis() as u64,
-            );
+            let load_span = trace_span!("forward_index_read", batch_size = batch.len());
+            let loaded = async {
+                let futures: Vec<_> = batch
+                    .iter()
+                    .map(|sr| self.storage.get_vector_data(sr.internal_id, dimensions))
+                    .collect();
+                futures::future::join_all(futures).await
+            }
+            .instrument(load_span)
+            .await;
 
             for (sr, vector_data) in batch.iter().zip(loaded) {
                 let Some(vector_data) = vector_data? else {
@@ -415,6 +452,7 @@ impl QueryEngine {
     ///
     /// Collects all candidate IDs into a bitmap, evaluates the filter against
     /// the inverted index, then retains only candidates that pass the filter.
+    #[trace_instrument(name = "apply_filter", skip_all)]
     async fn apply_filter(
         sorted_lists: &mut [Vec<ScoredCandidate>],
         filter: &Filter,

--- a/vector/src/reader.rs
+++ b/vector/src/reader.rs
@@ -155,6 +155,7 @@ mod tests {
             distance_metric: DistanceMetric::L2,
             query_pruning_factor: None,
             metadata_fields: vec![],
+            tracing: Default::default(),
         };
         let reader = VectorDbReader::open(reader_config).await.unwrap();
         let results = reader

--- a/vector/src/server/middleware.rs
+++ b/vector/src/server/middleware.rs
@@ -6,8 +6,28 @@ use std::task::{Context, Poll};
 use std::time::Instant;
 
 use axum::body::Body;
-use axum::http::{Request, Response};
+use axum::http::{HeaderValue, Request, Response};
+use common::tracing::{request_trace_span, request_trace_span_with_filter};
 use tower::{Layer, Service};
+use tracing::Instrument;
+
+/// HTTP header that opts a single request into query tracing. When present
+/// with a truthy value (`true`, `1`, `yes`), the handler runs under a
+/// [`request_trace_span`] so all instrumented sub-operations land in the
+/// Chrome trace file.
+pub const TRACE_OPT_IN_HEADER: &str = "x-opendata-trace";
+/// Optional HTTP header with an `EnvFilter` directive string applied as the
+/// per-request level filter (e.g. `vector::query_engine=debug`). When
+/// present, replaces the process-wide `OPENDATA_TRACE` for this request's
+/// descendant spans. Implies tracing opt-in.
+pub const TRACE_FILTER_HEADER: &str = "x-opendata-trace-filter";
+/// Response header that carries the assigned trace ID back to the client.
+pub const TRACE_ID_HEADER: &str = "x-opendata-trace-id";
+/// Query parameter that opts into tracing (alternative to the header — easier
+/// to set from a browser / curl one-liner).
+pub const TRACE_OPT_IN_QUERY_PARAM: &str = "trace";
+/// Query parameter form of [`TRACE_FILTER_HEADER`].
+pub const TRACE_FILTER_QUERY_PARAM: &str = "trace_filter";
 
 /// Layer that wraps services with request tracing.
 #[derive(Clone)]
@@ -75,11 +95,26 @@ where
             "HTTP request received"
         );
 
+        let filter_directive = trace_filter_directive(&request);
+        let (trace_id, trace_span) = if trace_opt_in(&request) || filter_directive.is_some() {
+            let id = ulid::Ulid::new().to_string();
+            let span = match &filter_directive {
+                Some(filter) => request_trace_span_with_filter(&id, filter),
+                None => request_trace_span(&id),
+            };
+            (Some(id), Some(span))
+        } else {
+            (None, None)
+        };
+
         let start_time = Instant::now();
         let future = self.inner.call(request);
 
         Box::pin(async move {
-            let response = future.await?;
+            let mut response = match trace_span {
+                Some(span) => future.instrument(span).await?,
+                None => future.await?,
+            };
             let status = response.status().as_u16();
             let elapsed = start_time.elapsed();
 
@@ -91,7 +126,209 @@ where
                 "HTTP request completed"
             );
 
+            if let Some(id) = trace_id.as_deref()
+                && let Ok(value) = HeaderValue::from_str(id)
+            {
+                response.headers_mut().insert(TRACE_ID_HEADER, value);
+            }
+
             Ok(response)
         })
+    }
+}
+
+/// Returns true if the request opts into tracing via the
+/// `X-Opendata-Trace` header or `?trace=1` query parameter.
+fn trace_opt_in(request: &Request<Body>) -> bool {
+    if request
+        .headers()
+        .get(TRACE_OPT_IN_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(is_truthy)
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    query_param_value(request, TRACE_OPT_IN_QUERY_PARAM)
+        .map(|v| is_truthy(&v))
+        .unwrap_or(false)
+}
+
+/// Returns the `EnvFilter` directive string opted in via the
+/// `X-Opendata-Trace-Filter` header or `?trace_filter=...` query parameter,
+/// if any.
+fn trace_filter_directive(request: &Request<Body>) -> Option<String> {
+    if let Some(value) = request
+        .headers()
+        .get(TRACE_FILTER_HEADER)
+        .and_then(|v| v.to_str().ok())
+    {
+        let trimmed = value.trim();
+        if !trimmed.is_empty() {
+            return Some(trimmed.to_string());
+        }
+    }
+    query_param_value(request, TRACE_FILTER_QUERY_PARAM).and_then(|raw| {
+        // URL-decode common ASCII escapes so curl users can pass
+        // `?trace_filter=vector%3A%3Aquery_engine=debug`.
+        let decoded = percent_decode(&raw);
+        let trimmed = decoded.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn query_param_value(request: &Request<Body>, key: &str) -> Option<String> {
+    let query = request.uri().query()?;
+    for pair in query.split('&') {
+        let mut parts = pair.splitn(2, '=');
+        let k = parts.next().unwrap_or("");
+        let v = parts.next().unwrap_or("");
+        if k.eq_ignore_ascii_case(key) {
+            return Some(v.to_string());
+        }
+    }
+    None
+}
+
+/// Minimal percent-decode for the handful of escapes a `trace_filter`
+/// directive actually needs (`%3A` for `:`, `%3D` for `=`, etc.).
+/// Non-ASCII / malformed escapes are preserved as-is.
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(h), Some(l)) = (hex_digit(bytes[i + 1]), hex_digit(bytes[i + 2]))
+        {
+            out.push((h << 4) | l);
+            i += 3;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+}
+
+fn hex_digit(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn is_truthy(value: &str) -> bool {
+    matches!(
+        value.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::Request;
+
+    #[test]
+    fn should_detect_trace_opt_in_via_header() {
+        // given
+        let req = Request::builder()
+            .uri("/api/v1/vector/search")
+            .header(TRACE_OPT_IN_HEADER, "true")
+            .body(Body::empty())
+            .unwrap();
+
+        // when / then
+        assert!(trace_opt_in(&req));
+    }
+
+    #[test]
+    fn should_detect_trace_opt_in_via_query_param() {
+        // given
+        let req = Request::builder()
+            .uri("/api/v1/vector/search?trace=1&other=x")
+            .body(Body::empty())
+            .unwrap();
+
+        // when / then
+        assert!(trace_opt_in(&req));
+    }
+
+    #[test]
+    fn should_reject_trace_opt_in_when_absent() {
+        // given
+        let req = Request::builder()
+            .uri("/api/v1/vector/search")
+            .body(Body::empty())
+            .unwrap();
+
+        // when / then
+        assert!(!trace_opt_in(&req));
+    }
+
+    #[test]
+    fn should_reject_trace_opt_in_when_header_falsy() {
+        // given
+        let req = Request::builder()
+            .uri("/api/v1/vector/search")
+            .header(TRACE_OPT_IN_HEADER, "false")
+            .body(Body::empty())
+            .unwrap();
+
+        // when / then
+        assert!(!trace_opt_in(&req));
+    }
+
+    #[test]
+    fn should_extract_trace_filter_directive_from_header() {
+        // given
+        let req = Request::builder()
+            .uri("/api/v1/vector/search")
+            .header(TRACE_FILTER_HEADER, "vector::query_engine=debug")
+            .body(Body::empty())
+            .unwrap();
+
+        // when / then
+        assert_eq!(
+            trace_filter_directive(&req).as_deref(),
+            Some("vector::query_engine=debug")
+        );
+    }
+
+    #[test]
+    fn should_percent_decode_trace_filter_query_param() {
+        // given - URL-encoded colons in the module path
+        let req = Request::builder()
+            .uri("/api/v1/vector/search?trace_filter=vector%3A%3Aquery_engine%3Ddebug")
+            .body(Body::empty())
+            .unwrap();
+
+        // when / then
+        assert_eq!(
+            trace_filter_directive(&req).as_deref(),
+            Some("vector::query_engine=debug")
+        );
+    }
+
+    #[test]
+    fn should_return_none_when_trace_filter_header_is_empty() {
+        // given
+        let req = Request::builder()
+            .uri("/api/v1/vector/search")
+            .header(TRACE_FILTER_HEADER, "   ")
+            .body(Body::empty())
+            .unwrap();
+
+        // when / then
+        assert!(trace_filter_directive(&req).is_none());
     }
 }

--- a/vector/src/write/indexer/tree/centroids.rs
+++ b/vector/src/write/indexer/tree/centroids.rs
@@ -51,6 +51,7 @@ use crate::storage::VectorDbStorageReadExt;
 use crate::write::indexer::drivers::AsyncBatchDriver;
 use crate::write::indexer::tree::posting_list::{Posting, PostingList};
 use common::StorageRead;
+use common::tracing::trace_span;
 use futures::future::BoxFuture;
 use rayon::iter::ParallelIterator;
 use rayon::prelude::IntoParallelIterator;
@@ -58,7 +59,7 @@ use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::fmt::{Display, Formatter};
 use std::hash::Hash;
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use tracing::Instrument;
 use tracing::debug;
 
 /// Represents a tree depth of some number of levels. Trees always have at least
@@ -948,23 +949,29 @@ pub(crate) async fn batch_search_centroids<K: Hash + Eq + Sized + Send + Sync>(
     k: usize,
     queries: Vec<(K, &[f32])>,
 ) -> Result<HashMap<K, Vec<Posting>>> {
-    let t = Instant::now();
     let nqueries = queries.len();
-    let result =
-        batch_search_centroids_in_level(index, k, queries, TreeLevel::leaf(index.depth)).await;
-    debug!(
-        op = "batch_search_centroids_in_level",
+    let span = trace_span!(
+        "batch_search_centroids",
         k = k,
         queries = nqueries,
-        duration_ms = t.elapsed().as_millis() as u64,
+        depth = %index.depth,
     );
-    result
+    async move {
+        batch_search_centroids_in_level(index, k, queries, TreeLevel::leaf(index.depth)).await
+    }
+    .instrument(span)
+    .await
 }
 
 /// Search a batch of queries in a given level of the centroid tree. This fn drives
 /// the main search loop for the tree. It takes a batch of queries, then in a loop,
 /// searches the index, loads any missing postings, and then resumes until all searches
 /// complete.
+///
+/// Instrumentation: each outer-loop iteration is wrapped in a `centroid_level` span
+/// (an "overarching" per-level span) with child `score_level_postings` and
+/// `load_level_postings` spans so the Chrome trace shows the work at each tree
+/// level of the search.
 pub(crate) async fn batch_search_centroids_in_level<K: Hash + Eq + Sized + Send + Sync>(
     index: &LeveledCentroidIndex<'_>,
     k: usize,
@@ -977,55 +984,55 @@ pub(crate) async fn batch_search_centroids_in_level<K: Hash + Eq + Sized + Send 
         .map(|(k, queries)| (k, queries, None))
         .collect();
     let mut queries = Some(queries);
+    let mut iteration: u32 = 0;
     loop {
         let Some(remaining) = queries.take() else {
             break;
         };
-        // find results / intermediate results
-        let t = Instant::now();
-        let intermediate = remaining
-            .into_par_iter()
-            .map(|(key, q, ip)| {
-                let result = if let Some(ip) = ip {
-                    index.resume_search_in_level(q, k, level, ip)
-                } else {
-                    index.search_in_level(q, k, level)
-                };
-                (key, q, result)
-            })
-            .collect::<Vec<_>>();
-        debug!(
-            op = "batch_search_centroids_in_level/search_in_level",
-            duration_ms = t.elapsed().as_millis() as u64,
+        iteration += 1;
+
+        // The level being scored this iteration: taken from any query's
+        // resumable state (all queries in a batch advance together). For the
+        // very first iteration there is no state yet — we're about to fetch
+        // the root.
+        let current_level = remaining
+            .first()
+            .and_then(|(_, _, ip)| ip.as_ref().map(|s| format!("{}", s.level)))
+            .unwrap_or_else(|| "root".to_string());
+
+        let level_span = trace_span!(
+            "centroid_level",
+            iteration = iteration,
+            level = %current_level,
+            n_queries = remaining.len(),
         );
-        let mut posting_reads = HashMap::new();
-        let mut pending = Vec::with_capacity(intermediate.len());
-        // separate finished results from intermediate posting reads
-        for (key, q, result) in intermediate {
-            match result {
-                SearchResult::ReadsRequired(reads) => {
-                    let (reads, in_flight) = reads.start();
-                    for (centroid, fut) in reads {
-                        posting_reads.insert(centroid, fut);
-                    }
-                    pending.push((key, q, in_flight))
-                }
-                SearchResult::Ann(ann) => {
-                    results.insert(key, ann);
-                }
-            }
+
+        let (pending, posting_reads, finished) = score_and_partition(index, k, level, remaining)
+            .instrument(level_span.clone())
+            .await;
+        for (key, ann) in finished {
+            results.insert(key, ann);
         }
         if pending.is_empty() {
             break;
         }
-        let posting_reads = posting_reads.into_values().collect::<Vec<_>>();
-        let t = Instant::now();
-        let posting_reads = AsyncBatchDriver::execute(posting_reads).await;
-        debug!(
-            op = "batch_search_centroids_in_level/execute reads",
-            reads = posting_reads.len(),
-            duration_ms = t.elapsed().as_millis() as u64,
+
+        let load_level = pending
+            .first()
+            .map(|(_, _, ip)| format!("{}", ip.level))
+            .unwrap_or_default();
+        let n_reads = posting_reads.len();
+        let load_span = trace_span!(
+            "load_level_postings",
+            level = %load_level,
+            n_reads = n_reads,
         );
+
+        let posting_reads = posting_reads.into_values().collect::<Vec<_>>();
+        let posting_reads = AsyncBatchDriver::execute(posting_reads)
+            .instrument(load_span)
+            .instrument(level_span)
+            .await;
         let mut postings = HashMap::with_capacity(posting_reads.len());
         for pr in posting_reads {
             let (centroid, pl) = pr?;
@@ -1040,6 +1047,57 @@ pub(crate) async fn batch_search_centroids_in_level<K: Hash + Eq + Sized + Send 
         );
     }
     Ok(results)
+}
+
+/// Score the current batch of queries at `level` and partition the results
+/// into ones that are done (returned as `finished`) and ones that are blocked
+/// on further posting reads (returned as `pending` plus the de-duplicated
+/// `posting_reads` to run). Wrapped in its own span — this is the CPU-bound
+/// "scoring postings at this level" phase of centroid search.
+#[allow(clippy::type_complexity)]
+async fn score_and_partition<'a, K: Hash + Eq + Sized + Send + Sync>(
+    index: &LeveledCentroidIndex<'a>,
+    k: usize,
+    level: TreeLevel,
+    remaining: Vec<(K, &'a [f32], Option<ResumableCentroidSearch>)>,
+) -> (
+    Vec<(K, &'a [f32], InFlightBlockedCentroidSearch)>,
+    HashMap<VectorId, PostingListReadFuture>,
+    Vec<(K, Vec<Posting>)>,
+) {
+    let score_span = trace_span!("score_level_postings", n_queries = remaining.len());
+    let intermediate = score_span.in_scope(|| {
+        remaining
+            .into_par_iter()
+            .map(|(key, q, ip)| {
+                let result = if let Some(ip) = ip {
+                    index.resume_search_in_level(q, k, level, ip)
+                } else {
+                    index.search_in_level(q, k, level)
+                };
+                (key, q, result)
+            })
+            .collect::<Vec<_>>()
+    });
+
+    let mut posting_reads = HashMap::new();
+    let mut pending = Vec::with_capacity(intermediate.len());
+    let mut finished = Vec::new();
+    for (key, q, result) in intermediate {
+        match result {
+            SearchResult::ReadsRequired(reads) => {
+                let (reads, in_flight) = reads.start();
+                for (centroid, fut) in reads {
+                    posting_reads.insert(centroid, fut);
+                }
+                pending.push((key, q, in_flight))
+            }
+            SearchResult::Ann(ann) => {
+                finished.push((key, ann));
+            }
+        }
+    }
+    (pending, posting_reads, finished)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

We use the tracing crate throughout the codebase to collect traces However out-of-the-box it doesn't let you distinguish between perf and functional diagnostic use cases. Traces are very useful for being able to understand where some logical operaiton spends time. However when we enable debug traces we bring along very verbose debug logs that make the traces harder to grok from the log and can themselves hinder performance. This PR addresses this by adding a framework for recording just timing traces and toggling this at either the process level or per-operation. The traces go to a file in chrome format so they can be visualized using Chrome or Perfetto, e.g:

<img width="1466" height="677" alt="Screenshot 2026-04-18 at 1 08 43 PM" src="https://github.com/user-attachments/assets/f05cc65e-5398-427f-b292-72a51f4aacc9" />


## Checklist

- [ ] Tests added/updated
- [ ] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
