### PR TITLE
decode posting lists without deserializing vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,6 +2736,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "bytemuck",
  "bytes",
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ async-trait = "0.1"
 axum = "0.8"
 axum-extra = { version = "0.12", features = ["query", "form"] }
 base64 = "0.22"
+bytemuck = { version = "1", features = ["extern_crate_alloc"] }
 bytes = "1.0"
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "env"] }

--- a/vector/Cargo.toml
+++ b/vector/Cargo.toml
@@ -30,6 +30,7 @@ avx512 = []
 anyhow.workspace = true
 async-trait.workspace = true
 common.workspace = true
+bytemuck.workspace = true
 bytes.workspace = true
 dashmap.workspace = true
 fail.workspace = true

--- a/vector/Cargo.toml
+++ b/vector/Cargo.toml
@@ -31,6 +31,7 @@ avx512 = []
 anyhow.workspace = true
 async-trait.workspace = true
 common.workspace = true
+bytemuck.workspace = true
 bytes.workspace = true
 dashmap.workspace = true
 fail.workspace = true

--- a/vector/rfcs/0001-storage.md
+++ b/vector/rfcs/0001-storage.md
@@ -327,7 +327,8 @@ with future schema changes that may require sub-type discrimination.
 - `Utf8`: `len: u16` followed by `len` bytes of UTF-8 payload.
 - `Vector<D>`: `D` elements of `f32`, where `D` is the dimensionality stored in collection metadata.
   Total size is `D * 4` bytes.
-- `Array<T>`: `count: u16` followed by `count` serialized elements of type `T`.
+- `Array<S=u16,T>`: `count: S` followed by `count` serialized elements of type `T`. Arrays that 
+  use the default count size `u16` are written as `Array<T>`.
 - `FixedElementArray<T>`: Serialized elements back-to-back with no count prefix;
 - `RoaringTreemap`: Roaring treemap serialization format for compressed u64 integer sets (64-bit
   extension of Roaring bitmap).
@@ -443,29 +444,32 @@ their vectors evaluated.
 ┌────────────────────────────────────────────────────────────────┐
 │                     PostingListValue                           │
 ├────────────────────────────────────────────────────────────────┤
-│  postings: FixedElementArray<Posting>                          │
+│  postings: Array<u32, Posting>                                 │
+│  data: FixedElementArray<f32>                                  │
 │                                                                │
 │  Posting                                                       │
 │  ┌──────────────────────────────────────────────────────────┐  │
-│  │  type:        u8 (0x0 => Append, 0x1 => Delete)          │  │
 |  |  id:          u64                                        │  │
-│  │  vector:      FixedElementArray<f32>                     │  │
-│  │               (dimensions elements)                      │  │
+│  │  offset:      u32 (0xFFFFFFFF | offset in data)          │  │
 │  └──────────────────────────────────────────────────────────┘  │
 └────────────────────────────────────────────────────────────────┘
 ```
 
 **Structure:**
 
-- The value is a simple array of mutations to the posting. The mutations are ordered by vector id.
-- Each entry specifies a mutation type. 0x0 indicates the vector is added, 0x1 indicates its deleted.
+- The postings field is an array of mutations to the posting. The mutations are ordered by 
+  vector id.
+- Each entry specifies either addition or deletion of a vector. The distinction is made by the 
+  value of the offset field. If its set to `u32::MAX` (`0xFFFFFFFF`) then the entry represents a
+  delete. Otherwise, the entry represents addition and the value indicates the position of the 
+  vector in he dta field.
 - Posting lists are balanced by the hierarchical clustering algorithm (target size configurable,
   e.g., 50-150 vectors)
 - It's expected that posting lists will be relatively small. Our evaluation of SPFresh has found
   that it is optimal to maintain one centroid for ~100 vectors. We also expect Vector to have a
-  high ingestion rate and modest query rate. So we optimize for a structure that can be
-  efficiently updated. The small size means that it should be relatively cheap to intersect with
-  the inverted index at query time.
+  high ingestion rate and modest query rate. For query, deserializing posting lists is a hotspot. 
+  So we optimize for a structure that can be efficiently updated. At query time, we can access the
+  vector data from the raw bytes.
 
 **Merge Operators:**
 

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -372,7 +372,7 @@ impl VectorDb {
             .await?
             .ok_or_else(|| Error::Storage("missing centroid tree metadata".to_string()))?;
         let root_posting_list =
-            PostingList::from_value(snapshot.get_root_posting_list(dimensions).await?);
+            PostingList::from_value(snapshot.get_root_posting_list(dimensions).await?, true);
         let centroids: HashMap<VectorId, CentroidInfoValue> = snapshot
             .scan_all_centroid_info()
             .await?
@@ -391,7 +391,10 @@ impl VectorDb {
                 assert_ne!(centroid_id, ROOT_VECTOR_ID);
                 centroids.get(&centroid_id).map(|centroid| {
                     assert!(centroid.level > LEAF_LEVEL);
-                    (centroid_id, Arc::new(PostingList::from_value(posting_list)))
+                    (
+                        centroid_id,
+                        Arc::new(PostingList::from_value(posting_list, true)),
+                    )
                 })
             })
             .collect();

--- a/vector/src/lib.rs
+++ b/vector/src/lib.rs
@@ -47,6 +47,7 @@ pub(crate) mod storage;
 
 #[cfg(test)]
 pub(crate) mod test_utils;
+pub(crate) mod utils;
 pub(crate) mod write;
 
 // Public API exports

--- a/vector/src/query_engine.rs
+++ b/vector/src/query_engine.rs
@@ -283,7 +283,7 @@ impl QueryEngine {
             let q = query_vec.clone();
             handles.push(tokio::spawn(async move {
                 let posting_list =
-                    PostingList::from_value(snap.get_posting_list(cid, dimensions).await?);
+                    PostingList::from_value(snap.get_posting_list(cid, dimensions).await?, false);
                 let mut scored: Vec<ScoredCandidate> = posting_list
                     .iter()
                     .map(|posting| {
@@ -580,10 +580,10 @@ mod tests {
         let query = [0.0, 0.0, 0.0];
         let engine = db.query_engine();
         let all_centroids = vec![
-            Posting::new(data_id(1), vec![1.0, 0.0, 0.0]),
-            Posting::new(data_id(2), vec![1.4, 0.0, 0.0]),
-            Posting::new(data_id(3), vec![2.0, 0.0, 0.0]),
-            Posting::new(data_id(4), vec![5.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(1), vec![1.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(2), vec![1.4, 0.0, 0.0]),
+            Posting::from_vec(data_id(3), vec![2.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(4), vec![5.0, 0.0, 0.0]),
         ];
 
         // when
@@ -610,8 +610,8 @@ mod tests {
         let query = [0.0, 0.0, 0.0];
         let engine = db.query_engine();
         let all_centroids = vec![
-            Posting::new(data_id(1), vec![1.0, 0.0, 0.0]),
-            Posting::new(data_id(2), vec![100.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(1), vec![1.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(2), vec![100.0, 0.0, 0.0]),
         ];
 
         // when
@@ -644,9 +644,9 @@ mod tests {
         let engine = db.query_engine();
         // pass centroids in reverse distance order: far, medium, close
         let ids = vec![
-            Posting::new(data_id(1), vec![5.0, 0.0, 0.0]),
-            Posting::new(data_id(3), vec![3.0, 0.0, 0.0]),
-            Posting::new(data_id(2), vec![1.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(1), vec![5.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(3), vec![3.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(2), vec![1.0, 0.0, 0.0]),
         ];
 
         // when

--- a/vector/src/serde/posting_list.rs
+++ b/vector/src/serde/posting_list.rs
@@ -17,11 +17,20 @@
 //!
 //! ## Value Format
 //!
-//! The value is a FixedElementArray of PostingUpdate entries, **sorted by id**.
-//! Each entry contains:
-//! - `posting_type`: 0x0 for Append, 0x1 for Delete
-//! - `id`: Internal vector ID (u64)
-//! - `vector`: The full vector data (dimensions * f32)
+//! The stored value is a split layout: a sorted-by-id header of fixed-size
+//! `(id, offset)` entries, followed by a contiguous vector data blob.
+//!
+//! ```text
+//! +-----------------------------------------------------------------+
+//! |  count:    u32 LE                                               |
+//! |  postings: count * (id: u64 BE, offset: u32 LE)                 |
+//! |  data:     FixedElementArray<f32>  (LE f32s, back-to-back)      |
+//! +-----------------------------------------------------------------+
+//! ```
+//!
+//! `offset` is a byte offset into the `data` section. The sentinel value
+//! `0xFFFFFFFF` (`u32::MAX`) marks a delete entry — delete entries occupy a
+//! slot in the header but contribute no bytes to `data`.
 //!
 //! ## Merge Operators
 //!
@@ -32,16 +41,29 @@
 
 use super::{Decode, Encode, EncodingError};
 use crate::serde::vector_id::VectorId;
-use bytes::{Buf, BufMut, Bytes, BytesMut};
+use crate::utils::aligned_bytes_from_vec;
+use bytes::{BufMut, Bytes, BytesMut};
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
-use std::sync::Arc;
+use tracing::debug_span;
 
-/// Byte value for append posting type in encoded format.
-pub(crate) const POSTING_UPDATE_TYPE_APPEND_BYTE: u8 = 0x0;
+/// Compile-time assertion that this build target is little-endian. The
+/// on-disk posting list format stores f32 values as raw bytes and we expose
+/// them to callers via `bytemuck::cast_slice`; that reinterpret-cast only
+/// preserves values on little-endian targets.
+const _: () = assert!(
+    cfg!(target_endian = "little"),
+    "opendata-vector assumes a little-endian target"
+);
 
-/// Byte value for delete posting type in encoded format.
-pub(crate) const POSTING_UPDATE_TYPE_DELETE_BYTE: u8 = 0x1;
+/// Offset sentinel in the posting header meaning "this is a delete entry".
+pub(crate) const POSTING_DELETE_OFFSET: u32 = u32::MAX;
+
+/// Size of a single posting header entry: `id(u64) + offset(u32)`.
+const POSTING_ENTRY_SIZE: usize = 8 + 4;
+
+/// Size of the `count` prefix at the start of the encoded value.
+const COUNT_PREFIX_SIZE: usize = 4;
 
 /// A single posting update entry containing vector data.
 ///
@@ -49,13 +71,14 @@ pub(crate) const POSTING_UPDATE_TYPE_DELETE_BYTE: u8 = 0x1;
 /// within a centroid's posting list.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum PostingUpdate {
-    /// The type of update: Append or Delete.
+    /// Append a vector to the posting list (or overwrite if id already exists).
     Append {
         /// Internal vector ID.
         id: VectorId,
-        /// The full vector data.
-        vector: Arc<Vec<f32>>,
+        /// Raw f32 vector bytes. Length is always `dimensions * 4`.
+        vector: Bytes,
     },
+    /// Delete the entry for `id` from the posting list.
     Delete {
         /// Internal vector ID
         id: VectorId,
@@ -63,11 +86,14 @@ pub(crate) enum PostingUpdate {
 }
 
 impl PostingUpdate {
-    /// Create a new append posting update.
+    /// Create a new append posting update from a `Vec<f32>`.
+    ///
+    /// The `Vec<f32>` is moved into a `Bytes` via [`Bytes::from_owner`] so the
+    /// underlying storage keeps its f32 alignment.
     pub(crate) fn append(id: VectorId, vector: Vec<f32>) -> Self {
         Self::Append {
             id,
-            vector: Arc::new(vector),
+            vector: aligned_bytes_from_vec(vector),
         }
     }
 
@@ -95,102 +121,6 @@ impl PostingUpdate {
             Self::Delete { id } => *id,
         }
     }
-
-    /// Returns the vector data if this is an Append, None if Delete.
-    #[allow(dead_code)]
-    pub(crate) fn vector(&self) -> Option<&[f32]> {
-        match self {
-            Self::Append { vector, .. } => Some(vector.as_slice()),
-            Self::Delete { .. } => None,
-        }
-    }
-
-    /// Encode this posting update to bytes.
-    ///
-    /// Format: type (1 byte) + id (8 bytes LE) + vector (N*4 bytes, each f32 LE)
-    pub(crate) fn encode(&self, buf: &mut BytesMut) {
-        match self {
-            Self::Append { id, vector } => {
-                buf.put_u8(POSTING_UPDATE_TYPE_APPEND_BYTE);
-                id.encode(buf);
-                for &val in vector.as_slice() {
-                    buf.put_f32_le(val);
-                }
-            }
-            Self::Delete { id } => {
-                buf.put_u8(POSTING_UPDATE_TYPE_DELETE_BYTE);
-                id.encode(buf);
-            }
-        }
-    }
-
-    /// Decode a posting update from bytes.
-    ///
-    /// Requires knowing the dimensions to determine vector size for Append entries.
-    pub fn decode(buf: &mut &[u8], dimensions: usize) -> Result<Self, EncodingError> {
-        let min_size = 1 + 8; // type + id
-        if buf.remaining() < min_size {
-            return Err(EncodingError {
-                message: format!(
-                    "Buffer too short for PostingUpdate: expected at least {} bytes, got {}",
-                    min_size,
-                    buf.remaining()
-                ),
-            });
-        }
-
-        let posting_type = buf.get_u8();
-        let id = VectorId::decode(buf)?;
-
-        if posting_type == POSTING_UPDATE_TYPE_APPEND_BYTE {
-            let vector_size = dimensions * 4;
-            if buf.remaining() < vector_size {
-                return Err(EncodingError {
-                    message: format!(
-                        "Buffer too short for Append PostingUpdate vector: expected {} bytes, got {}",
-                        vector_size,
-                        buf.remaining()
-                    ),
-                });
-            }
-
-            let mut vector = Vec::with_capacity(dimensions);
-            for _ in 0..dimensions {
-                vector.push(buf.get_f32_le());
-            }
-
-            Ok(PostingUpdate::Append {
-                id,
-                vector: Arc::new(vector),
-            })
-        } else if posting_type == POSTING_UPDATE_TYPE_DELETE_BYTE {
-            Ok(PostingUpdate::Delete { id })
-        } else {
-            Err(EncodingError {
-                message: format!("Invalid posting type: 0x{:02x}", posting_type),
-            })
-        }
-    }
-
-    /// Returns the encoded size in bytes for an Append entry with given dimensionality.
-    #[cfg(test)]
-    pub fn encoded_size_append(dimensions: usize) -> usize {
-        1 + 8 + (dimensions * 4) // type + id + vector
-    }
-
-    /// Returns the encoded size in bytes for a Delete entry.
-    #[cfg(test)]
-    pub fn encoded_size_delete() -> usize {
-        1 + 8 // type + id
-    }
-
-    /// Returns the encoded size of this posting update.
-    pub fn encoded_size(&self) -> usize {
-        match self {
-            PostingUpdate::Append { vector, .. } => 1 + 8 + (vector.len() * 4),
-            PostingUpdate::Delete { .. } => 1 + 8,
-        }
-    }
 }
 
 /// PostingList value storing vector updates for a centroid cluster.
@@ -198,25 +128,10 @@ impl PostingUpdate {
 /// Each posting list maps a single centroid ID to the list of vector updates
 /// (appends or deletes) for that cluster.
 ///
-/// ## Value Layout
-///
-/// ```text
-/// +----------------------------------------------------------------+
-/// |  postings: FixedElementArray<PostingUpdate>                    |
-/// |            (no count prefix, elements back-to-back)            |
-/// +----------------------------------------------------------------+
-/// ```
-///
-/// Each PostingUpdate:
-/// ```text
-/// +--------+----------+----------------------------------+
-/// | type   | id       | vector                           |
-/// | 1 byte | 8 bytes  | dimensions * 4 bytes             |
-/// +--------+----------+----------------------------------+
-/// ```
+/// On-disk layout is documented at the module level.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct PostingListValue {
-    /// List of posting updates (appends or deletes).
+    /// List of posting updates (appends or deletes), sorted by id.
     pub(crate) postings: Vec<PostingUpdate>,
 }
 
@@ -239,8 +154,6 @@ impl PostingListValue {
         posting_updates: Vec<PostingUpdate>,
     ) -> Result<Self, EncodingError> {
         // Deduplicate by id, keeping the last occurrence (most recent operation).
-        // We iterate in reverse so that when we encounter a duplicate, the first
-        // insertion (= last in original order) wins via the Entry API.
         let mut last_by_id = std::collections::HashMap::new();
         for (idx, update) in posting_updates.iter().enumerate() {
             last_by_id.insert(update.id(), idx);
@@ -272,39 +185,209 @@ impl PostingListValue {
         self.postings.iter()
     }
 
-    /// Encode to bytes (variable-length entries).
+    /// Encode to bytes in the layout described in the module docs.
     pub(crate) fn encode_to_bytes(&self) -> Bytes {
         if self.postings.is_empty() {
             return Bytes::new();
         }
 
-        let total_size: usize = self.postings.iter().map(|p| p.encoded_size()).sum();
-        let mut buf = BytesMut::with_capacity(total_size);
+        let count = u32::try_from(self.postings.len())
+            .expect("posting list length exceeds u32::MAX entries");
+        let header_size = COUNT_PREFIX_SIZE + POSTING_ENTRY_SIZE * self.postings.len();
+        let data_size: usize = self
+            .postings
+            .iter()
+            .map(|p| match p {
+                PostingUpdate::Append { vector, .. } => vector.len(),
+                PostingUpdate::Delete { .. } => 0,
+            })
+            .sum();
 
-        for posting in &self.postings {
-            posting.encode(&mut buf);
+        let mut buf = BytesMut::with_capacity(header_size + data_size);
+        buf.put_u32_le(count);
+
+        // Write postings header. For each append, record its byte offset in the
+        // yet-to-be-written data section.
+        let mut data_cursor: u32 = 0;
+        for p in &self.postings {
+            match p {
+                PostingUpdate::Append { id, vector } => {
+                    id.encode(&mut buf);
+                    buf.put_u32_le(data_cursor);
+                    data_cursor = data_cursor
+                        .checked_add(u32::try_from(vector.len()).expect("vector too large"))
+                        .expect("posting data section exceeds u32::MAX bytes");
+                }
+                PostingUpdate::Delete { id } => {
+                    id.encode(&mut buf);
+                    buf.put_u32_le(POSTING_DELETE_OFFSET);
+                }
+            }
+        }
+
+        // Data section: append vectors back-to-back in header order.
+        for p in &self.postings {
+            if let PostingUpdate::Append { vector, .. } = p {
+                buf.extend_from_slice(vector);
+            }
         }
 
         buf.freeze()
     }
 
-    /// Decode from bytes (variable-length entries).
+    /// Decode from bytes.
     ///
-    /// Requires knowing the dimensions to determine vector size for Append entries.
-    pub(crate) fn decode_from_bytes(buf: &[u8], dimensions: usize) -> Result<Self, EncodingError> {
-        if buf.is_empty() {
+    /// Requires `dimensions` to know how many f32s belong to each append
+    /// entry.
+    ///
+    /// Takes `&Bytes` rather than `&[u8]` so each decoded `Append` can share
+    /// ownership of the input allocation: whenever the input's pointer plus
+    /// the entry offset lands on an f32-aligned address, we hand out a
+    /// `Bytes::slice` into the same buffer with no copy. When the resulting
+    /// address isn't aligned we fall back to copying that entry's vector
+    /// bytes into a fresh aligned allocation.
+    pub(crate) fn decode_from_bytes(buf: &Bytes, dimensions: usize) -> Result<Self, EncodingError> {
+        let Some(mut cursor) = Cursor::new(buf.clone())? else {
             return Ok(PostingListValue::new());
+        };
+        let vector_bytes = dimensions * 4;
+        let data_len = cursor.data_len();
+        let mut postings = Vec::with_capacity(cursor.remaining_entries());
+        while let Some((id, offset)) = cursor.next() {
+            if offset == POSTING_DELETE_OFFSET {
+                postings.push(PostingUpdate::Delete { id });
+                continue;
+            }
+            let start = offset as usize;
+            let end = start
+                .checked_add(vector_bytes)
+                .ok_or_else(|| EncodingError {
+                    message: format!(
+                        "posting offset overflow: offset={}, vector_bytes={}",
+                        offset, vector_bytes
+                    ),
+                })?;
+            if end > data_len {
+                return Err(EncodingError {
+                    message: format!(
+                        "posting offset {} out of bounds: data size {}, entry ends at {}",
+                        offset, data_len, end
+                    ),
+                });
+            }
+            let vector = cursor.data_slice(offset, vector_bytes);
+            postings.push(PostingUpdate::Append { id, vector });
         }
+        Ok(Self { postings })
+    }
+}
 
-        let mut buf = buf;
-        let mut postings = Vec::new();
+/// Cursor over an encoded `PostingListValue` buffer.
+///
+/// Parses the header on construction, then exposes a peek/advance interface
+/// over the fixed-size `(id, offset)` entries plus random-access slicing of
+/// the trailing data section.
+struct Cursor {
+    buf: Bytes,
+    /// Byte offset of the next unread posting header entry into `buf`.
+    header_pos: usize,
+    /// One past the last header entry byte in `buf`.
+    header_end: usize,
+    /// Byte offset of the data section in `buf`.
+    data_start: usize,
+}
 
-        while buf.has_remaining() {
-            let posting = PostingUpdate::decode(&mut buf, dimensions)?;
-            postings.push(posting);
+impl Cursor {
+    /// Parse the header. Returns `Ok(None)` for empty buffers or buffers
+    /// declaring zero entries; `Err` if the count prefix or header is
+    /// truncated.
+    fn new(buf: Bytes) -> Result<Option<Self>, EncodingError> {
+        if buf.is_empty() {
+            return Ok(None);
         }
+        if buf.len() < COUNT_PREFIX_SIZE {
+            return Err(EncodingError {
+                message: format!(
+                    "Buffer too short for PostingListValue count: expected at least {} bytes, got {}",
+                    COUNT_PREFIX_SIZE,
+                    buf.len()
+                ),
+            });
+        }
+        let count = u32::from_le_bytes([buf[0], buf[1], buf[2], buf[3]]) as usize;
+        if count == 0 {
+            return Ok(None);
+        }
+        let header_end = COUNT_PREFIX_SIZE + POSTING_ENTRY_SIZE * count;
+        if buf.len() < header_end {
+            return Err(EncodingError {
+                message: format!(
+                    "Buffer too short for {} postings: expected at least {} bytes, got {}",
+                    count,
+                    header_end,
+                    buf.len()
+                ),
+            });
+        }
+        Ok(Some(Self {
+            buf,
+            header_pos: COUNT_PREFIX_SIZE,
+            header_end,
+            data_start: header_end,
+        }))
+    }
 
-        PostingListValue::from_posting_updates(postings)
+    /// Returns the `(id, offset)` of the entry at the cursor without
+    /// advancing, or `None` if exhausted.
+    fn peek(&self) -> Option<(VectorId, u32)> {
+        if self.header_pos >= self.header_end {
+            return None;
+        }
+        let entry = &self.buf[self.header_pos..self.header_pos + POSTING_ENTRY_SIZE];
+        let mut id_buf = &entry[..8];
+        let id = VectorId::decode(&mut id_buf).expect("failed to decode vector id");
+        let offset = u32::from_le_bytes([entry[8], entry[9], entry[10], entry[11]]);
+        Some((id, offset))
+    }
+
+    fn advance(&mut self) {
+        self.header_pos += POSTING_ENTRY_SIZE;
+    }
+
+    fn next(&mut self) -> Option<(VectorId, u32)> {
+        let next = self.peek();
+        if next.is_some() {
+            self.advance();
+        }
+        next
+    }
+
+    /// Number of entries remaining at or after the cursor.
+    fn remaining_entries(&self) -> usize {
+        (self.header_end - self.header_pos) / POSTING_ENTRY_SIZE
+    }
+
+    /// Total number of entries the buffer was constructed with.
+    fn total_entries(&self) -> usize {
+        (self.header_end - COUNT_PREFIX_SIZE) / POSTING_ENTRY_SIZE
+    }
+
+    /// Length in bytes of the data section.
+    fn data_len(&self) -> usize {
+        self.buf.len() - self.data_start
+    }
+
+    /// Zero-copy slice into the data section, sharing ownership of `buf`.
+    fn data_slice(&self, offset: u32, len: usize) -> Bytes {
+        let start = self.data_start + offset as usize;
+        self.buf.slice(start..start + len)
+    }
+
+    /// Borrowed view of the data section, for callers that copy into another
+    /// buffer rather than retaining ownership.
+    fn data_bytes(&self, offset: u32, len: usize) -> &[u8] {
+        let start = self.data_start + offset as usize;
+        &self.buf[start..start + len]
     }
 }
 
@@ -314,11 +397,13 @@ impl Default for PostingListValue {
     }
 }
 
-/// K-way byte-level merge for posting lists across multiple operands.
+/// K-way merge for posting lists across multiple operands in the new format.
 ///
 /// Merges `existing` (oldest, priority 0) with `operands` (priority 1..N, newest last)
-/// using a min-heap over raw byte cursors. For equal IDs, the highest-priority (newest)
-/// entry wins. Operands are ordered oldest-to-newest per SlateDB convention.
+/// by sort-merging the fixed-size header entries on id, then copying each
+/// winner's vector bytes into a new data section with rewritten offsets.
+/// For equal IDs, the highest-priority (newest) entry wins. Operands are
+/// ordered oldest-to-newest per SlateDB convention.
 ///
 /// Short-circuits: returns the single input as-is when only one source is present.
 pub(crate) fn merge_batch_posting_list(
@@ -326,6 +411,9 @@ pub(crate) fn merge_batch_posting_list(
     operands: &[Bytes],
     dimensions: usize,
 ) -> Bytes {
+    let n_records = operands.len() + existing.is_some() as usize;
+    let _span = debug_span!("merge_posting_list", n_records = n_records).entered();
+
     // Short-circuit: single source, no merge needed
     if operands.is_empty() {
         return existing.unwrap_or_default();
@@ -334,48 +422,41 @@ pub(crate) fn merge_batch_posting_list(
         return operands[0].clone();
     }
 
-    let vector_size = dimensions * 4;
-    let append_size = 1 + 8 + vector_size;
-    let delete_size = 1 + 8;
+    let vector_bytes = dimensions * 4;
 
-    // Each cursor: (Bytes buffer, priority). Higher priority = newer.
-    // existing_value has priority 0, operands[0] has priority 1, ..., operands[N-1] has priority N.
-    struct Cursor {
-        buf: Bytes,
-        priority: usize,
+    // Each cursor's priority is its index in `cursors_priority` (parallel to
+    // `cursors`): 0 = oldest (existing), N = newest. Malformed inputs are
+    // silently skipped to preserve historical merge behavior.
+    let mut cursors: Vec<Cursor> = Vec::with_capacity(1 + operands.len());
+    let mut cursors_priority: Vec<usize> = Vec::with_capacity(1 + operands.len());
+    if let Some(ex) = existing
+        && let Some(c) = Cursor::new(ex).ok().flatten()
+    {
+        cursors.push(c);
+        cursors_priority.push(0);
+    }
+    for (i, op) in operands.iter().enumerate() {
+        if let Some(c) = Cursor::new(op.clone()).ok().flatten() {
+            cursors.push(c);
+            cursors_priority.push(i + 1);
+        }
     }
 
-    let peek_entry =
-        |buf: &[u8], append_size: usize, delete_size: usize| -> Option<(VectorId, usize)> {
-            if buf.is_empty() {
-                return None;
-            }
-            assert!(buf.len() >= delete_size);
-            let entry_type = buf[0];
-            let mut id_buf = &buf[1..];
-            let id = VectorId::decode(&mut id_buf).expect("failed to decode vector id");
-            let entry_size = if entry_type == POSTING_UPDATE_TYPE_APPEND_BYTE {
-                append_size
-            } else {
-                delete_size
-            };
-            Some((id, entry_size))
-        };
+    if cursors.is_empty() {
+        return Bytes::new();
+    }
 
-    // Heap entry: (id, Reverse(priority), cursor_index)
-    // BinaryHeap is max-heap, so we use Reverse for id (want smallest first)
-    // and raw priority (want largest/newest to win on ties).
+    // Heap: min-heap by id, max-heap by priority (newest wins on ties).
     #[derive(Eq, PartialEq)]
     struct HeapEntry {
         id: VectorId,
         priority: usize,
         cursor_idx: usize,
-        entry_size: usize,
+        offset: u32,
     }
 
     impl Ord for HeapEntry {
         fn cmp(&self, other: &Self) -> Ordering {
-            // Min-heap by id, max-heap by priority for ties
             other
                 .id
                 .cmp(&self.id)
@@ -389,88 +470,126 @@ pub(crate) fn merge_batch_posting_list(
         }
     }
 
-    let mut cursors: Vec<Cursor> = Vec::with_capacity(1 + operands.len());
-
-    if let Some(ex) = existing
-        && !ex.is_empty()
-    {
-        cursors.push(Cursor {
-            buf: ex,
-            priority: 0,
-        });
-    }
-    for (i, op) in operands.iter().enumerate() {
-        if !op.is_empty() {
-            cursors.push(Cursor {
-                buf: op.clone(),
-                priority: i + 1,
-            });
-        }
-    }
-
-    if cursors.is_empty() {
-        return Bytes::new();
-    }
-
-    let total_size: usize = cursors.iter().map(|c| c.buf.len()).sum();
-    let mut result = BytesMut::with_capacity(total_size);
     let mut heap = BinaryHeap::with_capacity(cursors.len());
-
-    // Seed the heap
     for (idx, cursor) in cursors.iter().enumerate() {
-        if let Some((id, entry_size)) = peek_entry(&cursor.buf, append_size, delete_size) {
+        if let Some((id, offset)) = cursor.peek() {
             heap.push(HeapEntry {
                 id,
-                priority: cursor.priority,
+                priority: cursors_priority[idx],
                 cursor_idx: idx,
-                entry_size,
+                offset,
             });
         }
     }
+
+    // Estimate output size as the sum of all inputs — an upper bound since
+    // duplicate ids collapse into a single output entry.
+    let total_header_entries: usize = cursors.iter().map(|c| c.total_entries()).sum();
+    let mut out_header = BytesMut::with_capacity(POSTING_ENTRY_SIZE * total_header_entries);
+    let total_data_bytes: usize = cursors.iter().map(|c| c.data_len()).sum();
+    let mut out_data = BytesMut::with_capacity(total_data_bytes);
+
+    let mut out_count: u32 = 0;
 
     while let Some(winner) = heap.pop() {
         let id = winner.id;
 
-        // Write the winner's entry bytes
-        let cursor = &mut cursors[winner.cursor_idx];
-        result.put_slice(&cursor.buf[..winner.entry_size]);
-        cursor.buf.advance(winner.entry_size);
+        // Emit winner's entry with rewritten offset.
+        id.encode(&mut out_header);
+        if winner.offset == POSTING_DELETE_OFFSET {
+            out_header.put_u32_le(POSTING_DELETE_OFFSET);
+        } else {
+            let new_offset =
+                u32::try_from(out_data.len()).expect("merged data section exceeds u32::MAX bytes");
+            out_header.put_u32_le(new_offset);
+            let cursor = &cursors[winner.cursor_idx];
+            out_data.extend_from_slice(cursor.data_bytes(winner.offset, vector_bytes));
+        }
+        out_count += 1;
 
-        // Advance the winner's cursor
-        if let Some((next_id, next_size)) = peek_entry(&cursor.buf, append_size, delete_size) {
+        // Advance the winner's cursor.
+        let cursor = &mut cursors[winner.cursor_idx];
+        cursor.advance();
+        if let Some((next_id, next_offset)) = cursor.peek() {
             heap.push(HeapEntry {
                 id: next_id,
-                priority: cursor.priority,
+                priority: cursors_priority[winner.cursor_idx],
                 cursor_idx: winner.cursor_idx,
-                entry_size: next_size,
+                offset: next_offset,
             });
         }
 
-        // Skip all other entries with the same id (losers)
+        // Skip all other entries with the same id (losers).
         while heap.peek().is_some_and(|e| e.id == id) {
             let loser = heap.pop().unwrap();
             let cursor = &mut cursors[loser.cursor_idx];
-            cursor.buf.advance(loser.entry_size);
-
-            // Advance the loser's cursor
-            if let Some((next_id, next_size)) = peek_entry(&cursor.buf, append_size, delete_size) {
+            cursor.advance();
+            if let Some((next_id, next_offset)) = cursor.peek() {
                 heap.push(HeapEntry {
                     id: next_id,
-                    priority: cursor.priority,
+                    priority: cursors_priority[loser.cursor_idx],
                     cursor_idx: loser.cursor_idx,
-                    entry_size: next_size,
+                    offset: next_offset,
                 });
             }
         }
     }
 
-    result.freeze()
+    if out_count == 0 {
+        return Bytes::new();
+    }
+
+    // Assemble: count || header || data.
+    //
+    // Over-allocate by `align - 1` bytes so we can shift the visible payload
+    // forward by up to that many bytes and land the returned `Bytes` pointer
+    // on an f32-aligned address, regardless of what the allocator gave us.
+    // Downstream readers (e.g. `PostingList::from_value`) can then read the
+    // data section via `bytemuck::cast_slice` with no extra copy. This is an optimization
+    // so that we don't have to copy the data again after merging on the read path
+    let payload_size = COUNT_PREFIX_SIZE + out_header.len() + out_data.len();
+    let align = std::mem::align_of::<f32>();
+    let mut out = BytesMut::with_capacity(payload_size + align - 1);
+    let skip = match out.as_ptr().align_offset(align) {
+        // edge case for cases where ptr cant be aligned to the specified offset
+        // should never happen for &[u8]
+        usize::MAX => 0,
+        n => n,
+    };
+    for _ in 0..skip {
+        out.put_u8(0);
+    }
+    out.put_u32_le(out_count);
+    out.extend_from_slice(&out_header);
+    out.extend_from_slice(&out_data);
+    out.freeze().slice(skip..)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::write::indexer::tree::posting_list::PostingList;
+    use bytes::Buf;
+
+    impl crate::serde::posting_list::PostingUpdate {
+        /// Returns the vector data if this is an Append, None if Delete. This fn doesn't
+        /// assume that the vector data is aligned to the in-memory format, so it deserializes
+        /// the data into vector
+        pub(crate) fn decode_vector(&self) -> Option<Vec<f32>> {
+            match self {
+                Self::Append { vector, .. } => {
+                    let len = vector.len() / size_of::<f32>();
+                    let mut data = Vec::with_capacity(len);
+                    let mut buf = vector.clone();
+                    for _ in 0..len {
+                        data.push(buf.get_f32_le())
+                    }
+                    Some(data)
+                }
+                Self::Delete { .. } => None,
+            }
+        }
+    }
 
     #[test]
     fn should_encode_and_decode_empty_posting_list() {
@@ -515,21 +634,6 @@ mod tests {
         fn delete(id_num: impl CompatId) -> super::PostingUpdate {
             super::PostingUpdate::delete(id_num.into_vector_id())
         }
-
-        fn decode(
-            buf: &mut &[u8],
-            dimensions: usize,
-        ) -> Result<super::PostingUpdate, EncodingError> {
-            super::PostingUpdate::decode(buf, dimensions)
-        }
-
-        fn encoded_size_append(dimensions: usize) -> usize {
-            super::PostingUpdate::encoded_size_append(dimensions)
-        }
-
-        fn encoded_size_delete() -> usize {
-            super::PostingUpdate::encoded_size_delete()
-        }
     }
 
     struct Posting;
@@ -540,7 +644,10 @@ mod tests {
             id_num: impl CompatId,
             vector: Vec<f32>,
         ) -> crate::write::indexer::tree::posting_list::Posting {
-            crate::write::indexer::tree::posting_list::Posting::new(id_num.into_vector_id(), vector)
+            crate::write::indexer::tree::posting_list::Posting::from_vec(
+                id_num.into_vector_id(),
+                vector,
+            )
         }
     }
 
@@ -562,10 +669,16 @@ mod tests {
         assert_eq!(decoded.len(), 2);
         assert!(decoded.postings[0].is_append());
         assert_eq!(decoded.postings[0].id(), id(1));
-        assert_eq!(decoded.postings[0].vector().unwrap(), &[1.0, 2.0, 3.0]);
+        assert_eq!(
+            decoded.postings[0].decode_vector().unwrap(),
+            &[1.0, 2.0, 3.0]
+        );
         assert!(decoded.postings[1].is_append());
         assert_eq!(decoded.postings[1].id(), id(2));
-        assert_eq!(decoded.postings[1].vector().unwrap(), &[4.0, 5.0, 6.0]);
+        assert_eq!(
+            decoded.postings[1].decode_vector().unwrap(),
+            &[4.0, 5.0, 6.0]
+        );
     }
 
     #[test]
@@ -588,6 +701,29 @@ mod tests {
     }
 
     #[test]
+    fn should_interleave_appends_and_deletes() {
+        // given - mixed entries in the same value
+        let postings = vec![
+            PostingUpdate::append(1, vec![1.0, 1.0]),
+            PostingUpdate::delete(2),
+            PostingUpdate::append(3, vec![3.0, 3.0]),
+        ];
+        let value = PostingListValue::from_posting_updates(postings).unwrap();
+
+        // when
+        let encoded = value.encode_to_bytes();
+        let decoded = PostingListValue::decode_from_bytes(&encoded, 2).unwrap();
+
+        // then
+        assert_eq!(decoded.len(), 3);
+        assert!(decoded.postings[0].is_append());
+        assert_eq!(decoded.postings[0].decode_vector().unwrap(), &[1.0, 1.0]);
+        assert!(decoded.postings[1].is_delete());
+        assert!(decoded.postings[2].is_append());
+        assert_eq!(decoded.postings[2].decode_vector().unwrap(), &[3.0, 3.0]);
+    }
+
+    #[test]
     fn should_create_posting_update_append() {
         // given / when
         let update = PostingUpdate::append(42, vec![1.0, 2.0]);
@@ -596,7 +732,7 @@ mod tests {
         assert!(update.is_append());
         assert!(!update.is_delete());
         assert_eq!(update.id(), id(42));
-        assert_eq!(update.vector().unwrap(), &[1.0, 2.0]);
+        assert_eq!(update.decode_vector().unwrap(), &[1.0, 2.0]);
     }
 
     #[test]
@@ -611,55 +747,28 @@ mod tests {
     }
 
     #[test]
-    fn should_encode_and_decode_single_posting_update() {
-        // given
-        let update = PostingUpdate::append(id(12345), vec![1.5, 2.5, 3.5, 4.5]);
-        let mut buf = BytesMut::new();
-        update.encode(&mut buf);
+    fn should_reject_buffer_too_short_for_header() {
+        // given - only 2 bytes, not enough for u32 count
+        let buf = Bytes::copy_from_slice(&[0u8; 2]);
 
         // when
-        let mut buf_ref: &[u8] = &buf;
-        let decoded = PostingUpdate::decode(&mut buf_ref, 4).unwrap();
-
-        // then
-        assert!(decoded.is_append());
-        assert_eq!(decoded.id(), id(12345));
-        assert_eq!(decoded.vector().unwrap(), &[1.5, 2.5, 3.5, 4.5]);
-    }
-
-    #[test]
-    fn should_calculate_correct_encoded_size() {
-        // when / then
-        assert_eq!(PostingUpdate::encoded_size_append(3), 1 + 8 + 12); // 21 bytes
-        assert_eq!(PostingUpdate::encoded_size_append(128), 1 + 8 + 512); // 521 bytes
-        assert_eq!(PostingUpdate::encoded_size_delete(), 1 + 8); // 9 bytes
-    }
-
-    #[test]
-    fn should_reject_invalid_posting_type() {
-        // given
-        let mut buf = BytesMut::new();
-        buf.put_u8(0xFF); // Invalid type
-        buf.put_u64_le(1);
-        buf.put_f32_le(1.0);
-
-        // when
-        let mut buf_ref: &[u8] = &buf;
-        let result = PostingUpdate::decode(&mut buf_ref, 1);
+        let result = PostingListValue::decode_from_bytes(&buf, 3);
 
         // then
         assert!(result.is_err());
-        assert!(result.unwrap_err().message.contains("Invalid posting type"));
+        assert!(result.unwrap_err().message.contains("Buffer too short"));
     }
 
     #[test]
-    fn should_reject_buffer_too_short() {
-        // given
-        let buf = [0u8; 5]; // Too short for any valid posting
+    fn should_reject_buffer_too_short_for_postings() {
+        // given - claims 2 postings but header is truncated
+        let mut buf = BytesMut::new();
+        buf.extend_from_slice(&2u32.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 5]); // less than 2 * 12 bytes
+        let buf = buf.freeze();
 
         // when
-        let mut buf_ref: &[u8] = &buf;
-        let result = PostingUpdate::decode(&mut buf_ref, 3);
+        let result = PostingListValue::decode_from_bytes(&buf, 3);
 
         // then
         assert!(result.is_err());
@@ -678,7 +787,7 @@ mod tests {
             .expect("unexpected error creating posting updates");
 
         // when
-        let postings: PostingList = PostingList::from_value(value);
+        let postings: PostingList = PostingList::from_value(value, false);
 
         // then - sorted by id
         assert_eq!(
@@ -703,7 +812,7 @@ mod tests {
             .expect("unexpected error creating posting updates");
 
         // when
-        let postings: PostingList = PostingList::from_value(value);
+        let postings: PostingList = PostingList::from_value(value, false);
 
         // then - delete entry not in result, sorted by id
         assert_eq!(
@@ -836,9 +945,12 @@ mod tests {
         // then - id 1 has new vector, id 2 unchanged, sorted order
         assert_eq!(decoded.len(), 2);
         assert_eq!(decoded.postings[0].id(), id(1));
-        assert_eq!(decoded.postings[0].vector().unwrap(), &[100.0, 200.0]);
+        assert_eq!(
+            decoded.postings[0].decode_vector().unwrap(),
+            &[100.0, 200.0]
+        );
         assert_eq!(decoded.postings[1].id(), id(2));
-        assert_eq!(decoded.postings[1].vector().unwrap(), &[3.0, 4.0]);
+        assert_eq!(decoded.postings[1].decode_vector().unwrap(), &[3.0, 4.0]);
     }
 
     #[test]
@@ -1010,7 +1122,7 @@ mod tests {
         assert_eq!(decoded.postings[0].id(), id(10));
         assert_eq!(decoded.postings[1].id(), id(20));
         assert_eq!(decoded.postings[2].id(), id(30));
-        assert_eq!(decoded.postings[2].vector().unwrap(), &[300.0]); // new value won
+        assert_eq!(decoded.postings[2].decode_vector().unwrap(), &[300.0]); // new value won
         assert_eq!(decoded.postings[3].id(), id(40));
         assert_eq!(decoded.postings[4].id(), id(50));
     }
@@ -1029,7 +1141,7 @@ mod tests {
             .expect("unexpected error creating posting updates");
 
         // when
-        let posting_list = PostingList::from_value(value)
+        let posting_list = PostingList::from_value(value, false)
             .into_iter()
             .collect::<Vec<_>>();
 
@@ -1070,13 +1182,13 @@ mod tests {
         // then - id 2 has value from op2 (newest), all 4 ids present
         assert_eq!(decoded.len(), 4);
         assert_eq!(decoded.postings[0].id(), id(1));
-        assert_eq!(decoded.postings[0].vector().unwrap(), &[10.0]);
+        assert_eq!(decoded.postings[0].decode_vector().unwrap(), &[10.0]);
         assert_eq!(decoded.postings[1].id(), id(2));
-        assert_eq!(decoded.postings[1].vector().unwrap(), &[2000.0]);
+        assert_eq!(decoded.postings[1].decode_vector().unwrap(), &[2000.0]);
         assert_eq!(decoded.postings[2].id(), id(3));
-        assert_eq!(decoded.postings[2].vector().unwrap(), &[30.0]);
+        assert_eq!(decoded.postings[2].decode_vector().unwrap(), &[30.0]);
         assert_eq!(decoded.postings[3].id(), id(4));
-        assert_eq!(decoded.postings[3].vector().unwrap(), &[40.0]);
+        assert_eq!(decoded.postings[3].decode_vector().unwrap(), &[40.0]);
     }
 
     #[test]
@@ -1171,5 +1283,83 @@ mod tests {
         assert!(decoded.postings[1].is_delete());
         assert_eq!(decoded.postings[2].id(), id(3));
         assert!(decoded.postings[2].is_append());
+    }
+
+    #[test]
+    fn should_reuse_input_buffer_when_decoding_aligned_bytes() {
+        // given - encode something so the value's data section is aligned
+        // relative to the buffer start (encode_to_bytes produces a
+        // header whose size is a multiple of 4, so data starts at a 4-aligned
+        // offset from `buf.as_ptr()`; combined with an aligned allocation
+        // this means every append should be zero-copy).
+        let value = PostingListValue::from_posting_updates(vec![
+            PostingUpdate::append(1, vec![1.0, 2.0]),
+            PostingUpdate::append(2, vec![3.0, 4.0]),
+        ])
+        .unwrap();
+        let encoded = value.encode_to_bytes();
+
+        // Skip the test if the allocator happened to give us an unaligned
+        // buffer — decode still succeeds (it'd fall back to copying) but the
+        // pointer-identity assertion wouldn't apply.
+        if !(encoded.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()) {
+            return;
+        }
+        let encoded_ptr = encoded.as_ptr() as usize;
+        let encoded_end = encoded_ptr + encoded.len();
+
+        // when
+        let decoded = PostingListValue::decode_from_bytes(&encoded, 2).unwrap();
+
+        // then - each Append's vector Bytes points into the encoded buffer.
+        let mut seen_appends = 0;
+        for p in &decoded.postings {
+            if let super::PostingUpdate::Append { vector, .. } = p {
+                let ptr = vector.as_ptr() as usize;
+                assert!(
+                    ptr >= encoded_ptr && ptr + vector.len() <= encoded_end,
+                    "append vector Bytes ptr {:#x} is not a slice of encoded buffer {:#x}..{:#x}",
+                    ptr,
+                    encoded_ptr,
+                    encoded_end,
+                );
+                seen_appends += 1;
+            }
+        }
+        assert_eq!(seen_appends, 2);
+    }
+
+    #[test]
+    fn should_return_f32_aligned_bytes_from_merge() {
+        // given - a handful of inputs so we exercise the assembly path
+        // (short-circuits don't go through the padding logic)
+        let existing = PostingListValue::from_posting_updates(vec![
+            PostingUpdate::append(1, vec![1.0, 2.0, 3.0]),
+            PostingUpdate::append(3, vec![4.0, 5.0, 6.0]),
+        ])
+        .unwrap()
+        .encode_to_bytes();
+        let op0 = PostingListValue::from_posting_updates(vec![PostingUpdate::append(
+            2,
+            vec![7.0, 8.0, 9.0],
+        )])
+        .unwrap()
+        .encode_to_bytes();
+        let op1 = PostingListValue::from_posting_updates(vec![PostingUpdate::delete(3)])
+            .unwrap()
+            .encode_to_bytes();
+
+        // when — run merge enough times to exercise every residue class of
+        // the allocator's pointer mod 4. 16 rounds is plenty; each iteration
+        // independently allocates so we see a variety of start pointers.
+        for _ in 0..16 {
+            let merged =
+                merge_batch_posting_list(Some(existing.clone()), &[op0.clone(), op1.clone()], 3);
+            assert!(
+                (merged.as_ptr() as usize).is_multiple_of(std::mem::align_of::<f32>()),
+                "merge output not f32-aligned: ptr={:p}",
+                merged.as_ptr()
+            );
+        }
     }
 }

--- a/vector/src/storage/mod.rs
+++ b/vector/src/storage/mod.rs
@@ -371,7 +371,7 @@ mod tests {
 
         // then - read
         let result = storage.get_posting_list(centroid_id, 3).await.unwrap();
-        let result: Vec<_> = PostingList::from_value(result).into_iter().collect();
+        let result: Vec<_> = PostingList::from_value(result, false).into_iter().collect();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].id(), VectorId::data_vector_id(1));
         assert_eq!(result[1].id(), VectorId::data_vector_id(2));

--- a/vector/src/utils.rs
+++ b/vector/src/utils.rs
@@ -1,0 +1,20 @@
+//! Crate-wide utility helpers.
+use bytemuck::NoUninit;
+use bytes::Bytes;
+
+/// Owner wrapper for a `Vec<T>` exposed as its raw byte representation, so
+/// we can hand ownership to `Bytes::from_owner` while preserving the natural
+/// alignment of the underlying allocation.
+struct AlignedBuf<T: NoUninit>(Vec<T>);
+
+impl<T: NoUninit> AsRef<[u8]> for AlignedBuf<T> {
+    fn as_ref(&self) -> &[u8] {
+        bytemuck::cast_slice(&self.0)
+    }
+}
+
+/// Turn a `Vec<T>` into a `Bytes` whose pointer is guaranteed to have at least
+/// `align_of::<T>()` alignment (the Vec's natural allocator alignment).
+pub(crate) fn aligned_bytes_from_vec<T: NoUninit + Send + 'static>(vec: Vec<T>) -> Bytes {
+    Bytes::from_owner(AlignedBuf(vec))
+}

--- a/vector/src/write/flusher.rs
+++ b/vector/src/write/flusher.rs
@@ -234,7 +234,7 @@ mod tests {
             .await
             .unwrap();
         let centroid_cache = AllCentroidsCacheWriter::new(
-            Arc::new(PostingList::from_iter(vec![Posting::new(
+            Arc::new(PostingList::from_iter(vec![Posting::from_vec(
                 leaf_centroid_id(1),
                 vec![0.0; DIMS],
             )])),

--- a/vector/src/write/flusher.rs
+++ b/vector/src/write/flusher.rs
@@ -235,7 +235,7 @@ mod tests {
             .await
             .unwrap();
         let centroid_cache = AllCentroidsCacheWriter::new(
-            Arc::new(PostingList::from_iter(vec![Posting::new(
+            Arc::new(PostingList::from_iter(vec![Posting::from_vec(
                 leaf_centroid_id(1),
                 vec![0.0; DIMS],
             )])),

--- a/vector/src/write/indexer/tree/centroids.rs
+++ b/vector/src/write/indexer/tree/centroids.rs
@@ -705,6 +705,7 @@ impl CentroidReader for StoredCentroidReader {
         MaybeCached::Future(Box::pin(async move {
             Ok(Arc::new(PostingList::from_value(
                 snapshot.get_posting_list(centroid_id, dimensions).await?,
+                false,
             )))
         }))
     }
@@ -827,13 +828,16 @@ impl AllCentroidsCacheWriter {
             posting_list: Option<&Arc<PostingList>>,
             updates: Vec<PostingUpdate>,
         ) -> Arc<PostingList> {
-            let Some(posting_list) = posting_list else {
-                return Arc::new(PostingList::from_value(
+            let pl = if let Some(posting_list) = posting_list {
+                posting_list.clone_with_updates(updates, true)
+            } else {
+                PostingList::from_value(
                     PostingListValue::from_posting_updates(updates)
                         .expect("posting updates should always encode"),
-                ));
+                    true,
+                )
             };
-            Arc::new(posting_list.update_and_flatten(updates))
+            Arc::new(pl)
         }
 
         let mut inner = self.inner.lock().expect("lock poisoned");
@@ -1118,9 +1122,9 @@ mod tests {
         let target_level = TreeLevel::leaf(TreeDepth::of(3));
         let postings = Arc::new(
             vec![
-                Posting::new(vector_id(1, 10), vec![1.0, 0.0]),
-                Posting::new(vector_id(1, 11), vec![0.0, 1.0]),
-                Posting::new(vector_id(1, 12), vec![3.0, 0.0]),
+                Posting::from_vec(vector_id(1, 10), vec![1.0, 0.0]),
+                Posting::from_vec(vector_id(1, 11), vec![0.0, 1.0]),
+                Posting::from_vec(vector_id(1, 12), vec![3.0, 0.0]),
             ]
             .into_iter()
             .collect(),
@@ -1148,16 +1152,19 @@ mod tests {
         let target_level = TreeLevel::leaf(TreeDepth::of(3));
         let postings_a = Arc::new(
             vec![
-                Posting::new(vector_id(1, 10), vec![1.0, 0.0]),
-                Posting::new(vector_id(1, 11), vec![0.0, 1.0]),
+                Posting::from_vec(vector_id(1, 10), vec![1.0, 0.0]),
+                Posting::from_vec(vector_id(1, 11), vec![0.0, 1.0]),
             ]
             .into_iter()
             .collect(),
         );
         let postings_b = Arc::new(
-            vec![Posting::new(VectorId::centroid_id(1, 10), vec![1.0, 0.0])]
-                .into_iter()
-                .collect(),
+            vec![Posting::from_vec(
+                VectorId::centroid_id(1, 10),
+                vec![1.0, 0.0],
+            )]
+            .into_iter()
+            .collect(),
         );
 
         // when
@@ -1192,7 +1199,7 @@ mod tests {
         Arc::new(
             postings
                 .into_iter()
-                .map(|(level, id, vector)| Posting::new(vector_id(level, id), vector))
+                .map(|(level, id, vector)| Posting::from_vec(vector_id(level, id), vector))
                 .collect(),
         )
     }
@@ -1227,7 +1234,7 @@ mod tests {
     ) -> Arc<PostingList> {
         let key = PostingListKey::new(centroid_id).encode();
         let value = posting_list_value(postings);
-        let posting_list = Arc::new(PostingList::from_value(value.clone()));
+        let posting_list = Arc::new(PostingList::from_value(value.clone(), false));
         storage
             .put(vec![Record::new(key, value.encode_to_bytes()).into()])
             .await

--- a/vector/src/write/indexer/tree/merge.rs
+++ b/vector/src/write/indexer/tree/merge.rs
@@ -324,7 +324,8 @@ mod tests {
                 .is_some()
         );
         // assert centroids removed from root
-        let root = PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap());
+        let root =
+            PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap(), false);
         let root_ids: HashSet<_> = root.iter().map(|p| p.id()).collect();
         assert_eq!(root_ids, HashSet::from([CENTROID_C]));
         // assert all vectors added to reassign set
@@ -465,12 +466,14 @@ mod tests {
                 .get_posting_list(L2_CENTROID_A, DIMS)
                 .await
                 .unwrap(),
+            false,
         );
         let parent_b_posting = PostingList::from_value(
             h.storage
                 .get_posting_list(L2_CENTROID_B, DIMS)
                 .await
                 .unwrap(),
+            false,
         );
         let parent_a_ids: HashSet<_> = parent_a_posting.iter().map(|p| p.id()).collect();
         let parent_b_ids: HashSet<_> = parent_b_posting.iter().map(|p| p.id()).collect();
@@ -502,8 +505,10 @@ mod tests {
         // then
         assert_eq!(merge_count, 2);
         assert_eq!(reassignments.len(), 3);
-        let parent_posting =
-            PostingList::from_value(h.storage.get_posting_list(parent, DIMS).await.unwrap());
+        let parent_posting = PostingList::from_value(
+            h.storage.get_posting_list(parent, DIMS).await.unwrap(),
+            false,
+        );
         let parent_ids: HashSet<_> = parent_posting.iter().map(|p| p.id()).collect();
         assert_eq!(parent_ids, HashSet::from([c]));
     }
@@ -569,7 +574,8 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
-        let root = PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap());
+        let root =
+            PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap(), false);
         let root_ids: HashSet<_> = root.iter().map(|p| p.id()).collect();
         assert_eq!(root_ids, HashSet::from([L2_CENTROID_A, L2_CENTROID_B]));
         assert_eq!(ROOT_LEVEL, 0xFF);

--- a/vector/src/write/indexer/tree/posting_list.rs
+++ b/vector/src/write/indexer/tree/posting_list.rs
@@ -1,43 +1,40 @@
 use crate::serde::posting_list::{PostingListValue, PostingUpdate};
 use crate::serde::vector_id::VectorId;
+use crate::utils::aligned_bytes_from_vec;
+use bytemuck::{AnyBitPattern, NoUninit};
+use bytes::Bytes;
 use std::collections::{HashMap, HashSet};
 use std::iter::FromIterator;
-use std::sync::Arc;
 
-/// An in-memory format for posting lists optimized for exhaustive ANN search over all postings
-/// This format lays out all vectors in a flat buffer, and tracks offsets in the buffer from
-/// individual postings. The format still allows postings to be added incrementally by allowing
-/// each posting to hold its own reference to `Arc<Vec<f32>>`.
+/// An in-memory format for posting lists optimized for exhaustive ANN search
+/// over all postings. Every vector for a given posting list lives in a
+/// shared `Bytes` buffer, and each [`Posting`] holds a slice into it. This allows
+/// for vectors to be adjacent in memory and accessible directly from raw bytes.
+/// The buffer is always `align_of::<f32>()`-aligned so [`Posting::vector`]
+/// can reinterpret the bytes as `&[f32]` without a copy.
 #[derive(Clone)]
 pub(crate) struct Posting {
     id: VectorId,
-    buffer: Arc<Vec<f32>>,
-    offset: usize,
-    length: usize,
+    buffer: Bytes,
+    /// Number of f32 elements (not bytes) that make up this posting's vector.
+    dimensions: usize,
 }
 
 impl Posting {
-    pub(crate) fn new(id: VectorId, vector: Vec<f32>) -> Self {
-        let length = vector.len();
+    pub(crate) fn from_vec(id: VectorId, vector: Vec<f32>) -> Self {
+        let dimensions = vector.len();
         Self {
             id,
-            buffer: Arc::new(vector),
-            offset: 0,
-            length,
+            buffer: aligned_bytes_from_vec(vector),
+            dimensions,
         }
     }
 
-    fn from_shared_buffer(
-        id: VectorId,
-        buffer: Arc<Vec<f32>>,
-        offset: usize,
-        length: usize,
-    ) -> Self {
+    fn from_bytes(id: VectorId, buffer: Bytes, dimensions: usize) -> Self {
         Self {
             id,
             buffer,
-            offset,
-            length,
+            dimensions,
         }
     }
 
@@ -45,14 +42,25 @@ impl Posting {
         self.id
     }
 
+    /// Returns this posting's vector as `&[f32]`.
+    ///
+    /// # Panics
+    /// Panics if the byte slice is not aligned to `align_of::<f32>()`.
     pub(crate) fn vector(&self) -> &[f32] {
-        &self.buffer[self.offset..self.offset + self.length]
+        self.try_vector()
+            .expect("vector bytes cannot be read as &[f32]")
+    }
+
+    fn try_vector(&self) -> Result<&[f32], String> {
+        let byte_len = self.dimensions * size_of::<f32>();
+        let bytes = &self.buffer[..byte_len];
+        bytemuck::try_cast_slice(bytes).map_err(|e| e.to_string())
     }
 }
 
 impl PartialEq for Posting {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.vector() == other.vector()
+        self.id == other.id && self.buffer == other.buffer
     }
 }
 
@@ -71,6 +79,19 @@ impl From<Posting> for PostingUpdate {
     }
 }
 
+/// In-memory collection of [`Posting`]s for a single centroid cluster, used
+/// on the write/scoring path.
+///
+/// Differs from [`PostingListValue`] (the on-disk representation): this type
+/// holds resolved appends only — deletes have already been applied — and each
+/// posting's vector bytes are guaranteed `align_of::<f32>()`-aligned so
+/// scoring can read them as `&[f32]` without copying.
+///
+/// Use [`PostingList::from_value`] to materialize one from a stored
+/// `PostingListValue`, and [`PostingList::clone_with_updates`] to apply a
+/// batch of [`PostingUpdate`]s. Both accept a `realloc` flag that, when set,
+/// flattens all postings into a single contiguous buffer for cache-friendly
+/// scoring and bounded allocation size.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct PostingList {
     postings: Vec<Posting>,
@@ -103,93 +124,115 @@ impl PostingList {
         self.postings.iter()
     }
 
-    pub(crate) fn update_in_place(&self, updates: Vec<PostingUpdate>) -> Self {
-        let updates = dedupe_updates(updates);
-        if updates.is_empty() {
-            return self.clone();
-        }
-
-        let updated_ids: HashSet<VectorId> = updates.iter().map(PostingUpdate::id).collect();
-        let mut postings = self
-            .postings
-            .iter()
-            .filter(|posting| !updated_ids.contains(&posting.id))
-            .cloned()
-            .collect::<Vec<_>>();
-        postings.extend(updates.into_iter().filter_map(|update| match update {
-            PostingUpdate::Append { id, vector } => Some(Posting::from_shared_buffer(
-                id,
-                vector.clone(),
-                0,
-                vector.len(),
-            )),
-            PostingUpdate::Delete { .. } => None,
-        }));
-        Self { postings }
-    }
-
-    pub(crate) fn update_and_flatten(&self, updates: Vec<PostingUpdate>) -> Self {
-        let updates = dedupe_updates(updates);
-        if updates.is_empty() {
-            return self.flatten();
-        }
-
-        let updated_ids: HashSet<VectorId> = updates.iter().map(PostingUpdate::id).collect();
-        let retained = self
-            .postings
-            .iter()
-            .filter(|posting| !updated_ids.contains(&posting.id))
-            .map(|posting| (posting.id, posting.vector()));
-        let appended = updates.iter().filter_map(|update| match update {
-            PostingUpdate::Append { id, vector } => Some((*id, vector.as_slice())),
-            PostingUpdate::Delete { .. } => None,
-        });
-        Self::from_vectors(retained.chain(appended).collect())
-    }
-
-    fn flatten(&self) -> Self {
-        Self::from_vectors(
-            self.postings
+    /// Creates a copy of the posting list with the result of applying the provided updates,
+    /// and optionally reallocate the underlying vector allocation. Reallocating serves 2 purposes.
+    /// First, it limits the size of the underlying allocation. Note that individual vectors may
+    /// still be reallocated to ensure proper alignment even if `realloc` is false. Second,
+    /// contiguous storage ensure efficient loading of vectors in the posting list for scoring.
+    pub(crate) fn clone_with_updates(&self, updates: Vec<PostingUpdate>, realloc: bool) -> Self {
+        let mut posting_list = if updates.is_empty() {
+            self.clone()
+        } else {
+            let updates = Self::dedupe_updates(updates);
+            let updated_ids: HashSet<VectorId> = updates.iter().map(PostingUpdate::id).collect();
+            let mut postings = self
+                .postings
                 .iter()
-                .map(|posting| (posting.id, posting.vector()))
-                .collect(),
-        )
-    }
-
-    fn from_vectors(vectors: Vec<(VectorId, &[f32])>) -> Self {
-        let total_len = vectors.iter().map(|(_, vector)| vector.len()).sum();
-        let mut buffer = Vec::with_capacity(total_len);
-        let mut offsets = Vec::with_capacity(vectors.len());
-        for (id, vector) in vectors {
-            let offset = buffer.len();
-            let length = vector.len();
-            buffer.extend(vector);
-            offsets.push((id, offset, length));
+                .filter(|posting| !updated_ids.contains(&posting.id))
+                .cloned()
+                .collect::<Vec<_>>();
+            postings.extend(updates.into_iter().filter_map(|update| match update {
+                PostingUpdate::Append { id, vector } => {
+                    let buffer = ensure_aligned::<f32>(vector);
+                    let dimensions = buffer.len() / std::mem::size_of::<f32>();
+                    Some(Posting::from_bytes(id, buffer, dimensions))
+                }
+                PostingUpdate::Delete { .. } => None,
+            }));
+            Self { postings }
+        };
+        if realloc {
+            posting_list.realloc();
         }
-        let buffer = Arc::new(buffer);
-        let postings = offsets
-            .into_iter()
-            .map(|(id, offset, length)| {
-                Posting::from_shared_buffer(id, buffer.clone(), offset, length)
-            })
-            .collect();
-        Self { postings }
+        posting_list
     }
 
-    pub(crate) fn from_value(value: PostingListValue) -> Self {
+    /// create from a [`PostingListValue`] read from storage and optionally reallocate the
+    /// underlying vector allocation. Reallocating serves 2 purposes. First, it limits the size of
+    /// the underlying allocation. When reading from storage, vectors may be part of a larger buffer
+    /// allocated by the storage layer. Note that individual vectors may still be reallocated to
+    /// ensure proper alignment even if `realloc` is false. Second, contiguous storage ensure
+    /// efficient loading of vectors in the posting list for scoring. This is generally not
+    /// important when loading from storage as the storage layer itself tries to keep vectors
+    /// contiguous.
+    pub(crate) fn from_value(value: PostingListValue, realloc: bool) -> Self {
         let mut seen = HashSet::new();
-        let vectors = value
+        let postings = value
             .postings
-            .iter()
+            .into_iter()
             .filter_map(|posting| {
                 assert!(seen.insert(posting.id()));
                 match posting {
-                    PostingUpdate::Append { id, vector } => Some((*id, vector.as_slice())),
+                    PostingUpdate::Append { id, vector } => {
+                        let buffer = ensure_aligned::<f32>(vector);
+                        let dimensions = buffer.len() / size_of::<f32>();
+                        Some(Posting::from_bytes(id, buffer, dimensions))
+                    }
                     PostingUpdate::Delete { .. } => None,
                 }
             })
+            .collect::<Vec<_>>();
+        let mut posting_list = Self { postings };
+        if realloc {
+            posting_list.realloc();
+        }
+        posting_list
+    }
+
+    /// reallocates memory for the stored vectors so that they are all slices of a single
+    /// contiguous buffer. This serves 2 purposes. First, it limits the memory referenced by the
+    /// underlying allocation. When reading from storage, vectors may be part of a larger buffer
+    /// allocated by the storage layer. Second, contiguous storage supports efficient loading of
+    /// vectors in the posting list for scoring.
+    fn realloc(&mut self) {
+        let total_len: usize = self.postings.iter().map(|p| p.vector().len()).sum();
+        let mut buffer: Vec<f32> = Vec::with_capacity(total_len);
+        let mut offsets = Vec::with_capacity(self.postings.len());
+        for posting in &self.postings {
+            let element_offset = buffer.len();
+            let vector = posting.vector();
+            let length = vector.len();
+            buffer.extend_from_slice(vector);
+            offsets.push((posting.id(), element_offset, length));
+        }
+        let buffer = aligned_bytes_from_vec(buffer);
+        let postings = offsets
+            .into_iter()
+            .map(|(id, element_offset, dimensions)| {
+                let start = element_offset * size_of::<f32>();
+                let end = start + dimensions * size_of::<f32>();
+                Posting::from_bytes(id, buffer.slice(start..end), dimensions)
+            })
             .collect();
-        Self::from_vectors(vectors)
+        self.postings = postings;
+    }
+
+    fn dedupe_updates(updates: Vec<PostingUpdate>) -> Vec<PostingUpdate> {
+        let mut last_by_id = HashMap::with_capacity(updates.len());
+        for (idx, update) in updates.iter().enumerate() {
+            last_by_id.insert(update.id(), idx);
+        }
+        updates
+            .into_iter()
+            .enumerate()
+            .filter_map(|(idx, update)| {
+                if last_by_id.get(&update.id()) == Some(&idx) {
+                    Some(update)
+                } else {
+                    None
+                }
+            })
+            .collect()
     }
 }
 
@@ -225,23 +268,16 @@ impl PartialEq for PostingList {
     }
 }
 
-fn dedupe_updates(updates: Vec<PostingUpdate>) -> Vec<PostingUpdate> {
-    let mut last_by_id = HashMap::with_capacity(updates.len());
-    for (idx, update) in updates.iter().enumerate() {
-        last_by_id.insert(update.id(), idx);
+/// Ensure the given `Bytes` payload is f32-aligned. If it already is, return
+/// it unchanged; otherwise copy into a fresh aligned allocation.
+fn ensure_aligned<T: NoUninit + AnyBitPattern + Send + 'static>(bytes: Bytes) -> Bytes {
+    if (bytes.as_ptr() as usize).is_multiple_of(align_of::<T>()) {
+        bytes
+    } else {
+        let mut v = vec![T::zeroed(); bytes.len() / size_of::<T>()];
+        bytemuck::cast_slice_mut::<T, u8>(&mut v).copy_from_slice(&bytes);
+        aligned_bytes_from_vec(v)
     }
-
-    updates
-        .into_iter()
-        .enumerate()
-        .filter_map(|(idx, update)| {
-            if last_by_id.get(&update.id()) == Some(&idx) {
-                Some(update)
-            } else {
-                None
-            }
-        })
-        .collect()
 }
 
 #[cfg(test)]
@@ -251,32 +287,51 @@ mod tests {
     fn posting_list(entries: Vec<(u64, Vec<f32>)>) -> PostingList {
         entries
             .into_iter()
-            .map(|(id, vector)| Posting::new(VectorId::data_vector_id(id), vector))
+            .map(|(id, vector)| Posting::from_vec(VectorId::data_vector_id(id), vector))
             .collect()
     }
 
     #[test]
-    fn should_convert_posting_list_value_into_flattened_postings() {
-        // given
-        let value = PostingListValue::from_posting_updates(vec![
-            PostingUpdate::append(VectorId::data_vector_id(1), vec![1.0, 2.0]),
-            PostingUpdate::append(VectorId::data_vector_id(2), vec![3.0, 4.0]),
-        ])
-        .unwrap();
+    fn should_convert_posting_list_value_by_reusing_append_bytes() {
+        // given - two appends built from distinct Vec<f32>s
+        let append_one = PostingUpdate::append(VectorId::data_vector_id(1), vec![1.0, 2.0]);
+        let append_two = PostingUpdate::append(VectorId::data_vector_id(2), vec![3.0, 4.0]);
+        let PostingUpdate::Append {
+            vector: vector_one, ..
+        } = &append_one
+        else {
+            unreachable!()
+        };
+        let PostingUpdate::Append {
+            vector: vector_two, ..
+        } = &append_two
+        else {
+            unreachable!()
+        };
+        let expected_one_ptr = vector_one.as_ptr();
+        let expected_two_ptr = vector_two.as_ptr();
+
+        let value = PostingListValue::from_posting_updates(vec![append_one, append_two]).unwrap();
 
         // when
-        let postings = PostingList::from_value(value);
+        let postings = PostingList::from_value(value, false);
 
-        // then
-        let collected: Vec<_> = postings.iter().map(|posting| posting.id()).collect();
+        // then - ids and values preserved
+        let collected: Vec<_> = postings
+            .iter()
+            .map(|posting| (posting.id(), posting.vector().to_vec()))
+            .collect();
         assert_eq!(
             collected,
-            vec![VectorId::data_vector_id(1), VectorId::data_vector_id(2)]
+            vec![
+                (VectorId::data_vector_id(1), vec![1.0, 2.0]),
+                (VectorId::data_vector_id(2), vec![3.0, 4.0]),
+            ]
         );
-        assert!(Arc::ptr_eq(
-            &postings.postings[0].buffer,
-            &postings.postings[1].buffer
-        ));
+        // and - each Posting reuses the exact Bytes that lived on its source
+        // PostingUpdate (no flatten-into-shared-buffer copy happens here).
+        assert_eq!(postings.postings[0].buffer.as_ptr(), expected_one_ptr);
+        assert_eq!(postings.postings[1].buffer.as_ptr(), expected_two_ptr);
     }
 
     #[test]
@@ -287,13 +342,16 @@ mod tests {
             (2, vec![2.0, 0.0]),
             (3, vec![3.0, 0.0]),
         ]);
-        let untouched_buffer = postings.postings[0].buffer.clone();
+        let untouched_ptr = postings.postings[0].buffer.as_ptr();
 
         // when
-        let updated = postings.update_in_place(vec![
-            PostingUpdate::delete(VectorId::data_vector_id(2)),
-            PostingUpdate::append(VectorId::data_vector_id(4), vec![4.0, 0.0]),
-        ]);
+        let updated = postings.clone_with_updates(
+            vec![
+                PostingUpdate::delete(VectorId::data_vector_id(2)),
+                PostingUpdate::append(VectorId::data_vector_id(4), vec![4.0, 0.0]),
+            ],
+            false,
+        );
 
         // then
         let collected: Vec<_> = updated
@@ -308,11 +366,11 @@ mod tests {
                 (VectorId::data_vector_id(4), vec![4.0, 0.0])
             ]
         );
-        assert!(Arc::ptr_eq(&untouched_buffer, &updated.postings[0].buffer));
-        assert!(!Arc::ptr_eq(
-            &updated.postings[0].buffer,
-            &updated.postings[2].buffer
-        ));
+        assert_eq!(updated.postings[0].buffer.as_ptr(), untouched_ptr);
+        assert_ne!(
+            updated.postings[0].buffer.as_ptr(),
+            updated.postings[2].buffer.as_ptr()
+        );
     }
 
     #[test]
@@ -321,10 +379,13 @@ mod tests {
         let postings = posting_list(vec![(1, vec![1.0, 0.0]), (2, vec![2.0, 0.0])]);
 
         // when
-        let updated = postings.update_and_flatten(vec![
-            PostingUpdate::delete(VectorId::data_vector_id(1)),
-            PostingUpdate::append(VectorId::data_vector_id(3), vec![3.0, 0.0]),
-        ]);
+        let updated = postings.clone_with_updates(
+            vec![
+                PostingUpdate::delete(VectorId::data_vector_id(1)),
+                PostingUpdate::append(VectorId::data_vector_id(3), vec![3.0, 0.0]),
+            ],
+            true,
+        );
 
         // then
         let collected: Vec<_> = updated
@@ -338,10 +399,9 @@ mod tests {
                 (VectorId::data_vector_id(3), vec![3.0, 0.0])
             ]
         );
-        assert!(Arc::ptr_eq(
-            &updated.postings[0].buffer,
-            &updated.postings[1].buffer
-        ));
+        let p0_addr = updated.postings[0].buffer.as_ptr() as u64;
+        let p1_addr = updated.postings[1].buffer.as_ptr() as u64;
+        assert_eq!(p0_addr + 8, p1_addr);
     }
 
     #[test]
@@ -350,12 +410,15 @@ mod tests {
         let postings = posting_list(vec![(1, vec![1.0, 0.0]), (2, vec![2.0, 0.0])]);
 
         // when
-        let updated = postings.update_in_place(vec![
-            PostingUpdate::append(VectorId::data_vector_id(2), vec![20.0, 0.0]),
-            PostingUpdate::delete(VectorId::data_vector_id(2)),
-            PostingUpdate::delete(VectorId::data_vector_id(3)),
-            PostingUpdate::append(VectorId::data_vector_id(3), vec![30.0, 0.0]),
-        ]);
+        let updated = postings.clone_with_updates(
+            vec![
+                PostingUpdate::append(VectorId::data_vector_id(2), vec![20.0, 0.0]),
+                PostingUpdate::delete(VectorId::data_vector_id(2)),
+                PostingUpdate::delete(VectorId::data_vector_id(3)),
+                PostingUpdate::append(VectorId::data_vector_id(3), vec![30.0, 0.0]),
+            ],
+            false,
+        );
 
         // then
         let collected: Vec<_> = updated

--- a/vector/src/write/indexer/tree/root.rs
+++ b/vector/src/write/indexer/tree/root.rs
@@ -147,7 +147,8 @@ mod tests {
         // then
         assert_eq!(h.state.centroids_meta().depth, original_depth);
         assert_eq!(h.state.root_centroid_count(), original_root_count);
-        let root = PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap());
+        let root =
+            PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap(), false);
         let root_ids: HashSet<_> = root.iter().map(|p| p.id()).collect();
         assert_eq!(root_ids, HashSet::from([C0, C1]));
     }
@@ -176,7 +177,8 @@ mod tests {
         // then
         assert_eq!(h.state.centroids_meta().depth, 4);
         assert_eq!(h.state.root_centroid_count(), 2);
-        let root = PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap());
+        let root =
+            PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap(), false);
         assert_eq!(root.len(), 2);
         let new_root_ids: Vec<_> = root.iter().map(|p| p.id()).collect();
         assert!(new_root_ids.iter().all(|id| id.level() == 2));
@@ -187,6 +189,7 @@ mod tests {
                     .get_posting_list(*new_root_id, DIMS)
                     .await
                     .unwrap(),
+                false,
             );
             assert!(!posting.is_empty());
             for child in posting.iter() {

--- a/vector/src/write/indexer/tree/split.rs
+++ b/vector/src/write/indexer/tree/split.rs
@@ -473,9 +473,9 @@ impl SplitCentroid {
             let d1 = distance::compute_distance(vector, &c1_vector, self.distance_metric);
 
             if d0 <= d1 {
-                c0_postings.push(Posting::new(*id, vector.clone()));
+                c0_postings.push(Posting::from_vec(*id, vector.clone()));
             } else {
-                c1_postings.push(Posting::new(*id, vector.clone()));
+                c1_postings.push(Posting::from_vec(*id, vector.clone()));
             }
         }
 
@@ -769,7 +769,8 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
-        let root = PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap());
+        let root =
+            PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap(), false);
         let root_ids: HashSet<_> = root.iter().map(|p| p.id()).collect();
         assert!(root_ids.contains(&CENTROID_B));
         let mut all_posted_ids = HashSet::new();
@@ -786,6 +787,7 @@ mod tests {
                     .get_posting_list(*new_centroid_id, DIMS)
                     .await
                     .unwrap(),
+                false,
             );
             assert_eq!(posting.len(), 3);
             assert_eq!(
@@ -842,7 +844,8 @@ mod tests {
                 .unwrap()
                 .is_none()
         );
-        let root = PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap());
+        let root =
+            PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap(), false);
         assert_eq!(root.len(), 2);
         let mut total = 0;
         for p in root.iter() {
@@ -942,8 +945,10 @@ mod tests {
 
         // then
         assert!(h.storage.get_centroid_info(target).await.unwrap().is_none());
-        let parent_posting =
-            PostingList::from_value(h.storage.get_posting_list(parent, DIMS).await.unwrap());
+        let parent_posting = PostingList::from_value(
+            h.storage.get_posting_list(parent, DIMS).await.unwrap(),
+            false,
+        );
         let parent_ids: HashSet<_> = parent_posting.iter().map(|p| p.id()).collect();
         assert_eq!(parent_ids.len(), 2);
         let split_summary = &result.splits[0];
@@ -994,8 +999,10 @@ mod tests {
         assert!(result.splits.is_empty());
         assert_eq!(result.imbalanced, vec![(target, 5)]);
         assert!(result.reassignments.is_empty());
-        let parent_posting =
-            PostingList::from_value(h.storage.get_posting_list(parent, DIMS).await.unwrap());
+        let parent_posting = PostingList::from_value(
+            h.storage.get_posting_list(parent, DIMS).await.unwrap(),
+            false,
+        );
         let parent_ids: HashSet<_> = parent_posting.iter().map(|p| p.id()).collect();
         assert_eq!(parent_ids, HashSet::from([target]));
         assert!(h.storage.get_centroid_info(target).await.unwrap().is_some());
@@ -1055,8 +1062,10 @@ mod tests {
                 .unwrap()
                 .is_some()
         );
-        let posting_b =
-            PostingList::from_value(h.storage.get_posting_list(CENTROID_B, DIMS).await.unwrap());
+        let posting_b = PostingList::from_value(
+            h.storage.get_posting_list(CENTROID_B, DIMS).await.unwrap(),
+            false,
+        );
         assert_eq!(posting_b.len(), 2);
     }
 
@@ -1104,7 +1113,8 @@ mod tests {
         assert!(h.storage.get_centroid_info(b).await.unwrap().is_some());
         assert!(h.storage.get_centroid_info(c).await.unwrap().is_some());
         assert!(h.storage.get_centroid_info(d).await.unwrap().is_some());
-        let root = PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap());
+        let root =
+            PostingList::from_value(h.storage.get_root_posting_list(DIMS).await.unwrap(), false);
         let root_ids: HashSet<_> = root.iter().map(|p| p.id()).collect();
         assert_eq!(root_ids.len(), 3);
         assert!(root_ids.contains(&p1));
@@ -1187,10 +1197,10 @@ mod tests {
         let depth = TreeDepth::of(h.state.centroids_meta().depth);
         let level = TreeLevel::leaf(depth);
         let mut posting = PostingList::with_capacity(4);
-        posting.push(Posting::new(data_id(1), vec![0.9, 0.1]));
-        posting.push(Posting::new(data_id(2), vec![0.8, 0.2]));
-        posting.push(Posting::new(data_id(3), vec![0.1, 0.9]));
-        posting.push(Posting::new(data_id(4), vec![0.2, 0.8]));
+        posting.push(Posting::from_vec(data_id(1), vec![0.9, 0.1]));
+        posting.push(Posting::from_vec(data_id(2), vec![0.8, 0.2]));
+        posting.push(Posting::from_vec(data_id(3), vec![0.1, 0.9]));
+        posting.push(Posting::from_vec(data_id(4), vec![0.2, 0.8]));
         let postings = HashMap::from([(CENTROID_ID, Arc::new(posting))]);
 
         let split = SplitCentroid {
@@ -1240,8 +1250,8 @@ mod tests {
         let c0_vector = vec![1.0, 0.0];
         let c1_vector = vec![0.0, 1.0];
         let mut postings = PostingList::with_capacity(2);
-        postings.push(Posting::new(data_id(10), vec![0.1, 0.1]));
-        postings.push(Posting::new(data_id(11), vec![0.9, 0.1]));
+        postings.push(Posting::from_vec(data_id(10), vec![0.1, 0.1]));
+        postings.push(Posting::from_vec(data_id(11), vec![0.9, 0.1]));
 
         let split = SplitCentroid {
             c: CENTROID_ID,
@@ -1284,8 +1294,8 @@ mod tests {
         let c1_vector = vec![0.0, 1.0];
         let neighbour_id = VectorId::centroid_id(1, 99);
         let mut neighbour_postings = PostingList::with_capacity(2);
-        neighbour_postings.push(Posting::new(data_id(20), vec![0.9, 0.1]));
-        neighbour_postings.push(Posting::new(data_id(21), vec![0.5, 0.5]));
+        neighbour_postings.push(Posting::from_vec(data_id(20), vec![0.9, 0.1]));
+        neighbour_postings.push(Posting::from_vec(data_id(21), vec![0.5, 0.5]));
         let postings = HashMap::from([(neighbour_id, Arc::new(neighbour_postings))]);
 
         let split = SplitCentroid {

--- a/vector/src/write/indexer/tree/state.rs
+++ b/vector/src/write/indexer/tree/state.rs
@@ -254,7 +254,7 @@ impl SearchIndexDelta {
         for new_c_vec in new_root_centroids {
             let (new_c_id, new_c) = self.add_centroid(new_level, new_c_vec, ROOT_VECTOR_ID);
             info!("writing new root centroid {}/{}", new_level, new_c_id);
-            new_root_postings.push(Posting::new(new_c_id, new_c.vector))
+            new_root_postings.push(Posting::from_vec(new_c_id, new_c.vector))
         }
         for p in &new_root_postings {
             assert_eq!(p.id().level(), depth.max_inner_level())
@@ -275,10 +275,8 @@ impl SearchIndexDelta {
         let depth = TreeDepth::of(self.centroids_meta.depth);
         assert_eq!(depth.max_inner_level(), centroid_id.level());
         assert!(centroid_id.is_centroid());
-        self.root_updates.push(PostingUpdate::Append {
-            id: centroid_id,
-            vector: Arc::new(vector),
-        });
+        self.root_updates
+            .push(PostingUpdate::append(centroid_id, vector));
         self.root_centroid_count += 1;
     }
 
@@ -601,7 +599,7 @@ impl<'a> DirtyCentroidReader<'a> {
         posting_list: &PostingList,
         updates: &[PostingUpdate],
     ) -> Arc<PostingList> {
-        Arc::new(posting_list.update_in_place(updates.to_vec()))
+        Arc::new(posting_list.clone_with_updates(updates.to_vec(), false))
     }
 }
 
@@ -611,7 +609,7 @@ impl<'a> CentroidReader for DirtyCentroidReader<'a> {
             let mut root = root.clone();
             root.extend(self.delta.root_updates.iter().cloned());
             let root = PostingListValue::from_posting_updates(root).expect("unreachable");
-            MaybeCached::Value(Arc::new(PostingList::from_value(root)))
+            MaybeCached::Value(Arc::new(PostingList::from_value(root, false)))
         } else {
             let stored = self.reader.clone();
             let updates = self.delta.root_updates.clone();
@@ -970,7 +968,7 @@ mod tests {
         let actual_storage = storage.get_root_posting_list(DIMS).await.unwrap();
         assert_eq!(actual_storage, expected_storage);
 
-        let expected_cache = PostingList::from_value(expected_storage);
+        let expected_cache = PostingList::from_value(expected_storage, false);
         let actual_cache = state.centroid_cache().root(u64::MAX).unwrap();
         assert_eq!(actual_cache.as_ref(), &expected_cache);
     }
@@ -1154,7 +1152,8 @@ mod tests {
             Some(CentroidsValue::new(4))
         );
         assert_eq!(state.root_centroid_count(), 2);
-        let root = PostingList::from_value(storage.get_root_posting_list(DIMS).await.unwrap());
+        let root =
+            PostingList::from_value(storage.get_root_posting_list(DIMS).await.unwrap(), false);
         let expected = vec![
             (internal_centroid(2, 1), vec![1.0, 0.0]),
             (internal_centroid(2, 2), vec![0.0, 1.0]),
@@ -1204,7 +1203,8 @@ mod tests {
 
         // then:
         assert_eq!(state.root_centroid_count(), 1);
-        let posting = PostingList::from_value(storage.get_root_posting_list(DIMS).await.unwrap());
+        let posting =
+            PostingList::from_value(storage.get_root_posting_list(DIMS).await.unwrap(), false);
         assert_eq!(
             posting
                 .iter()
@@ -1373,7 +1373,7 @@ mod tests {
 
         // then:
         let posting =
-            PostingList::from_value(storage.get_posting_list(parent, DIMS).await.unwrap());
+            PostingList::from_value(storage.get_posting_list(parent, DIMS).await.unwrap(), false);
         assert_eq!(
             posting
                 .iter()
@@ -1421,7 +1421,7 @@ mod tests {
 
         // then:
         let posting =
-            PostingList::from_value(storage.get_posting_list(parent, DIMS).await.unwrap());
+            PostingList::from_value(storage.get_posting_list(parent, DIMS).await.unwrap(), false);
         assert!(posting.is_empty());
         let cached = state.centroid_cache().posting(parent, u64::MAX).unwrap();
         assert_eq!(cached.as_ref(), &posting);

--- a/vector/src/write/indexer/tree/state.rs
+++ b/vector/src/write/indexer/tree/state.rs
@@ -278,7 +278,7 @@ impl SearchIndexDelta {
         for new_c_vec in new_root_centroids {
             let (new_c_id, new_c) = self.add_centroid(new_level, new_c_vec, ROOT_VECTOR_ID);
             info!("writing new root centroid {}/{}", new_level, new_c_id);
-            new_root_postings.push(Posting::new(new_c_id, new_c.vector))
+            new_root_postings.push(Posting::from_vec(new_c_id, new_c.vector))
         }
         for p in &new_root_postings {
             assert_eq!(p.id().level(), depth.max_inner_level())
@@ -299,10 +299,8 @@ impl SearchIndexDelta {
         let depth = TreeDepth::of(self.centroids_meta.depth);
         assert_eq!(depth.max_inner_level(), centroid_id.level());
         assert!(centroid_id.is_centroid());
-        self.root_updates.push(PostingUpdate::Append {
-            id: centroid_id,
-            vector: Arc::new(vector),
-        });
+        self.root_updates
+            .push(PostingUpdate::append(centroid_id, vector));
         self.root_centroid_count += 1;
     }
 
@@ -625,7 +623,7 @@ impl<'a> DirtyCentroidReader<'a> {
         posting_list: &PostingList,
         updates: &[PostingUpdate],
     ) -> Arc<PostingList> {
-        Arc::new(posting_list.update_in_place(updates.to_vec()))
+        Arc::new(posting_list.clone_with_updates(updates.to_vec(), false))
     }
 }
 
@@ -635,7 +633,7 @@ impl<'a> CentroidReader for DirtyCentroidReader<'a> {
             let mut root = root.clone();
             root.extend(self.delta.root_updates.iter().cloned());
             let root = PostingListValue::from_posting_updates(root).expect("unreachable");
-            MaybeCached::Value(Arc::new(PostingList::from_value(root)))
+            MaybeCached::Value(Arc::new(PostingList::from_value(root, false)))
         } else {
             let stored = self.reader.clone();
             let updates = self.delta.root_updates.clone();
@@ -1002,7 +1000,7 @@ mod tests {
         let actual_storage = storage.get_root_posting_list(DIMS).await.unwrap();
         assert_eq!(actual_storage, expected_storage);
 
-        let expected_cache = PostingList::from_value(expected_storage);
+        let expected_cache = PostingList::from_value(expected_storage, false);
         let actual_cache = state.centroid_cache().root(u64::MAX).unwrap();
         assert_eq!(actual_cache.as_ref(), &expected_cache);
     }
@@ -1275,7 +1273,8 @@ mod tests {
             Some(CentroidsValue::new(4))
         );
         assert_eq!(state.root_centroid_count(), 2);
-        let root = PostingList::from_value(storage.get_root_posting_list(DIMS).await.unwrap());
+        let root =
+            PostingList::from_value(storage.get_root_posting_list(DIMS).await.unwrap(), false);
         let expected = vec![
             (internal_centroid(2, 1), vec![1.0, 0.0]),
             (internal_centroid(2, 2), vec![0.0, 1.0]),
@@ -1325,7 +1324,8 @@ mod tests {
 
         // then:
         assert_eq!(state.root_centroid_count(), 1);
-        let posting = PostingList::from_value(storage.get_root_posting_list(DIMS).await.unwrap());
+        let posting =
+            PostingList::from_value(storage.get_root_posting_list(DIMS).await.unwrap(), false);
         assert_eq!(
             posting
                 .iter()
@@ -1494,7 +1494,7 @@ mod tests {
 
         // then:
         let posting =
-            PostingList::from_value(storage.get_posting_list(parent, DIMS).await.unwrap());
+            PostingList::from_value(storage.get_posting_list(parent, DIMS).await.unwrap(), false);
         assert_eq!(
             posting
                 .iter()
@@ -1542,7 +1542,7 @@ mod tests {
 
         // then:
         let posting =
-            PostingList::from_value(storage.get_posting_list(parent, DIMS).await.unwrap());
+            PostingList::from_value(storage.get_posting_list(parent, DIMS).await.unwrap(), false);
         assert!(posting.is_empty());
         let cached = state.centroid_cache().posting(parent, u64::MAX).unwrap();
         assert_eq!(cached.as_ref(), &posting);

--- a/vector/src/write/indexer/tree/validator.rs
+++ b/vector/src/write/indexer/tree/validator.rs
@@ -32,7 +32,7 @@ pub(crate) async fn validate(
     }
 
     let root_posting_list =
-        PostingList::from_value(snapshot.get_root_posting_list(dimensions).await?);
+        PostingList::from_value(snapshot.get_root_posting_list(dimensions).await?, false);
     let centroid_info: HashMap<VectorId, CentroidInfoValue> = snapshot
         .scan_all_centroid_info()
         .await?
@@ -87,7 +87,8 @@ pub(crate) async fn validate_state_and_storage_consistent(
         .get_centroids_meta()
         .await?
         .ok_or_else(|| Error::Internal("missing centroid tree metadata".to_string()))?;
-    let storage_root = PostingList::from_value(snapshot.get_root_posting_list(dimensions).await?);
+    let storage_root =
+        PostingList::from_value(snapshot.get_root_posting_list(dimensions).await?, false);
     let cached_root = last_applied_snapshot
         .centroid_cache
         .root(u64::MAX)
@@ -516,7 +517,9 @@ async fn load_centroid_postings(
         .scan_all_posting_lists(dimensions)
         .await?
         .into_iter()
-        .map(|(centroid_id, posting_list)| (centroid_id, PostingList::from_value(posting_list)))
+        .map(|(centroid_id, posting_list)| {
+            (centroid_id, PostingList::from_value(posting_list, false))
+        })
         .collect())
 }
 
@@ -766,7 +769,7 @@ mod tests {
         let centroid_cache = AllCentroidsCacheWriter::new(
             Arc::new(
                 root.into_iter()
-                    .map(|(id, vector)| Posting::new(root_posting_id(depth, id), vector))
+                    .map(|(id, vector)| Posting::from_vec(root_posting_id(depth, id), vector))
                     .collect::<PostingList>(),
             ),
             centroid_postings
@@ -778,7 +781,7 @@ mod tests {
                             postings
                                 .into_iter()
                                 .map(|(id, vector)| {
-                                    Posting::new(VectorId::data_vector_id(id), vector)
+                                    Posting::from_vec(VectorId::data_vector_id(id), vector)
                                 })
                                 .collect::<PostingList>(),
                         ),
@@ -819,7 +822,7 @@ mod tests {
             Arc::new(
                 root.clone()
                     .into_iter()
-                    .map(|(id, vector)| Posting::new(root_posting_id(depth, id), vector))
+                    .map(|(id, vector)| Posting::from_vec(root_posting_id(depth, id), vector))
                     .collect::<PostingList>(),
             ),
             centroid_postings
@@ -830,7 +833,7 @@ mod tests {
                         Arc::new(
                             postings
                                 .into_iter()
-                                .map(|(id, vector)| Posting::new(centroid_id(1, id), vector))
+                                .map(|(id, vector)| Posting::from_vec(centroid_id(1, id), vector))
                                 .collect::<PostingList>(),
                         ),
                     )

--- a/vector/src/write/indexer/tree/vector.rs
+++ b/vector/src/write/indexer/tree/vector.rs
@@ -586,6 +586,7 @@ mod tests {
                 .get_posting_list(centroid_id(CENTROID_ID_NUM), DIMS)
                 .await
                 .unwrap(),
+            false,
         );
         assert_eq!(posting.len(), 3);
         for p in posting.iter() {
@@ -712,6 +713,7 @@ mod tests {
                 .get_posting_list(centroid_id(CENTROID_ID_NUM), DIMS)
                 .await
                 .unwrap(),
+            false,
         );
         assert_eq!(posting.len(), 1);
     }
@@ -761,13 +763,13 @@ mod tests {
 
         // then
         let posting_a =
-            PostingList::from_value(h.storage.get_posting_list(c_a, DIMS).await.unwrap());
+            PostingList::from_value(h.storage.get_posting_list(c_a, DIMS).await.unwrap(), false);
         let ids_a: HashSet<VectorId> = posting_a.iter().map(|p: &Posting| p.id()).collect();
         assert!(ids_a.contains(&id_a));
         assert!(!ids_a.contains(&id_b));
         assert!(!ids_a.contains(&id_c));
         let posting_b =
-            PostingList::from_value(h.storage.get_posting_list(c_b, DIMS).await.unwrap());
+            PostingList::from_value(h.storage.get_posting_list(c_b, DIMS).await.unwrap(), false);
         let ids_b: HashSet<VectorId> = posting_b.iter().map(|p: &Posting| p.id()).collect();
         assert!(ids_b.contains(&id_b));
         assert!(ids_b.contains(&id_c));
@@ -849,11 +851,11 @@ mod tests {
 
         // then
         let posting_c0 =
-            PostingList::from_value(h.storage.get_posting_list(c0, DIMS).await.unwrap());
+            PostingList::from_value(h.storage.get_posting_list(c0, DIMS).await.unwrap(), false);
         let ids_c0: HashSet<VectorId> = posting_c0.iter().map(|p: &Posting| p.id()).collect();
         assert!(ids_c0.contains(&id_a));
         let posting_c1 =
-            PostingList::from_value(h.storage.get_posting_list(c1, DIMS).await.unwrap());
+            PostingList::from_value(h.storage.get_posting_list(c1, DIMS).await.unwrap(), false);
         let ids_c1: HashSet<VectorId> = posting_c1.iter().map(|p: &Posting| p.id()).collect();
         assert!(!ids_c1.contains(&id_a));
     }

--- a/vector/src/write/indexer/tree/vector.rs
+++ b/vector/src/write/indexer/tree/vector.rs
@@ -979,7 +979,7 @@ mod tests {
         );
 
         let posting =
-            PostingList::from_value(h.storage.get_posting_list(leaf, DIMS).await.unwrap());
+            PostingList::from_value(h.storage.get_posting_list(leaf, DIMS).await.unwrap(), false);
         let posting_ids: HashSet<VectorId> = posting.iter().map(|p: &Posting| p.id()).collect();
         assert!(posting_ids.contains(&id_b));
         assert!(!posting_ids.contains(&id_a));

--- a/vector/src/write/indexer/tree/vector.rs
+++ b/vector/src/write/indexer/tree/vector.rs
@@ -663,6 +663,7 @@ mod tests {
                 .get_posting_list(centroid_id(CENTROID_ID_NUM), DIMS)
                 .await
                 .unwrap(),
+            false,
         );
         assert_eq!(posting.len(), 3);
         for p in posting.iter() {
@@ -789,6 +790,7 @@ mod tests {
                 .get_posting_list(centroid_id(CENTROID_ID_NUM), DIMS)
                 .await
                 .unwrap(),
+            false,
         );
         assert_eq!(posting.len(), 1);
     }
@@ -838,13 +840,13 @@ mod tests {
 
         // then
         let posting_a =
-            PostingList::from_value(h.storage.get_posting_list(c_a, DIMS).await.unwrap());
+            PostingList::from_value(h.storage.get_posting_list(c_a, DIMS).await.unwrap(), false);
         let ids_a: HashSet<VectorId> = posting_a.iter().map(|p: &Posting| p.id()).collect();
         assert!(ids_a.contains(&id_a));
         assert!(!ids_a.contains(&id_b));
         assert!(!ids_a.contains(&id_c));
         let posting_b =
-            PostingList::from_value(h.storage.get_posting_list(c_b, DIMS).await.unwrap());
+            PostingList::from_value(h.storage.get_posting_list(c_b, DIMS).await.unwrap(), false);
         let ids_b: HashSet<VectorId> = posting_b.iter().map(|p: &Posting| p.id()).collect();
         assert!(ids_b.contains(&id_b));
         assert!(ids_b.contains(&id_c));
@@ -926,11 +928,11 @@ mod tests {
 
         // then
         let posting_c0 =
-            PostingList::from_value(h.storage.get_posting_list(c0, DIMS).await.unwrap());
+            PostingList::from_value(h.storage.get_posting_list(c0, DIMS).await.unwrap(), false);
         let ids_c0: HashSet<VectorId> = posting_c0.iter().map(|p: &Posting| p.id()).collect();
         assert!(ids_c0.contains(&id_a));
         let posting_c1 =
-            PostingList::from_value(h.storage.get_posting_list(c1, DIMS).await.unwrap());
+            PostingList::from_value(h.storage.get_posting_list(c1, DIMS).await.unwrap(), false);
         let ids_c1: HashSet<VectorId> = posting_c1.iter().map(|p: &Posting| p.id()).collect();
         assert!(!ids_c1.contains(&id_a));
     }


### PR DESCRIPTION
## Summary

This patch changes the format of posting lists to allow us to load a contiguous buffer for vectors and then changes the posting list in-memory format to access the vectors directly from the byte buffer. This allows us to load posting lists from slatedb without copying the vectors to Vec<f32> first.

## Test Plan

- unit tests where applicable
- sift100K integration test passes
- benchmark results show improvement of p90 warm latency from ~12ms to ~7ms. The following is a run with this optimization + zero-copy in slatedb and parallel centroid scoring:
```bash
  [benchmark=recall, commit=2e36a161609af20536f34d60441520b210c2153e, branch=vector-warm-query-optimizations, block_cache_bytes=8589934592, data_dir=/home/ubuntu/opendata/vector/tests/data, dataset=cohere1m, max_pending_and_running_rebalance_tasks=32, merge_threshold=50, nprobe=100, num_queries=1000, query_pruning_factor=0, rebalance_backpressure_resume_threshold=16, root_threshold=100, split_search_neighbourhood=0, split_threshold=150]
    recall_at_k          0.91
    k                    10
    qps                  32.02
    num_queries          1.00K
    num_centroids        9.35K
    cold_p50_latency_us  475.22K
    cold_p90_latency_us  596.76K
    cold_p99_latency_us  1.59M
    p50_latency_us       4.64K
    p90_latency_us       5.05K
    p99_latency_us       6.08K
    num_vectors          1.00M
    ingest_secs          599.10
    ingest_vec_per_sec   1.67K
```

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
