### PR TITLE
[timeseries] Bucketlist skip redundant merge

### DIFF
--- a/timeseries/rfcs/0001-tsdb-storage.md
+++ b/timeseries/rfcs/0001-tsdb-storage.md
@@ -209,6 +209,11 @@ first-sightings from independent flushers remain correct. The singleton key
 stays hot in SlateDB's block cache (it is read on every query), so the pre-check
 is effectively free.
 
+On startup, before ingestion begins, the materialized `BucketList` is written
+back as a single `Put`. This flattens any merge operands accumulated in prior
+process lifetimes into one record so later reads don't have to replay them
+across SSTs.
+
 ### `SeriesDictionary` (`RecordType::SeriesDictionary` = `0x02`)
 
 The series dictionary maps label sets (label/value pairs) to series IDs.
@@ -542,4 +547,4 @@ This was rejected in favor of separate deployments per namespace:
 | 2025-12-17 | Initial draft |
 | 2026-01-18 | Updated InvertedIndex key encoding: attribute uses terminated bytes, value uses raw UTF-8 (backward incompatible) |
 | 2026-04-01 | Added metric_name to TimeSeries key: layout changed from `<bucket, series_id>` to `<bucket, metric_name, series_id>` for storage locality (backward incompatible, #349) |
-| 2026-04-19 | Documented BucketList write protocol: flushers read-check before emitting a merge to avoid per-flush merge churn on the hot singleton key |
+| 2026-04-19 | Documented BucketList write protocol: flushers read-check before emitting a merge to avoid per-flush merge churn on the hot singleton key; startup coalesces merge operands into a single Put |

--- a/timeseries/rfcs/0001-tsdb-storage.md
+++ b/timeseries/rfcs/0001-tsdb-storage.md
@@ -199,6 +199,16 @@ will be replaced by the new coarse buckets in the listing.
 - `bucket_size` (u8): The size of the time bucket in hours
 - `time_bucket` (u32): The number of minutes since the UNIX epoch
 
+**Write Protocol:**
+
+Updates go through the merge operator so concurrent ingesters can register new
+buckets without coordination. To keep the merge stream small, flushers read the
+current `BucketList` first and only emit a single-element merge when their
+bucket is not already present. The merge operator deduplicates, so concurrent
+first-sightings from independent flushers remain correct. The singleton key
+stays hot in SlateDB's block cache (it is read on every query), so the pre-check
+is effectively free.
+
 ### `SeriesDictionary` (`RecordType::SeriesDictionary` = `0x02`)
 
 The series dictionary maps label sets (label/value pairs) to series IDs.
@@ -532,3 +542,4 @@ This was rejected in favor of separate deployments per namespace:
 | 2025-12-17 | Initial draft |
 | 2026-01-18 | Updated InvertedIndex key encoding: attribute uses terminated bytes, value uses raw UTF-8 (backward incompatible) |
 | 2026-04-01 | Added metric_name to TimeSeries key: layout changed from `<bucket, series_id>` to `<bucket, metric_name, series_id>` for storage locality (backward incompatible, #349) |
+| 2026-04-19 | Documented BucketList write protocol: flushers read-check before emitting a merge to avoid per-flush merge churn on the hot singleton key |

--- a/timeseries/src/flusher.rs
+++ b/timeseries/src/flusher.rs
@@ -6,7 +6,7 @@ use common::coordinator::Flusher;
 use common::storage::{Storage, StorageSnapshot};
 
 use crate::delta::{FrozenTsdbDelta, TsdbWriteDelta};
-use crate::storage::OpenTsdbStorageExt;
+use crate::storage::{OpenTsdbStorageExt, OpenTsdbStorageReadExt};
 use crate::tsdb_metrics;
 
 /// Flusher implementation for the timeseries write coordinator.
@@ -32,11 +32,23 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         let start = std::time::Instant::now();
 
         let mut ops = Vec::new();
-        ops.push(
-            self.storage
-                .merge_bucket_list(frozen.bucket)
-                .map_err(|e| e.to_string())?,
-        );
+        // Suppress the BucketList merge when this bucket is already listed.
+        // Without this check, every flush emits an identical single-element
+        // merge operand on a singleton hot key that only coalesces at major
+        // compaction. `merge_batch_bucket_list` still dedupes, so concurrent
+        // first-sightings from two flushers are safe.
+        let bucket_announced = self
+            .storage
+            .bucket_list_contains(frozen.bucket)
+            .await
+            .map_err(|e| e.to_string())?;
+        if !bucket_announced {
+            ops.push(
+                self.storage
+                    .merge_bucket_list(frozen.bucket)
+                    .map_err(|e| e.to_string())?,
+            );
+        }
 
         for (fingerprint, series_id) in &frozen.series_dict_delta {
             ops.push(
@@ -105,8 +117,11 @@ mod tests {
     use super::*;
     use crate::delta::TsdbContext;
     use crate::model::{Label, MetricType, Sample, Series, TimeBucket};
+    use crate::serde::bucket_list::BucketListValue;
+    use crate::serde::key::BucketListKey;
     use crate::storage::OpenTsdbStorageReadExt;
     use crate::storage::merge_operator::OpenTsdbMergeOperator;
+    use common::Record;
     use common::coordinator::Delta;
     use common::storage::in_memory::InMemoryStorage;
     use std::collections::HashMap;
@@ -269,6 +284,117 @@ mod tests {
             result.unwrap_err().contains("test flush error"),
             "expected test flush error message"
         );
+    }
+
+    #[tokio::test]
+    async fn should_register_bucket_on_first_flush() {
+        // given
+        let storage = create_test_storage();
+        let mut flusher = TsdbFlusher {
+            storage: storage.clone(),
+        };
+        let ctx = TsdbContext {
+            bucket: create_test_bucket(),
+            series_dict: Arc::new(HashMap::new()),
+            next_series_id: 0,
+        };
+        let mut delta = TsdbWriteDelta::init(ctx);
+        delta
+            .apply(vec![create_test_series(
+                "m",
+                vec![("env", "prod")],
+                create_test_sample(),
+            )])
+            .unwrap();
+        let (frozen, _, _) = delta.freeze();
+
+        // when
+        let snapshot = flusher.flush_delta(frozen, &(1..2)).await.unwrap();
+
+        // then
+        let buckets = snapshot.get_buckets_in_range(None, None).await.unwrap();
+        assert_eq!(buckets, vec![create_test_bucket()]);
+    }
+
+    #[tokio::test]
+    async fn should_not_duplicate_bucket_across_multiple_flushes() {
+        // given: two back-to-back flushes for the same bucket
+        let storage = create_test_storage();
+        let mut flusher = TsdbFlusher {
+            storage: storage.clone(),
+        };
+        let bucket = create_test_bucket();
+
+        for (i, name) in ["metric_a", "metric_b"].iter().enumerate() {
+            let ctx = TsdbContext {
+                bucket,
+                series_dict: Arc::new(HashMap::new()),
+                next_series_id: i as u32,
+            };
+            let mut delta = TsdbWriteDelta::init(ctx);
+            delta
+                .apply(vec![create_test_series(
+                    name,
+                    vec![("env", "prod")],
+                    Sample {
+                        timestamp_ms: 60_000_000 + i as i64,
+                        value: i as f64,
+                    },
+                )])
+                .unwrap();
+            let (frozen, _, _) = delta.freeze();
+
+            // when
+            flusher.flush_delta(frozen, &(1..2)).await.unwrap();
+        }
+
+        // then: bucket appears exactly once
+        let snapshot = storage.snapshot().await.unwrap();
+        let buckets = snapshot.get_buckets_in_range(None, None).await.unwrap();
+        assert_eq!(buckets, vec![bucket]);
+    }
+
+    #[tokio::test]
+    async fn should_skip_bucket_list_merge_when_bucket_already_present() {
+        // given: storage pre-populated with the bucket in the BucketList
+        let storage = create_test_storage();
+        let bucket = create_test_bucket();
+        let pre_existing = BucketListValue {
+            buckets: vec![(bucket.size, bucket.start)],
+        }
+        .encode();
+        storage
+            .put(vec![common::storage::PutRecordOp::new(Record {
+                key: BucketListKey.encode(),
+                value: pre_existing,
+            })])
+            .await
+            .unwrap();
+
+        let mut flusher = TsdbFlusher {
+            storage: storage.clone(),
+        };
+        let ctx = TsdbContext {
+            bucket,
+            series_dict: Arc::new(HashMap::new()),
+            next_series_id: 0,
+        };
+        let mut delta = TsdbWriteDelta::init(ctx);
+        delta
+            .apply(vec![create_test_series(
+                "m",
+                vec![("env", "prod")],
+                create_test_sample(),
+            )])
+            .unwrap();
+        let (frozen, _, _) = delta.freeze();
+
+        // when
+        let snapshot = flusher.flush_delta(frozen, &(1..2)).await.unwrap();
+
+        // then: list still has exactly one entry for this bucket
+        let buckets = snapshot.get_buckets_in_range(None, None).await.unwrap();
+        assert_eq!(buckets, vec![bucket]);
     }
 
     #[tokio::test]

--- a/timeseries/src/storage/mod.rs
+++ b/timeseries/src/storage/mod.rs
@@ -228,6 +228,23 @@ pub(crate) trait OpenTsdbStorageReadExt: StorageRead {
         Ok(max_series_id)
     }
 
+    /// Check whether `bucket` is already present in the stored `BucketList`.
+    ///
+    /// Used by the flush path to suppress redundant single-element merges
+    /// on a bucket that has already been announced. The `BucketListKey` is
+    /// a global singleton that stays hot in SlateDB's block cache (read on
+    /// every query and warmed at startup), so this is a cache hit in the
+    /// common case.
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn bucket_list_contains(&self, bucket: TimeBucket) -> Result<bool> {
+        let key = BucketListKey.encode();
+        let Some(record) = self.get(key).await? else {
+            return Ok(false);
+        };
+        let list = BucketListValue::decode(record.value.as_ref())?;
+        Ok(list.buckets.contains(&(bucket.size, bucket.start)))
+    }
+
     /// Get all unique values for a specific label name within a bucket.
     /// This method scans only the inverted index keys for the specified label,
     /// which is more efficient than loading all inverted index entries.
@@ -429,5 +446,77 @@ mod tests {
         let s = storage_with_buckets(&[0, 60]).await;
         let buckets = s.get_buckets_for_ranges(&[(3600, 7200)]).await.unwrap();
         assert_eq!(starts(&buckets), vec![60]);
+    }
+
+    // ── bucket_list_contains tests ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn should_return_true_when_bucket_in_list() {
+        // given
+        let storage = storage_with_buckets(&[0, 60, 120]).await;
+
+        // when
+        let present = storage
+            .bucket_list_contains(TimeBucket { size: 1, start: 60 })
+            .await
+            .unwrap();
+
+        // then
+        assert!(present);
+    }
+
+    #[tokio::test]
+    async fn should_return_false_when_bucket_absent() {
+        // given
+        let storage = storage_with_buckets(&[0, 60]).await;
+
+        // when
+        let present = storage
+            .bucket_list_contains(TimeBucket {
+                size: 1,
+                start: 180,
+            })
+            .await
+            .unwrap();
+
+        // then
+        assert!(!present);
+    }
+
+    #[tokio::test]
+    async fn should_return_false_when_bucket_list_key_missing() {
+        // given
+        let storage = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
+            OpenTsdbMergeOperator,
+        )));
+
+        // when
+        let present = storage
+            .bucket_list_contains(TimeBucket { size: 1, start: 0 })
+            .await
+            .unwrap();
+
+        // then
+        assert!(!present);
+    }
+
+    #[tokio::test]
+    async fn should_distinguish_buckets_with_same_start_but_different_size() {
+        // given: only a size=1 bucket at start=60 is present
+        let storage = storage_with_buckets(&[60]).await;
+
+        // when
+        let size_one = storage
+            .bucket_list_contains(TimeBucket { size: 1, start: 60 })
+            .await
+            .unwrap();
+        let size_two = storage
+            .bucket_list_contains(TimeBucket { size: 2, start: 60 })
+            .await
+            .unwrap();
+
+        // then
+        assert!(size_one);
+        assert!(!size_two);
     }
 }

--- a/timeseries/src/storage/mod.rs
+++ b/timeseries/src/storage/mod.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use common::storage::RecordOp;
+use common::storage::{PutRecordOp, RecordOp};
 use common::{Record, Storage, StorageRead};
 use roaring::RoaringBitmap;
 
@@ -364,6 +364,26 @@ pub(crate) trait OpenTsdbStorageExt: Storage {
 // Implement the trait for all types that implement Storage
 impl<T: ?Sized + Storage> OpenTsdbStorageExt for T {}
 
+/// Read the current `BucketList` value and rewrite it as a single `Put`,
+/// collapsing the merge chain that accrues across ingestion batches into
+/// one flat record. Intended to run once at startup before ingestion
+/// begins, so later reads don't have to replay operands scattered across
+/// SSTs. Safe only when there are no concurrent writers.
+#[tracing::instrument(level = "info", skip_all)]
+pub(crate) async fn coalesce_bucket_list(storage: &dyn Storage) -> Result<()> {
+    let key = BucketListKey.encode();
+    let Some(record) = storage.get(key.clone()).await? else {
+        return Ok(());
+    };
+    storage
+        .put(vec![PutRecordOp::new(Record {
+            key,
+            value: record.value,
+        })])
+        .await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -518,5 +538,52 @@ mod tests {
         // then
         assert!(size_one);
         assert!(!size_two);
+    }
+
+    // ── coalesce_bucket_list tests ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn should_coalesce_bucket_list_preserving_merged_value() {
+        // given: several merge operands have accrued on the BucketList key
+        let storage = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
+            OpenTsdbMergeOperator,
+        )));
+        let ops = vec![
+            storage
+                .merge_bucket_list(TimeBucket { size: 1, start: 0 })
+                .unwrap(),
+            storage
+                .merge_bucket_list(TimeBucket { size: 1, start: 60 })
+                .unwrap(),
+            storage
+                .merge_bucket_list(TimeBucket {
+                    size: 1,
+                    start: 120,
+                })
+                .unwrap(),
+        ];
+        storage.apply(ops).await.unwrap();
+
+        // when
+        coalesce_bucket_list(storage.as_ref()).await.unwrap();
+
+        // then: readable value still reflects the full merged list
+        let buckets = storage.get_buckets_in_range(None, None).await.unwrap();
+        assert_eq!(starts(&buckets), vec![0, 60, 120]);
+    }
+
+    #[tokio::test]
+    async fn should_be_noop_when_bucket_list_absent() {
+        // given
+        let storage = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
+            OpenTsdbMergeOperator,
+        )));
+
+        // when
+        coalesce_bucket_list(storage.as_ref()).await.unwrap();
+
+        // then: key is still absent
+        let record = storage.get(BucketListKey.encode()).await.unwrap();
+        assert!(record.is_none());
     }
 }

--- a/timeseries/src/timeseries.rs
+++ b/timeseries/src/timeseries.rs
@@ -13,6 +13,7 @@ use common::{StorageBuilder, StorageSemantics};
 use crate::config::Config;
 use crate::error::{QueryError, Result};
 use crate::model::{Labels, MetricMetadata, QueryValue, RangeSample, Series};
+use crate::storage::coalesce_bucket_list;
 use crate::storage::merge_operator::OpenTsdbMergeOperator;
 use crate::tsdb::{
     Tsdb, TsdbReadEngine, eval_query_range_bounds, find_label_values_in_range,
@@ -84,6 +85,10 @@ impl TimeSeriesDb {
             )
             .build()
             .await?;
+        // Flatten accumulated BucketList merge operands into a single Put so
+        // later reads don't have to replay them across SSTs. Runs before any
+        // writer is started, so no concurrent merges can race the Put.
+        coalesce_bucket_list(storage.as_ref()).await?;
         let tsdb = Tsdb::new(storage);
         Ok(Self { tsdb })
     }


### PR DESCRIPTION
Every flush batch was pushing a single-element RecordOp::Merge on the global BucketListKey, producing one merge operand per flush on a singleton hot key. The merge operator dedupes correctly, but the operands only coalesce at major compaction, leaving hundreds of thousands of no-op records in the LSM in the meantime. 

**NOTE**: I have no idea why these weren't being merged more aggressively, probably because of our snapshot mechanism or something like that preventing merges. That's probably a worthwile investigation to have on its own. That said, this shouldn't have an impact on ingest throughput, especially because there will be fewer entries in the list.

Read the current list before emitting the merge and skip the push when the bucket is already registered. The key stays hot in SlateDB's block cache (it is read on every query and warmed at startup), so the extra read is a cache hit in the common case. Merge semantics are unchanged, so concurrent first-sightings from independent flushers remain safe via merge_batch_bucket_list.