### PR TITLE
[timeseries] add metrics for ingest backpressure diagnosis

### DIFF
--- a/common/src/coordinator/handle.rs
+++ b/common/src/coordinator/handle.rs
@@ -1,3 +1,4 @@
+use super::metrics;
 use super::{BroadcastedView, WriteCommand};
 use super::{Delta, Durability, WriteError, WriteResult};
 use crate::StorageRead;
@@ -6,7 +7,7 @@ use crate::storage::StorageSnapshot;
 use futures::FutureExt;
 use futures::future::Shared;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{broadcast, mpsc, oneshot, watch};
 
 /// A point-in-time view of all applied writes, broadcast by the coordinator
@@ -142,6 +143,7 @@ impl<M: Clone + Send + 'static> WriteHandle<M> {
 /// This is the main interface for interacting with the write coordinator.
 /// It can be cloned and shared across tasks.
 pub struct WriteCoordinatorHandle<D: Delta> {
+    name: Arc<str>,
     write_tx: mpsc::Sender<WriteCommand<D>>,
     watchers: EpochWatcher,
     view: Arc<BroadcastedView<D>>,
@@ -149,11 +151,13 @@ pub struct WriteCoordinatorHandle<D: Delta> {
 
 impl<D: Delta> WriteCoordinatorHandle<D> {
     pub(crate) fn new(
+        name: String,
         write_tx: mpsc::Sender<WriteCommand<D>>,
         watchers: EpochWatcher,
         view: Arc<BroadcastedView<D>>,
     ) -> Self {
         Self {
+            name: Arc::from(name),
             write_tx,
             watchers,
             view,
@@ -166,6 +170,35 @@ impl<D: Delta> WriteCoordinatorHandle<D> {
     /// Returns 0 if no data has been flushed yet.
     pub fn flushed_epoch(&self) -> u64 {
         *self.watchers.written_rx.borrow()
+    }
+
+    /// Sample queue depth on each send. Cheap atomic reads on `mpsc::Sender`.
+    fn record_queue_depth(&self) {
+        let max = self.write_tx.max_capacity();
+        let free = self.write_tx.capacity();
+        ::metrics::gauge!(
+            metrics::COORDINATOR_QUEUE_DEPTH,
+            "channel" => self.name.to_string(),
+        )
+        .set(max.saturating_sub(free) as f64);
+    }
+
+    fn record_send(&self, command: &'static str, status: &'static str, started: Instant) {
+        ::metrics::histogram!(
+            metrics::COORDINATOR_SEND_DURATION_SECONDS,
+            "command" => command,
+            "status" => status,
+        )
+        .record(started.elapsed().as_secs_f64());
+    }
+
+    fn record_backpressure(&self, command: &'static str, reason: &'static str) {
+        ::metrics::counter!(
+            metrics::COORDINATOR_QUEUE_BACKPRESSURE_TOTAL,
+            "command" => command,
+            "reason" => reason,
+        )
+        .increment(1);
     }
 }
 
@@ -186,8 +219,12 @@ impl<D: Delta> WriteCoordinatorHandle<D> {
         write: D::Write,
         timeout: Duration,
     ) -> Result<WriteHandle<D::ApplyResult>, WriteError<D::Write>> {
+        const COMMAND: &str = "write_timeout";
+        self.record_queue_depth();
+        let started = Instant::now();
         let (tx, rx) = oneshot::channel();
-        self.write_tx
+        let send_result = self
+            .write_tx
             .send_timeout(
                 WriteCommand::Write {
                     write,
@@ -195,18 +232,24 @@ impl<D: Delta> WriteCoordinatorHandle<D> {
                 },
                 timeout,
             )
-            .await
-            .map_err(|e| match e {
-                mpsc::error::SendTimeoutError::Timeout(WriteCommand::Write { write, .. }) => {
-                    WriteError::TimeoutError(write)
-                }
-                mpsc::error::SendTimeoutError::Closed(WriteCommand::Write { write, .. }) => {
-                    WriteError::Shutdown
-                }
-                _ => unreachable!("sent a Write command"),
-            })?;
-
-        Ok(WriteHandle::new(rx, self.watchers.clone()))
+            .await;
+        match send_result {
+            Ok(()) => {
+                self.record_send(COMMAND, "ok", started);
+                Ok(WriteHandle::new(rx, self.watchers.clone()))
+            }
+            Err(mpsc::error::SendTimeoutError::Timeout(WriteCommand::Write { write, .. })) => {
+                self.record_send(COMMAND, "timeout", started);
+                self.record_backpressure(COMMAND, "timeout");
+                Err(WriteError::TimeoutError(write))
+            }
+            Err(mpsc::error::SendTimeoutError::Closed(WriteCommand::Write { .. })) => {
+                self.record_send(COMMAND, "shutdown", started);
+                self.record_backpressure(COMMAND, "closed");
+                Err(WriteError::Shutdown)
+            }
+            Err(_) => unreachable!("sent a Write command"),
+        }
     }
 
     /// Submit a write to the coordinator, blocking indefinitely until there is
@@ -222,19 +265,29 @@ impl<D: Delta> WriteCoordinatorHandle<D> {
         &self,
         write: D::Write,
     ) -> Result<WriteHandle<D::ApplyResult>, WriteError<D::Write>> {
+        const COMMAND: &str = "write";
+        self.record_queue_depth();
+        let started = Instant::now();
         let (tx, rx) = oneshot::channel();
-        self.write_tx
+        let send_result = self
+            .write_tx
             .send(WriteCommand::Write {
                 write,
                 result_tx: tx,
             })
-            .await
-            .map_err(|e| match e {
-                mpsc::error::SendError(WriteCommand::Write { write, .. }) => WriteError::Shutdown,
-                _ => unreachable!("sent a Write command"),
-            })?;
-
-        Ok(WriteHandle::new(rx, self.watchers.clone()))
+            .await;
+        match send_result {
+            Ok(()) => {
+                self.record_send(COMMAND, "ok", started);
+                Ok(WriteHandle::new(rx, self.watchers.clone()))
+            }
+            Err(mpsc::error::SendError(WriteCommand::Write { .. })) => {
+                self.record_send(COMMAND, "shutdown", started);
+                self.record_backpressure(COMMAND, "closed");
+                Err(WriteError::Shutdown)
+            }
+            Err(_) => unreachable!("sent a Write command"),
+        }
     }
 
     /// Submit a write to the coordinator.
@@ -247,23 +300,31 @@ impl<D: Delta> WriteCoordinatorHandle<D> {
         &self,
         write: D::Write,
     ) -> Result<WriteHandle<D::ApplyResult>, WriteError<D::Write>> {
+        const COMMAND: &str = "try_write";
+        self.record_queue_depth();
+        let started = Instant::now();
         let (tx, rx) = oneshot::channel();
-        self.write_tx
-            .try_send(WriteCommand::Write {
-                write,
-                result_tx: tx,
-            })
-            .map_err(|e| match e {
-                mpsc::error::TrySendError::Full(WriteCommand::Write { write, .. }) => {
-                    WriteError::Backpressure(write)
-                }
-                mpsc::error::TrySendError::Closed(WriteCommand::Write { write, .. }) => {
-                    WriteError::Shutdown
-                }
-                _ => unreachable!("sent a Write command"),
-            })?;
-
-        Ok(WriteHandle::new(rx, self.watchers.clone()))
+        let send_result = self.write_tx.try_send(WriteCommand::Write {
+            write,
+            result_tx: tx,
+        });
+        match send_result {
+            Ok(()) => {
+                self.record_send(COMMAND, "ok", started);
+                Ok(WriteHandle::new(rx, self.watchers.clone()))
+            }
+            Err(mpsc::error::TrySendError::Full(WriteCommand::Write { write, .. })) => {
+                self.record_send(COMMAND, "backpressure", started);
+                self.record_backpressure(COMMAND, "full");
+                Err(WriteError::Backpressure(write))
+            }
+            Err(mpsc::error::TrySendError::Closed(WriteCommand::Write { .. })) => {
+                self.record_send(COMMAND, "shutdown", started);
+                self.record_backpressure(COMMAND, "closed");
+                Err(WriteError::Shutdown)
+            }
+            Err(_) => unreachable!("sent a Write command"),
+        }
     }
 
     /// Request a flush of the current delta.
@@ -273,18 +334,30 @@ impl<D: Delta> WriteCoordinatorHandle<D> {
     /// to guarantee durability, and the durable watermark will be advanced.
     /// Returns a handle that can be used to wait for the flush to complete.
     pub async fn flush(&self, flush_storage: bool) -> WriteResult<WriteHandle> {
+        const COMMAND: &str = "flush";
+        self.record_queue_depth();
+        let started = Instant::now();
         let (tx, rx) = oneshot::channel();
-        self.write_tx
-            .try_send(WriteCommand::Flush {
-                epoch_tx: tx,
-                flush_storage,
-            })
-            .map_err(|e| match e {
-                mpsc::error::TrySendError::Full(_) => WriteError::Backpressure(()),
-                mpsc::error::TrySendError::Closed(_) => WriteError::Shutdown,
-            })?;
-
-        Ok(WriteHandle::new(rx, self.watchers.clone()))
+        let send_result = self.write_tx.try_send(WriteCommand::Flush {
+            epoch_tx: tx,
+            flush_storage,
+        });
+        match send_result {
+            Ok(()) => {
+                self.record_send(COMMAND, "ok", started);
+                Ok(WriteHandle::new(rx, self.watchers.clone()))
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.record_send(COMMAND, "backpressure", started);
+                self.record_backpressure(COMMAND, "full");
+                Err(WriteError::Backpressure(()))
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.record_send(COMMAND, "shutdown", started);
+                self.record_backpressure(COMMAND, "closed");
+                Err(WriteError::Shutdown)
+            }
+        }
     }
 
     pub fn view(&self) -> Arc<View<D>> {
@@ -299,6 +372,7 @@ impl<D: Delta> WriteCoordinatorHandle<D> {
 impl<D: Delta> Clone for WriteCoordinatorHandle<D> {
     fn clone(&self) -> Self {
         Self {
+            name: self.name.clone(),
             write_tx: self.write_tx.clone(),
             watchers: self.watchers.clone(),
             view: self.view.clone(),

--- a/common/src/coordinator/metrics.rs
+++ b/common/src/coordinator/metrics.rs
@@ -1,0 +1,108 @@
+//! Metrics for the write coordinator.
+//!
+//! These metric names are stable strings shared between the coordinator and
+//! the flush task. Calls are no-ops when no global recorder is installed.
+
+// ── Write-queue ingress (the channel that backs WriteCoordinatorHandle) ──
+
+/// Histogram of how long it takes to enqueue a coordinator command.
+/// Labels: `command` ∈ {`write`, `write_timeout`, `try_write`, `flush`},
+/// `status` ∈ {`ok`, `backpressure`, `timeout`, `shutdown`}.
+pub(crate) const COORDINATOR_SEND_DURATION_SECONDS: &str =
+    "opendata_write_coordinator_send_duration_seconds";
+
+/// Counter incremented when the queue rejects a send because it is full.
+/// Labels: `command`, `reason` ∈ {`full`, `timeout`, `closed`}.
+pub(crate) const COORDINATOR_QUEUE_BACKPRESSURE_TOTAL: &str =
+    "opendata_write_coordinator_queue_backpressure_total";
+
+/// Approximate depth of the write queue, sampled on each send.
+/// Labels: `channel`.
+pub(crate) const COORDINATOR_QUEUE_DEPTH: &str = "opendata_write_coordinator_queue_depth";
+
+// ── Delta lifecycle (apply / freeze / flush dispatch) ──
+
+/// Histogram of `Delta::apply` durations on the coordinator hot path.
+pub(crate) const COORDINATOR_DELTA_APPLY_DURATION_SECONDS: &str =
+    "opendata_write_coordinator_delta_apply_duration_seconds";
+
+/// Estimated current delta size in bytes (gauge), sampled after each apply.
+pub(crate) const COORDINATOR_DELTA_ESTIMATED_BYTES: &str =
+    "opendata_write_coordinator_delta_estimated_bytes";
+
+/// Histogram of `Delta::freeze` durations.
+pub(crate) const COORDINATOR_DELTA_FREEZE_DURATION_SECONDS: &str =
+    "opendata_write_coordinator_delta_freeze_duration_seconds";
+
+/// Histogram of how long the coordinator waits when sending a flush event to
+/// the flush task. A high value means the flush task is the bottleneck and
+/// new writes will not be accepted until the event is dispatched.
+pub(crate) const COORDINATOR_FLUSH_EVENT_SEND_DURATION_SECONDS: &str =
+    "opendata_write_coordinator_flush_event_send_duration_seconds";
+
+/// Approximate depth of the flush event channel, sampled on each send.
+pub(crate) const COORDINATOR_FLUSH_EVENT_QUEUE_DEPTH: &str =
+    "opendata_write_coordinator_flush_event_queue_depth";
+
+/// Counter of flush triggers, labeled by reason.
+/// Labels: `reason` ∈ {`size_threshold`, `interval`, `explicit`, `shutdown`}.
+pub(crate) const COORDINATOR_FLUSH_TOTAL: &str = "opendata_write_coordinator_flush_total";
+
+// ── Flush task (background) ──
+
+/// Histogram of `Flusher::flush_delta` durations on the background flush task.
+pub(crate) const COORDINATOR_FLUSH_DELTA_DURATION_SECONDS: &str =
+    "opendata_write_coordinator_flush_delta_duration_seconds";
+
+/// Histogram of `Flusher::flush_storage` durations on the background flush task.
+pub(crate) const COORDINATOR_FLUSH_STORAGE_DURATION_SECONDS: &str =
+    "opendata_write_coordinator_flush_storage_duration_seconds";
+
+/// Describe all coordinator metrics on the global recorder. Safe to call more
+/// than once; the `metrics` crate dedupes descriptions.
+pub fn describe_coordinator_metrics() {
+    metrics::describe_histogram!(
+        COORDINATOR_SEND_DURATION_SECONDS,
+        "Latency of submitting a command to the write coordinator queue (seconds)"
+    );
+    metrics::describe_counter!(
+        COORDINATOR_QUEUE_BACKPRESSURE_TOTAL,
+        "Coordinator queue rejections due to a full or closed queue"
+    );
+    metrics::describe_gauge!(
+        COORDINATOR_QUEUE_DEPTH,
+        "Approximate write coordinator queue depth, sampled on each send"
+    );
+    metrics::describe_histogram!(
+        COORDINATOR_DELTA_APPLY_DURATION_SECONDS,
+        "Time spent in Delta::apply on the coordinator hot path (seconds)"
+    );
+    metrics::describe_gauge!(
+        COORDINATOR_DELTA_ESTIMATED_BYTES,
+        "Estimated bytes in the current (mutable) delta"
+    );
+    metrics::describe_histogram!(
+        COORDINATOR_DELTA_FREEZE_DURATION_SECONDS,
+        "Time spent freezing the current delta on the coordinator hot path (seconds)"
+    );
+    metrics::describe_histogram!(
+        COORDINATOR_FLUSH_EVENT_SEND_DURATION_SECONDS,
+        "Time spent dispatching a flush event from the coordinator to the flush task (seconds)"
+    );
+    metrics::describe_gauge!(
+        COORDINATOR_FLUSH_EVENT_QUEUE_DEPTH,
+        "Approximate depth of the coordinator's flush-event channel"
+    );
+    metrics::describe_counter!(
+        COORDINATOR_FLUSH_TOTAL,
+        "Coordinator flush triggers labeled by reason"
+    );
+    metrics::describe_histogram!(
+        COORDINATOR_FLUSH_DELTA_DURATION_SECONDS,
+        "Background Flusher::flush_delta duration (seconds)"
+    );
+    metrics::describe_histogram!(
+        COORDINATOR_FLUSH_STORAGE_DURATION_SECONDS,
+        "Background Flusher::flush_storage duration (seconds)"
+    );
+}

--- a/common/src/coordinator/mod.rs
+++ b/common/src/coordinator/mod.rs
@@ -2,6 +2,7 @@
 
 mod error;
 mod handle;
+pub(crate) mod metrics;
 pub mod subscriber;
 mod traits;
 
@@ -12,6 +13,7 @@ use std::ops::{Deref, DerefMut};
 pub use error::{WriteError, WriteResult};
 use futures::stream::{self, SelectAll, StreamExt};
 pub use handle::{View, WriteCoordinatorHandle, WriteHandle};
+pub use metrics::describe_coordinator_metrics;
 pub use subscriber::{SubscribeError, ViewMonitor, ViewSubscriber};
 pub use traits::{Delta, Durability, EpochStamped, Flusher};
 
@@ -125,10 +127,11 @@ impl<D: Delta, F: Flusher<D>> WriteCoordinator<D, F> {
 
         let mut handles = HashMap::new();
         for name in channels {
-            let write_tx = write_txs.remove(&name.to_string()).expect("unreachable");
+            let name = name.to_string();
+            let write_tx = write_txs.remove(&name).expect("unreachable");
             handles.insert(
-                name.to_string(),
-                WriteCoordinatorHandle::new(write_tx, watcher.clone(), view.clone()),
+                name.clone(),
+                WriteCoordinatorHandle::new(name, write_tx, watcher.clone(), view.clone()),
             );
         }
 
@@ -294,7 +297,7 @@ impl<D: Delta> WriteCoordinatorTask<D> {
                                 epoch: self.epoch.saturating_sub(1),
                                 result: (),
                             }));
-                            self.handle_flush(flush_storage).await;
+                            self.handle_flush(FlushReason::Explicit, flush_storage).await;
                         }
                         None => {
                             // All write channels closed
@@ -304,7 +307,7 @@ impl<D: Delta> WriteCoordinatorTask<D> {
                 }
 
                 _ = self.flush_interval.tick() => {
-                    self.handle_flush(false).await;
+                    self.handle_flush(FlushReason::Interval, false).await;
                 }
 
                 _ = self.stop_tok.cancelled() => {
@@ -314,7 +317,7 @@ impl<D: Delta> WriteCoordinatorTask<D> {
         }
 
         // Flush any remaining pending writes before shutdown
-        self.handle_flush(false).await;
+        self.handle_flush(FlushReason::Shutdown, false).await;
 
         // Signal the flush task to stop
         self.flush_stop_tok.cancel();
@@ -333,7 +336,11 @@ impl<D: Delta> WriteCoordinatorTask<D> {
         let write_epoch = self.epoch;
         self.epoch += 1;
 
+        let apply_start = std::time::Instant::now();
         let result = self.delta.apply(write);
+        ::metrics::histogram!(metrics::COORDINATOR_DELTA_APPLY_DURATION_SECONDS)
+            .record(apply_start.elapsed().as_secs_f64());
+
         // Ignore error if receiver was dropped (fire-and-forget write)
         let _ = result_tx.send(
             result
@@ -350,30 +357,42 @@ impl<D: Delta> WriteCoordinatorTask<D> {
         // Ignore error if no watchers are listening - this is non-fatal
         self.watermarks.update_applied(write_epoch);
 
-        if self.delta.estimate_size() >= self.config.flush_size_threshold {
-            self.handle_flush(false).await;
+        let estimated = self.delta.estimate_size();
+        ::metrics::gauge!(metrics::COORDINATOR_DELTA_ESTIMATED_BYTES).set(estimated as f64);
+        if estimated >= self.config.flush_size_threshold {
+            self.handle_flush(FlushReason::SizeThreshold, false).await;
         }
 
         Ok(())
     }
 
-    async fn handle_flush(&mut self, flush_storage: bool) {
-        self.flush_if_delta_has_writes().await;
+    async fn handle_flush(&mut self, reason: FlushReason, flush_storage: bool) {
+        self.flush_if_delta_has_writes(reason).await;
         if flush_storage {
-            let _ = self.flush_tx.send(FlushEvent::FlushStorage).await;
+            self.send_flush_event(FlushEvent::FlushStorage).await;
         }
     }
 
-    async fn flush_if_delta_has_writes(&mut self) {
+    async fn flush_if_delta_has_writes(&mut self, reason: FlushReason) {
         if self.epoch == self.delta_start_epoch {
             return;
         }
 
         self.flush_interval.reset();
 
+        ::metrics::counter!(metrics::COORDINATOR_FLUSH_TOTAL, "reason" => reason.as_str())
+            .increment(1);
+
         let epoch_range = self.delta_start_epoch..self.epoch;
         self.delta_start_epoch = self.epoch;
+
+        let freeze_start = std::time::Instant::now();
         let (frozen, frozen_reader) = self.delta.freeze_and_init();
+        ::metrics::histogram!(metrics::COORDINATOR_DELTA_FREEZE_DURATION_SECONDS)
+            .record(freeze_start.elapsed().as_secs_f64());
+        // Reset estimated bytes gauge: the new delta starts empty.
+        ::metrics::gauge!(metrics::COORDINATOR_DELTA_ESTIMATED_BYTES).set(0.0);
+
         let stamped_frozen = EpochStamped::new(frozen, epoch_range.clone());
         let stamped_frozen_reader = EpochStamped::new(frozen_reader, epoch_range.clone());
         let reader = self.delta.reader();
@@ -382,12 +401,44 @@ impl<D: Delta> WriteCoordinatorTask<D> {
         self.view.update_delta_frozen(stamped_frozen_reader, reader);
         // this is the blocking section of the flush, new writes will not be accepted
         // until the event is sent to the FlushTask
-        let _ = self
-            .flush_tx
-            .send(FlushEvent::FlushDelta {
-                frozen: stamped_frozen,
-            })
-            .await;
+        self.send_flush_event(FlushEvent::FlushDelta {
+            frozen: stamped_frozen,
+        })
+        .await;
+    }
+
+    async fn send_flush_event(&self, event: FlushEvent<D>) {
+        // Sample queue depth (in-flight events) just before sending. `max_capacity`
+        // and `capacity` are cheap atomic reads.
+        let max = self.flush_tx.max_capacity();
+        let free = self.flush_tx.capacity();
+        ::metrics::gauge!(metrics::COORDINATOR_FLUSH_EVENT_QUEUE_DEPTH)
+            .set(max.saturating_sub(free) as f64);
+
+        let send_start = std::time::Instant::now();
+        let _ = self.flush_tx.send(event).await;
+        ::metrics::histogram!(metrics::COORDINATOR_FLUSH_EVENT_SEND_DURATION_SECONDS)
+            .record(send_start.elapsed().as_secs_f64());
+    }
+}
+
+/// Reason a flush was triggered. Used as a low-cardinality `reason` label.
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum FlushReason {
+    SizeThreshold,
+    Interval,
+    Explicit,
+    Shutdown,
+}
+
+impl FlushReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            FlushReason::SizeThreshold => "size_threshold",
+            FlushReason::Interval => "interval",
+            FlushReason::Explicit => "explicit",
+            FlushReason::Shutdown => "shutdown",
+        }
     }
 }
 
@@ -428,10 +479,15 @@ impl<D: Delta, F: Flusher<D>> FlushTask<D, F> {
         match event {
             FlushEvent::FlushDelta { frozen } => self.handle_flush(frozen).await,
             FlushEvent::FlushStorage => {
-                self.flusher
+                let start = std::time::Instant::now();
+                let result = self
+                    .flusher
                     .flush_storage()
                     .await
-                    .map_err(|e| WriteError::FlushError(e.to_string()))?;
+                    .map_err(|e| WriteError::FlushError(e.to_string()));
+                ::metrics::histogram!(metrics::COORDINATOR_FLUSH_STORAGE_DURATION_SECONDS)
+                    .record(start.elapsed().as_secs_f64());
+                result?;
                 self.watermarks.update_durable(self.last_flushed_epoch);
                 Ok(())
             }
@@ -441,11 +497,15 @@ impl<D: Delta, F: Flusher<D>> FlushTask<D, F> {
     async fn handle_flush(&mut self, frozen: EpochStamped<D::Frozen>) -> WriteResult<()> {
         let delta = frozen.val;
         let epoch_range = frozen.epoch_range;
-        let snapshot = self
+        let start = std::time::Instant::now();
+        let result = self
             .flusher
             .flush_delta(delta, &epoch_range)
             .await
-            .map_err(|e| WriteError::FlushError(e.to_string()))?;
+            .map_err(|e| WriteError::FlushError(e.to_string()));
+        ::metrics::histogram!(metrics::COORDINATOR_FLUSH_DELTA_DURATION_SECONDS)
+            .record(start.elapsed().as_secs_f64());
+        let snapshot = result?;
         self.last_flushed_epoch = epoch_range.end - 1;
         // Publish the refreshed view first so any waiter awoken by the
         // watermark notification below observes a view that already includes

--- a/timeseries/src/flusher.rs
+++ b/timeseries/src/flusher.rs
@@ -4,12 +4,23 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common::coordinator::Flusher;
-use common::storage::{Storage, StorageSnapshot, Ttl};
+use common::storage::{RecordOp, Storage, StorageSnapshot, Ttl};
 
 use crate::delta::{FrozenTsdbDelta, TsdbWriteDelta};
 use crate::model::TimeBucket;
 use crate::storage::{OpenTsdbStorageExt, OpenTsdbStorageReadExt};
 use crate::tsdb_metrics;
+
+/// Sum the wire-equivalent size of an op as `key.len() + value.len()`. This
+/// is intentionally cheap (just two `Bytes::len` reads) so it is safe to
+/// accumulate while building the op vec on the flush hot path.
+fn op_estimated_bytes(op: &RecordOp) -> usize {
+    match op {
+        RecordOp::Put(p) => p.record.key.len() + p.record.value.len(),
+        RecordOp::Merge(m) => m.record.key.len() + m.record.value.len(),
+        RecordOp::Delete(k) => k.len(),
+    }
+}
 
 /// Flusher implementation for the timeseries write coordinator.
 ///
@@ -45,26 +56,42 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         _epoch_range: &Range<u64>,
     ) -> Result<Arc<dyn StorageSnapshot>, String> {
         if frozen.is_empty() {
-            return self.storage.snapshot().await.map_err(|e| e.to_string());
+            let snap_start = std::time::Instant::now();
+            let snapshot = self.storage.snapshot().await.map_err(|e| e.to_string());
+            ::metrics::histogram!(tsdb_metrics::TSDB_FLUSH_STORAGE_SNAPSHOT_DURATION_SECONDS)
+                .record(snap_start.elapsed().as_secs_f64());
+            return snapshot;
         }
 
         let new_series_count = frozen.series_dict_delta.len() as u64;
+        let sample_count: u64 = frozen.samples.values().map(|s| s.points.len() as u64).sum();
         let start = std::time::Instant::now();
         let ttl = bucket_ttl(frozen.bucket, self.retention);
 
-        let mut ops = Vec::new();
-        // Suppress the BucketList merge when this bucket is already listed.
-        // Without this check, every flush emits an identical single-element
-        // merge operand on a singleton hot key that only coalesces at major
-        // compaction. `merge_batch_bucket_list` still dedupes, so concurrent
-        // first-sightings from two flushers are safe.
+        // Phase 1: bucket-list lookup. Skips the redundant BucketList merge
+        // operand on hot key when this bucket is already listed.
+        let lookup_start = std::time::Instant::now();
         let bucket_announced = self
             .storage
             .bucket_list_contains(frozen.bucket)
             .await
             .map_err(|e| e.to_string())?;
+        ::metrics::histogram!(tsdb_metrics::TSDB_FLUSH_BUCKET_LIST_LOOKUP_DURATION_SECONDS)
+            .record(lookup_start.elapsed().as_secs_f64());
+
+        // Phase 2: build storage ops. Track estimated key+value bytes by
+        // summing `Bytes::len()` on each produced op (cheap, no extra clone).
+        let build_start = std::time::Instant::now();
+        let mut ops = Vec::new();
+        let mut estimated_bytes: u64 = 0;
+        let push_op = |ops: &mut Vec<RecordOp>, estimated: &mut u64, op: RecordOp| {
+            *estimated += op_estimated_bytes(&op) as u64;
+            ops.push(op);
+        };
         if !bucket_announced {
-            ops.push(
+            push_op(
+                &mut ops,
+                &mut estimated_bytes,
                 self.storage
                     .merge_bucket_list(frozen.bucket, ttl)
                     .map_err(|e| e.to_string())?,
@@ -72,7 +99,9 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         }
 
         for (fingerprint, series_id) in &frozen.series_dict_delta {
-            ops.push(
+            push_op(
+                &mut ops,
+                &mut estimated_bytes,
                 self.storage
                     .insert_series_id(frozen.bucket, *fingerprint, *series_id, ttl)
                     .map_err(|e| e.to_string())?,
@@ -80,7 +109,9 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         }
 
         for entry in frozen.forward_index.series.iter() {
-            ops.push(
+            push_op(
+                &mut ops,
+                &mut estimated_bytes,
                 self.storage
                     .insert_forward_index(frozen.bucket, *entry.key(), entry.value().clone(), ttl)
                     .map_err(|e| e.to_string())?,
@@ -88,7 +119,9 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         }
 
         for entry in frozen.inverted_index.postings.iter() {
-            ops.push(
+            push_op(
+                &mut ops,
+                &mut estimated_bytes,
                 self.storage
                     .merge_inverted_index(
                         frozen.bucket,
@@ -101,7 +134,9 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         }
 
         for (series_id, series_samples) in frozen.samples {
-            ops.push(
+            push_op(
+                &mut ops,
+                &mut estimated_bytes,
                 self.storage
                     .merge_samples(
                         frozen.bucket,
@@ -113,10 +148,23 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
                     .map_err(|e| e.to_string())?,
             );
         }
+        let ops_count = ops.len() as u64;
+        ::metrics::histogram!(tsdb_metrics::TSDB_FLUSH_BUILD_OPS_DURATION_SECONDS)
+            .record(build_start.elapsed().as_secs_f64());
+        ::metrics::histogram!(tsdb_metrics::TSDB_FLUSH_OPS).record(ops_count as f64);
+        ::metrics::histogram!(tsdb_metrics::TSDB_FLUSH_ESTIMATED_BYTES)
+            .record(estimated_bytes as f64);
+        ::metrics::histogram!(tsdb_metrics::TSDB_FLUSH_NEW_SERIES).record(new_series_count as f64);
+        ::metrics::histogram!(tsdb_metrics::TSDB_FLUSH_SAMPLES).record(sample_count as f64);
 
+        // Phase 3: SlateDB apply. Time spent here reflects SlateDB write
+        // backpressure (memtable full, WAL stall, etc.).
+        let apply_start = std::time::Instant::now();
         let result = self.storage.apply(ops).await.map_err(|e| e.to_string());
-        let elapsed = start.elapsed().as_secs_f64();
+        ::metrics::histogram!(tsdb_metrics::TSDB_FLUSH_STORAGE_APPLY_DURATION_SECONDS)
+            .record(apply_start.elapsed().as_secs_f64());
 
+        let elapsed = start.elapsed().as_secs_f64();
         match &result {
             Ok(_) => {
                 ::metrics::counter!(tsdb_metrics::TSDB_FLUSH_TOTAL, "status" => "success")
@@ -131,7 +179,13 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         ::metrics::histogram!(tsdb_metrics::TSDB_FLUSH_DURATION_SECONDS).record(elapsed);
 
         result?;
-        self.storage.snapshot().await.map_err(|e| e.to_string())
+
+        // Phase 4: snapshot refresh.
+        let snap_start = std::time::Instant::now();
+        let snapshot = self.storage.snapshot().await.map_err(|e| e.to_string());
+        ::metrics::histogram!(tsdb_metrics::TSDB_FLUSH_STORAGE_SNAPSHOT_DURATION_SECONDS)
+            .record(snap_start.elapsed().as_secs_f64());
+        snapshot
     }
 
     async fn flush_storage(&self) -> Result<(), String> {

--- a/timeseries/src/tsdb_metrics.rs
+++ b/timeseries/src/tsdb_metrics.rs
@@ -11,6 +11,26 @@ pub(crate) const TSDB_FLUSH_DURATION_SECONDS: &str = "tsdb_flush_duration_second
 pub(crate) const TSDB_FLUSH_TOTAL: &str = "tsdb_flush_total";
 pub(crate) const TSDB_BACKPRESSURE: &str = "tsdb_backpressure_total";
 
+// ── Flusher phases ──
+//
+// Existing `tsdb_flush_duration_seconds` covers the whole flush; the
+// constants below split it into its phases so a slow flush can be attributed
+// to a specific phase (op-building vs. SlateDB apply vs. snapshot refresh).
+
+pub(crate) const TSDB_FLUSH_BUCKET_LIST_LOOKUP_DURATION_SECONDS: &str =
+    "tsdb_flush_bucket_list_lookup_duration_seconds";
+pub(crate) const TSDB_FLUSH_BUILD_OPS_DURATION_SECONDS: &str =
+    "tsdb_flush_build_ops_duration_seconds";
+pub(crate) const TSDB_FLUSH_STORAGE_APPLY_DURATION_SECONDS: &str =
+    "tsdb_flush_storage_apply_duration_seconds";
+pub(crate) const TSDB_FLUSH_STORAGE_SNAPSHOT_DURATION_SECONDS: &str =
+    "tsdb_flush_storage_snapshot_duration_seconds";
+
+pub(crate) const TSDB_FLUSH_OPS: &str = "tsdb_flush_ops";
+pub(crate) const TSDB_FLUSH_ESTIMATED_BYTES: &str = "tsdb_flush_estimated_bytes";
+pub(crate) const TSDB_FLUSH_NEW_SERIES: &str = "tsdb_flush_new_series";
+pub(crate) const TSDB_FLUSH_SAMPLES: &str = "tsdb_flush_samples";
+
 // ── Read path ──
 
 pub(crate) const TSDB_QUERIES: &str = "tsdb_queries_total";
@@ -42,6 +62,38 @@ pub(crate) fn describe_engine_metrics() {
         TSDB_BACKPRESSURE,
         "Total writes rejected due to backpressure"
     );
+    metrics::describe_histogram!(
+        TSDB_FLUSH_BUCKET_LIST_LOOKUP_DURATION_SECONDS,
+        "Time spent looking up the BucketList during a delta flush (seconds)"
+    );
+    metrics::describe_histogram!(
+        TSDB_FLUSH_BUILD_OPS_DURATION_SECONDS,
+        "Time spent building storage ops for a delta flush (seconds)"
+    );
+    metrics::describe_histogram!(
+        TSDB_FLUSH_STORAGE_APPLY_DURATION_SECONDS,
+        "Time spent in Storage::apply during a delta flush (seconds). Indicates SlateDB write backpressure."
+    );
+    metrics::describe_histogram!(
+        TSDB_FLUSH_STORAGE_SNAPSHOT_DURATION_SECONDS,
+        "Time spent refreshing the post-apply storage snapshot (seconds)"
+    );
+    metrics::describe_histogram!(
+        TSDB_FLUSH_OPS,
+        "Number of storage ops produced by a single delta flush"
+    );
+    metrics::describe_histogram!(
+        TSDB_FLUSH_ESTIMATED_BYTES,
+        "Estimated key+value bytes produced by a single delta flush"
+    );
+    metrics::describe_histogram!(
+        TSDB_FLUSH_NEW_SERIES,
+        "Number of new series registered by a single delta flush"
+    );
+    metrics::describe_histogram!(
+        TSDB_FLUSH_SAMPLES,
+        "Number of samples written by a single delta flush"
+    );
     metrics::describe_counter!(TSDB_QUERIES, "Total PromQL queries evaluated");
     metrics::describe_histogram!(
         TSDB_QUERY_DURATION_SECONDS,
@@ -51,4 +103,6 @@ pub(crate) fn describe_engine_metrics() {
         TSDB_INGEST_ENTRIES_SKIPPED,
         "Ingest consumer entries skipped due to errors"
     );
+
+    common::coordinator::describe_coordinator_metrics();
 }


### PR DESCRIPTION
Add coordinator-level (`opendata_write_coordinator_*`) and timeseries flusher (`tsdb_flush_*`) metrics so a backed-up write path can be attributed to its bottleneck: write queue, flush event channel, op-building, SlateDB apply, or snapshot refresh.

- common: queue depth/send-latency/backpressure counters, delta apply/freeze histograms, flush-event send latency + queue depth, flush count by reason, background flush_delta/flush_storage timers.
- timeseries: split flush_delta into per-phase histograms and per-flush size histograms (ops, est. key+value bytes, new series, samples).

No behavior changes; instrumentation only. No high-cardinality labels (~30 total).