### PR TITLE
ci: include otel feature in opendata-timeseries binary builds

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -44,7 +44,7 @@ jobs:
               ;;
             opendata-timeseries)
               echo "has_binary=true" >> "$GITHUB_OUTPUT"
-              echo "features=remote-write" >> "$GITHUB_OUTPUT"
+              echo "features=remote-write,otel" >> "$GITHUB_OUTPUT"
               echo "docker_image=timeseries" >> "$GITHUB_OUTPUT"
               ;;
             opendata-vector)


### PR DESCRIPTION
The published Docker image is built with `remote-write,otel`, but the GitHub release binaries (including aarch64-apple-darwin) were built with only `remote-write`. That dropped buffer_consumer (gated behind otel), so consumers running the native binary couldn't ingest from an opendata buffer. Match the Dockerfile features so all release artifacts expose the same surface.
