### PR TITLE
buffer-inspect: read-only inspector for ODB manifests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -422,6 +422,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "buffer-inspect"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bytes",
+ "clap",
+ "opendata-buffer",
+ "opendata-common",
+ "opentelemetry-proto",
+ "prost",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "slatedb",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2811,6 +2831,7 @@ dependencies = [
  "futures-util",
  "glob",
  "opentelemetry",
+ "serde_json",
  "thiserror 2.0.17",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "bencher",
     "buffer",
+    "buffer-inspect",
     "common",
     "keyvalue",
     "log",
@@ -57,7 +58,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ulid = "1"
 uuid = "1.14.0"
-opentelemetry-proto = { version = "0.28", default-features = false, features = ["metrics", "gen-tonic-messages"] }
+opentelemetry-proto = { version = "0.28", default-features = false, features = ["logs", "metrics", "gen-tonic-messages"] }
 prost = "0.13"
 proptest = "1"
 dashu-float = "0.4"

--- a/buffer-inspect/Cargo.toml
+++ b/buffer-inspect/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "buffer-inspect"
+version.workspace = true
+edition.workspace = true
+description = "Read-only inspection tool for OpenData Buffer manifests and batches"
+license = "MIT"
+repository = "https://github.com/opendata-oss/opendata"
+
+[[bin]]
+name = "buffer-inspect"
+path = "src/main.rs"
+
+[dependencies]
+anyhow.workspace = true
+base64.workspace = true
+buffer.workspace = true
+bytes.workspace = true
+clap = { workspace = true }
+common.workspace = true
+opentelemetry-proto = { workspace = true }
+prost.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+slatedb.workspace = true
+tempfile.workspace = true

--- a/buffer-inspect/src/inspect.rs
+++ b/buffer-inspect/src/inspect.rs
@@ -320,23 +320,24 @@ fn decode_logs_payload(record_index: u32, payload: &Bytes) -> RecordReport {
                     }
                 }
                 if let Some(scope_logs) = resource_logs.scope_logs.first()
-                    && let Some(rec) = scope_logs.log_records.first() {
-                        timestamp_unix_nano = rec.time_unix_nano;
-                        severity_number = rec.severity_number;
-                        severity_text = rec.severity_text.clone();
-                        body_summary = body_to_string(&rec.body);
-                        for kv in &rec.attributes {
-                            if let Some(value) = string_value(&kv.value) {
-                                log_attributes.insert(kv.key.clone(), value);
-                            }
-                        }
-                        if !rec.trace_id.is_empty() {
-                            trace_id_hex = Some(hex_encode(&rec.trace_id));
-                        }
-                        if !rec.span_id.is_empty() {
-                            span_id_hex = Some(hex_encode(&rec.span_id));
+                    && let Some(rec) = scope_logs.log_records.first()
+                {
+                    timestamp_unix_nano = rec.time_unix_nano;
+                    severity_number = rec.severity_number;
+                    severity_text = rec.severity_text.clone();
+                    body_summary = body_to_string(&rec.body);
+                    for kv in &rec.attributes {
+                        if let Some(value) = string_value(&kv.value) {
+                            log_attributes.insert(kv.key.clone(), value);
                         }
                     }
+                    if !rec.trace_id.is_empty() {
+                        trace_id_hex = Some(hex_encode(&rec.trace_id));
+                    }
+                    if !rec.span_id.is_empty() {
+                        span_id_hex = Some(hex_encode(&rec.span_id));
+                    }
+                }
             }
 
             RecordReport::Logs(LogsRecord {
@@ -371,14 +372,15 @@ fn decode_metrics_payload(record_index: u32, payload: &Bytes) -> RecordReport {
 
             for resource_metrics in &req.resource_metrics {
                 if let Some(resource) = &resource_metrics.resource
-                    && service_name.is_none() {
-                        for kv in &resource.attributes {
-                            if kv.key == "service.name" {
-                                service_name = string_value(&kv.value);
-                                break;
-                            }
+                    && service_name.is_none()
+                {
+                    for kv in &resource.attributes {
+                        if kv.key == "service.name" {
+                            service_name = string_value(&kv.value);
+                            break;
                         }
                     }
+                }
                 for scope in &resource_metrics.scope_metrics {
                     scope_metric_count += 1;
                     for metric in &scope.metrics {

--- a/buffer-inspect/src/inspect.rs
+++ b/buffer-inspect/src/inspect.rs
@@ -1,0 +1,749 @@
+//! Manifest inspection logic.
+//!
+//! Reads a manifest via [`buffer::BufferReader`], then for each entry in the
+//! requested range fetches the referenced batch object, decodes per-entry
+//! metadata envelopes, and produces a JSON-serializable summary. Signal
+//! decoding (OTLP logs, OTLP metrics) is best-effort: unknown envelopes are
+//! reported with their raw bytes rather than crashing the tool.
+
+use std::collections::BTreeMap;
+
+use anyhow::{Context, Result, anyhow};
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use buffer::{BufferReader, ManifestEntry, Metadata};
+use bytes::Bytes;
+use clap::ValueEnum;
+use opentelemetry_proto::tonic::collector::logs::v1::ExportLogsServiceRequest;
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
+use prost::Message;
+use serde::Serialize;
+
+/// CLI-supplied options that shape what `inspect_manifest` returns.
+pub struct InspectOptions {
+    pub from_sequence: Option<u64>,
+    pub limit: usize,
+    pub decode_signal: SignalDecodeMode,
+    pub records_per_entry: usize,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum SignalDecodeMode {
+    /// Dispatch decoding on each entry's envelope.
+    Auto,
+    /// Decode every entry as OTLP metrics regardless of envelope.
+    Metrics,
+    /// Decode every entry as OTLP logs regardless of envelope.
+    Logs,
+    /// Skip signal decoding; just print envelope and payload sizes.
+    Raw,
+}
+
+/// Top-level JSON shape emitted by `inspect_manifest`.
+#[derive(Serialize)]
+pub struct ManifestReport {
+    pub manifest_path: String,
+    pub epoch: u64,
+    pub next_sequence: u64,
+    pub total_entries: usize,
+    pub returned: usize,
+    pub entries: Vec<EntryReport>,
+}
+
+#[derive(Serialize)]
+pub struct EntryReport {
+    pub sequence: u64,
+    pub location: String,
+    pub batch_record_count: Option<usize>,
+    pub envelopes: Vec<EnvelopeReport>,
+    pub records: Vec<RecordReport>,
+    /// Populated when batch fetch or decode failed; the entry summary still
+    /// renders so the operator can see manifest-level information.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub batch_error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct EnvelopeReport {
+    pub start_index: u32,
+    pub ingestion_time_ms: i64,
+    /// Decoded envelope when the payload is the 4-byte OpenData envelope
+    /// header. `None` for opaque or non-conforming payloads.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decoded: Option<DecodedEnvelope>,
+    pub raw_bytes_base64: String,
+}
+
+#[derive(Serialize, Copy, Clone, Debug)]
+pub struct DecodedEnvelope {
+    pub version: u8,
+    pub signal_type: u8,
+    pub signal_name: &'static str,
+    pub encoding: u8,
+    pub encoding_name: &'static str,
+    pub reserved: u8,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind")]
+pub enum RecordReport {
+    Logs(LogsRecord),
+    Metrics(MetricsRecord),
+    Raw(RawRecord),
+    DecodeError(DecodeErrorRecord),
+}
+
+#[derive(Serialize)]
+pub struct LogsRecord {
+    pub record_index: u32,
+    pub timestamp_unix_nano: u64,
+    pub severity_number: i32,
+    pub severity_text: String,
+    pub body_summary: String,
+    pub service_name: Option<String>,
+    pub resource_attributes: BTreeMap<String, String>,
+    pub log_attributes: BTreeMap<String, String>,
+    pub trace_id_hex: Option<String>,
+    pub span_id_hex: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct MetricsRecord {
+    pub record_index: u32,
+    pub resource_metric_count: usize,
+    pub scope_metric_count: usize,
+    pub metric_count: usize,
+    pub data_point_count: usize,
+    pub metric_names: Vec<String>,
+    pub service_name: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct RawRecord {
+    pub record_index: u32,
+    pub size_bytes: usize,
+}
+
+#[derive(Serialize)]
+pub struct DecodeErrorRecord {
+    pub record_index: u32,
+    pub stage: &'static str,
+    pub error: String,
+}
+
+/// Inspect the manifest and the requested range of entries, returning a
+/// fully-decoded [`ManifestReport`] suitable for JSON serialization.
+pub async fn inspect_manifest(
+    reader: &BufferReader,
+    options: &InspectOptions,
+) -> Result<ManifestReport> {
+    let view = reader
+        .read_manifest()
+        .await
+        .with_context(|| format!("reading manifest at {}", reader.manifest_path()))?;
+
+    let all = view.entries();
+    let total_entries = all.len();
+    let selected = select_entries(all, options.from_sequence, options.limit);
+
+    let mut entries = Vec::with_capacity(selected.len());
+    for entry in selected {
+        entries.push(inspect_entry(reader, entry, options).await);
+    }
+
+    Ok(ManifestReport {
+        manifest_path: reader.manifest_path().to_string(),
+        epoch: view.epoch,
+        next_sequence: view.next_sequence,
+        total_entries,
+        returned: entries.len(),
+        entries,
+    })
+}
+
+fn select_entries(
+    all: &[ManifestEntry],
+    from_sequence: Option<u64>,
+    limit: usize,
+) -> Vec<&ManifestEntry> {
+    let limit = limit.max(1);
+    match from_sequence {
+        Some(seq) => all
+            .iter()
+            .filter(|e| e.sequence >= seq)
+            .take(limit)
+            .collect(),
+        None => {
+            let start = all.len().saturating_sub(limit);
+            all[start..].iter().collect()
+        }
+    }
+}
+
+async fn inspect_entry(
+    reader: &BufferReader,
+    entry: &ManifestEntry,
+    options: &InspectOptions,
+) -> EntryReport {
+    let envelopes: Vec<EnvelopeReport> = entry.metadata.iter().map(envelope_report).collect();
+
+    let batch_result = reader.read_batch(&entry.location).await;
+    let (records, batch_record_count, batch_error) = match batch_result {
+        Ok(payloads) => {
+            let count = payloads.len();
+            let records = decode_records(&payloads, &entry.metadata, options);
+            (records, Some(count), None)
+        }
+        Err(err) => (Vec::new(), None, Some(err.to_string())),
+    };
+
+    EntryReport {
+        sequence: entry.sequence,
+        location: entry.location.clone(),
+        batch_record_count,
+        envelopes,
+        records,
+        batch_error,
+    }
+}
+
+fn envelope_report(metadata: &Metadata) -> EnvelopeReport {
+    let raw = metadata.payload.as_ref();
+    EnvelopeReport {
+        start_index: metadata.start_index,
+        ingestion_time_ms: metadata.ingestion_time_ms,
+        decoded: decode_envelope(raw).ok(),
+        raw_bytes_base64: BASE64.encode(raw),
+    }
+}
+
+fn decode_envelope(payload: &[u8]) -> Result<DecodedEnvelope> {
+    if payload.len() < 4 {
+        return Err(anyhow!(
+            "envelope payload is {} bytes; expected at least 4",
+            payload.len()
+        ));
+    }
+    let version = payload[0];
+    let signal = payload[1];
+    let encoding = payload[2];
+    let reserved = payload[3];
+    Ok(DecodedEnvelope {
+        version,
+        signal_type: signal,
+        signal_name: signal_name(signal),
+        encoding,
+        encoding_name: encoding_name(encoding),
+        reserved,
+    })
+}
+
+fn signal_name(signal_type: u8) -> &'static str {
+    match signal_type {
+        1 => "metrics",
+        2 => "logs",
+        _ => "unknown",
+    }
+}
+
+fn encoding_name(encoding: u8) -> &'static str {
+    match encoding {
+        1 => "otlp_protobuf",
+        _ => "unknown",
+    }
+}
+
+/// Map a record's flat index into the per-range envelope it belongs to.
+fn envelope_for_record(metadata: &[Metadata], record_index: u32) -> Option<&Metadata> {
+    metadata
+        .iter()
+        .rev()
+        .find(|m| m.start_index <= record_index)
+}
+
+fn decode_records(
+    payloads: &[Bytes],
+    metadata: &[Metadata],
+    options: &InspectOptions,
+) -> Vec<RecordReport> {
+    let take = payloads.len().min(options.records_per_entry);
+    let mut out = Vec::with_capacity(take);
+    for (idx, payload) in payloads.iter().take(take).enumerate() {
+        let record_index = idx as u32;
+        let mode = match options.decode_signal {
+            SignalDecodeMode::Auto => match envelope_for_record(metadata, record_index)
+                .and_then(|m| decode_envelope(m.payload.as_ref()).ok())
+                .map(|env| env.signal_type)
+            {
+                Some(1) => SignalDecodeMode::Metrics,
+                Some(2) => SignalDecodeMode::Logs,
+                _ => SignalDecodeMode::Raw,
+            },
+            other => other,
+        };
+
+        let report = match mode {
+            SignalDecodeMode::Logs => decode_logs_payload(record_index, payload),
+            SignalDecodeMode::Metrics => decode_metrics_payload(record_index, payload),
+            SignalDecodeMode::Raw | SignalDecodeMode::Auto => RecordReport::Raw(RawRecord {
+                record_index,
+                size_bytes: payload.len(),
+            }),
+        };
+        out.push(report);
+    }
+    out
+}
+
+fn decode_logs_payload(record_index: u32, payload: &Bytes) -> RecordReport {
+    match ExportLogsServiceRequest::decode(payload.as_ref()) {
+        Ok(req) => {
+            let mut service_name = None;
+            let mut resource_attributes = BTreeMap::new();
+            let mut log_attributes = BTreeMap::new();
+            let mut timestamp_unix_nano = 0u64;
+            let mut severity_number = 0;
+            let mut severity_text = String::new();
+            let mut body_summary = String::new();
+            let mut trace_id_hex = None;
+            let mut span_id_hex = None;
+
+            if let Some(resource_logs) = req.resource_logs.first() {
+                if let Some(resource) = &resource_logs.resource {
+                    for kv in &resource.attributes {
+                        if let Some(value) = string_value(&kv.value) {
+                            if kv.key == "service.name" {
+                                service_name = Some(value.clone());
+                            }
+                            resource_attributes.insert(kv.key.clone(), value);
+                        }
+                    }
+                }
+                if let Some(scope_logs) = resource_logs.scope_logs.first()
+                    && let Some(rec) = scope_logs.log_records.first() {
+                        timestamp_unix_nano = rec.time_unix_nano;
+                        severity_number = rec.severity_number;
+                        severity_text = rec.severity_text.clone();
+                        body_summary = body_to_string(&rec.body);
+                        for kv in &rec.attributes {
+                            if let Some(value) = string_value(&kv.value) {
+                                log_attributes.insert(kv.key.clone(), value);
+                            }
+                        }
+                        if !rec.trace_id.is_empty() {
+                            trace_id_hex = Some(hex_encode(&rec.trace_id));
+                        }
+                        if !rec.span_id.is_empty() {
+                            span_id_hex = Some(hex_encode(&rec.span_id));
+                        }
+                    }
+            }
+
+            RecordReport::Logs(LogsRecord {
+                record_index,
+                timestamp_unix_nano,
+                severity_number,
+                severity_text,
+                body_summary,
+                service_name,
+                resource_attributes,
+                log_attributes,
+                trace_id_hex,
+                span_id_hex,
+            })
+        }
+        Err(err) => RecordReport::DecodeError(DecodeErrorRecord {
+            record_index,
+            stage: "otlp_logs",
+            error: err.to_string(),
+        }),
+    }
+}
+
+fn decode_metrics_payload(record_index: u32, payload: &Bytes) -> RecordReport {
+    match ExportMetricsServiceRequest::decode(payload.as_ref()) {
+        Ok(req) => {
+            let mut service_name = None;
+            let mut metric_names: Vec<String> = Vec::new();
+            let mut scope_metric_count = 0usize;
+            let mut metric_count = 0usize;
+            let mut data_point_count = 0usize;
+
+            for resource_metrics in &req.resource_metrics {
+                if let Some(resource) = &resource_metrics.resource
+                    && service_name.is_none() {
+                        for kv in &resource.attributes {
+                            if kv.key == "service.name" {
+                                service_name = string_value(&kv.value);
+                                break;
+                            }
+                        }
+                    }
+                for scope in &resource_metrics.scope_metrics {
+                    scope_metric_count += 1;
+                    for metric in &scope.metrics {
+                        metric_count += 1;
+                        if metric_names.len() < 16 {
+                            metric_names.push(metric.name.clone());
+                        }
+                        data_point_count += metric_data_point_count(metric);
+                    }
+                }
+            }
+
+            RecordReport::Metrics(MetricsRecord {
+                record_index,
+                resource_metric_count: req.resource_metrics.len(),
+                scope_metric_count,
+                metric_count,
+                data_point_count,
+                metric_names,
+                service_name,
+            })
+        }
+        Err(err) => RecordReport::DecodeError(DecodeErrorRecord {
+            record_index,
+            stage: "otlp_metrics",
+            error: err.to_string(),
+        }),
+    }
+}
+
+fn string_value(
+    value: &Option<opentelemetry_proto::tonic::common::v1::AnyValue>,
+) -> Option<String> {
+    use opentelemetry_proto::tonic::common::v1::any_value::Value;
+    match value.as_ref().and_then(|v| v.value.as_ref()) {
+        Some(Value::StringValue(s)) => Some(s.clone()),
+        Some(Value::BoolValue(b)) => Some(b.to_string()),
+        Some(Value::IntValue(i)) => Some(i.to_string()),
+        Some(Value::DoubleValue(d)) => Some(d.to_string()),
+        Some(Value::BytesValue(bytes)) => Some(BASE64.encode(bytes)),
+        Some(Value::ArrayValue(_)) | Some(Value::KvlistValue(_)) => Some("<complex>".to_string()),
+        None => None,
+    }
+}
+
+fn body_to_string(body: &Option<opentelemetry_proto::tonic::common::v1::AnyValue>) -> String {
+    string_value(body).unwrap_or_default()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push_str(&format!("{:02x}", b));
+    }
+    out
+}
+
+fn metric_data_point_count(metric: &opentelemetry_proto::tonic::metrics::v1::Metric) -> usize {
+    use opentelemetry_proto::tonic::metrics::v1::metric::Data;
+    match &metric.data {
+        Some(Data::Gauge(g)) => g.data_points.len(),
+        Some(Data::Sum(s)) => s.data_points.len(),
+        Some(Data::Histogram(h)) => h.data_points.len(),
+        Some(Data::ExponentialHistogram(eh)) => eh.data_points.len(),
+        Some(Data::Summary(s)) => s.data_points.len(),
+        None => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use buffer::Metadata;
+
+    fn metadata(start_index: u32, signal: u8) -> Metadata {
+        Metadata {
+            start_index,
+            ingestion_time_ms: 0,
+            payload: Bytes::copy_from_slice(&[1, signal, 1, 0]),
+        }
+    }
+
+    #[test]
+    fn envelope_for_record_picks_largest_start_index_at_or_below() {
+        let ranges = vec![metadata(0, 1), metadata(2, 2), metadata(5, 1)];
+        assert_eq!(envelope_for_record(&ranges, 0).unwrap().start_index, 0);
+        assert_eq!(envelope_for_record(&ranges, 1).unwrap().start_index, 0);
+        assert_eq!(envelope_for_record(&ranges, 2).unwrap().start_index, 2);
+        assert_eq!(envelope_for_record(&ranges, 3).unwrap().start_index, 2);
+        assert_eq!(envelope_for_record(&ranges, 5).unwrap().start_index, 5);
+        assert_eq!(envelope_for_record(&ranges, 9).unwrap().start_index, 5);
+    }
+
+    #[test]
+    fn decode_envelope_rejects_short_payload() {
+        assert!(decode_envelope(&[1, 2]).is_err());
+    }
+
+    #[test]
+    fn decode_envelope_reads_signal_and_encoding() {
+        let env = decode_envelope(&[1, 2, 1, 0]).expect("decode");
+        assert_eq!(env.version, 1);
+        assert_eq!(env.signal_type, 2);
+        assert_eq!(env.signal_name, "logs");
+        assert_eq!(env.encoding, 1);
+        assert_eq!(env.encoding_name, "otlp_protobuf");
+        assert_eq!(env.reserved, 0);
+    }
+
+    #[test]
+    fn decode_logs_payload_summarizes_first_record() {
+        use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value::Value};
+        use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+        use opentelemetry_proto::tonic::resource::v1::Resource;
+
+        let req = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                resource: Some(Resource {
+                    attributes: vec![KeyValue {
+                        key: "service.name".into(),
+                        value: Some(AnyValue {
+                            value: Some(Value::StringValue("controller".into())),
+                        }),
+                    }],
+                    dropped_attributes_count: 0,
+                }),
+                scope_logs: vec![ScopeLogs {
+                    scope: None,
+                    log_records: vec![LogRecord {
+                        time_unix_nano: 1_700_000_000_000_000_000,
+                        observed_time_unix_nano: 0,
+                        severity_number: 9,
+                        severity_text: "INFO".into(),
+                        body: Some(AnyValue {
+                            value: Some(Value::StringValue("hello".into())),
+                        }),
+                        attributes: vec![KeyValue {
+                            key: "topic".into(),
+                            value: Some(AnyValue {
+                                value: Some(Value::StringValue("foo".into())),
+                            }),
+                        }],
+                        dropped_attributes_count: 0,
+                        flags: 0,
+                        trace_id: vec![0xde, 0xad, 0xbe, 0xef],
+                        span_id: vec![],
+                        event_name: String::new(),
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+        let mut buf = Vec::with_capacity(req.encoded_len());
+        req.encode(&mut buf).expect("encode");
+
+        let report = decode_logs_payload(0, &Bytes::from(buf));
+        match report {
+            RecordReport::Logs(logs) => {
+                assert_eq!(logs.severity_text, "INFO");
+                assert_eq!(logs.severity_number, 9);
+                assert_eq!(logs.body_summary, "hello");
+                assert_eq!(logs.service_name.as_deref(), Some("controller"));
+                assert_eq!(
+                    logs.log_attributes.get("topic").map(String::as_str),
+                    Some("foo")
+                );
+                assert_eq!(logs.trace_id_hex.as_deref(), Some("deadbeef"));
+            }
+            other => panic!(
+                "expected logs record, got {other:?}",
+                other = serde_json::to_string(&other).unwrap()
+            ),
+        }
+    }
+
+    #[test]
+    fn raw_decode_mode_skips_signal_decoding() {
+        let payloads = vec![Bytes::from_static(b"raw-bytes")];
+        let metadata = vec![metadata(0, 99)]; // unknown signal
+        let opts = InspectOptions {
+            from_sequence: None,
+            limit: 1,
+            decode_signal: SignalDecodeMode::Raw,
+            records_per_entry: 1,
+        };
+        let records = decode_records(&payloads, &metadata, &opts);
+        assert_eq!(records.len(), 1);
+        match &records[0] {
+            RecordReport::Raw(raw) => {
+                assert_eq!(raw.record_index, 0);
+                assert_eq!(raw.size_bytes, 9);
+            }
+            _ => panic!("expected raw record"),
+        }
+    }
+
+    #[test]
+    fn auto_decode_falls_back_to_raw_on_unknown_signal() {
+        let payloads = vec![Bytes::from_static(b"opaque")];
+        let metadata = vec![metadata(0, 7)]; // not metrics, not logs
+        let opts = InspectOptions {
+            from_sequence: None,
+            limit: 1,
+            decode_signal: SignalDecodeMode::Auto,
+            records_per_entry: 1,
+        };
+        let records = decode_records(&payloads, &metadata, &opts);
+        match &records[0] {
+            RecordReport::Raw(_) => {}
+            _ => panic!("auto mode should fall through to raw for unknown signals"),
+        }
+    }
+
+    #[test]
+    fn select_entries_takes_last_n_when_no_from_sequence() {
+        let entries: Vec<ManifestEntry> = (0..5u64)
+            .map(|seq| ManifestEntry {
+                sequence: seq,
+                location: format!("loc-{seq}"),
+                metadata: vec![],
+            })
+            .collect();
+        let picked = select_entries(&entries, None, 2);
+        let seqs: Vec<u64> = picked.iter().map(|e| e.sequence).collect();
+        assert_eq!(seqs, vec![3, 4]);
+    }
+
+    #[test]
+    fn select_entries_starts_at_from_sequence() {
+        let entries: Vec<ManifestEntry> = (0..5u64)
+            .map(|seq| ManifestEntry {
+                sequence: seq,
+                location: format!("loc-{seq}"),
+                metadata: vec![],
+            })
+            .collect();
+        let picked = select_entries(&entries, Some(2), 2);
+        let seqs: Vec<u64> = picked.iter().map(|e| e.sequence).collect();
+        assert_eq!(seqs, vec![2, 3]);
+    }
+
+    #[tokio::test]
+    async fn inspect_manifest_summarizes_real_otlp_logs_payload() {
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        use buffer::{BufferReader, CompressionType, Producer, ProducerConfig};
+        use common::ObjectStoreConfig;
+        use common::clock::SystemClock;
+        use opentelemetry_proto::tonic::common::v1::{AnyValue, KeyValue, any_value::Value};
+        use opentelemetry_proto::tonic::logs::v1::{LogRecord, ResourceLogs, ScopeLogs};
+        use opentelemetry_proto::tonic::resource::v1::Resource;
+        use slatedb::object_store::ObjectStore;
+        use slatedb::object_store::memory::InMemory;
+
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let manifest_path = "ingest/test/inspect-logs-manifest";
+
+        let producer_config = ProducerConfig {
+            object_store: ObjectStoreConfig::InMemory,
+            data_path_prefix: "ingest/test/inspect-logs-data".to_string(),
+            manifest_path: manifest_path.to_string(),
+            flush_interval: Duration::from_secs(24 * 60 * 60),
+            flush_size_bytes: 64 * 1024 * 1024,
+            max_buffered_inputs: 1000,
+            batch_compression: CompressionType::None,
+        };
+        let producer =
+            Producer::with_object_store(producer_config, Arc::clone(&store), Arc::new(SystemClock))
+                .expect("producer");
+
+        // Build a real OTLP logs export request and feed it through the
+        // producer with a logs envelope, exactly like the opendata-go logs
+        // exporter would.
+        let req = ExportLogsServiceRequest {
+            resource_logs: vec![ResourceLogs {
+                resource: Some(Resource {
+                    attributes: vec![KeyValue {
+                        key: "service.name".into(),
+                        value: Some(AnyValue {
+                            value: Some(Value::StringValue("controller".into())),
+                        }),
+                    }],
+                    dropped_attributes_count: 0,
+                }),
+                scope_logs: vec![ScopeLogs {
+                    scope: None,
+                    log_records: vec![LogRecord {
+                        time_unix_nano: 1_700_000_000_000_000_000,
+                        observed_time_unix_nano: 0,
+                        severity_number: 9,
+                        severity_text: "INFO".into(),
+                        body: Some(AnyValue {
+                            value: Some(Value::StringValue("reconciled topic foo".into())),
+                        }),
+                        attributes: vec![KeyValue {
+                            key: "topic".into(),
+                            value: Some(AnyValue {
+                                value: Some(Value::StringValue("foo".into())),
+                            }),
+                        }],
+                        dropped_attributes_count: 0,
+                        flags: 0,
+                        trace_id: vec![0xde, 0xad, 0xbe, 0xef],
+                        span_id: vec![],
+                        event_name: String::new(),
+                    }],
+                    schema_url: String::new(),
+                }],
+                schema_url: String::new(),
+            }],
+        };
+        let mut payload = Vec::with_capacity(req.encoded_len());
+        req.encode(&mut payload).expect("encode");
+
+        let envelope = Bytes::copy_from_slice(&[1, 2, 1, 0]); // logs, OTLP protobuf
+        producer
+            .produce(vec![Bytes::from(payload)], envelope)
+            .await
+            .expect("produce");
+        producer.flush().await.expect("flush");
+
+        let reader = BufferReader::new(Arc::clone(&store), manifest_path.to_string());
+        let options = InspectOptions {
+            from_sequence: None,
+            limit: 5,
+            decode_signal: SignalDecodeMode::Auto,
+            records_per_entry: 5,
+        };
+        let report = inspect_manifest(&reader, &options).await.expect("inspect");
+
+        assert_eq!(report.manifest_path, manifest_path);
+        assert_eq!(report.total_entries, 1);
+        assert_eq!(report.entries.len(), 1);
+        let entry = &report.entries[0];
+        assert_eq!(entry.batch_record_count, Some(1));
+        assert_eq!(entry.envelopes.len(), 1);
+        let env = entry.envelopes[0].decoded.expect("envelope should decode");
+        assert_eq!(env.signal_name, "logs");
+        assert_eq!(env.encoding_name, "otlp_protobuf");
+
+        assert_eq!(entry.records.len(), 1);
+        match &entry.records[0] {
+            RecordReport::Logs(logs) => {
+                assert_eq!(logs.severity_text, "INFO");
+                assert_eq!(logs.body_summary, "reconciled topic foo");
+                assert_eq!(logs.service_name.as_deref(), Some("controller"));
+                assert_eq!(
+                    logs.log_attributes.get("topic").map(String::as_str),
+                    Some("foo")
+                );
+                assert_eq!(logs.trace_id_hex.as_deref(), Some("deadbeef"));
+            }
+            other => panic!(
+                "expected Logs record, got {}",
+                serde_json::to_string(other).unwrap()
+            ),
+        }
+
+        // Crucially: the inspector must not have advanced the manifest
+        // epoch. Re-reading via BufferReader should show the same epoch.
+        let after = reader.read_manifest().await.expect("re-read");
+        assert_eq!(after.epoch, 0, "BufferReader must not advance the epoch");
+
+        producer.close().await.expect("close producer");
+    }
+}

--- a/buffer-inspect/src/main.rs
+++ b/buffer-inspect/src/main.rs
@@ -1,0 +1,119 @@
+//! `buffer-inspect` — read-only inspector for OpenData Buffer manifests and
+//! their referenced batch objects.
+//!
+//! Reads the manifest and any referenced batches via [`buffer::BufferReader`],
+//! never invoking [`buffer::Consumer`]. Decodes per-entry metadata envelopes
+//! and, when an envelope identifies an OTLP signal, summarizes the payload.
+//! Unknown envelopes are reported verbatim and never crash the tool.
+//!
+//! Usage:
+//!
+//! ```text
+//! buffer-inspect \
+//!   --object-store-config object-store.yaml \
+//!   --manifest-path ingest/otel/logs/manifest \
+//!   --limit 10 \
+//!   --records-per-entry 5
+//! ```
+//!
+//! The `--object-store-config` file is a YAML representation of
+//! [`common::ObjectStoreConfig`]; for example:
+//!
+//! ```yaml
+//! type: Aws
+//! region: us-west-2
+//! bucket: responsive-prod-opendata-otel-logs-us-west-2
+//! ```
+
+mod inspect;
+
+use std::path::PathBuf;
+use std::process;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use buffer::BufferReader;
+use clap::Parser;
+use common::create_object_store;
+
+use crate::inspect::{InspectOptions, SignalDecodeMode, inspect_manifest};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "buffer-inspect",
+    about = "Read-only inspector for OpenData Buffer manifests"
+)]
+struct Cli {
+    /// Path to a YAML file containing a `common::ObjectStoreConfig`.
+    #[arg(long, value_name = "PATH")]
+    object_store_config: PathBuf,
+
+    /// Manifest object path inside the configured object store.
+    #[arg(long, value_name = "PATH")]
+    manifest_path: String,
+
+    /// Optional starting sequence. When omitted, the tool inspects the
+    /// most recent `--limit` entries on the manifest.
+    #[arg(long, value_name = "SEQUENCE")]
+    from_sequence: Option<u64>,
+
+    /// Maximum number of manifest entries to inspect (default 10).
+    #[arg(long, default_value_t = 10)]
+    limit: usize,
+
+    /// How to interpret per-entry payloads when summarizing.
+    ///
+    /// - `auto`: dispatch on each entry's metadata envelope (default).
+    /// - `metrics`: assume OTLP metrics regardless of envelope.
+    /// - `logs`: assume OTLP logs regardless of envelope.
+    /// - `raw`: print envelope and payload bytes; no signal decoding.
+    #[arg(long, value_enum, default_value_t = SignalDecodeMode::Auto)]
+    decode_signal: SignalDecodeMode,
+
+    /// Maximum number of payload records to summarize per manifest entry.
+    #[arg(long, default_value_t = 5)]
+    records_per_entry: usize,
+}
+
+fn main() {
+    if let Err(err) = run() {
+        eprintln!("buffer-inspect: {err:?}");
+        process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let cli = Cli::parse();
+
+    let config_bytes = std::fs::read(&cli.object_store_config).with_context(|| {
+        format!(
+            "reading object-store config {}",
+            cli.object_store_config.display()
+        )
+    })?;
+    let object_store_config: common::ObjectStoreConfig = serde_yaml::from_slice(&config_bytes)
+        .with_context(|| {
+            format!(
+                "parsing object-store config {}",
+                cli.object_store_config.display()
+            )
+        })?;
+    let object_store =
+        create_object_store(&object_store_config).context("creating object store")?;
+
+    let reader = BufferReader::new(Arc::clone(&object_store), cli.manifest_path.clone());
+    let options = InspectOptions {
+        from_sequence: cli.from_sequence,
+        limit: cli.limit,
+        decode_signal: cli.decode_signal,
+        records_per_entry: cli.records_per_entry,
+    };
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("building tokio runtime")?;
+    let report = runtime.block_on(inspect_manifest(&reader, &options))?;
+    println!("{}", serde_json::to_string_pretty(&report)?);
+    Ok(())
+}

--- a/buffer/src/lib.rs
+++ b/buffer/src/lib.rs
@@ -6,6 +6,7 @@ mod metric_names;
 mod model;
 mod producer;
 mod queue;
+mod reader;
 mod util;
 
 pub use config::{ConsumerConfig, ProducerConfig};
@@ -14,3 +15,4 @@ pub use error::{Error, Result};
 pub use model::CompressionType;
 pub use producer::{DurabilityWatcher, Producer, WriteHandle};
 pub use queue::{ManifestEntry, ManifestView, Metadata, parse_manifest};
+pub use reader::BufferReader;

--- a/buffer/src/reader.rs
+++ b/buffer/src/reader.rs
@@ -1,0 +1,213 @@
+//! Read-only entry point into a Buffer.
+//!
+//! [`BufferReader`] opens a manifest object directly via the object store,
+//! parses it with the same binary format the [`Consumer`](crate::Consumer)
+//! uses, and reads referenced batch objects. It performs **no** writes,
+//! never increments the manifest's epoch, and never starts the garbage
+//! collector. Use this when an inspection tool, audit, or debugger needs
+//! to look at a Buffer manifest without disturbing the active consumer.
+//!
+//! [`Consumer::new`](crate::Consumer) (and the `initialize` flow it
+//! requires) is *not* read-only — it bumps the manifest epoch on
+//! initialization and fences any other consumer. Tools that point at a
+//! production manifest must use [`BufferReader`] instead.
+
+use std::sync::Arc;
+
+use bytes::Bytes;
+use slatedb::object_store::ObjectStore;
+use slatedb::object_store::path::Path;
+
+use crate::error::{Error, Result};
+use crate::model::decode_batch;
+use crate::queue::{ManifestView, parse_manifest};
+
+/// Read-only access to a Buffer manifest and its referenced batch objects.
+#[derive(Clone)]
+pub struct BufferReader {
+    object_store: Arc<dyn ObjectStore>,
+    manifest_path: String,
+}
+
+impl BufferReader {
+    /// Construct a reader for the manifest at `manifest_path`, served by
+    /// `object_store`.
+    pub fn new(object_store: Arc<dyn ObjectStore>, manifest_path: String) -> Self {
+        Self {
+            object_store,
+            manifest_path,
+        }
+    }
+
+    /// Path of the manifest object this reader is bound to.
+    pub fn manifest_path(&self) -> &str {
+        &self.manifest_path
+    }
+
+    /// Fetch and parse the manifest from object storage.
+    ///
+    /// Returns the manifest view at the time of the read; concurrent
+    /// producers may have appended further entries by the time the
+    /// caller acts on the view.
+    pub async fn read_manifest(&self) -> Result<ManifestView> {
+        let path = Path::from(self.manifest_path.as_str());
+        let result = self
+            .object_store
+            .get(&path)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let bytes = result
+            .bytes()
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        parse_manifest(bytes)
+    }
+
+    /// Fetch and decode a batch object at the given object-store path.
+    ///
+    /// Returns the entry payloads in the same order they were written by
+    /// the producer. The caller is responsible for interpreting each
+    /// entry's bytes; per-entry metadata envelopes come from the
+    /// manifest, not the batch.
+    pub async fn read_batch(&self, location: &str) -> Result<Vec<Bytes>> {
+        let path = Path::from(location);
+        let result = self
+            .object_store
+            .get(&path)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        let bytes = result
+            .bytes()
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+        decode_batch(bytes)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use common::ObjectStoreConfig;
+    use common::clock::SystemClock;
+    use slatedb::object_store::ObjectStore;
+    use slatedb::object_store::memory::InMemory;
+    use slatedb::object_store::path::Path;
+
+    use crate::config::ProducerConfig;
+    use crate::model::CompressionType;
+    use crate::producer::Producer;
+
+    use super::BufferReader;
+
+    fn test_config(manifest_path: &str) -> ProducerConfig {
+        ProducerConfig {
+            object_store: ObjectStoreConfig::InMemory,
+            data_path_prefix: "test/data".to_string(),
+            manifest_path: manifest_path.to_string(),
+            flush_interval: Duration::from_secs(24 * 60 * 60),
+            flush_size_bytes: 64 * 1024 * 1024,
+            max_buffered_inputs: 1000,
+            batch_compression: CompressionType::None,
+        }
+    }
+
+    async fn produce_and_flush(producer: &Producer, payload: &[u8], metadata: Bytes) {
+        producer
+            .produce(vec![Bytes::copy_from_slice(payload)], metadata)
+            .await
+            .expect("produce");
+        producer.flush().await.expect("flush");
+    }
+
+    async fn manifest_etag(store: &Arc<dyn ObjectStore>, path: &str) -> Option<String> {
+        match store.get(&Path::from(path)).await {
+            Ok(result) => result.meta.e_tag.clone(),
+            Err(_) => None,
+        }
+    }
+
+    #[tokio::test]
+    async fn read_manifest_round_trips_producer_writes() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let manifest_path = "ingest/test/manifest";
+        let producer = Producer::with_object_store(
+            test_config(manifest_path),
+            Arc::clone(&store),
+            Arc::new(SystemClock),
+        )
+        .expect("producer");
+        let reader = BufferReader::new(Arc::clone(&store), manifest_path.to_string());
+
+        let metadata = Bytes::from_static(&[1, 1, 1, 0]);
+        produce_and_flush(&producer, b"row-0", metadata.clone()).await;
+
+        let view = reader.read_manifest().await.expect("read manifest");
+        assert_eq!(view.entries().len(), 1);
+        let entry = &view.entries()[0];
+        assert_eq!(entry.metadata.len(), 1);
+        assert_eq!(&entry.metadata[0].payload[..], &[1, 1, 1, 0]);
+        assert!(view.next_sequence > 0);
+
+        let payloads = reader
+            .read_batch(&entry.location)
+            .await
+            .expect("read batch");
+        assert_eq!(payloads, vec![Bytes::from_static(b"row-0")]);
+
+        producer.close().await.expect("close producer");
+    }
+
+    /// Pin down the read-only contract: invoking BufferReader against a
+    /// manifest must not change the manifest object's ETag and must not
+    /// advance its epoch. This is the property that lets us point this
+    /// tool at a live production manifest without fencing the active
+    /// consumer.
+    #[tokio::test]
+    async fn read_manifest_does_not_mutate_object() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let manifest_path = "ingest/test/manifest-readonly";
+        let producer = Producer::with_object_store(
+            test_config(manifest_path),
+            Arc::clone(&store),
+            Arc::new(SystemClock),
+        )
+        .expect("producer");
+        let reader = BufferReader::new(Arc::clone(&store), manifest_path.to_string());
+
+        let metadata = Bytes::from_static(&[1, 1, 1, 0]);
+        produce_and_flush(&producer, b"row-0", metadata.clone()).await;
+
+        let etag_before = manifest_etag(&store, manifest_path)
+            .await
+            .expect("manifest written");
+        let view_before = reader.read_manifest().await.expect("read manifest");
+        let epoch_before = view_before.epoch;
+
+        // Multiple read passes — including a batch fetch — must not touch
+        // the manifest object.
+        let _view_again = reader.read_manifest().await.expect("read manifest 2");
+        let _payloads = reader
+            .read_batch(&view_before.entries()[0].location)
+            .await
+            .expect("read batch");
+
+        let etag_after = manifest_etag(&store, manifest_path)
+            .await
+            .expect("manifest still present");
+        let epoch_after = reader.read_manifest().await.expect("final read").epoch;
+
+        assert_eq!(
+            etag_before, etag_after,
+            "BufferReader must not modify the manifest object's ETag",
+        );
+        assert_eq!(
+            epoch_before, epoch_after,
+            "BufferReader must not advance the manifest epoch",
+        );
+
+        producer.close().await.expect("close producer");
+    }
+}


### PR DESCRIPTION
## Summary

Adds two pieces, originally developed during the ClickHouse-ingestor work but generic to any Buffer signal:

- **`buffer::reader::BufferReader`** — a typed read-only entry point on the `buffer` crate that fetches a manifest object, parses it via the existing `parse_manifest`, and walks referenced batches via `model::decode_batch`. It deliberately does **not** call `Consumer::new` (which bumps the manifest epoch and fences any active consumer), never writes the manifest, and never starts the garbage collector. Tests pin the manifest object's ETag and epoch across multiple read passes.
- **`buffer-inspect` workspace crate** (binary + library) — CLI that uses `BufferReader` to enumerate recent batches, decode per-entry metadata envelopes, and summarize OTLP logs/metrics payloads. Unknown signals/encodings print metadata bytes verbatim instead of crashing. Validated against the production logs and metrics manifests in the alpha; the inspector is signal-agnostic at the envelope layer and dispatched on each entry.

The ClickHouse-ingestor crate (which originally lived alongside this code on `ch-integration/odb-clickhouse-ingestor`) has been extracted into the new [`opendata-oss/opendata-contrib`](https://github.com/opendata-oss/opendata-contrib) repository and released as `clickhouse-ingestor v0.1.1`. This PR brings the generic Buffer tooling — the only artifact from that branch that belongs in the core repo — onto `main`.

## Test plan

- [x] `cargo test -p opendata-buffer -p buffer-inspect --lib` (96 passing locally on this branch)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p opendata-buffer -p buffer-inspect --all-targets -- -D warnings`
- [ ] CI green