### PR TITLE
[vector] Add RFC for integration of Buffer in Vector 

### DIFF
--- a/vector/rfcs/0007-buffer-consumer.md
+++ b/vector/rfcs/0007-buffer-consumer.md
@@ -1,0 +1,322 @@
+# RFC 0007: Buffer Consumer
+
+**Status**: Draft
+
+## Summary
+
+This RFC defines a durable ingestion path for vector upserts and
+deletes via `opendata-buffer`. Producers write Vector protobuf
+(`WriteRequest` / `DeleteRequest` from RFC 0004) through the buffer
+`Producer` to object storage. An embedded background task in the
+vector service consumes batches, decodes each entry, and applies it
+to `VectorDb` via `write()` (upsert) or `delete()`. This complements
+the direct HTTP endpoints (RFC 0004).
+
+## Motivation
+
+The direct HTTP path (RFC 0004) couples ingestion availability to
+the vector service availability. If the service is down or crashes
+after acknowledging a request, writes are lost. The 
+[OpenData _Buffer_](buffer/rfcs/0001-stateless-buffer.md) decouples 
+these: data is durable in object storage
+before the service processes it, producers continue writing when the
+service is down, and a crashed consumer resumes from the last
+checkpoint via epoch-based fencing. Additionally, embedding-write
+traffic is often produced in batch jobs that cross availability
+zones; routing it through object storage avoids cross-AZ transfer
+fees that are acute at this scale.
+
+## Goals
+
+- Define the contract between writer (any language with a buffer
+  Producer) and reader (Rust, in `opendata`) -- the 3-byte metadata
+  protocol is the key interface, since producer and consumer may
+  live in different repositories
+- Support both upsert and delete operations through a single buffer
+  channel
+- Define an embedded buffer consumer in the vector service
+- Coexist with the direct HTTP write/delete endpoints
+- Disabled by default; enabled via service-level config
+
+## Non-Goals
+
+- **Search-side caching of buffered writes** -- writes become visible
+  only after the consumer applies them to `VectorDb`
+- **Multi-consumer parallelism** -- single-consumer fencing is
+  sufficient initially
+- **Exactly-once guarantees** -- at-least-once; duplicate upserts
+  are idempotent (last-write-wins by external ID), and duplicate
+  deletes are idempotent (unknown IDs are silently skipped)
+- **Changes to the buffer crate API**
+
+## Design
+
+### Architecture Overview
+
+```
+    ┌────────────────┐
+    │  Client / Job  │
+    └────────┬───────┘
+             │ Vector proto
+             │ (WriteRequest / DeleteRequest)
+             ▼
+    ┌────────────────┐            ┌────────────────────┐
+    │ Buffer Producer├───────────▶│   Object Storage   │
+    └────────────────┘            │ (data + manifest)  │
+                                  └──────────┬─────────┘
+                                             │
+                              ╔══════════════▼═════════════╗
+                              ║ Vector Service             ║
+                              ║                            ║
+                              ║ ┌────────────────────────┐ ║
+                              ║ │ BufferConsumer         │ ║
+                              ║ │                        │ ║
+                              ║ │  Consumer              │ ║
+                              ║ │  -> decode metadata    │ ║
+                              ║ │  -> prost decode       │ ║
+                              ║ │  -> VectorDb::write    │ ║
+                              ║ │     or ::delete        │ ║
+                              ║ └────────────────────────┘ ║
+                              ╚════════════════════════════╝
+```
+
+Both this path and the direct HTTP path converge at
+`VectorDb::write()` / `VectorDb::delete()`.
+
+### Metadata Protocol
+
+A 3-byte payload attached to each `Producer::produce()` call:
+
+| Byte | Field              | Values                              |
+|------|--------------------|-------------------------------------|
+| 0    | `version`          | `1`                                 |
+| 1    | `operation`        | `1`=upsert, `2`=delete              |
+| 2    | `payload_encoding` | `1`=Vector protobuf (RFC 0004)      |
+
+The consumer MUST reject unknown version or payload_encoding values.
+Unknown operation values are skipped per-entry without stopping the
+poll loop.
+
+Each `produce()` call carries one metadata range that applies to the
+entries appended in that call, so metadata unambiguously describes
+its entry even when the buffer batches multiple calls into a single
+data file. Upserts and deletes can therefore be interleaved on the
+same buffer channel and are applied in the order the consumer
+observes them.
+
+**Encoding (any producer):**
+
+```
+[METADATA_VERSION, operation, payload_encoding]
+// upsert: [1, 1, 1]
+// delete: [1, 2, 1]
+```
+
+**Rust decoding:**
+
+```rust
+struct BufferMetadata {
+    operation: u8,
+    payload_encoding: u8,
+}
+
+impl BufferMetadata {
+    fn decode(payload: &[u8]) -> Result<Self> {
+        // reject if len < 3 or version != 1
+    }
+}
+```
+
+### Payload Encoding
+
+The protobuf schema reuses the messages defined in RFC 0004 verbatim
+so that a single encoder works for both the HTTP path and the
+buffer path:
+
+- `operation = 1` (upsert): a `prost`-encoded `WriteRequest` with
+  one or more `Vector` entries. Identical to what the HTTP write
+  handler accepts under `Content-Type: application/protobuf`.
+- `operation = 2` (delete): a `prost`-encoded `DeleteRequest` with
+  one or more external IDs. Identical to what the HTTP delete
+  handler accepts.
+
+Per-entry decoding errors are logged and skipped; they do not stop
+the poll loop or block subsequent batches.
+
+### Producer
+
+The producer side is intentionally generic: any process that can
+encode the RFC 0004 protobuf messages and call
+`buffer::Producer::produce()` can ingest into the vector service.
+Typical producers include:
+
+- Rust client libraries that already construct `WriteRequest` /
+  `DeleteRequest` for the HTTP API and reuse the same encoder for
+  the buffer.
+- Batch indexing jobs that emit large embedding payloads from offline
+  pipelines and want durable buffering rather than an open HTTP
+  connection to the service.
+- Sidecar processes co-located with applications that buffer writes
+  during transient service unavailability.
+
+A producer:
+
+1. Constructs a `WriteRequest` or `DeleteRequest`.
+2. Encodes it with `prost` to bytes.
+3. Calls `producer.produce(vec![entry_bytes], metadata_bytes)` with
+   metadata `[1, 1, 1]` for an upsert or `[1, 2, 1]` for a delete.
+4. Awaits `WriteHandle::await_durable()` (or the language equivalent)
+   before acknowledging the caller, so durability is reported only
+   after the buffer has flushed to object storage.
+
+This RFC does not prescribe a specific exporter or sidecar
+implementation; it specifies only the wire contract that any such
+producer must follow.
+
+### Vector Buffer Consumer
+
+A `BufferConsumer` background task runs inside `VectorServer`,
+started from `VectorServer::with_buffer_consumer()` and stopped
+during graceful shutdown. It reuses the same `VectorDb` instance as
+the HTTP handlers, so writes from both paths share the same
+write coordinator, indexer queue, and durability semantics.
+
+**Internal structure:**
+
+The consumer splits work across two cooperating tasks connected by
+bounded `mpsc` channels:
+
+- A **collector loop** drives `buffer::Consumer`. It calls
+  `next_batch()`, forwards consumed batches over a prefetch channel,
+  and applies acks received over an ack channel. It owns the only
+  `&mut Consumer`.
+- A **poll loop** receives batches from the prefetch channel,
+  processes each entry, and sends the batch sequence number back to
+  the collector loop for ack.
+
+The prefetch channel has capacity `1`, so the collector fetches at
+most one batch ahead of the processor. This bounds memory and lets
+fetch and decode/apply overlap without unbounded queueing.
+
+**Per-entry processing:**
+
+1. Locate the metadata range covering this entry index (entries
+   without metadata are skipped with a log line).
+2. Decode the 3-byte metadata header.
+3. Reject unknown `payload_encoding` (logged, entry skipped).
+4. Dispatch on `operation`:
+   - `1` → decode `WriteRequest`, call `VectorDb::write()`.
+   - `2` → decode `DeleteRequest`, call `VectorDb::delete()`.
+   - other → log and skip.
+
+**Lifecycle:**
+
+- On startup, `BufferConsumer::run()` constructs a
+  `buffer::Consumer` from `BufferConsumerConfig` and spawns the two
+  loops. `run()` returns a `ConsumerHandle` carrying a
+  `CancellationToken` and a `JoinHandle`.
+- On `ConsumerHandle::shutdown()`, the token is cancelled. The
+  collector drains any pending acks from the ack channel, then calls
+  `Consumer::close()` to flush.
+- Errors from `next_batch()` use exponential backoff up to a 5s
+  cap, resetting on the next successful poll.
+
+### Configuration
+
+`buffer_consumer: Option<BufferConsumerConfig>` is added to the
+top-level `Config`. When absent (the default), no consumer starts.
+
+```rust
+#[cfg(feature = "buffer")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BufferConsumerConfig {
+    /// Object store where the buffer queue lives. Must match the producer.
+    pub object_store: ObjectStoreConfig,
+
+    /// Path to the queue manifest. Must match the producer.
+    /// Default: "ingest/manifest"
+    #[serde(default = "default_buffer_manifest_path")]
+    pub manifest_path: String,
+
+    /// Path prefix for data batch objects. Must match the producer.
+    /// Default: "ingest"
+    #[serde(default = "default_buffer_data_path_prefix")]
+    pub data_path_prefix: String,
+
+    /// Poll interval when the queue is empty. Default: 100ms.
+    #[serde(default = "default_buffer_poll_interval", with = "duration_secs")]
+    pub poll_interval: Duration,
+
+    /// How often the garbage collector runs. Default: 300s.
+    #[serde(default = "default_buffer_gc_interval", with = "duration_secs")]
+    pub gc_interval: Duration,
+
+    /// Minimum age before an unreferenced batch file is deleted. Default: 600s.
+    #[serde(default = "default_buffer_gc_grace_period", with = "duration_secs")]
+    pub gc_grace_period: Duration,
+}
+```
+
+**Feature gate:** New cargo feature `buffer = ["http-server",
+"dep:buffer"]`. The `BufferConsumerConfig` field, the
+`with_buffer_consumer()` builder method on `VectorServer`, and the
+binary's wiring are all gated behind it.
+
+**Example YAML:**
+
+```yaml
+buffer_consumer:
+  object_store:
+    type: S3
+    bucket: my-ingest-bucket
+    region: us-east-1
+  manifest_path: "ingest/vector/manifest"
+  data_path_prefix: "ingest/vector"
+  poll_interval: 100ms
+  gc_interval: 300s
+  gc_grace_period: 600s
+```
+
+The buffer object store may differ from the vector service's storage
+backend -- the buffer is an intermediary store.
+
+### Coexistence with HTTP Endpoints
+
+The HTTP write/delete handlers and the buffer consumer share the
+same `Arc<VectorDb>` instance. There is no separate code path for
+applying buffered writes: both call `VectorDb::write()` /
+`VectorDb::delete()`, which serializes through the existing write
+coordinator. Search visibility, flush behavior, and indexer
+backpressure are therefore identical regardless of which path was
+used to ingest.
+
+A deployment may use either path exclusively, both simultaneously,
+or migrate from one to the other without changing the on-disk state
+or the read API.
+
+## Alternatives Considered
+
+- **Separate consumer binary** -- adds operational complexity;
+  embedding the consumer next to `VectorDb` removes a network hop
+  and lets both ingest paths share the same write coordinator.
+- **Direct HTTP only** -- already exists (RFC 0004); the object
+  storage path adds durability and producer-side decoupling that
+  direct HTTP cannot provide.
+- **Separate buffer channels for upsert and delete** -- two
+  manifests would force producers to coordinate ordering between
+  two queues (an upsert followed immediately by a delete might be
+  reordered). A single channel with an `operation` byte preserves
+  per-producer ordering and simplifies configuration.
+- **JSON metadata** -- wasteful for a fixed 3-byte schema and harder
+  to extend cheaply with bit flags later.
+- **Reusing the timeseries 4-byte metadata layout** -- the vector
+  consumer needs to distinguish upsert from delete on every entry,
+  which the timeseries `signal_type` byte does not encode. A
+  vector-specific 3-byte layout keeps the dispatch byte first-class
+  rather than overloading an unrelated field.
+
+## Updates
+
+| Date       | Description   |
+|------------|---------------|
+| 2026-05-08 | Initial draft |

--- a/vector/src/server/buffer_consumer.rs
+++ b/vector/src/server/buffer_consumer.rs
@@ -1,15 +1,21 @@
 //! Background buffer consumer that reads vector batches from a buffer queue
 //! and ingests them into [`VectorDb`].
 //!
-//! The wire format on the buffer is a `prost`-encoded
-//! [`super::proto::WriteRequest`], identical to what the HTTP write handler
-//! accepts under `application/protobuf`. Each entry is preceded by a 2-byte
-//! metadata payload `[version=1, payload_encoding=1]` so future format
-//! changes can be detected.
+//! Entries are accompanied by a 3-byte metadata payload
+//! `[version, operation, payload_encoding]`:
+//!
+//! - `operation` selects the action and which message type the entry decodes to:
+//!   - `1` ([`OPERATION_UPSERT`]): a `prost`-encoded
+//!     [`super::proto::WriteRequest`], identical to what the HTTP write
+//!     handler accepts under `application/protobuf`. Applied via
+//!     [`VectorDb::write`].
+//!   - `2` ([`OPERATION_DELETE`]): a `prost`-encoded
+//!     [`super::proto::DeleteRequest`]. Applied via [`VectorDb::delete`].
+//! - `payload_encoding` describes the wire format. Currently only
+//!   `1` ([`PAYLOAD_ENCODING_VECTOR_PROTO`]) is supported.
 //!
 //! Per-entry decoding errors are logged and skipped; they do not stop the
-//! poll loop. Entries that successfully decode are written via
-//! [`VectorDb::write`].
+//! poll loop.
 
 use std::sync::Arc;
 
@@ -20,19 +26,22 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
-use super::request::WriteRequest;
+use super::request::{DeleteRequest, WriteRequest};
 use crate::VectorDb;
 use crate::model::BufferConsumerConfig;
 
 const METADATA_VERSION: u8 = 1;
+const OPERATION_UPSERT: u8 = 1;
+const OPERATION_DELETE: u8 = 2;
 const PAYLOAD_ENCODING_VECTOR_PROTO: u8 = 1;
-const METADATA_LEN: usize = 2;
+const METADATA_LEN: usize = 3;
 const PREFETCH_BATCH_BUFFER: usize = 1;
 const ACK_SEQUENCE_BUFFER: usize = 1;
 const MAX_ERROR_RETRY_BACKOFF: std::time::Duration = std::time::Duration::from_secs(5);
 
 #[derive(Debug)]
 struct BufferMetadata {
+    operation: u8,
     payload_encoding: u8,
 }
 
@@ -49,7 +58,8 @@ impl BufferMetadata {
             return Err(format!("unknown metadata version: {}", payload[0]));
         }
         Ok(Self {
-            payload_encoding: payload[1],
+            operation: payload[1],
+            payload_encoding: payload[2],
         })
     }
 }
@@ -327,6 +337,14 @@ async fn process_entry(
         ));
     }
 
+    match parsed.operation {
+        OPERATION_UPSERT => apply_upsert(db, entry).await,
+        OPERATION_DELETE => apply_delete(db, entry).await,
+        other => Err(format!("unsupported operation: {}", other)),
+    }
+}
+
+async fn apply_upsert(db: &VectorDb, entry: &Bytes) -> Result<(), String> {
     let request = WriteRequest::from_protobuf(entry.as_ref())
         .map_err(|e| format!("vector proto decode failed: {e}"))?;
 
@@ -337,6 +355,21 @@ async fn process_entry(
     db.write(request.upsert_vectors)
         .await
         .map_err(|e| format!("vector db write failed: {e}"))?;
+
+    Ok(())
+}
+
+async fn apply_delete(db: &VectorDb, entry: &Bytes) -> Result<(), String> {
+    let request = DeleteRequest::from_protobuf(entry.as_ref())
+        .map_err(|e| format!("vector delete proto decode failed: {e}"))?;
+
+    if request.ids.is_empty() {
+        return Ok(());
+    }
+
+    db.delete(request.ids)
+        .await
+        .map_err(|e| format!("vector db delete failed: {e}"))?;
 
     Ok(())
 }
@@ -358,34 +391,139 @@ fn find_metadata_for_entry(metadata: &[Metadata], idx: u32) -> Option<&Metadata>
 mod tests {
     use super::*;
 
+    fn make_producer(
+        obj_store: Arc<dyn slatedb::object_store::ObjectStore>,
+        manifest: &str,
+        data_prefix: &str,
+    ) -> buffer::Producer {
+        use std::time::Duration;
+
+        use common::ObjectStoreConfig;
+        use common::clock::SystemClock;
+
+        let producer_config = buffer::ProducerConfig {
+            object_store: ObjectStoreConfig::InMemory,
+            data_path_prefix: data_prefix.to_string(),
+            manifest_path: manifest.to_string(),
+            flush_interval: Duration::from_millis(10),
+            flush_size_bytes: 64 * 1024 * 1024,
+            max_buffered_inputs: 1000,
+            batch_compression: buffer::CompressionType::None,
+        };
+        buffer::Producer::with_object_store(producer_config, obj_store, Arc::new(SystemClock))
+            .unwrap()
+    }
+
+    async fn produce_upsert(producer: &buffer::Producer, vectors: Vec<(&str, Vec<f32>)>) {
+        use std::collections::HashMap;
+
+        use prost::Message;
+
+        use crate::server::proto;
+
+        let proto_request = proto::WriteRequest {
+            upsert_vectors: vectors
+                .into_iter()
+                .map(|(id, values)| proto::Vector {
+                    id: id.to_string(),
+                    attributes: HashMap::from([(
+                        "vector".to_string(),
+                        proto::AttributeValueMessage::new(proto::AttributeValueProto::VectorValue(
+                            proto::VectorValueProto { values },
+                        )),
+                    )]),
+                })
+                .collect(),
+        };
+        let entry_bytes = proto_request.encode_to_vec();
+        let metadata_bytes = Bytes::from_static(&[
+            METADATA_VERSION,
+            OPERATION_UPSERT,
+            PAYLOAD_ENCODING_VECTOR_PROTO,
+        ]);
+
+        producer
+            .produce(vec![Bytes::from(entry_bytes)], metadata_bytes)
+            .await
+            .unwrap();
+    }
+
+    async fn produce_delete(producer: &buffer::Producer, ids: Vec<String>) {
+        use prost::Message;
+
+        use crate::server::proto;
+
+        let proto_request = proto::DeleteRequest { ids };
+        let entry_bytes = proto_request.encode_to_vec();
+        let metadata_bytes = Bytes::from_static(&[
+            METADATA_VERSION,
+            OPERATION_DELETE,
+            PAYLOAD_ENCODING_VECTOR_PROTO,
+        ]);
+
+        producer
+            .produce(vec![Bytes::from(entry_bytes)], metadata_bytes)
+            .await
+            .unwrap();
+    }
+
     #[test]
-    fn should_decode_valid_metadata() {
+    fn should_decode_metadata_for_upsert_operation() {
         // given
-        let payload = vec![1, 1];
+        let payload = vec![
+            METADATA_VERSION,
+            OPERATION_UPSERT,
+            PAYLOAD_ENCODING_VECTOR_PROTO,
+        ];
 
         // when
         let meta = BufferMetadata::decode(&payload).unwrap();
 
         // then
+        assert_eq!(meta.operation, OPERATION_UPSERT);
+        assert_eq!(meta.payload_encoding, PAYLOAD_ENCODING_VECTOR_PROTO);
+    }
+
+    #[test]
+    fn should_decode_metadata_for_delete_operation() {
+        // given
+        let payload = vec![
+            METADATA_VERSION,
+            OPERATION_DELETE,
+            PAYLOAD_ENCODING_VECTOR_PROTO,
+        ];
+
+        // when
+        let meta = BufferMetadata::decode(&payload).unwrap();
+
+        // then
+        assert_eq!(meta.operation, OPERATION_DELETE);
         assert_eq!(meta.payload_encoding, PAYLOAD_ENCODING_VECTOR_PROTO);
     }
 
     #[test]
     fn should_decode_metadata_with_trailing_bytes() {
         // given
-        let payload = vec![1, 1, 0, 0];
+        let payload = vec![
+            METADATA_VERSION,
+            OPERATION_UPSERT,
+            PAYLOAD_ENCODING_VECTOR_PROTO,
+            0,
+            0,
+        ];
 
         // when
         let meta = BufferMetadata::decode(&payload).unwrap();
 
         // then
+        assert_eq!(meta.operation, OPERATION_UPSERT);
         assert_eq!(meta.payload_encoding, PAYLOAD_ENCODING_VECTOR_PROTO);
     }
 
     #[test]
     fn should_reject_unknown_version() {
         // given
-        let payload = vec![99, 1];
+        let payload = vec![99, OPERATION_UPSERT, PAYLOAD_ENCODING_VECTOR_PROTO];
 
         // when
         let result = BufferMetadata::decode(&payload);
@@ -398,7 +536,7 @@ mod tests {
     #[test]
     fn should_reject_short_metadata() {
         // given
-        let payload = vec![1];
+        let payload = vec![METADATA_VERSION, OPERATION_UPSERT];
 
         // when
         let result = BufferMetadata::decode(&payload);
@@ -415,12 +553,12 @@ mod tests {
             Metadata {
                 start_index: 0,
                 ingestion_time_ms: 1000,
-                payload: Bytes::from_static(&[1, 1]),
+                payload: Bytes::from_static(&[1, 1, 1]),
             },
             Metadata {
                 start_index: 3,
                 ingestion_time_ms: 2000,
-                payload: Bytes::from_static(&[1, 1]),
+                payload: Bytes::from_static(&[1, 1, 1]),
             },
         ];
 
@@ -443,78 +581,32 @@ mod tests {
 
     /// End-to-end: Producer → BufferConsumer → VectorDb → search.
     #[tokio::test]
-    async fn should_ingest_via_consumer_and_search_back() {
-        use std::collections::HashMap;
+    async fn should_apply_upsert_via_consumer() {
         use std::time::Duration;
 
         use common::ObjectStoreConfig;
-        use common::clock::SystemClock;
-        use prost::Message;
         use slatedb::object_store::ObjectStore;
         use slatedb::object_store::memory::InMemory;
 
         use crate::VectorDbRead;
         use crate::model::{Config, DistanceMetric, Query};
-        use crate::server::proto;
 
         // given
         let obj_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let manifest = "ingest/manifest".to_string();
         let data_prefix = "ingest".to_string();
 
-        // Build a WriteRequest with two vectors
-        let proto_request = proto::WriteRequest {
-            upsert_vectors: vec![
-                proto::Vector {
-                    id: "vec-1".to_string(),
-                    attributes: HashMap::from([(
-                        "vector".to_string(),
-                        proto::AttributeValueMessage::new(proto::AttributeValueProto::VectorValue(
-                            proto::VectorValueProto {
-                                values: vec![1.0, 0.0, 0.0],
-                            },
-                        )),
-                    )]),
-                },
-                proto::Vector {
-                    id: "vec-2".to_string(),
-                    attributes: HashMap::from([(
-                        "vector".to_string(),
-                        proto::AttributeValueMessage::new(proto::AttributeValueProto::VectorValue(
-                            proto::VectorValueProto {
-                                values: vec![0.0, 1.0, 0.0],
-                            },
-                        )),
-                    )]),
-                },
+        let producer = make_producer(obj_store.clone(), &manifest, &data_prefix);
+        produce_upsert(
+            &producer,
+            vec![
+                ("vec-1", vec![1.0, 0.0, 0.0]),
+                ("vec-2", vec![0.0, 1.0, 0.0]),
             ],
-        };
-        let entry_bytes = proto_request.encode_to_vec();
-        let metadata_bytes = Bytes::from_static(&[METADATA_VERSION, PAYLOAD_ENCODING_VECTOR_PROTO]);
-
-        // Produce via Producer
-        let producer_config = buffer::ProducerConfig {
-            object_store: ObjectStoreConfig::InMemory,
-            data_path_prefix: data_prefix.clone(),
-            manifest_path: manifest.clone(),
-            flush_interval: Duration::from_millis(10),
-            flush_size_bytes: 64 * 1024 * 1024,
-            max_buffered_inputs: 1000,
-            batch_compression: buffer::CompressionType::None,
-        };
-        let producer = buffer::Producer::with_object_store(
-            producer_config,
-            obj_store.clone(),
-            Arc::new(SystemClock),
         )
-        .unwrap();
-        producer
-            .produce(vec![Bytes::from(entry_bytes)], metadata_bytes)
-            .await
-            .unwrap();
+        .await;
         producer.close().await.unwrap();
 
-        // Open a vector db (in-memory storage)
         let db = Arc::new(
             VectorDb::open(Config {
                 dimensions: 3,
@@ -525,7 +617,6 @@ mod tests {
             .unwrap(),
         );
 
-        // Start the consumer against the shared object store
         let consumer_config = BufferConsumerConfig {
             object_store: ObjectStoreConfig::InMemory,
             manifest_path: manifest,
@@ -537,20 +628,115 @@ mod tests {
         let consumer = Arc::new(BufferConsumer::new(db.clone(), consumer_config));
         let handle = consumer.run_with_object_store(obj_store).await.unwrap();
 
-        // Wait for the consumer to process and write
+        // when / then — both vectors must be reachable via get() and search()
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
             db.flush().await.unwrap();
-            let results = db
+            let search_results = db
                 .search(&Query::new(vec![1.0, 0.0, 0.0]).with_limit(2))
                 .await
                 .unwrap();
-            if results.iter().any(|r| r.vector.id == "vec-1") {
+            let vec_1 = db.get("vec-1").await.unwrap();
+            let vec_2 = db.get("vec-2").await.unwrap();
+            let vec_1_in_search = search_results.iter().any(|r| r.vector.id == "vec-1");
+            let vec_2_in_search = search_results.iter().any(|r| r.vector.id == "vec-2");
+            if vec_1.is_some() && vec_2.is_some() && vec_1_in_search && vec_2_in_search {
                 break;
             }
             if std::time::Instant::now() >= deadline {
                 handle.shutdown().await;
-                panic!("consumer did not ingest the produced batch in time");
+                panic!(
+                    "consumer did not ingest the produced batch in time \
+                     (vec-1 get={}, vec-2 get={}, vec-1 search={}, vec-2 search={})",
+                    vec_1.is_some(),
+                    vec_2.is_some(),
+                    vec_1_in_search,
+                    vec_2_in_search,
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        handle.shutdown().await;
+    }
+
+    /// End-to-end: Producer (upsert + delete) → BufferConsumer → VectorDb,
+    /// confirming that a delete payload removes a previously-upserted vector.
+    #[tokio::test]
+    async fn should_apply_delete_via_consumer() {
+        use std::time::Duration;
+
+        use common::ObjectStoreConfig;
+        use slatedb::object_store::ObjectStore;
+        use slatedb::object_store::memory::InMemory;
+
+        use crate::VectorDbRead;
+        use crate::model::{Config, DistanceMetric, Query};
+
+        // given
+        let obj_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let manifest = "ingest/manifest".to_string();
+        let data_prefix = "ingest".to_string();
+
+        let producer = make_producer(obj_store.clone(), &manifest, &data_prefix);
+        produce_upsert(
+            &producer,
+            vec![
+                ("vec-1", vec![1.0, 0.0, 0.0]),
+                ("vec-2", vec![0.0, 1.0, 0.0]),
+            ],
+        )
+        .await;
+        produce_delete(&producer, vec!["vec-1".to_string()]).await;
+        producer.close().await.unwrap();
+
+        let db = Arc::new(
+            VectorDb::open(Config {
+                dimensions: 3,
+                distance_metric: DistanceMetric::L2,
+                ..Default::default()
+            })
+            .await
+            .unwrap(),
+        );
+
+        let consumer_config = BufferConsumerConfig {
+            object_store: ObjectStoreConfig::InMemory,
+            manifest_path: manifest,
+            data_path_prefix: data_prefix,
+            poll_interval: Duration::from_millis(10),
+            gc_interval: Duration::from_secs(300),
+            gc_grace_period: Duration::from_secs(600),
+        };
+        let consumer = Arc::new(BufferConsumer::new(db.clone(), consumer_config));
+        let handle = consumer.run_with_object_store(obj_store).await.unwrap();
+
+        // when / then — vec-1 must be gone from both get() and search(),
+        // and vec-2 must remain reachable via both
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            db.flush().await.unwrap();
+            let search_results = db
+                .search(&Query::new(vec![1.0, 0.0, 0.0]).with_limit(2))
+                .await
+                .unwrap();
+            let vec_1 = db.get("vec-1").await.unwrap();
+            let vec_2 = db.get("vec-2").await.unwrap();
+            let vec_1_in_search = search_results.iter().any(|r| r.vector.id == "vec-1");
+            let vec_2_in_search = search_results.iter().any(|r| r.vector.id == "vec-2");
+            if vec_1.is_none() && vec_2.is_some() && !vec_1_in_search && vec_2_in_search {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                handle.shutdown().await;
+                panic!(
+                    "consumer did not apply delete in time \
+                     (vec-1 get={}, vec-2 get={}, vec-1 search={}, vec-2 search={})",
+                    vec_1.is_some(),
+                    vec_2.is_some(),
+                    vec_1_in_search,
+                    vec_2_in_search,
+                );
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }

--- a/vector/src/server/request.rs
+++ b/vector/src/server/request.rs
@@ -130,7 +130,7 @@ impl DeleteRequest {
         }
     }
 
-    fn from_protobuf(body: &[u8]) -> Result<Self, Error> {
+    pub(crate) fn from_protobuf(body: &[u8]) -> Result<Self, Error> {
         let proto_request = proto::DeleteRequest::decode(body)
             .map_err(|e| Error::InvalidInput(format!("Invalid protobuf: {}", e)))?;
         Self::validate(proto_request.ids)


### PR DESCRIPTION
## Summary

Adds RFC that describes the integration of Buffer in Vector.

Note: This is a stacked PR on top of https://github.com/opendata-oss/opendata/pull/440. Only consider commits after [bdcaf8b](https://github.com/opendata-oss/opendata/pull/441/commits/bdcaf8bfb149ca626197225eb98364e0ff74ebd6) inclusive.

## Checklist

- [ ] Tests added/updated
- [ ] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
