### PR TITLE
score centroids in parallel when walking centroid tree

### DIFF
--- a/vector/src/write/indexer/tree/centroids.rs
+++ b/vector/src/write/indexer/tree/centroids.rs
@@ -474,44 +474,52 @@ impl<'a> LeveledCentroidIndex<'a> {
             return Vec::new();
         }
 
-        if k == usize::MAX {
-            let mut seen = HashSet::new();
-            let mut ranked = Vec::new();
-            for posting_list in postings {
+        // Parallelize scoring over posting lists: each rayon task walks one
+        // posting list end-to-end and builds a per-list top-k heap, which
+        // keeps scheduling overhead small (scoring a single f32 pair is far
+        // cheaper than a rayon job). The final reduction merges those,
+        // dedups by id, and keeps the global top-k.
+        let per_list_topk: Vec<Vec<RankedPosting>> = postings
+            .into_par_iter()
+            .map(|posting_list| {
+                let cap = k.min(posting_list.len());
+                let mut heap: BinaryHeap<RankedPosting> = BinaryHeap::with_capacity(cap);
                 for posting in posting_list.iter() {
                     assert_eq!(posting.id().level(), postings_level.level());
-                    if !seen.insert(posting.id()) {
-                        continue;
-                    }
-                    ranked.push(RankedPosting {
+                    let candidate = RankedPosting {
                         posting,
                         distance: compute_distance(query, posting.vector(), distance_metric),
-                    });
+                    };
+                    if heap.len() < k {
+                        heap.push(candidate);
+                    } else if let Some(worst) = heap.peek()
+                        && candidate < *worst
+                    {
+                        heap.pop();
+                        heap.push(candidate);
+                    }
                 }
-            }
-            ranked.sort_unstable();
-            return ranked.into_iter().map(|rp| rp.posting.clone()).collect();
-        }
+                // Sorted ascending so the final merge can iterate best-first
+                // and stop pushing into the global heap once it stabilises.
+                heap.into_sorted_vec()
+            })
+            .collect();
 
-        let mut ranked = BinaryHeap::with_capacity(k);
-        let mut heap_ids = HashSet::with_capacity(k);
+        let total: usize = per_list_topk.iter().map(|l| l.len()).sum();
+        let cap = k.min(total);
+        let mut ranked: BinaryHeap<RankedPosting> = BinaryHeap::with_capacity(cap);
+        let mut heap_ids = HashSet::with_capacity(cap);
 
-        for posting_list in postings {
-            for posting in posting_list.iter() {
-                assert_eq!(posting.id().level(), postings_level.level());
-                let distance = compute_distance(query, posting.vector(), distance_metric);
-                let candidate = RankedPosting { posting, distance };
-
+        for list in per_list_topk {
+            for candidate in list {
                 if heap_ids.contains(&candidate.posting.id()) {
                     continue;
                 }
-
                 if ranked.len() < k {
                     heap_ids.insert(candidate.posting.id());
                     ranked.push(candidate);
                     continue;
                 }
-
                 let Some(worst) = ranked.peek() else {
                     continue;
                 };
@@ -520,6 +528,10 @@ impl<'a> LeveledCentroidIndex<'a> {
                     heap_ids.remove(&removed.posting.id());
                     heap_ids.insert(candidate.posting.id());
                     ranked.push(candidate);
+                } else {
+                    // Remaining entries in this list are all farther than
+                    // `worst` (list is sorted ascending) — skip the tail.
+                    break;
                 }
             }
         }


### PR DESCRIPTION
## Summary

Score centroids in parallel when walking centroid tree to reduce centroid search latency

## How was this tested?

unit/integration tests. Benchmark show 2-3ms latency reduction

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
