### PR TITLE
[timeseries] Stamp flushed records with bucket-aligned Ttl::ExpireAt

### DIFF
--- a/common/src/storage/in_memory.rs
+++ b/common/src/storage/in_memory.rs
@@ -48,12 +48,12 @@ impl StoredValue {
 
 /// Computes the absolute expiration timestamp from TTL options.
 fn compute_expire_ts(now: i64, ttl: Ttl, default_ttl: Option<u64>) -> Option<i64> {
-    let duration = match ttl {
-        Ttl::Default => default_ttl,
+    match ttl {
+        Ttl::Default => default_ttl.map(|ms| now + ms as i64),
         Ttl::NoExpiry => None,
-        Ttl::ExpireAfter(ms) => Some(ms),
-    };
-    duration.map(|ms| now + ms as i64)
+        Ttl::ExpireAfter(ms) => Some(now + ms as i64),
+        Ttl::ExpireAt(ts) => Some(ts),
+    }
 }
 
 /// In-memory implementation of the Storage trait using a BTreeMap.

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -31,6 +31,7 @@ pub enum Ttl {
     Default,
     NoExpiry,
     ExpireAfter(u64),
+    ExpireAt(i64),
 }
 
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -364,6 +364,7 @@ impl From<Ttl> for slatedb::config::Ttl {
             Ttl::Default => slatedb::config::Ttl::Default,
             Ttl::NoExpiry => slatedb::config::Ttl::NoExpiry,
             Ttl::ExpireAfter(ts) => slatedb::config::Ttl::ExpireAfter(ts),
+            Ttl::ExpireAt(ts) => slatedb::config::Ttl::ExpireAt(ts),
         }
     }
 }

--- a/timeseries/src/flusher.rs
+++ b/timeseries/src/flusher.rs
@@ -1,11 +1,13 @@
 use std::ops::Range;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use common::coordinator::Flusher;
-use common::storage::{Storage, StorageSnapshot};
+use common::storage::{Storage, StorageSnapshot, Ttl};
 
 use crate::delta::{FrozenTsdbDelta, TsdbWriteDelta};
+use crate::model::TimeBucket;
 use crate::storage::{OpenTsdbStorageExt, OpenTsdbStorageReadExt};
 use crate::tsdb_metrics;
 
@@ -15,6 +17,24 @@ use crate::tsdb_metrics;
 /// atomically, then returns a new snapshot for readers.
 pub(crate) struct TsdbFlusher {
     pub(crate) storage: Arc<dyn Storage>,
+    /// Optional retention duration. When set, every record produced by a flush
+    /// is stamped with the same `Ttl::ExpireAt(bucket_start_ms + retention_ms)`
+    /// so SlateDB can collapse merge operands during compaction. Without a
+    /// shared expiration, operands written at different wall-clock times get
+    /// different TTLs and never merge — see issue #342.
+    pub(crate) retention: Option<Duration>,
+}
+
+/// Compute the absolute expire-at timestamp (ms since epoch) shared by every
+/// record in `bucket` for the given `retention`. Returns `Ttl::Default` when
+/// retention is disabled.
+fn bucket_ttl(bucket: TimeBucket, retention: Option<Duration>) -> Ttl {
+    let Some(retention) = retention else {
+        return Ttl::Default;
+    };
+    let bucket_start_ms = bucket.start as i64 * 60 * 1000;
+    let retention_ms = retention.as_millis() as i64;
+    Ttl::ExpireAt(bucket_start_ms.saturating_add(retention_ms))
 }
 
 #[async_trait]
@@ -30,6 +50,7 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
 
         let new_series_count = frozen.series_dict_delta.len() as u64;
         let start = std::time::Instant::now();
+        let ttl = bucket_ttl(frozen.bucket, self.retention);
 
         let mut ops = Vec::new();
         // Suppress the BucketList merge when this bucket is already listed.
@@ -45,7 +66,7 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         if !bucket_announced {
             ops.push(
                 self.storage
-                    .merge_bucket_list(frozen.bucket)
+                    .merge_bucket_list(frozen.bucket, ttl)
                     .map_err(|e| e.to_string())?,
             );
         }
@@ -53,7 +74,7 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         for (fingerprint, series_id) in &frozen.series_dict_delta {
             ops.push(
                 self.storage
-                    .insert_series_id(frozen.bucket, *fingerprint, *series_id)
+                    .insert_series_id(frozen.bucket, *fingerprint, *series_id, ttl)
                     .map_err(|e| e.to_string())?,
             );
         }
@@ -61,7 +82,7 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         for entry in frozen.forward_index.series.iter() {
             ops.push(
                 self.storage
-                    .insert_forward_index(frozen.bucket, *entry.key(), entry.value().clone())
+                    .insert_forward_index(frozen.bucket, *entry.key(), entry.value().clone(), ttl)
                     .map_err(|e| e.to_string())?,
             );
         }
@@ -69,7 +90,12 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         for entry in frozen.inverted_index.postings.iter() {
             ops.push(
                 self.storage
-                    .merge_inverted_index(frozen.bucket, entry.key().clone(), entry.value().clone())
+                    .merge_inverted_index(
+                        frozen.bucket,
+                        entry.key().clone(),
+                        entry.value().clone(),
+                        ttl,
+                    )
                     .map_err(|e| e.to_string())?,
             );
         }
@@ -82,6 +108,7 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
                         series_id,
                         &series_samples.metric_name,
                         series_samples.points,
+                        ttl,
                     )
                     .map_err(|e| e.to_string())?,
             );
@@ -136,6 +163,50 @@ mod tests {
         TimeBucket::hour(1000)
     }
 
+    #[test]
+    fn should_return_default_ttl_when_retention_is_none() {
+        // given
+        let bucket = create_test_bucket();
+
+        // when
+        let ttl = bucket_ttl(bucket, None);
+
+        // then
+        assert_eq!(ttl, Ttl::Default);
+    }
+
+    #[test]
+    fn should_compute_expire_at_from_bucket_start_and_retention() {
+        // given: hour bucket starts at minute 1000, retention 7d
+        let bucket = TimeBucket::hour(1000);
+        let retention = Duration::from_secs(7 * 86_400);
+
+        // when
+        let ttl = bucket_ttl(bucket, Some(retention));
+
+        // then: bucket_start_ms = 1000 * 60 * 1000; retention_ms = 7d in ms
+        let expected = 1000_i64 * 60 * 1000 + 7 * 86_400 * 1000;
+        assert_eq!(ttl, Ttl::ExpireAt(expected));
+    }
+
+    #[test]
+    fn should_match_expire_at_for_same_bucket_across_calls() {
+        // given: same bucket, same retention, called at different wall times
+        let bucket = TimeBucket::hour(42);
+        let retention = Some(Duration::from_secs(86_400));
+
+        // when
+        let ttl_a = bucket_ttl(bucket, retention);
+        // sleep is OK because its deterministic, not required for test
+        // to succeed
+        std::thread::sleep(Duration::from_millis(2));
+        let ttl_b = bucket_ttl(bucket, retention);
+
+        // then: every record stamped with this TTL gets the same expire_at,
+        // which is the property SlateDB compaction needs to merge operands.
+        assert_eq!(ttl_a, ttl_b);
+    }
+
     fn create_test_sample() -> Sample {
         Sample {
             timestamp_ms: 60_000_001,
@@ -156,6 +227,7 @@ mod tests {
         let storage = create_test_storage();
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention: None,
         };
         let ctx = TsdbContext {
             bucket: create_test_bucket(),
@@ -183,6 +255,7 @@ mod tests {
         let storage = create_test_storage();
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention: None,
         };
         let ctx = TsdbContext {
             bucket: create_test_bucket(),
@@ -227,6 +300,7 @@ mod tests {
         let storage = create_failing_storage();
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention: None,
         };
         storage.fail_apply(common::StorageError::Storage("test apply error".into()));
 
@@ -249,6 +323,7 @@ mod tests {
         let storage = create_failing_storage();
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention: None,
         };
         // Apply succeeds, but snapshot after apply fails
         storage.fail_snapshot(common::StorageError::Storage("test snapshot error".into()));
@@ -272,6 +347,7 @@ mod tests {
         let storage = create_failing_storage();
         let flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention: None,
         };
         storage.fail_flush(common::StorageError::Storage("test flush error".into()));
 
@@ -292,6 +368,7 @@ mod tests {
         let storage = create_test_storage();
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention: None,
         };
         let ctx = TsdbContext {
             bucket: create_test_bucket(),
@@ -322,6 +399,7 @@ mod tests {
         let storage = create_test_storage();
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention: None,
         };
         let bucket = create_test_bucket();
 
@@ -373,6 +451,7 @@ mod tests {
 
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention: None,
         };
         let ctx = TsdbContext {
             bucket,
@@ -403,6 +482,7 @@ mod tests {
         let storage = create_test_storage();
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention: None,
         };
         let ctx = TsdbContext {
             bucket: create_test_bucket(),

--- a/timeseries/src/minitsdb.rs
+++ b/timeseries/src/minitsdb.rs
@@ -195,7 +195,11 @@ impl MiniTsdb {
         }
     }
 
-    pub(crate) async fn load(bucket: TimeBucket, storage: Arc<dyn Storage>) -> Result<Self> {
+    pub(crate) async fn load(
+        bucket: TimeBucket,
+        storage: Arc<dyn Storage>,
+        retention: Option<Duration>,
+    ) -> Result<Self> {
         let snapshot = storage.snapshot().await?;
 
         let mut series_dict = HashMap::new();
@@ -213,6 +217,7 @@ impl MiniTsdb {
 
         let flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention,
         };
 
         let initial_snapshot: Arc<dyn StorageSnapshot> = storage
@@ -364,6 +369,7 @@ mod tests {
 
         let flusher = TsdbFlusher {
             storage: storage.clone(),
+            retention: None,
         };
 
         let initial_snapshot: Arc<dyn StorageSnapshot> = storage.snapshot().await.unwrap();

--- a/timeseries/src/storage/mod.rs
+++ b/timeseries/src/storage/mod.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use common::storage::{PutRecordOp, RecordOp};
+use common::storage::{MergeOptions, MergeRecordOp, PutOptions, PutRecordOp, RecordOp, Ttl};
 use common::{Record, Storage, StorageRead};
 use roaring::RoaringBitmap;
 
@@ -331,14 +331,17 @@ pub(crate) trait OpenTsdbStorageReadExt: StorageRead {
 impl<T: ?Sized + StorageRead> OpenTsdbStorageReadExt for T {}
 
 pub(crate) trait OpenTsdbStorageExt: Storage {
-    fn merge_bucket_list(&self, bucket: TimeBucket) -> Result<RecordOp> {
+    fn merge_bucket_list(&self, bucket: TimeBucket, ttl: Ttl) -> Result<RecordOp> {
         let key = BucketListKey.encode();
         let value = BucketListValue {
             buckets: vec![(bucket.size, bucket.start)],
         }
         .encode();
 
-        Ok(RecordOp::Merge(Record { key, value }.into()))
+        Ok(RecordOp::Merge(MergeRecordOp::new_with_ttl(
+            Record { key, value },
+            MergeOptions { ttl },
+        )))
     }
 
     fn insert_series_id(
@@ -346,6 +349,7 @@ pub(crate) trait OpenTsdbStorageExt: Storage {
         bucket: TimeBucket,
         fingerprint: SeriesFingerprint,
         id: SeriesId,
+        ttl: Ttl,
     ) -> Result<RecordOp> {
         let key = SeriesDictionaryKey {
             time_bucket: bucket.start,
@@ -354,7 +358,10 @@ pub(crate) trait OpenTsdbStorageExt: Storage {
         }
         .encode();
         let value = SeriesDictionaryValue { series_id: id }.encode();
-        Ok(RecordOp::Put(Record { key, value }.into()))
+        Ok(RecordOp::Put(PutRecordOp::new_with_options(
+            Record { key, value },
+            PutOptions { ttl },
+        )))
     }
 
     fn insert_forward_index(
@@ -362,6 +369,7 @@ pub(crate) trait OpenTsdbStorageExt: Storage {
         bucket: TimeBucket,
         series_id: SeriesId,
         series_spec: SeriesSpec,
+        ttl: Ttl,
     ) -> Result<RecordOp> {
         let key = ForwardIndexKey {
             time_bucket: bucket.start,
@@ -376,7 +384,10 @@ pub(crate) trait OpenTsdbStorageExt: Storage {
             labels: series_spec.labels,
         }
         .encode();
-        Ok(RecordOp::Put(Record { key, value }.into()))
+        Ok(RecordOp::Put(PutRecordOp::new_with_options(
+            Record { key, value },
+            PutOptions { ttl },
+        )))
     }
 
     fn merge_inverted_index(
@@ -384,6 +395,7 @@ pub(crate) trait OpenTsdbStorageExt: Storage {
         bucket: TimeBucket,
         label: Label,
         postings: RoaringBitmap,
+        ttl: Ttl,
     ) -> Result<RecordOp> {
         let key = InvertedIndexKey {
             time_bucket: bucket.start,
@@ -393,7 +405,10 @@ pub(crate) trait OpenTsdbStorageExt: Storage {
         }
         .encode();
         let value = InvertedIndexValue { postings }.encode()?;
-        Ok(RecordOp::Merge(Record { key, value }.into()))
+        Ok(RecordOp::Merge(MergeRecordOp::new_with_ttl(
+            Record { key, value },
+            MergeOptions { ttl },
+        )))
     }
 
     fn merge_samples(
@@ -402,6 +417,7 @@ pub(crate) trait OpenTsdbStorageExt: Storage {
         series_id: SeriesId,
         metric_name: &str,
         samples: Vec<Sample>,
+        ttl: Ttl,
     ) -> Result<RecordOp> {
         let key = TimeSeriesKey {
             time_bucket: bucket.start,
@@ -411,7 +427,10 @@ pub(crate) trait OpenTsdbStorageExt: Storage {
         }
         .encode();
         let value = TimeSeriesValue { points: samples }.encode()?;
-        Ok(RecordOp::Merge(Record { key, value }.into()))
+        Ok(RecordOp::Merge(MergeRecordOp::new_with_ttl(
+            Record { key, value },
+            MergeOptions { ttl },
+        )))
     }
 }
 
@@ -604,16 +623,19 @@ mod tests {
         )));
         let ops = vec![
             storage
-                .merge_bucket_list(TimeBucket { size: 1, start: 0 })
+                .merge_bucket_list(TimeBucket { size: 1, start: 0 }, Ttl::Default)
                 .unwrap(),
             storage
-                .merge_bucket_list(TimeBucket { size: 1, start: 60 })
+                .merge_bucket_list(TimeBucket { size: 1, start: 60 }, Ttl::Default)
                 .unwrap(),
             storage
-                .merge_bucket_list(TimeBucket {
-                    size: 1,
-                    start: 120,
-                })
+                .merge_bucket_list(
+                    TimeBucket {
+                        size: 1,
+                        start: 120,
+                    },
+                    Ttl::Default,
+                )
                 .unwrap(),
         ];
         storage.apply(ops).await.unwrap();

--- a/timeseries/src/timeseries.rs
+++ b/timeseries/src/timeseries.rs
@@ -88,7 +88,7 @@ impl TimeSeriesDb {
         // later reads don't have to replay them across SSTs. Runs before any
         // writer is started, so no concurrent merges can race the Put.
         coalesce_bucket_list(storage.as_ref()).await?;
-        let tsdb = Tsdb::new(storage);
+        let tsdb = Tsdb::with_retention(storage, config.retention);
         Ok(Self { tsdb })
     }
 

--- a/timeseries/src/tsdb.rs
+++ b/timeseries/src/tsdb.rs
@@ -974,12 +974,21 @@ pub(crate) struct Tsdb {
     /// Also used during queries so that unflushed data is visible.
     ingest_cache: Cache<TimeBucket, Arc<MiniTsdb>>,
 
+    /// Retention duration plumbed into each `MiniTsdb` so the flusher can
+    /// stamp records with a bucket-aligned `Ttl::ExpireAt`. `None` disables
+    /// per-record expiration.
+    retention: Option<Duration>,
+
     // Metadata catalog (keyed by metric name)
     pub(crate) metadata_catalog: RwLock<HashMap<String, Vec<MetricMetadata>>>,
 }
 
 impl Tsdb {
     pub(crate) fn new(storage: Arc<dyn Storage>) -> Self {
+        Self::with_retention(storage, None)
+    }
+
+    pub(crate) fn with_retention(storage: Arc<dyn Storage>, retention: Option<Duration>) -> Self {
         // TTI cache: 15 minute idle timeout for ingest buckets
         let ingest_cache = Cache::builder()
             .time_to_idle(Duration::from_secs(15 * 60))
@@ -988,6 +997,7 @@ impl Tsdb {
         Self {
             storage,
             ingest_cache,
+            retention,
             metadata_catalog: RwLock::new(HashMap::new()),
         }
     }
@@ -1010,7 +1020,7 @@ impl Tsdb {
         }
 
         // Load from storage and put in ingest cache
-        let mini = Arc::new(MiniTsdb::load(bucket, self.storage.clone()).await?);
+        let mini = Arc::new(MiniTsdb::load(bucket, self.storage.clone(), self.retention).await?);
         self.ingest_cache.insert(bucket, mini.clone()).await;
         Ok(mini)
     }


### PR DESCRIPTION
Every record produced by a flush now carries the same `Ttl::ExpireAt(bucket_start_ms + retention_ms)`, so SlateDB compaction can collapse merge operands for a given (series, bucket). Previously the default per-write `ExpireAfter` gave each operand a slightly different expiration, blocking the merge and driving read amplification on hot keys (see #338).

Fixes #342 
