### PR TITLE
add metrics for vector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2745,6 +2745,8 @@ dependencies = [
  "figment",
  "futures",
  "log",
+ "metrics",
+ "metrics-exporter-prometheus",
  "opendata-buffer",
  "opendata-common",
  "opendata-macros",

--- a/vector/Cargo.toml
+++ b/vector/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["http-server"]
 
 [features]
 default = []
-http-server = ["dep:axum", "dep:tower", "dep:clap", "dep:prost", "dep:serde_json", "dep:serde_with"]
+http-server = ["dep:axum", "dep:tower", "dep:clap", "dep:prost", "dep:serde_json", "dep:serde_with", "dep:metrics-exporter-prometheus"]
 embedded-reader = ["dep:reqwest", "dep:serde_json"]
 buffer = ["http-server", "dep:buffer"]
 bench-internals = []
@@ -34,6 +34,7 @@ common.workspace = true
 bytemuck.workspace = true
 bytes.workspace = true
 dashmap.workspace = true
+metrics.workspace = true
 fail.workspace = true
 figment.workspace = true
 futures.workspace = true
@@ -58,6 +59,7 @@ clap = { workspace = true, optional = true }
 prost = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 serde_with = { workspace = true, optional = true }
+metrics-exporter-prometheus = { workspace = true, optional = true }
 
 # Embedded reader dependencies (optional, enabled by embedded-reader feature)
 reqwest = { workspace = true, optional = true, features = ["json"] }

--- a/vector/src/bin/server.rs
+++ b/vector/src/bin/server.rs
@@ -8,7 +8,8 @@ use tracing_subscriber::EnvFilter;
 use vector::VectorDb;
 use vector::VectorDbReader;
 use vector::server::{
-    VectorReaderServer, VectorServer, VectorServerConfig, load_reader_config, load_vector_config,
+    MetricsState, VectorReaderServer, VectorServer, VectorServerConfig, load_reader_config,
+    load_vector_config,
 };
 
 /// CLI arguments for the vector server.
@@ -50,6 +51,15 @@ async fn main() {
         )
         .init();
 
+    // Install the metrics-rs Prometheus recorder before any subsystem
+    // (including slatedb) emits metrics. The resulting handle is rendered by
+    // the `/metrics` route.
+    let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+    let metrics_state = MetricsState {
+        handle: recorder.handle(),
+    };
+    metrics::set_global_recorder(recorder).expect("global metrics recorder already installed");
+
     // Parse CLI arguments
     let args = CliArgs::parse();
     let server_config = VectorServerConfig { port: args.port };
@@ -68,7 +78,7 @@ async fn main() {
                     .expect("Failed to open vector database"),
             );
 
-            let server = VectorServer::new(db, server_config, metadata_fields);
+            let server = VectorServer::new(db, server_config, metadata_fields, metrics_state);
 
             #[cfg(feature = "buffer")]
             let server = match buffer_consumer_config {
@@ -90,7 +100,12 @@ async fn main() {
                 .await
                 .expect("Failed to open vector database reader");
 
-            let server = VectorReaderServer::new(Arc::new(reader), server_config, metadata_fields);
+            let server = VectorReaderServer::new(
+                Arc::new(reader),
+                server_config,
+                metadata_fields,
+                metrics_state,
+            );
             server.run().await;
         }
     }

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -13,6 +13,7 @@
 
 use crate::VectorDbReader;
 use crate::error::{Error, Result};
+use crate::metric_names::{VECTOR_DELETES_TOTAL, VECTOR_UPSERTS_TOTAL};
 use crate::model::{
     AttributeValue, Config, Query, SearchOptions, SearchResult, VECTOR_FIELD_NAME, Vector,
     attributes_to_map,
@@ -538,6 +539,8 @@ impl VectorDb {
             writes.push(self.prepare_vector_write(vector)?);
         }
 
+        metrics::counter!(VECTOR_UPSERTS_TOTAL).increment(writes.len() as u64);
+
         // Send all writes to coordinator in a single batch and wait to be applied
         let mut write_handle = self
             .write_coordinator
@@ -586,6 +589,8 @@ impl VectorDb {
         for vector in vectors {
             writes.push(self.prepare_vector_write(vector)?);
         }
+
+        metrics::counter!(VECTOR_UPSERTS_TOTAL).increment(writes.len() as u64);
 
         // Send all writes to coordinator in a single batch and wait to be applied
         let mut write_handle = self
@@ -747,6 +752,8 @@ impl VectorDb {
             }
             collected.push(id);
         }
+
+        metrics::counter!(VECTOR_DELETES_TOTAL).increment(collected.len() as u64);
 
         let mut handle = self
             .write_coordinator

--- a/vector/src/lib.rs
+++ b/vector/src/lib.rs
@@ -37,6 +37,7 @@ pub mod admin;
 pub mod db;
 pub(crate) mod error;
 pub mod math;
+pub mod metric_names;
 pub mod model;
 pub(crate) mod query_engine;
 pub mod reader;

--- a/vector/src/metric_names.rs
+++ b/vector/src/metric_names.rs
@@ -1,0 +1,33 @@
+//! Metric name constants for the vector crate.
+//!
+//! All instrumentation flows through the `metrics-rs` facade. Emitted counters
+//! are no-ops when no global recorder is installed, so embedded users opt in by
+//! installing their own recorder. The vector server binary installs a
+//! `PrometheusBuilder` recorder; see [`crate::server`] for the scrape endpoint.
+
+/// Counter for upserted vectors observed by `VectorDb::write`.
+pub const VECTOR_UPSERTS_TOTAL: &str = "vector_upserts_total";
+
+/// Counter for deleted vector ids observed by `VectorDb::delete`.
+pub const VECTOR_DELETES_TOTAL: &str = "vector_deletes_total";
+
+/// Counter for writes (upserts and deletes) seen by the indexer at the start of
+/// each `WriteVectors` op.
+pub const INDEXER_WRITES_TOTAL: &str = "vector_indexer_writes_total";
+
+/// Counter for centroids split by the indexer. Labeled by tree `level`
+/// (255 for the root level).
+pub const INDEXER_ANN_SPLITS_TOTAL: &str = "vector_indexer_ann_splits_total";
+
+/// Counter for centroids merged by the indexer. Labeled by tree `level`.
+pub const INDEXER_ANN_MERGES_TOTAL: &str = "vector_indexer_ann_merges_total";
+
+/// Counter for vectors reassigned by the indexer. Labeled by tree `level`.
+pub const INDEXER_ANN_REASSIGNS_TOTAL: &str = "vector_indexer_ann_reassigns_total";
+
+/// Counter for the total number of candidate vectors scored during query
+/// execution (sum of posting-list lengths over loaded centroids).
+pub const QUERY_VECTORS_SCORED_TOTAL: &str = "vector_query_vectors_scored_total";
+
+/// Histogram of end-to-end `search_with_options` latency, in seconds.
+pub const QUERY_SEARCH_DURATION_SECONDS: &str = "vector_query_search_duration_seconds";

--- a/vector/src/query_engine.rs
+++ b/vector/src/query_engine.rs
@@ -1,5 +1,6 @@
 use crate::error::{Error, Result};
 use crate::math::distance;
+use crate::metric_names::{QUERY_SEARCH_DURATION_SECONDS, QUERY_VECTORS_SCORED_TOTAL};
 use crate::model::{FieldSelection, Filter, Query, SearchOptions, SearchResult};
 use crate::serde::collection_meta::DistanceMetric;
 use crate::serde::vector_data::VectorDataValue;
@@ -145,6 +146,18 @@ impl QueryEngine {
     }
 
     pub(crate) async fn search_with_options(
+        &self,
+        query: &Query,
+        options: SearchOptions,
+    ) -> Result<Vec<SearchResult>> {
+        let search_start = Instant::now();
+        let result = self.search_with_options_inner(query, options).await;
+        metrics::histogram!(QUERY_SEARCH_DURATION_SECONDS)
+            .record(search_start.elapsed().as_secs_f64());
+        result
+    }
+
+    async fn search_with_options_inner(
         &self,
         query: &Query,
         options: SearchOptions,
@@ -306,13 +319,16 @@ impl QueryEngine {
             elapsed_ms = elapsed.as_millis()
         );
         let mut sorted_lists: Vec<Vec<ScoredCandidate>> = Vec::with_capacity(results.len());
+        let mut total_scored: u64 = 0;
         for result in results {
             let scored =
                 result.map_err(|e| Error::Internal(format!("task join error: {}", e)))??;
+            total_scored += scored.len() as u64;
             if !scored.is_empty() {
                 sorted_lists.push(scored);
             }
         }
+        metrics::counter!(QUERY_VECTORS_SCORED_TOTAL).increment(total_scored);
 
         Ok(sorted_lists)
     }

--- a/vector/src/server/metrics.rs
+++ b/vector/src/server/metrics.rs
@@ -1,0 +1,29 @@
+//! Prometheus metrics for the vector server.
+//!
+//! Vector instrumentation flows through the `metrics-rs` facade. The server
+//! binary installs a `PrometheusBuilder` recorder at startup, which captures
+//! both vector-server counters emitted via [`metrics::counter!`] and metrics
+//! emitted by slatedb through the same facade. The `/metrics` route renders
+//! the recorder's accumulated state.
+
+use axum::extract::State;
+use metrics_exporter_prometheus::PrometheusHandle;
+
+/// Counter name for vector API requests, labeled by `endpoint`.
+pub const API_REQUESTS_TOTAL: &str = "vector_api_requests_total";
+
+/// Endpoint label values for [`API_REQUESTS_TOTAL`].
+pub const ENDPOINT_WRITE: &str = "write";
+pub const ENDPOINT_DELETE: &str = "delete";
+pub const ENDPOINT_SEARCH: &str = "search";
+
+/// Handle to the global Prometheus recorder, shared with the `/metrics` route.
+#[derive(Clone)]
+pub struct MetricsState {
+    pub handle: PrometheusHandle,
+}
+
+/// Handle GET /metrics
+pub(crate) async fn handle_metrics(State(state): State<MetricsState>) -> String {
+    state.handle.render()
+}

--- a/vector/src/server/middleware.rs
+++ b/vector/src/server/middleware.rs
@@ -9,6 +9,8 @@ use axum::body::Body;
 use axum::http::{Request, Response};
 use tower::{Layer, Service};
 
+use super::metrics::{API_REQUESTS_TOTAL, ENDPOINT_DELETE, ENDPOINT_SEARCH, ENDPOINT_WRITE};
+
 /// Layer that wraps services with request tracing.
 #[derive(Clone)]
 pub struct TracingLayer;
@@ -93,5 +95,91 @@ where
 
             Ok(response)
         })
+    }
+}
+
+/// Layer that records per-endpoint API call counters via the metrics-rs facade.
+#[derive(Clone, Default)]
+pub struct MetricsLayer;
+
+impl MetricsLayer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl<S> Layer<S> for MetricsLayer {
+    type Service = MetricsService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        MetricsService { inner }
+    }
+}
+
+/// Service that increments `vector_api_requests_total` for write/delete/search calls.
+#[derive(Clone)]
+pub struct MetricsService<S> {
+    inner: S,
+}
+
+impl<S, ResBody> Service<Request<Body>> for MetricsService<S>
+where
+    S: Service<Request<Body>, Response = Response<ResBody>> + Clone + Send + 'static,
+    S::Future: Send,
+    ResBody: Send,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        if let Some(endpoint) = endpoint_label(request.uri().path()) {
+            metrics::counter!(API_REQUESTS_TOTAL, "endpoint" => endpoint).increment(1);
+        }
+        let future = self.inner.call(request);
+        Box::pin(future)
+    }
+}
+
+/// Map a request path to the endpoint label, or `None` if the path is not
+/// one of the counted API calls.
+fn endpoint_label(path: &str) -> Option<&'static str> {
+    match path {
+        "/api/v1/vector/write" => Some(ENDPOINT_WRITE),
+        "/api/v1/vector/delete" => Some(ENDPOINT_DELETE),
+        "/api/v1/vector/search" => Some(ENDPOINT_SEARCH),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_map_known_endpoints_to_labels() {
+        // given/when/then
+        assert_eq!(endpoint_label("/api/v1/vector/write"), Some(ENDPOINT_WRITE));
+        assert_eq!(
+            endpoint_label("/api/v1/vector/delete"),
+            Some(ENDPOINT_DELETE)
+        );
+        assert_eq!(
+            endpoint_label("/api/v1/vector/search"),
+            Some(ENDPOINT_SEARCH)
+        );
+    }
+
+    #[test]
+    fn should_return_none_for_unmetered_paths() {
+        // given/when/then
+        assert_eq!(endpoint_label("/-/healthy"), None);
+        assert_eq!(endpoint_label("/-/ready"), None);
+        assert_eq!(endpoint_label("/metrics"), None);
+        assert_eq!(endpoint_label("/api/v1/vector/vectors/abc"), None);
     }
 }

--- a/vector/src/server/mod.rs
+++ b/vector/src/server/mod.rs
@@ -8,6 +8,7 @@ pub(crate) mod buffer_consumer;
 mod config;
 mod error;
 mod handlers;
+mod metrics;
 mod middleware;
 mod proto;
 mod request;
@@ -16,5 +17,6 @@ mod vector;
 mod vector_reader;
 
 pub use config::{VectorServerConfig, load_reader_config, load_vector_config};
+pub use metrics::MetricsState;
 pub use vector::VectorServer;
 pub use vector_reader::VectorReaderServer;

--- a/vector/src/server/vector.rs
+++ b/vector/src/server/vector.rs
@@ -15,7 +15,8 @@ use super::handlers::{
     AppState, handle_delete, handle_get_vector, handle_healthy, handle_ready, handle_search,
     handle_write,
 };
-use super::middleware::TracingLayer;
+use super::metrics::{MetricsState, handle_metrics};
+use super::middleware::{MetricsLayer, TracingLayer};
 #[cfg(feature = "buffer")]
 use crate::model::BufferConsumerConfig;
 use crate::{FieldType, MetadataFieldSpec, VectorDb};
@@ -25,6 +26,7 @@ pub struct VectorServer {
     db: Arc<VectorDb>,
     config: VectorServerConfig,
     metadata_fields: Vec<MetadataFieldSpec>,
+    metrics: MetricsState,
     #[cfg(feature = "buffer")]
     buffer_consumer: Option<Arc<BufferConsumer>>,
 }
@@ -35,11 +37,13 @@ impl VectorServer {
         db: Arc<VectorDb>,
         config: VectorServerConfig,
         metadata_fields: Vec<MetadataFieldSpec>,
+        metrics: MetricsState,
     ) -> Self {
         Self {
             db,
             config,
             metadata_fields,
+            metrics,
             #[cfg(feature = "buffer")]
             buffer_consumer: None,
         }
@@ -59,6 +63,7 @@ impl VectorServer {
             db,
             config,
             metadata_fields,
+            metrics,
             #[cfg(feature = "buffer")]
             buffer_consumer,
         } = self;
@@ -79,6 +84,10 @@ impl VectorServer {
             None => None,
         };
 
+        let metrics_router = Router::new()
+            .route("/metrics", get(handle_metrics))
+            .with_state(metrics);
+
         let app = Router::new()
             .route("/api/v1/vector/write", post(handle_write))
             .route("/api/v1/vector/delete", post(handle_delete))
@@ -89,8 +98,10 @@ impl VectorServer {
             )
             .route("/-/healthy", get(handle_healthy))
             .route("/-/ready", get(handle_ready))
-            .layer(TracingLayer::new())
-            .with_state(state);
+            .with_state(state)
+            .merge(metrics_router)
+            .layer(MetricsLayer::new())
+            .layer(TracingLayer::new());
 
         let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
         tracing::info!("Starting Vector HTTP server on {}", addr);

--- a/vector/src/server/vector_reader.rs
+++ b/vector/src/server/vector_reader.rs
@@ -10,7 +10,8 @@ use tokio::signal;
 
 use super::config::VectorServerConfig;
 use super::handlers::{AppState, handle_get_vector, handle_healthy, handle_ready, handle_search};
-use super::middleware::TracingLayer;
+use super::metrics::{MetricsState, handle_metrics};
+use super::middleware::{MetricsLayer, TracingLayer};
 use crate::{FieldType, MetadataFieldSpec, VectorDbReader};
 
 /// HTTP server for the vector reader service (read-only).
@@ -18,6 +19,7 @@ pub struct VectorReaderServer {
     db: Arc<VectorDbReader>,
     config: VectorServerConfig,
     metadata_fields: Vec<MetadataFieldSpec>,
+    metrics: MetricsState,
 }
 
 impl VectorReaderServer {
@@ -26,11 +28,13 @@ impl VectorReaderServer {
         db: Arc<VectorDbReader>,
         config: VectorServerConfig,
         metadata_fields: Vec<MetadataFieldSpec>,
+        metrics: MetricsState,
     ) -> Self {
         Self {
             db,
             config,
             metadata_fields,
+            metrics,
         }
     }
 
@@ -40,11 +44,16 @@ impl VectorReaderServer {
             db,
             config,
             metadata_fields,
+            metrics,
         } = self;
         let state = AppState {
             db,
             metadata_fields: metadata_fields_by_name(&metadata_fields),
         };
+
+        let metrics_router = Router::new()
+            .route("/metrics", get(handle_metrics))
+            .with_state(metrics);
 
         let app = Router::new()
             .route(
@@ -57,8 +66,10 @@ impl VectorReaderServer {
             )
             .route("/-/healthy", get(handle_healthy))
             .route("/-/ready", get(handle_ready))
-            .layer(TracingLayer::new())
-            .with_state(state);
+            .with_state(state)
+            .merge(metrics_router)
+            .layer(MetricsLayer::new())
+            .layer(TracingLayer::new());
 
         let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
         tracing::info!("Starting Vector Reader HTTP server on {}", addr);

--- a/vector/src/write/indexer/tree/merge.rs
+++ b/vector/src/write/indexer/tree/merge.rs
@@ -1,4 +1,5 @@
 use crate::Result;
+use crate::metric_names::INDEXER_ANN_MERGES_TOTAL;
 use crate::serde::centroid_info::CentroidInfoValue;
 use crate::serde::vector_id::VectorId;
 use crate::write::indexer::drivers::AsyncBatchDriver;
@@ -121,6 +122,12 @@ impl MergeCentroids {
                 ));
             }
         }
+
+        metrics::counter!(
+            INDEXER_ANN_MERGES_TOTAL,
+            "level" => self.level.level().to_string(),
+        )
+        .increment(merge_count as u64);
 
         // return reassign set
         Ok((reassignments, merge_count))

--- a/vector/src/write/indexer/tree/root.rs
+++ b/vector/src/write/indexer/tree/root.rs
@@ -1,4 +1,6 @@
 use crate::Result;
+use crate::metric_names::INDEXER_ANN_SPLITS_TOTAL;
+use crate::serde::vector_id::ROOT_LEVEL;
 use crate::write::indexer::tree::IndexerOpts;
 use crate::write::indexer::tree::centroids::SearchResult;
 use crate::write::indexer::tree::state::{VectorIndexDelta, VectorIndexState, VectorIndexView};
@@ -35,6 +37,12 @@ impl SplitRoot {
         if view.root_count() < self.opts.root_threshold_vectors as u64 {
             return Ok(());
         }
+
+        metrics::counter!(
+            INDEXER_ANN_SPLITS_TOTAL,
+            "level" => ROOT_LEVEL.to_string(),
+        )
+        .increment(1);
 
         let original_root_postings = view.root_posting_list(self.opts.dimensions).get().await?;
         let root_vecs: Vec<_> = original_root_postings

--- a/vector/src/write/indexer/tree/split.rs
+++ b/vector/src/write/indexer/tree/split.rs
@@ -1,5 +1,6 @@
 use crate::math::kmeans::Clustering;
 use crate::math::{distance, heuristics, kmeans};
+use crate::metric_names::INDEXER_ANN_SPLITS_TOTAL;
 use crate::serde::centroid_info::CentroidInfoValue;
 use crate::serde::vector_id::VectorId;
 use crate::write::indexer::drivers::AsyncBatchDriver;
@@ -416,6 +417,12 @@ impl SplitCentroids {
                 new_centroids,
             })
         }
+
+        metrics::counter!(
+            INDEXER_ANN_SPLITS_TOTAL,
+            "level" => self.level.level().to_string(),
+        )
+        .increment(splits.len() as u64);
 
         // return reassign set
         let reassignments: Vec<_> = reassignments.values().cloned().collect();

--- a/vector/src/write/indexer/tree/vector.rs
+++ b/vector/src/write/indexer/tree/vector.rs
@@ -1,5 +1,6 @@
 use crate::Error::Internal;
 use crate::Result;
+use crate::metric_names::{INDEXER_ANN_REASSIGNS_TOTAL, INDEXER_WRITES_TOTAL};
 use crate::model::AttributeValue;
 use crate::model::VECTOR_FIELD_NAME;
 use crate::serde::FieldValue;
@@ -63,6 +64,9 @@ impl WriteVectors {
         state: &VectorIndexState,
         delta: &mut VectorIndexDelta,
     ) -> Result<(usize, usize, usize)> {
+        let total_writes: usize = self.ops.iter().map(VectorDbOp::len).sum();
+        metrics::counter!(INDEXER_WRITES_TOTAL).increment(total_writes as u64);
+
         let (writes, delete_ids) = Self::collapse_ops(self.ops);
         if writes.is_empty() && delete_ids.is_empty() {
             return Ok((0, 0, 0));
@@ -419,7 +423,8 @@ impl ReassignVectors {
             reassignments
         };
 
-        if self.level.is_leaf() {
+        let level = self.level;
+        let reassigned = if level.is_leaf() {
             Self::execute_vector_reassignments(
                 &self.opts,
                 &self.snapshot,
@@ -428,7 +433,7 @@ impl ReassignVectors {
                 delta,
                 reassignments,
             )
-            .await
+            .await?
         } else {
             Self::execute_centroid_reassignments(
                 &self.snapshot,
@@ -437,8 +442,14 @@ impl ReassignVectors {
                 delta,
                 reassignments,
             )
-            .await
-        }
+            .await?
+        };
+        metrics::counter!(
+            INDEXER_ANN_REASSIGNS_TOTAL,
+            "level" => level.level().to_string(),
+        )
+        .increment(reassigned as u64);
+        Ok(reassigned)
     }
 
     async fn execute_centroid_reassignments(

--- a/vector/tests/http_server.rs
+++ b/vector/tests/http_server.rs
@@ -10,7 +10,7 @@ use reqwest::Client;
 use serde_json::json;
 use tokio::task::JoinHandle;
 use tokio::time::sleep;
-use vector::server::{VectorServer, VectorServerConfig};
+use vector::server::{MetricsState, VectorServer, VectorServerConfig};
 use vector::{Config, DistanceMetric, FieldType, MetadataFieldSpec, VectorDb};
 
 #[derive(Clone, Debug)]
@@ -130,10 +130,15 @@ async fn setup_server_with_vectors() -> TestServerFixture {
         ..Default::default()
     };
     let db = Arc::new(VectorDb::open(config).await.unwrap());
+    let metrics_recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
+    let metrics_state = MetricsState {
+        handle: metrics_recorder.handle(),
+    };
     let server = VectorServer::new(
         db.clone(),
         VectorServerConfig { port },
         metadata_fields.clone(),
+        metrics_state,
     );
     let server_task = tokio::spawn(async move {
         server.run().await;


### PR DESCRIPTION

## Summary

Adds metrics for vector plus prometheus scrape endpoint for server. Metrics are recorded using metrics-rs so embedded users can export metrics using their own exporters.

## Test Plan

- unit tests pass
- run server and scrape endpoint

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
