### PR TITLE
Jemalloc build batch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2715,6 +2715,7 @@ dependencies = [
  "snap",
  "tempfile",
  "thiserror 2.0.17",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "tower",
@@ -4324,6 +4325,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2094,6 +2094,7 @@ dependencies = [
  "bencher",
  "bytes",
  "opendata-log",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -2603,6 +2604,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "slatedb",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "tracing",
@@ -2643,6 +2645,7 @@ dependencies = [
  "serde_with",
  "slatedb",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tower",
  "tracing",
@@ -4389,6 +4392,7 @@ dependencies = [
  "bencher",
  "opendata-timeseries",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -4897,6 +4901,7 @@ dependencies = [
  "opendata-common",
  "opendata-vector",
  "serde_yaml",
+ "tikv-jemallocator",
  "tokio",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ metrics-exporter-prometheus = "0.16"
 zstd = "0.13"
 tempfile = "3"
 opendata-macros = { path = "./macros" }
+tikv-jemallocator = "0.6"
 
 [profile.release]
 debug = true

--- a/ingest/Cargo.toml
+++ b/ingest/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/bin/opendata_ingest/main.rs"
 required-features = ["cli"]
 
 [features]
-cli = ["dep:clap", "dep:base64", "dep:serde_json"]
+cli = ["dep:clap", "dep:base64", "dep:serde_json", "dep:tikv-jemallocator"]
 
 [dependencies]
 common.workspace = true
@@ -37,6 +37,9 @@ base64 = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 zstd.workspace = true
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/ingest/src/bin/opendata_ingest/main.rs
+++ b/ingest/src/bin/opendata_ingest/main.rs
@@ -22,6 +22,10 @@
 //! opendata-ingest manifest dump /tmp/manifest | jq '.entries | length'
 //! ```
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use clap::{Parser, Subcommand};
 
 mod manifest;

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -20,7 +20,7 @@ required-features = ["http-server"]
 
 [features]
 default = []
-http-server = ["dep:axum", "dep:tower", "dep:clap", "dep:prometheus-client", "dep:metrics-exporter-prometheus"]
+http-server = ["dep:axum", "dep:tower", "dep:clap", "dep:prometheus-client", "dep:metrics-exporter-prometheus", "dep:tikv-jemallocator"]
 
 [dependencies]
 async-trait.workspace = true
@@ -42,6 +42,9 @@ tower = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 prometheus-client = { version = "0.22", optional = true }
 metrics-exporter-prometheus = { workspace = true, optional = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
 
 [dev-dependencies]
 base64.workspace = true

--- a/log/bench/Cargo.toml
+++ b/log/bench/Cargo.toml
@@ -11,3 +11,6 @@ log = { path = "..", package = "opendata-log" }
 anyhow.workspace = true
 async-trait.workspace = true
 tokio.workspace = true
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator.workspace = true

--- a/log/bench/src/main.rs
+++ b/log/bench/src/main.rs
@@ -1,5 +1,9 @@
 //! Benchmarks for the log database.
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 mod ingest;
 
 use bencher::Benchmark;

--- a/log/src/main.rs
+++ b/log/src/main.rs
@@ -1,5 +1,9 @@
 //! OpenData Log HTTP Server binary entry point.
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use std::sync::Arc;
 
 use clap::Parser;

--- a/timeseries/Cargo.toml
+++ b/timeseries/Cargo.toml
@@ -27,6 +27,7 @@ http-server = [
     "dep:tower-http",
     "dep:clap",
     "dep:metrics-exporter-prometheus",
+    "dep:tikv-jemallocator",
 ]
 testing = []
 remote-write = ["http-server", "dep:prost", "dep:snap"]
@@ -71,6 +72,9 @@ regex-syntax = "0.8"
 roaring = "0.7"
 rust-embed = { version = "8", features = ["mime-guess"] }
 tsz = "0.1"
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
 
 # Optional dependencies for remote-write and otel features
 ingest = { workspace = true, optional = true }

--- a/timeseries/bench/Cargo.toml
+++ b/timeseries/bench/Cargo.toml
@@ -11,3 +11,6 @@ anyhow.workspace = true
 async-trait.workspace = true
 tokio.workspace = true
 tempfile.workspace = true
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator.workspace = true

--- a/timeseries/bench/src/main.rs
+++ b/timeseries/bench/src/main.rs
@@ -1,5 +1,9 @@
 //! Benchmarks for the timeseries database.
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 mod ingest;
 
 use bencher::Benchmark;

--- a/timeseries/src/main.rs
+++ b/timeseries/src/main.rs
@@ -1,5 +1,9 @@
 #![allow(dead_code)]
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 mod config;
 mod delta;
 mod error;

--- a/timeseries/src/promql/operators/vector_selector.rs
+++ b/timeseries/src/promql/operators/vector_selector.rs
@@ -475,45 +475,47 @@ impl<'a, S: SeriesSource + Send + Sync + 'a> VectorSelectorOp<'a, S> {
         // the step timestamp.
         let mut source_timestamps = vec![0i64; cell_count];
 
+        // Forward two-pointer per series: `effective_times` is non-decreasing
+        // across steps (monotonic grid, or constant when `@` is set), and
+        // each series' timestamps are ascending, so a cursor advancing past
+        // samples with `ts <= window_hi` is correct across all steps. The
+        // candidate is always `cursor - 1` (the newest in-window sample).
+        // This turns the old O(step_count × series × ts.len()) reverse scan
+        // into O(step_count × series + Σ ts.len()).
+        let mut cursors = vec![0usize; chunk_len];
+
         for step_off in 0..step_count {
             let step_idx = step_chunk_start + step_off;
             let effective = self.effective_times.get(step_idx);
             let window_lo = effective.saturating_sub(self.lookback_ms); // exclusive
             let window_hi = effective; // inclusive
 
-            for series_off in 0..chunk_len {
+            for (series_off, cursor) in cursors.iter_mut().enumerate() {
                 let ts = &samples.timestamps[series_off];
                 let vs = &samples.values[series_off];
-                // Walk from the newest sample backward; caller already
-                // sorted per-series samples ascending by timestamp, so we
-                // scan from the end and stop at the first in-window
-                // non-stale sample.
-                let mut selected: Option<(f64, i64)> = None;
-                for i in (0..ts.len()).rev() {
-                    let t = ts[i];
-                    if t > window_hi {
-                        continue;
-                    }
-                    if t <= window_lo {
-                        break;
-                    }
-                    let v = vs[i];
-                    if is_stale_nan(v) {
-                        // Per task spec: STALE_NAN terminates the lookback;
-                        // treat this cell as absent.
-                        break;
-                    }
-                    selected = Some((v, t));
-                    break;
+                while *cursor < ts.len() && ts[*cursor] <= window_hi {
+                    *cursor += 1;
+                }
+                if *cursor == 0 {
+                    continue;
+                }
+                let idx = *cursor - 1;
+                let t = ts[idx];
+                if t <= window_lo {
+                    continue;
+                }
+                let v = vs[idx];
+                if is_stale_nan(v) {
+                    // STALE_NAN terminates the lookback; treat the cell as
+                    // absent. Per-step; the cursor stays put so later steps
+                    // with wider `window_hi` may select a newer sample.
+                    continue;
                 }
 
                 let cell = step_off * chunk_len + series_off;
-                if let Some((v, t)) = selected {
-                    buffers.values[cell] = v;
-                    buffers.validity.set(cell);
-                    source_timestamps[cell] = t;
-                }
-                // else: values[cell] stays NaN, validity bit stays clear.
+                buffers.values[cell] = v;
+                buffers.validity.set(cell);
+                source_timestamps[cell] = t;
             }
         }
 

--- a/vector/bench/Cargo.toml
+++ b/vector/bench/Cargo.toml
@@ -13,3 +13,6 @@ anyhow.workspace = true
 async-trait.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator.workspace = true

--- a/vector/bench/src/main.rs
+++ b/vector/bench/src/main.rs
@@ -1,5 +1,9 @@
 //! Benchmarks for the vector database.
 
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 mod recall;
 
 use bencher::Benchmark;


### PR DESCRIPTION
CPU profiling showed ~29% of time in glibc malloc/free and 11.87% self time in `VectorSelectorOp::build_batch`. Two changes address both:

- Install `tikv-jemallocator` as the global allocator in the timeseries binary (gated to non-msvc targets, wired to the `http-server` feature).
- Rewrite the per-cell lookback scan as a forward two-pointer per series. `effective_times` is non-decreasing across steps (monotonic grid, or constant under `@`), and each series' timestamps are ascending, so a cursor advancing past samples with `ts <= window_hi` is correct across all steps. Complexity drops from O(step_count × series × ts.len()) to O(step_count × series + Σ ts.len()). STALE_NAN semantics preserved.

### Results

Note that this also includes the slatedb `main` upgrades to foyer cache, DBstats cloning and a few other changes.

<img width="1400" height="900" alt="loadtest_compare" src="https://github.com/user-attachments/assets/b9d832c8-00a8-4a4e-95c3-dc447e65dceb" />
