### PR TITLE
[timeseries] Add POST /-/checkpoint endpoint and reader checkpoint pinning

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -19,6 +19,6 @@ pub use storage::factory::{
 };
 pub use storage::loader::{LoadMetadata, LoadResult, LoadSpec, Loadable, Loader};
 pub use storage::{
-    MergeRecordOp, PutRecordOp, Record, Storage, StorageError, StorageIterator, StorageRead,
-    StorageResult, Ttl, WriteOptions, WriteResult,
+    CheckpointInfo, MergeRecordOp, PutRecordOp, Record, Storage, StorageError, StorageIterator,
+    StorageRead, StorageResult, Ttl, WriteOptions, WriteResult,
 };

--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -19,6 +19,7 @@ use slatedb::db_cache::{CachedKey, DbCache};
 use slatedb::object_store::{self, ObjectStore};
 pub use slatedb::{CompactorBuilder, DbBuilder};
 use tracing::info;
+use uuid::Uuid;
 
 /// Handle to a foyer hybrid cache that we own and must close explicitly on
 /// shutdown. Cloneable because foyer's `HybridCache` is Arc-backed.
@@ -182,6 +183,7 @@ impl StorageBuilder {
 pub struct StorageReaderRuntime {
     pub(crate) block_cache: Option<Arc<dyn DbCache>>,
     pub(crate) object_store: Option<Arc<dyn ObjectStore>>,
+    pub(crate) checkpoint_id: Option<Uuid>,
 }
 
 impl StorageReaderRuntime {
@@ -204,6 +206,18 @@ impl StorageReaderRuntime {
 
     pub fn with_object_store(mut self, object_store: Arc<dyn ObjectStore>) -> Self {
         self.object_store = Some(object_store);
+        self
+    }
+
+    /// Pins this reader to a specific SlateDB checkpoint.
+    ///
+    /// When set, the reader serves a consistent view of the database as of
+    /// the checkpoint and does not advance with newer writes. The checkpoint
+    /// must already exist in storage (typically created via
+    /// [`Storage::create_checkpoint`](crate::Storage::create_checkpoint)).
+    /// Only meaningful for SlateDB storage.
+    pub fn with_checkpoint_id(mut self, id: Uuid) -> Self {
+        self.checkpoint_id = Some(id);
         self
     }
 }
@@ -326,6 +340,9 @@ pub async fn create_storage_read(
             let mut builder = DbReader::builder(slate_config.path.clone(), object_store)
                 .with_options(reader_options)
                 .with_metrics_recorder(Arc::new(MetricsRsRecorder));
+            if let Some(checkpoint_id) = runtime.checkpoint_id {
+                builder = builder.with_checkpoint_id(checkpoint_id);
+            }
             if let Some(op) = semantics.merge_operator {
                 let adapter = SlateDbStorage::merge_operator_adapter(op);
                 builder = builder.with_merge_operator(Arc::new(adapter));

--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -214,8 +214,8 @@ impl StorageReaderRuntime {
     /// When set, the reader serves a consistent view of the database as of
     /// the checkpoint and does not advance with newer writes. The checkpoint
     /// must already exist in storage (typically created via
-    /// [`Storage::create_checkpoint`](crate::Storage::create_checkpoint)).
-    /// Only meaningful for SlateDB storage.
+    /// [`crate::Storage::create_checkpoint`]). Only meaningful for SlateDB
+    /// storage.
     pub fn with_checkpoint_id(mut self, id: Uuid) -> Self {
         self.checkpoint_id = Some(id);
         self

--- a/common/src/storage/in_memory.rs
+++ b/common/src/storage/in_memory.rs
@@ -9,7 +9,10 @@ use super::{
     MergeOperator, MergeRecordOp, PutRecordOp, Storage, StorageSnapshot, WriteOptions, WriteResult,
 };
 use crate::storage::RecordOp;
-use crate::{BytesRange, Record, StorageError, StorageIterator, StorageRead, StorageResult, Ttl};
+use crate::{
+    BytesRange, CheckpointInfo, Record, StorageError, StorageIterator, StorageRead, StorageResult,
+    Ttl,
+};
 
 /// Trait for providing the current time.
 pub trait Clock: Send + Sync {
@@ -442,6 +445,12 @@ impl Storage for InMemoryStorage {
         }
         Ok(())
     }
+
+    async fn create_checkpoint(&self) -> StorageResult<CheckpointInfo> {
+        Err(StorageError::Storage(
+            "checkpoints are not supported for in-memory storage".to_string(),
+        ))
+    }
 }
 
 /// Injected failure that fires either once or on every call.
@@ -629,6 +638,10 @@ impl super::Storage for FailingStorage {
     async fn flush(&self) -> super::StorageResult<()> {
         check_failure(&self.fail_flush)?;
         self.inner.flush().await
+    }
+
+    async fn create_checkpoint(&self) -> super::StorageResult<CheckpointInfo> {
+        self.inner.create_checkpoint().await
     }
 }
 

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -10,8 +10,20 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use uuid::Uuid;
 
 use crate::BytesRange;
+
+/// Identifies a checkpoint of a storage backend at a point in time.
+///
+/// Checkpoints capture a manifest snapshot that a reader can later open
+/// against to get a consistent view of the database at the time the
+/// checkpoint was created.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CheckpointInfo {
+    pub id: Uuid,
+    pub manifest_id: u64,
+}
 
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
 pub enum Ttl {
@@ -368,4 +380,18 @@ pub trait Storage: StorageRead {
     /// `DbStatus::durable_seq`. For in-memory storage, writes are immediately
     /// "durable" so the watermark matches the latest written seqnum.
     fn subscribe_durable(&self) -> tokio::sync::watch::Receiver<u64>;
+
+    /// Creates a durable checkpoint of the current state.
+    ///
+    /// The returned [`CheckpointInfo::id`] can later be passed to a
+    /// `StorageReaderRuntime` to open a reader pinned to this exact view of
+    /// the database. For SlateDB, this maps to `Db::create_checkpoint` with
+    /// `CheckpointScope::All` (flushes WALs and freezes the memtable so the
+    /// checkpoint includes recent writes).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying backend does not support
+    /// checkpoints, or if the checkpoint cannot be persisted.
+    async fn create_checkpoint(&self) -> StorageResult<CheckpointInfo>;
 }

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use crate::storage::factory::OwnedHybridCache;
 use crate::storage::{MergeOptions, PutOptions};
 use crate::{
-    BytesRange, Record, StorageError, StorageIterator, StorageRead, StorageResult, Ttl,
+    BytesRange, CheckpointInfo, Record, StorageError, StorageIterator, StorageRead, StorageResult,
+    Ttl,
     storage::{
         MergeOperator, MergeRecordOp, PutRecordOp, RecordOp, Storage, StorageSnapshot,
         WriteOptions, WriteResult,
@@ -12,7 +13,7 @@ use crate::{
 use async_trait::async_trait;
 use bytes::Bytes;
 use slatedb::IterationOrder;
-use slatedb::config::ScanOptions;
+use slatedb::config::{CheckpointOptions, CheckpointScope, ScanOptions};
 use slatedb::{
     Db, DbIterator, DbReader, DbSnapshot, MergeOperator as SlateDbMergeOperator,
     MergeOperatorError, WriteBatch, config::WriteOptions as SlateDbWriteOptions,
@@ -342,6 +343,18 @@ impl Storage for SlateDbStorage {
     async fn flush(&self) -> StorageResult<()> {
         self.db.flush().await.map_err(StorageError::from_storage)?;
         Ok(())
+    }
+
+    async fn create_checkpoint(&self) -> StorageResult<CheckpointInfo> {
+        let result = self
+            .db
+            .create_checkpoint(CheckpointScope::All, &CheckpointOptions::default())
+            .await
+            .map_err(StorageError::from_storage)?;
+        Ok(CheckpointInfo {
+            id: result.id,
+            manifest_id: result.manifest_id,
+        })
     }
 }
 

--- a/log/src/server/handlers.rs
+++ b/log/src/server/handlers.rs
@@ -390,6 +390,13 @@ mod tests {
             async fn flush(&self) -> common::StorageResult<()> {
                 self.check_failure()
             }
+
+            async fn create_checkpoint(&self) -> common::StorageResult<common::CheckpointInfo> {
+                self.check_failure()?;
+                Err(common::StorageError::Storage(
+                    "checkpoints not supported".to_string(),
+                ))
+            }
         }
 
         // given - a log backed by configurable storage

--- a/timeseries/src/main.rs
+++ b/timeseries/src/main.rs
@@ -83,19 +83,35 @@ async fn main() {
 
     let read_only = prometheus_config.read_only;
     let tsdb = if read_only {
-        // Read-only mode: open a non-fencing reader.
-        let reader = TimeSeriesDbReader::open(
-            prometheus_config.storage.clone(),
-            prometheus_config.reader.clone(),
-            prometheus_config.cache_capacity,
-        )
-        .await
+        // Read-only mode: open a non-fencing reader, optionally pinned to a checkpoint.
+        let reader = match prometheus_config.checkpoint_id {
+            Some(id) => {
+                TimeSeriesDbReader::open_at_checkpoint(
+                    prometheus_config.storage.clone(),
+                    prometheus_config.reader.clone(),
+                    prometheus_config.cache_capacity,
+                    id,
+                )
+                .await
+            }
+            None => {
+                TimeSeriesDbReader::open(
+                    prometheus_config.storage.clone(),
+                    prometheus_config.reader.clone(),
+                    prometheus_config.cache_capacity,
+                )
+                .await
+            }
+        }
         .unwrap_or_else(|e| {
             tracing::error!("Failed to open read-only storage: {}", e);
             std::process::exit(1);
         });
         let engine: Arc<TsdbEngine> = Arc::new(Arc::new(reader).into());
-        tracing::info!("Opened storage in read-only mode");
+        match prometheus_config.checkpoint_id {
+            Some(id) => tracing::info!("Opened storage in read-only mode at checkpoint {}", id),
+            None => tracing::info!("Opened storage in read-only mode"),
+        }
         engine
     } else {
         // Read-write mode: open full storage + Tsdb

--- a/timeseries/src/promql/config.rs
+++ b/timeseries/src/promql/config.rs
@@ -10,6 +10,7 @@ use common::ObjectStoreConfig;
 use common::storage::config::StorageConfig;
 use serde::{Deserialize, Deserializer};
 use slatedb::config::DbReaderOptions;
+use uuid::Uuid;
 
 #[cfg(feature = "http-server")]
 use clap::Parser;
@@ -56,6 +57,11 @@ pub struct PrometheusConfig {
         deserialize_with = "deserialize_reader_options"
     )]
     pub reader: DbReaderOptions,
+    /// Pin a read-only instance to a specific SlateDB checkpoint. Only
+    /// honored when `read_only` is true. When unset, the reader follows the
+    /// latest manifest as governed by `reader.manifest_poll_interval`.
+    #[serde(default)]
+    pub checkpoint_id: Option<Uuid>,
     /// Maximum number of bucket readers to cache in memory.
     #[serde(default = "default_cache_capacity")]
     pub cache_capacity: u64,
@@ -135,6 +141,7 @@ impl Default for PrometheusConfig {
             flush_interval_secs: default_flush_interval_secs(),
             read_only: false,
             reader: default_reader_options(),
+            checkpoint_id: None,
             cache_capacity: default_cache_capacity(),
             cache_warmer: default_cache_warmer(),
             tracing: TracingConfig::default(),

--- a/timeseries/src/reader.rs
+++ b/timeseries/src/reader.rs
@@ -17,6 +17,7 @@ use common::storage::factory::create_storage_read;
 use common::{StorageReaderRuntime, StorageSemantics};
 use futures::stream::{self, StreamExt};
 use moka::future::Cache;
+use uuid::Uuid;
 
 use crate::error::{QueryError, Result};
 use crate::index::{ForwardIndexLookup, InvertedIndexLookup};
@@ -184,9 +185,43 @@ impl TimeSeriesDbReader {
         reader_options: slatedb::config::DbReaderOptions,
         cache_capacity: u64,
     ) -> Result<Self> {
+        Self::open_inner(storage_config, reader_options, cache_capacity, None).await
+    }
+
+    /// Opens a read-only view pinned to a specific checkpoint.
+    ///
+    /// Unlike [`open`](Self::open), the returned reader serves a frozen view
+    /// of the database as of the checkpoint and does not advance with newer
+    /// writes. The checkpoint must already exist (typically created via
+    /// [`crate::TimeSeriesDb::create_checkpoint`]).
+    pub async fn open_at_checkpoint(
+        storage_config: StorageConfig,
+        reader_options: slatedb::config::DbReaderOptions,
+        cache_capacity: u64,
+        checkpoint_id: Uuid,
+    ) -> Result<Self> {
+        Self::open_inner(
+            storage_config,
+            reader_options,
+            cache_capacity,
+            Some(checkpoint_id),
+        )
+        .await
+    }
+
+    async fn open_inner(
+        storage_config: StorageConfig,
+        reader_options: slatedb::config::DbReaderOptions,
+        cache_capacity: u64,
+        checkpoint_id: Option<Uuid>,
+    ) -> Result<Self> {
+        let mut runtime = StorageReaderRuntime::new();
+        if let Some(id) = checkpoint_id {
+            runtime = runtime.with_checkpoint_id(id);
+        }
         let storage = create_storage_read(
             &storage_config,
-            StorageReaderRuntime::new(),
+            runtime,
             StorageSemantics::new().with_merge_operator(Arc::new(OpenTsdbMergeOperator)),
             reader_options,
         )
@@ -817,6 +852,113 @@ mod tests {
             "expected InvalidQuery, got {:?}",
             err
         );
+    }
+
+    /// Writes data, creates a checkpoint, writes more data, then opens a
+    /// reader pinned to the checkpoint and verifies it sees only the data
+    /// that was durable at checkpoint time (not later writes).
+    #[tokio::test]
+    async fn should_open_reader_pinned_to_checkpoint() {
+        use crate::config::Config;
+        use crate::timeseries::TimeSeriesDb;
+        use common::storage::config::{
+            LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig,
+        };
+
+        // given
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let storage_config = common::StorageConfig::SlateDb(SlateDbStorageConfig {
+            path: "data".to_string(),
+            object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
+                path: tmp_dir.path().to_str().unwrap().to_string(),
+            }),
+            settings_path: None,
+            block_cache: None,
+        });
+
+        let writer = TimeSeriesDb::open(Config {
+            storage: storage_config.clone(),
+            flush_interval: Duration::from_secs(60),
+            retention: None,
+        })
+        .await
+        .unwrap();
+
+        writer
+            .write(vec![
+                Series::builder("checkpointed")
+                    .label("env", "test")
+                    .sample(1700000001000, 1.0)
+                    .build(),
+            ])
+            .await
+            .unwrap();
+
+        // when — capture a checkpoint, then write a sample that must NOT be visible.
+        let checkpoint = writer.create_checkpoint().await.unwrap();
+
+        writer
+            .write(vec![
+                Series::builder("checkpointed")
+                    .label("env", "test")
+                    .sample(1700000002000, 2.0)
+                    .build(),
+            ])
+            .await
+            .unwrap();
+        writer.flush().await.unwrap();
+
+        let reader_options = slatedb::config::DbReaderOptions {
+            manifest_poll_interval: Duration::from_millis(100),
+            skip_wal_replay: true,
+            ..Default::default()
+        };
+        let reader = TimeSeriesDbReader::open_at_checkpoint(
+            storage_config,
+            reader_options,
+            50,
+            checkpoint.id,
+        )
+        .await
+        .unwrap();
+
+        // then — the pre-checkpoint sample is visible
+        let pre = reader
+            .query(
+                "checkpointed",
+                Some(SystemTime::UNIX_EPOCH + Duration::from_millis(1700000001000)),
+            )
+            .await
+            .unwrap();
+        match &pre {
+            QueryValue::Vector(samples) => {
+                assert_eq!(samples.len(), 1);
+                assert_eq!(samples[0].value, 1.0);
+            }
+            _ => panic!("expected Vector, got {:?}", pre),
+        }
+
+        // and — the post-checkpoint sample is NOT visible. PromQL lookback
+        // will surface the earlier (checkpointed) sample, so we assert the
+        // value is the pre-checkpoint one rather than the new write.
+        let post = reader
+            .query(
+                "checkpointed",
+                Some(SystemTime::UNIX_EPOCH + Duration::from_millis(1700000002000)),
+            )
+            .await
+            .unwrap();
+        match &post {
+            QueryValue::Vector(samples) => {
+                assert_eq!(samples.len(), 1);
+                assert_eq!(
+                    samples[0].value, 1.0,
+                    "reader pinned to checkpoint must not see writes made after the checkpoint",
+                );
+                assert_eq!(samples[0].timestamp_ms, 1700000002000);
+            }
+            _ => panic!("expected Vector, got {:?}", post),
+        }
     }
 
     #[test]

--- a/timeseries/src/reader.rs
+++ b/timeseries/src/reader.rs
@@ -193,7 +193,7 @@ impl TimeSeriesDbReader {
     /// Unlike [`open`](Self::open), the returned reader serves a frozen view
     /// of the database as of the checkpoint and does not advance with newer
     /// writes. The checkpoint must already exist (typically created via
-    /// [`crate::TimeSeriesDb::create_checkpoint`]).
+    /// `TimeSeriesDb::create_checkpoint`).
     pub async fn open_at_checkpoint(
         storage_config: StorageConfig,
         reader_options: slatedb::config::DbReaderOptions,

--- a/timeseries/src/server/http.rs
+++ b/timeseries/src/server/http.rs
@@ -95,7 +95,8 @@ pub(crate) fn build_router(
         .route("/metrics", get(handle_metrics))
         .route("/-/healthy", get(handle_healthy))
         .route("/-/ready", get(handle_ready))
-        .route("/-/flush", post(handle_flush));
+        .route("/-/flush", post(handle_flush))
+        .route("/-/checkpoint", post(handle_checkpoint));
 
     #[cfg(feature = "remote-write")]
     let app = app.route(
@@ -670,6 +671,26 @@ async fn handle_flush(
 ) -> Result<(StatusCode, &'static str), ApiError> {
     state.tsdb.flush().await?;
     Ok((StatusCode::OK, "OK"))
+}
+
+/// Handle /-/checkpoint endpoint - flushes pending data and creates a
+/// durable SlateDB checkpoint. Returns the checkpoint id and the manifest
+/// id it references; pass `checkpoint_id` to a read-only instance to open
+/// it pinned to this exact view.
+async fn handle_checkpoint(
+    State(state): State<AppState>,
+) -> Result<Json<CheckpointResponse>, ApiError> {
+    let info = state.tsdb.create_checkpoint().await?;
+    Ok(Json(CheckpointResponse {
+        checkpoint_id: info.id.to_string(),
+        manifest_id: info.manifest_id,
+    }))
+}
+
+#[derive(serde::Serialize)]
+struct CheckpointResponse {
+    checkpoint_id: String,
+    manifest_id: u64,
 }
 
 /// Redirect `/` to `/query`.

--- a/timeseries/src/timeseries.rs
+++ b/timeseries/src/timeseries.rs
@@ -257,6 +257,18 @@ impl TimeSeriesDb {
         self.tsdb.flush().await
     }
 
+    /// Flushes pending data and creates a durable checkpoint.
+    ///
+    /// The returned [`common::CheckpointInfo::id`] can be passed to
+    /// [`crate::TimeSeriesDbReader::open_at_checkpoint`] (or to the
+    /// `checkpoint_id` field on `PrometheusConfig`) to open a reader pinned
+    /// to this exact view of the database.
+    ///
+    /// Only supported by SlateDB-backed storage.
+    pub async fn create_checkpoint(&self) -> Result<common::CheckpointInfo> {
+        self.tsdb.create_checkpoint().await
+    }
+
     /// Closes the time series database, flushing any pending data and releasing
     /// resources.
     ///

--- a/timeseries/src/tsdb.rs
+++ b/timeseries/src/tsdb.rs
@@ -1093,6 +1093,17 @@ impl Tsdb {
         Ok(())
     }
 
+    /// Flushes pending writes and creates a durable checkpoint.
+    ///
+    /// The returned [`CheckpointInfo::id`] can be passed to
+    /// [`crate::reader::TimeSeriesDbReader::open`] (via
+    /// [`common::StorageReaderRuntime::with_checkpoint_id`]) to open a
+    /// reader pinned to this exact view of the database.
+    pub(crate) async fn create_checkpoint(&self) -> Result<common::CheckpointInfo> {
+        self.flush().await?;
+        Ok(self.storage.create_checkpoint().await?)
+    }
+
     pub(crate) async fn close(&self) -> Result<()> {
         self.flush().await?;
         self.storage.close().await?;
@@ -1481,6 +1492,15 @@ impl TsdbEngine {
         match self {
             Self::ReadWrite(tsdb) => tsdb.flush().await,
             Self::ReadOnly(_) => Ok(()),
+        }
+    }
+
+    pub(crate) async fn create_checkpoint(&self) -> Result<common::CheckpointInfo> {
+        match self {
+            Self::ReadWrite(tsdb) => tsdb.create_checkpoint().await,
+            Self::ReadOnly(_) => Err(crate::error::Error::InvalidInput(
+                "checkpoint creation is not supported in read-only mode".to_string(),
+            )),
         }
     }
 

--- a/timeseries/src/tsdb.rs
+++ b/timeseries/src/tsdb.rs
@@ -1095,7 +1095,7 @@ impl Tsdb {
 
     /// Flushes pending writes and creates a durable checkpoint.
     ///
-    /// The returned [`CheckpointInfo::id`] can be passed to
+    /// The returned [`common::CheckpointInfo::id`] can be passed to
     /// [`crate::reader::TimeSeriesDbReader::open`] (via
     /// [`common::StorageReaderRuntime::with_checkpoint_id`]) to open a
     /// reader pinned to this exact view of the database.

--- a/timeseries/tests/http_server.rs
+++ b/timeseries/tests/http_server.rs
@@ -114,6 +114,31 @@ async fn test_ready() {
 }
 
 #[tokio::test]
+async fn should_create_checkpoint_via_http() {
+    // given — a tsdb with at least one ingested sample, so the checkpoint
+    // covers a non-trivial state.
+    let (app, _) = setup_with_data().await;
+
+    // when
+    let req = Request::post("/-/checkpoint").body(Body::empty()).unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+
+    // then
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_string(resp).await;
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    let id = parsed
+        .get("checkpoint_id")
+        .and_then(|v| v.as_str())
+        .expect("checkpoint_id should be a string");
+    uuid::Uuid::parse_str(id).expect("checkpoint_id must be a valid UUID");
+    assert!(
+        parsed.get("manifest_id").and_then(|v| v.as_u64()).is_some(),
+        "expected numeric manifest_id, got: {body}"
+    );
+}
+
+#[tokio::test]
 async fn test_metrics() {
     let (app, _) = setup().await;
 


### PR DESCRIPTION
This is part of the work for building a soak cluster. if we determine some kind of problem we can checkpoint the state to reproduce the error to the best of our ability. We may clone + replay part of the WAL to get to the exact point or we can checkpoint in the soak cluster before issuing queries.

-----

Surfaces SlateDB's checkpoint API through the timeseries HTTP layer so a write-side instance can capture a durable snapshot, then a read-only instance can be opened pinned to that exact view.

- common: `Storage::create_checkpoint()` returning `CheckpointInfo { id, manifest_id }`; SlateDB impl maps to `Db::create_checkpoint` with `CheckpointScope::All`. In-memory backend errors out.
- common: `StorageReaderRuntime::with_checkpoint_id` threads through to `DbReaderBuilder::with_checkpoint_id` (kept `create_storage_read` signature stable so other crates' callers don't churn).
- timeseries: `TimeSeriesDb::create_checkpoint`, `TimeSeriesDbReader::open_at_checkpoint`, and a `checkpoint_id` field on `PrometheusConfig` so a read-only server can be pinned via config.
- HTTP: `POST /-/checkpoint` returning `{ checkpoint_id, manifest_id }`, alongside the existing `/-/flush`.