### PR TITLE
[timeseries] fix Windows build by moving prost/snap to unconditional deps

### DIFF
--- a/timeseries/Cargo.toml
+++ b/timeseries/Cargo.toml
@@ -73,14 +73,14 @@ roaring = "0.7"
 rust-embed = { version = "8", features = ["mime-guess"] }
 tsz = "0.1"
 
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { workspace = true, optional = true }
-
 # Optional dependencies for remote-write and otel features
 buffer = { workspace = true, optional = true }
 opentelemetry-proto = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 snap = { workspace = true, optional = true }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true, optional = true }
 
 [dev-dependencies]
 common = { workspace = true, features = ["test-utils"] }


### PR DESCRIPTION
## Summary

- Optional deps `prost`, `snap`, `buffer`, and `opentelemetry-proto` were sitting directly under `[target.'cfg(not(target_env = "msvc"))'.dependencies]` in `timeseries/Cargo.toml`, with only a blank line and a comment between them. TOML table headers stay in scope until the next `[...]` header, so cargo silently excluded those crates on `x86_64-pc-windows-msvc`.
- The release-binary workflow runs `cargo build --release -p opendata-timeseries --features remote-write`. The feature flags activated, but the crates were never linked on Windows, producing `unresolved import prost`, `unresolved snap`, and missing `WriteRequest::decode` errors. See the failing job: https://github.com/opendata-oss/opendata/actions/runs/25078631469/job/73480269937
- Move `prost`/`snap`/`buffer`/`opentelemetry-proto` back into the regular `[dependencies]` table; only `tikv-jemallocator` legitimately needs the MSVC-conditional gate.

## Test plan

- [x] `cargo build -p opendata-timeseries --features remote-write` (local, macOS) — passes
- [ ] Re-run Build Binaries workflow (or cut a fresh `opendata-timeseries/v*` tag) and confirm the `x86_64-pc-windows-msvc` job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)