### PR TITLE
Implement LogDb count api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,6 +2508,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "ulid",
  "uuid",
 ]
 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -29,6 +29,7 @@ mixtrics.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
 tracing.workspace = true
+ulid.workspace = true
 uuid.workspace = true
 serde.workspace = true
 arc-swap = { version = "1", optional = true }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -18,6 +18,7 @@ pub use storage::factory::{
     create_object_store, create_storage_read,
 };
 pub use storage::loader::{LoadMetadata, LoadResult, LoadSpec, Loadable, Loader};
+pub use storage::sst_blocks::{BlockOpCounts, CountResult, count_in_range};
 pub use storage::{
     CheckpointInfo, MergeRecordOp, PutRecordOp, Record, Storage, StorageError, StorageIterator,
     StorageRead, StorageResult, Ttl, WriteOptions, WriteResult,

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -4,6 +4,7 @@ pub mod in_memory;
 pub mod loader;
 pub mod metrics_recorder;
 pub mod slate;
+pub mod sst_blocks;
 pub mod util;
 
 use std::sync::Arc;

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -495,7 +495,10 @@ mod tests {
         storage.flush().await.unwrap();
 
         // Create reader and verify data
-        let reader = DbReader::builder(path, object_store).build().await.unwrap();
+        let reader = DbReader::builder(path, object_store.clone())
+            .build()
+            .await
+            .unwrap();
         let storage_reader = SlateDbStorageReader::new(Arc::new(reader));
 
         let record = storage_reader.get(Bytes::from("key1")).await.unwrap();
@@ -535,7 +538,10 @@ mod tests {
         storage.flush().await.unwrap();
 
         // Create reader and scan data
-        let reader = DbReader::builder(path, object_store).build().await.unwrap();
+        let reader = DbReader::builder(path, object_store.clone())
+            .build()
+            .await
+            .unwrap();
         let storage_reader = SlateDbStorageReader::new(Arc::new(reader));
 
         let mut iter = storage_reader
@@ -577,7 +583,10 @@ mod tests {
         storage.flush().await.unwrap();
 
         // Create reader while writer is still open - this should NOT cause fencing error
-        let reader = DbReader::builder(path, object_store).build().await.unwrap();
+        let reader = DbReader::builder(path, object_store.clone())
+            .build()
+            .await
+            .unwrap();
         let storage_reader = SlateDbStorageReader::new(Arc::new(reader));
 
         // Reader can read the data
@@ -604,7 +613,7 @@ mod tests {
         let path = "/test/ttl_db";
         let clock = Arc::new(MockSystemClock::new());
 
-        let db = DbBuilder::new(path, object_store)
+        let db = DbBuilder::new(path, object_store.clone())
             .with_settings(Settings {
                 default_ttl: Some(30_000),
                 ..Default::default()
@@ -681,7 +690,7 @@ mod tests {
 
         let merge_op: Arc<dyn MergeOperator> = Arc::new(ConcatMergeOperator);
         let slate_merge_op = SlateDbStorage::merge_operator_adapter(merge_op);
-        let db = DbBuilder::new(path, object_store)
+        let db = DbBuilder::new(path, object_store.clone())
             .with_settings(Settings {
                 default_ttl: Some(30_000),
                 ..Default::default()

--- a/common/src/storage/sst_blocks.rs
+++ b/common/src/storage/sst_blocks.rs
@@ -1,0 +1,690 @@
+//! Precise key-range record counts over a SlateDB manifest.
+//!
+//! Built on SlateDB RFC 0020 primitives — [`slatedb::Db::manifest`],
+//! [`slatedb::SstReader`], [`slatedb::SstFile::stats`],
+//! [`slatedb::SstFile::index`] — plus [`slatedb::SstFile::read_block`] for
+//! per-row precision on boundary blocks.
+//!
+//! The primary entry point is [`count_in_range`], which walks the manifest
+//! and returns the exact number of physical write operations (puts,
+//! deletes, merges) recorded within a query range.
+//!
+//! ## Walk structure
+//!
+//! For each SST overlapping the query:
+//!
+//! 1. **Back-scan** — walk blocks high-to-low, reading each, until we find
+//!    one with actual in-query rows. That "witness" block fixes
+//!    [`CountResult::covered_to`] from the highest in-query row key. If the
+//!    witness is the SST's last data block AND fully contained in the
+//!    query, [`slatedb::SstFile::info`]'s `last_entry` is a free witness
+//!    (no row read needed). Blocks scanned above the witness contributed
+//!    nothing in query, so we just keep walking.
+//! 2. **Forward fill** — for blocks below the witness, use the cheap stats
+//!    path when the block is fully contained in the query (no per-row I/O),
+//!    and read rows when the block straddles `query.start` (to filter out
+//!    below-query keys).
+//!
+//! ## Why the back-scan
+//!
+//! SlateDB's index returns separator keys, not first keys: `sep[i] <=
+//! first_key(block i)`. So a block's separator can place it "inside" the
+//! query while every real key in the block sits above `query.end`. Picking
+//! the highest *overlapping-by-separator* block as the witness can yield a
+//! block with zero in-query rows. The back-scan tolerates this by
+//! continuing downward until a block actually contributes.
+//!
+//! ## Known gap
+//!
+//! `SsTableView::visible_range` projection is not applied. Callers using
+//! view-projected SSTs may over-count rows outside the visible range.
+//! Fixable with the same `read_block` primitive (clip rows to
+//! `visible_range ∩ query`) — left as follow-up.
+//!
+//! ## Count semantics
+//!
+//! Counts are **physical write operations**, not visible rows. A key
+//! written twice contributes 2 to `num_puts`; a tombstone counts as a
+//! delete even if its put has compacted away. This matches the LogDb
+//! append-only model where physical ops equal logical records. If an
+//! update or delete API is added to LogDb, revisit.
+
+use std::ops::Bound;
+
+use bytes::Bytes;
+use slatedb::manifest::{SsTableView, VersionedManifest};
+use slatedb::{RowEntry, SstReader, SstStats, ValueDeletable};
+
+use crate::{BytesRange, StorageError, StorageResult};
+
+/// Counts of physical write operations within a query range.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct BlockOpCounts {
+    pub num_puts: u64,
+    pub num_deletes: u64,
+    pub num_merges: u64,
+}
+
+impl BlockOpCounts {
+    pub fn num_rows(&self) -> u64 {
+        self.num_puts + self.num_deletes + self.num_merges
+    }
+
+    pub fn add(&mut self, other: BlockOpCounts) {
+        self.num_puts += other.num_puts;
+        self.num_deletes += other.num_deletes;
+        self.num_merges += other.num_merges;
+    }
+}
+
+/// Result of a [`count_in_range`] walk: aggregate counts plus a witness
+/// of the highest key actually observed.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct CountResult {
+    /// Per-variant counts of physical write operations in `range`.
+    pub counts: BlockOpCounts,
+    /// Inclusive upper bound on the keys reflected in `counts`. If
+    /// `Some(k)`, every persisted entry in `[range.start, k]` is included.
+    /// `None` if no SSTs contributed to the count (no overlap, empty
+    /// manifest, etc.).
+    ///
+    /// Callers that need exact counts including not-yet-persisted writes
+    /// can combine this with a scan over `(covered_to, range.end)`.
+    pub covered_to: Option<Bytes>,
+}
+
+/// Counts every physical write operation in the manifest whose key falls
+/// in `query`, and returns a witness of how far up the walk observed data.
+///
+/// Covers L0 SSTs and the views returned by each compacted sorted run's
+/// `tables_covering_range(query)`. SSTs without a stats block (predating
+/// RFC 0020) are skipped with a tracing warning, so the result undercounts
+/// in that case.
+pub async fn count_in_range(
+    manifest: &VersionedManifest,
+    sst_reader: &SstReader,
+    query: &BytesRange,
+) -> StorageResult<CountResult> {
+    let mut result = CountResult::default();
+    for view in manifest.l0() {
+        count_view(sst_reader, view, query, &mut result).await?;
+    }
+    for run in manifest.compacted() {
+        for view in run.tables_covering_range::<BytesRange>(query.clone()) {
+            count_view(sst_reader, view, query, &mut result).await?;
+        }
+    }
+    Ok(result)
+}
+
+async fn count_view(
+    sst_reader: &SstReader,
+    view: &SsTableView,
+    query: &BytesRange,
+    result: &mut CountResult,
+) -> StorageResult<()> {
+    let sst_file = sst_reader
+        .open_with_handle(view.sst.clone())
+        .map_err(StorageError::from_storage)?;
+    let sst_id = sst_file.id();
+
+    let Some(stats) = sst_file.stats().await.map_err(StorageError::from_storage)? else {
+        tracing::warn!(?sst_id, "SST has no stats block; skipping");
+        return Ok(());
+    };
+
+    let index = sst_file.index().await.map_err(StorageError::from_storage)?;
+    let last_entry = sst_file.info().last_entry.clone();
+
+    let n = index.len();
+    let overlapping: Vec<usize> = (0..n)
+        .filter(|i| ranges_overlap(query, &block_key_range(&index, *i, last_entry.as_ref())))
+        .collect();
+
+    // Back-scan: walk overlapping blocks high-to-low, reading each, until we
+    // find one with actual in-query rows. SlateDB's index returns truncated
+    // separators (`sep[i] <= first_key(block i)`), so a block's separator can
+    // place it inside the query while its real keys all sit above `query.end`.
+    // The witness block — first one with non-empty in-query content from the
+    // top — pins down `covered_to`. Blocks scanned above the witness held
+    // nothing in query (already accounted for as zero); blocks below get the
+    // cheap stats path on the second pass.
+    let mut witness_pos: Option<usize> = None;
+    for pos in (0..overlapping.len()).rev() {
+        let i = overlapping[pos];
+        let key_range = block_key_range(&index, i, last_entry.as_ref());
+        let is_sst_last = i + 1 == n;
+        let contained = range_contains(query, &key_range);
+
+        // Shortcut: SST's last data block is contained in the query — its
+        // last_entry is a free witness (already in SsTableInfo, no read).
+        if is_sst_last
+            && contained
+            && let Some(last) = last_entry.as_ref()
+        {
+            result
+                .counts
+                .add(block_counts_from_stats(&stats, i, sst_id));
+            bump_covered_to(&mut result.covered_to, last.clone());
+            witness_pos = Some(pos);
+            break;
+        }
+
+        let rows = sst_file
+            .read_block(i)
+            .await
+            .map_err(StorageError::from_storage)?;
+        let (block_counts, block_max) = count_rows_in_range_with_max(&rows, query);
+        if let Some(max) = block_max {
+            result.counts.add(block_counts);
+            bump_covered_to(&mut result.covered_to, max);
+            witness_pos = Some(pos);
+            break;
+        }
+        // No in-query rows in this block; the separator was misleading.
+        // Continue scanning down. We've already added zero counts.
+    }
+
+    let Some(witness_pos) = witness_pos else {
+        // No SST contents in query.
+        return Ok(());
+    };
+
+    // Forward pass for blocks below the witness. Cheap stats path when
+    // contained; read for boundary blocks (needed to filter rows by query).
+    for &i in &overlapping[..witness_pos] {
+        let key_range = block_key_range(&index, i, last_entry.as_ref());
+        if range_contains(query, &key_range) {
+            result
+                .counts
+                .add(block_counts_from_stats(&stats, i, sst_id));
+        } else {
+            let rows = sst_file
+                .read_block(i)
+                .await
+                .map_err(StorageError::from_storage)?;
+            let (block_counts, _) = count_rows_in_range_with_max(&rows, query);
+            result.counts.add(block_counts);
+        }
+    }
+
+    Ok(())
+}
+
+fn bump_covered_to(covered_to: &mut Option<Bytes>, candidate: Bytes) {
+    match covered_to {
+        None => *covered_to = Some(candidate),
+        Some(existing) if *existing < candidate => *covered_to = Some(candidate),
+        _ => {}
+    }
+}
+
+fn block_counts_from_stats(stats: &SstStats, i: usize, sst_id: ulid::Ulid) -> BlockOpCounts {
+    match stats.block_stats.get(i) {
+        Some(bs) => BlockOpCounts {
+            num_puts: bs.num_puts as u64,
+            num_deletes: bs.num_deletes as u64,
+            num_merges: bs.num_merges as u64,
+        },
+        None => {
+            // Index and stats disagree on block count — shouldn't happen
+            // for an RFC-0020 SST. Skip the block rather than crash.
+            tracing::warn!(?sst_id, block_index = i, "missing block_stats entry");
+            BlockOpCounts::default()
+        }
+    }
+}
+
+fn count_rows_in_range_with_max(
+    rows: &[RowEntry],
+    query: &BytesRange,
+) -> (BlockOpCounts, Option<Bytes>) {
+    let mut counts = BlockOpCounts::default();
+    let mut max_key: Option<Bytes> = None;
+    for row in rows {
+        if !query.contains(&row.key) {
+            continue;
+        }
+        match row.value {
+            ValueDeletable::Value(_) => counts.num_puts += 1,
+            ValueDeletable::Merge(_) => counts.num_merges += 1,
+            ValueDeletable::Tombstone => counts.num_deletes += 1,
+        }
+        match &max_key {
+            None => max_key = Some(row.key.clone()),
+            Some(m) if *m < row.key => max_key = Some(row.key.clone()),
+            _ => {}
+        }
+    }
+    (counts, max_key)
+}
+
+fn block_key_range(index: &[(u64, Bytes)], i: usize, sst_last_entry: Option<&Bytes>) -> BytesRange {
+    let start = Bound::Included(index[i].1.clone());
+    let end = if i + 1 < index.len() {
+        Bound::Excluded(index[i + 1].1.clone())
+    } else {
+        match sst_last_entry {
+            Some(last) => Bound::Included(last.clone()),
+            None => Bound::Unbounded,
+        }
+    };
+    BytesRange::new(start, end)
+}
+
+fn ranges_overlap(a: &BytesRange, b: &BytesRange) -> bool {
+    lower_lt_upper(&a.start, &b.end) && lower_lt_upper(&b.start, &a.end)
+}
+
+fn lower_lt_upper(lower: &Bound<Bytes>, upper: &Bound<Bytes>) -> bool {
+    match (lower, upper) {
+        (Bound::Unbounded, _) | (_, Bound::Unbounded) => true,
+        (Bound::Included(l), Bound::Included(u)) => l <= u,
+        (Bound::Included(l), Bound::Excluded(u)) => l < u,
+        (Bound::Excluded(l), Bound::Included(u)) => l < u,
+        (Bound::Excluded(l), Bound::Excluded(u)) => l < u,
+    }
+}
+
+fn range_contains(outer: &BytesRange, inner: &BytesRange) -> bool {
+    lower_le_lower(&outer.start, &inner.start) && upper_ge_upper(&outer.end, &inner.end)
+}
+
+fn lower_le_lower(a: &Bound<Bytes>, b: &Bound<Bytes>) -> bool {
+    use Bound::*;
+    match (a, b) {
+        (Unbounded, _) => true,
+        (_, Unbounded) => false,
+        (Included(ak), Included(bk)) => ak <= bk,
+        (Included(ak), Excluded(bk)) => ak <= bk,
+        (Excluded(ak), Included(bk)) => ak < bk,
+        (Excluded(ak), Excluded(bk)) => ak <= bk,
+    }
+}
+
+fn upper_ge_upper(a: &Bound<Bytes>, b: &Bound<Bytes>) -> bool {
+    use Bound::*;
+    match (a, b) {
+        (Unbounded, _) => true,
+        (_, Unbounded) => false,
+        (Included(ak), Included(bk)) => ak >= bk,
+        (Included(ak), Excluded(bk)) => ak >= bk,
+        (Excluded(ak), Included(bk)) => ak > bk,
+        (Excluded(ak), Excluded(bk)) => ak >= bk,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::MergeOperator;
+    use slatedb::config::{FlushOptions, FlushType, PutOptions, SstBlockSize, WriteOptions};
+    use slatedb::object_store::memory::InMemory;
+    use slatedb::{Db, DbBuilder};
+    use std::sync::Arc;
+
+    const PATH: &str = "/test";
+
+    /// Trivial merge operator: concatenate operands in batch order.
+    struct ConcatMerger;
+
+    impl MergeOperator for ConcatMerger {
+        fn merge_batch(&self, _key: &Bytes, existing: Option<Bytes>, operands: &[Bytes]) -> Bytes {
+            let mut out = existing.map(|b| b.to_vec()).unwrap_or_default();
+            for op in operands {
+                out.extend_from_slice(op);
+            }
+            Bytes::from(out)
+        }
+    }
+
+    async fn build_db_with_entries(entries: &[(&[u8], &[u8])]) -> (Arc<Db>, Arc<InMemory>) {
+        let object_store: Arc<InMemory> = Arc::new(InMemory::new());
+        let db = DbBuilder::new(PATH, object_store.clone())
+            .with_sst_block_size(SstBlockSize::Block1Kib)
+            .build()
+            .await
+            .unwrap();
+        for (k, v) in entries {
+            db.put_with_options(*k, *v, &PutOptions::default(), &WriteOptions::default())
+                .await
+                .unwrap();
+        }
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        (Arc::new(db), object_store)
+    }
+
+    fn sst_reader(object_store: Arc<InMemory>) -> SstReader {
+        SstReader::new(PATH, object_store, None, None)
+    }
+
+    fn mk_range(lo: &[u8], hi: &[u8]) -> BytesRange {
+        BytesRange::new(
+            Bound::Included(Bytes::copy_from_slice(lo)),
+            Bound::Excluded(Bytes::copy_from_slice(hi)),
+        )
+    }
+
+    /// Builds ~250 entries with keys `kNNN` so an SST with 1 KiB blocks
+    /// produces several blocks. Each entry is ~30 bytes after encoding,
+    /// so ~30 entries/block → ~8+ blocks per SST.
+    fn many_entries(count: u16) -> Vec<(Vec<u8>, Vec<u8>)> {
+        (0..count)
+            .map(|i| {
+                let key = format!("k{:03}", i).into_bytes();
+                let val = format!("v{:03}aaaaaaaaaaaaaa", i).into_bytes();
+                (key, val)
+            })
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn empty_manifest_counts_zero() {
+        let object_store: Arc<InMemory> = Arc::new(InMemory::new());
+        let db = DbBuilder::new(PATH, object_store.clone())
+            .build()
+            .await
+            .unwrap();
+        let result = count_in_range(
+            &db.manifest(),
+            &sst_reader(object_store),
+            &BytesRange::unbounded(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.counts, BlockOpCounts::default());
+        assert!(result.covered_to.is_none());
+    }
+
+    #[tokio::test]
+    async fn unbounded_query_counts_every_put() {
+        let entries = many_entries(250);
+        let entries_ref: Vec<(&[u8], &[u8])> = entries
+            .iter()
+            .map(|(k, v)| (k.as_slice(), v.as_slice()))
+            .collect();
+        let (db, object_store) = build_db_with_entries(&entries_ref).await;
+
+        let result = count_in_range(
+            &db.manifest(),
+            &sst_reader(object_store),
+            &BytesRange::unbounded(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.counts.num_puts, 250);
+        assert_eq!(result.counts.num_deletes, 0);
+        assert_eq!(result.counts.num_merges, 0);
+        // Unbounded query → highest SST key is the witness. Last inserted key
+        // is `k249`; the SST's last_entry is exactly that.
+        assert_eq!(result.covered_to.as_deref(), Some(b"k249" as &[u8]));
+    }
+
+    /// The boundary-block path: query slices through interior blocks, so the
+    /// contained-path stats counts would over-count. Asserts the exact answer.
+    #[tokio::test]
+    async fn subrange_query_counts_exactly() {
+        let entries = many_entries(250);
+        let entries_ref: Vec<(&[u8], &[u8])> = entries
+            .iter()
+            .map(|(k, v)| (k.as_slice(), v.as_slice()))
+            .collect();
+        let (db, object_store) = build_db_with_entries(&entries_ref).await;
+
+        let result = count_in_range(
+            &db.manifest(),
+            &sst_reader(object_store),
+            &mk_range(b"k100", b"k150"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.counts.num_puts, 50, "exactly the 50 keys k100..k150");
+        // Boundary block at the top of query — last counted row is k149.
+        assert_eq!(result.covered_to.as_deref(), Some(b"k149" as &[u8]));
+    }
+
+    #[tokio::test]
+    async fn query_outside_keyspace_counts_zero() {
+        let entries = many_entries(50);
+        let entries_ref: Vec<(&[u8], &[u8])> = entries
+            .iter()
+            .map(|(k, v)| (k.as_slice(), v.as_slice()))
+            .collect();
+        let (db, object_store) = build_db_with_entries(&entries_ref).await;
+
+        let result = count_in_range(
+            &db.manifest(),
+            &sst_reader(object_store),
+            &mk_range(b"z", b"z\xff"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.counts, BlockOpCounts::default());
+        assert!(result.covered_to.is_none());
+    }
+
+    #[tokio::test]
+    async fn counts_across_multiple_l0_ssts() {
+        let object_store: Arc<InMemory> = Arc::new(InMemory::new());
+        let db = DbBuilder::new(PATH, object_store.clone())
+            .with_sst_block_size(SstBlockSize::Block1Kib)
+            .build()
+            .await
+            .unwrap();
+
+        for i in 0u8..5 {
+            db.put_with_options(
+                &[b'k', i],
+                &[b'v', i],
+                &PutOptions::default(),
+                &WriteOptions::default(),
+            )
+            .await
+            .unwrap();
+        }
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        for i in 5u8..10 {
+            db.put_with_options(
+                &[b'k', i],
+                &[b'v', i],
+                &PutOptions::default(),
+                &WriteOptions::default(),
+            )
+            .await
+            .unwrap();
+        }
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+
+        let manifest = db.manifest();
+        assert!(manifest.l0().len() >= 2);
+
+        let result = count_in_range(
+            &manifest,
+            &sst_reader(object_store),
+            &BytesRange::unbounded(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.counts.num_puts, 10);
+        // covered_to comes from the SST with the highest last_entry — `k\x09`.
+        assert_eq!(result.covered_to.as_deref(), Some(&b"k\x09"[..]));
+    }
+
+    #[tokio::test]
+    async fn counts_tombstones_and_merges() {
+        let object_store: Arc<InMemory> = Arc::new(InMemory::new());
+        let merge_op: Arc<dyn MergeOperator> = Arc::new(ConcatMerger);
+        let db = DbBuilder::new(PATH, object_store.clone())
+            .with_merge_operator(Arc::new(
+                crate::storage::slate::SlateDbStorage::merge_operator_adapter(merge_op),
+            ))
+            .build()
+            .await
+            .unwrap();
+
+        // Use distinct keys: slatedb collapses same-key ops in the memtable
+        // before flush (put+delete -> tombstone, put+merge -> value), so we
+        // need one key per ValueDeletable variant to land in the SST.
+        db.put_with_options(
+            b"k1",
+            b"v1",
+            &PutOptions::default(),
+            &WriteOptions::default(),
+        )
+        .await
+        .unwrap();
+        db.put_with_options(
+            b"k2",
+            b"v2",
+            &PutOptions::default(),
+            &WriteOptions::default(),
+        )
+        .await
+        .unwrap();
+        db.delete(b"k3").await.unwrap();
+        let mut batch = slatedb::WriteBatch::new();
+        batch.merge(b"k4", b"operand");
+        db.write_with_options(batch, &WriteOptions::default())
+            .await
+            .unwrap();
+
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+
+        let result = count_in_range(
+            &db.manifest(),
+            &sst_reader(object_store),
+            &BytesRange::unbounded(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.counts.num_puts, 2);
+        assert_eq!(result.counts.num_deletes, 1);
+        assert_eq!(result.counts.num_merges, 1);
+    }
+
+    /// The contained-interior-at-top case: query.end falls exactly on a
+    /// block separator. The block just below is contained AND interior
+    /// (the SST has more data above). count must still produce an exact
+    /// answer by reading that block.
+    #[tokio::test]
+    async fn subrange_query_ending_at_block_boundary() {
+        // Build a DB with enough entries that 1 KiB blocks split frequently,
+        // then query `[k000, k100)` which is unlikely to align perfectly
+        // with a block boundary BUT exercises the "highest-overlapping is
+        // contained, SST has more data above" path for the SST containing
+        // entries below k100.
+        let entries = many_entries(250);
+        let entries_ref: Vec<(&[u8], &[u8])> = entries
+            .iter()
+            .map(|(k, v)| (k.as_slice(), v.as_slice()))
+            .collect();
+        let (db, object_store) = build_db_with_entries(&entries_ref).await;
+
+        let result = count_in_range(
+            &db.manifest(),
+            &sst_reader(object_store),
+            &mk_range(b"k000", b"k100"),
+        )
+        .await
+        .unwrap();
+        // Whether the boundary lands inside a block or on a separator, the
+        // contract is the same: exactly 100 puts, and the witness key is
+        // the highest one observed in `[k000, k100)`.
+        assert_eq!(result.counts.num_puts, 100);
+        assert_eq!(result.covered_to.as_deref(), Some(b"k099" as &[u8]));
+    }
+
+    #[test]
+    fn range_contains_cases() {
+        use Bound::*;
+        let b = |s: &[u8]| Bytes::copy_from_slice(s);
+        let r = |lo, hi| BytesRange::new(lo, hi);
+
+        // Unbounded outer contains anything
+        assert!(range_contains(
+            &BytesRange::unbounded(),
+            &r(Included(b(b"x")), Excluded(b(b"y"))),
+        ));
+        // Equal ranges contain each other
+        let eq = r(Included(b(b"a")), Excluded(b(b"z")));
+        assert!(range_contains(&eq, &eq));
+        // Strict containment
+        assert!(range_contains(
+            &r(Included(b(b"a")), Excluded(b(b"z"))),
+            &r(Included(b(b"c")), Excluded(b(b"d"))),
+        ));
+        // Inner extends below outer
+        assert!(!range_contains(
+            &r(Included(b(b"b")), Excluded(b(b"z"))),
+            &r(Included(b(b"a")), Excluded(b(b"d"))),
+        ));
+        // Inner extends above outer
+        assert!(!range_contains(
+            &r(Included(b(b"a")), Excluded(b(b"d"))),
+            &r(Included(b(b"a")), Excluded(b(b"z"))),
+        ));
+        // Outer Included(k) vs inner Excluded(k) — outer's lower allows points inner doesn't need
+        assert!(range_contains(
+            &r(Included(b(b"a")), Included(b(b"z"))),
+            &r(Excluded(b(b"a")), Excluded(b(b"z"))),
+        ));
+        // Outer Excluded(k) vs inner Included(k) at start — outer starts past k, inner needs k
+        assert!(!range_contains(
+            &r(Excluded(b(b"a")), Unbounded),
+            &r(Included(b(b"a")), Unbounded),
+        ));
+    }
+
+    #[test]
+    fn ranges_overlap_all_combinations() {
+        use Bound::*;
+        let b = |s: &[u8]| Bytes::copy_from_slice(s);
+
+        // Disjoint
+        assert!(!ranges_overlap(
+            &BytesRange::new(Included(b(b"a")), Excluded(b(b"b"))),
+            &BytesRange::new(Included(b(b"c")), Excluded(b(b"d"))),
+        ));
+        // Touching at exclusive boundary — no overlap
+        assert!(!ranges_overlap(
+            &BytesRange::new(Included(b(b"a")), Excluded(b(b"b"))),
+            &BytesRange::new(Included(b(b"b")), Excluded(b(b"c"))),
+        ));
+        // Overlapping
+        assert!(ranges_overlap(
+            &BytesRange::new(Included(b(b"a")), Excluded(b(b"c"))),
+            &BytesRange::new(Included(b(b"b")), Excluded(b(b"d"))),
+        ));
+        // Contained
+        assert!(ranges_overlap(
+            &BytesRange::new(Included(b(b"a")), Excluded(b(b"z"))),
+            &BytesRange::new(Included(b(b"b")), Excluded(b(b"c"))),
+        ));
+        // Unbounded
+        assert!(ranges_overlap(
+            &BytesRange::unbounded(),
+            &BytesRange::new(Included(b(b"a")), Excluded(b(b"b"))),
+        ));
+        // Inclusive upper meets inclusive lower — overlap at the shared point
+        assert!(ranges_overlap(
+            &BytesRange::new(Included(b(b"a")), Included(b(b"b"))),
+            &BytesRange::new(Included(b(b"b")), Included(b(b"c"))),
+        ));
+    }
+}

--- a/common/src/storage/sst_blocks.rs
+++ b/common/src/storage/sst_blocks.rs
@@ -27,12 +27,16 @@
 //!
 //! ## Why the back-scan
 //!
-//! SlateDB's index returns separator keys, not first keys: `sep[i] <=
-//! first_key(block i)`. So a block's separator can place it "inside" the
-//! query while every real key in the block sits above `query.end`. Picking
-//! the highest *overlapping-by-separator* block as the witness can yield a
-//! block with zero in-query rows. The back-scan tolerates this by
-//! continuing downward until a block actually contributes.
+//! SlateDB's index stores separators, not first keys. A separator is the
+//! shortest prefix of `first_key(block i)` that is still strictly greater
+//! than `last_key(block i-1)` — so `sep[i] <= first_key(block i)`, often
+//! strict (e.g. for blocks ending at `k230` and starting at `k280`, the
+//! separator is `k28`). A block's separator can therefore place it
+//! "inside" the query while every real key in the block sits above
+//! `query.end`. Picking the highest *overlapping-by-separator* block as
+//! the witness can yield a block with zero in-query rows. The back-scan
+//! tolerates this by continuing downward until a block actually
+//! contributes.
 //!
 //! ## Known gap
 //!
@@ -141,16 +145,11 @@ async fn count_view(
         .filter(|i| ranges_overlap(query, &block_key_range(&index, *i, last_entry.as_ref())))
         .collect();
 
-    // Back-scan: walk overlapping blocks high-to-low, reading each, until we
-    // find one with actual in-query rows. SlateDB's index returns separator
-    // keys rather than first keys (`sep[i] <= first_key(block i)`), so a
-    // block's separator can place it inside the query while its real keys
-    // all sit above `query.end`. See the module-level "Why the back-scan"
-    // section for the full rationale. The witness block — first one with
-    // non-empty in-query content from the top — pins down `covered_to`.
-    // Blocks scanned above the witness held nothing in query (already
-    // accounted for as zero); blocks below get the cheap stats path on the
-    // second pass.
+    // Back-scan: walk overlapping blocks high-to-low, reading each, until
+    // we find one with in-query rows (see the module-level "Why the
+    // back-scan" section for the rationale). That witness pins down
+    // `covered_to`; blocks above contributed nothing (counted as zero),
+    // blocks below get the cheap stats path on the second pass.
     let mut witness_pos: Option<usize> = None;
     for pos in (0..overlapping.len()).rev() {
         let i = overlapping[pos];

--- a/common/src/storage/sst_blocks.rs
+++ b/common/src/storage/sst_blocks.rs
@@ -142,13 +142,15 @@ async fn count_view(
         .collect();
 
     // Back-scan: walk overlapping blocks high-to-low, reading each, until we
-    // find one with actual in-query rows. SlateDB's index returns truncated
-    // separators (`sep[i] <= first_key(block i)`), so a block's separator can
-    // place it inside the query while its real keys all sit above `query.end`.
-    // The witness block — first one with non-empty in-query content from the
-    // top — pins down `covered_to`. Blocks scanned above the witness held
-    // nothing in query (already accounted for as zero); blocks below get the
-    // cheap stats path on the second pass.
+    // find one with actual in-query rows. SlateDB's index returns separator
+    // keys rather than first keys (`sep[i] <= first_key(block i)`), so a
+    // block's separator can place it inside the query while its real keys
+    // all sit above `query.end`. See the module-level "Why the back-scan"
+    // section for the full rationale. The witness block — first one with
+    // non-empty in-query content from the top — pins down `covered_to`.
+    // Blocks scanned above the witness held nothing in query (already
+    // accounted for as zero); blocks below get the cheap stats path on the
+    // second pass.
     let mut witness_pos: Option<usize> = None;
     for pos in (0..overlapping.len()).rev() {
         let i = overlapping[pos];

--- a/log/c/include/opendata_log.h
+++ b/log/c/include/opendata_log.h
@@ -70,10 +70,6 @@ typedef struct opendata_log_seq_range_t {
   struct opendata_log_seq_bound_t end;
 } opendata_log_seq_range_t;
 
-typedef struct opendata_log_count_options_t {
-  bool approximate;
-} opendata_log_count_options_t;
-
 typedef struct opendata_log_segment_bound_t {
   uint8_t kind;
   uint32_t value;
@@ -134,13 +130,6 @@ struct opendata_log_result_t opendata_log_count(const struct opendata_log_t *log
                                                 const struct opendata_log_seq_range_t *seq_range,
                                                 uint64_t *out_count);
 
-struct opendata_log_result_t opendata_log_count_with_options(const struct opendata_log_t *log,
-                                                             const uint8_t *key,
-                                                             uintptr_t key_len,
-                                                             const struct opendata_log_seq_range_t *seq_range,
-                                                             const struct opendata_log_count_options_t *options,
-                                                             uint64_t *out_count);
-
 struct opendata_log_result_t opendata_log_list_keys(const struct opendata_log_t *log,
                                                     const struct opendata_log_segment_range_t *segment_range,
                                                     struct opendata_log_key_iterator_t **out_iterator);
@@ -200,13 +189,6 @@ struct opendata_log_result_t opendata_log_reader_count(const struct opendata_log
                                                        uintptr_t key_len,
                                                        const struct opendata_log_seq_range_t *seq_range,
                                                        uint64_t *out_count);
-
-struct opendata_log_result_t opendata_log_reader_count_with_options(const struct opendata_log_reader_t *reader,
-                                                                    const uint8_t *key,
-                                                                    uintptr_t key_len,
-                                                                    const struct opendata_log_seq_range_t *seq_range,
-                                                                    const struct opendata_log_count_options_t *options,
-                                                                    uint64_t *out_count);
 
 struct opendata_log_result_t opendata_log_reader_list_keys(const struct opendata_log_reader_t *reader,
                                                            const struct opendata_log_segment_range_t *segment_range,

--- a/log/c/src/db.rs
+++ b/log/c/src/db.rs
@@ -261,55 +261,6 @@ pub unsafe extern "C" fn opendata_log_count(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn opendata_log_count_with_options(
-    log: *const opendata_log_t,
-    key: *const u8,
-    key_len: usize,
-    seq_range: *const opendata_log_seq_range_t,
-    options: *const opendata_log_count_options_t,
-    out_count: *mut u64,
-) -> opendata_log_result_t {
-    if let Err(e) = require_handle(log, "log") {
-        return e;
-    }
-    if let Err(e) = require_handle(seq_range, "seq_range") {
-        return e;
-    }
-    if let Err(e) = require_handle(options, "options") {
-        return e;
-    }
-
-    let key_bytes = match bytes_from_ptr(key, key_len, "key") {
-        Ok(b) => Bytes::copy_from_slice(b),
-        Err(e) => return e,
-    };
-
-    let range = match convert_seq_range(&*seq_range) {
-        Ok(r) => r,
-        Err(e) => return e,
-    };
-
-    let rust_options = log::CountOptions {
-        approximate: (*options).approximate,
-    };
-
-    let handle = &*log;
-    match handle.runtime.block_on(
-        handle
-            .log
-            .count_with_options(key_bytes, range, rust_options),
-    ) {
-        Ok(count) => {
-            if !out_count.is_null() {
-                *out_count = count;
-            }
-            success_result()
-        }
-        Err(e) => error_from_log_error(&e),
-    }
-}
-
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn opendata_log_list_keys(
     log: *const opendata_log_t,
     segment_range: *const opendata_log_segment_range_t,

--- a/log/c/src/ffi.rs
+++ b/log/c/src/ffi.rs
@@ -110,11 +110,6 @@ pub struct opendata_log_segment_range_t {
 }
 
 #[repr(C)]
-pub struct opendata_log_count_options_t {
-    pub approximate: bool,
-}
-
-#[repr(C)]
 pub struct opendata_log_segment_t {
     pub id: u32,
     pub start_seq: u64,

--- a/log/c/src/reader.rs
+++ b/log/c/src/reader.rs
@@ -139,55 +139,6 @@ pub unsafe extern "C" fn opendata_log_reader_count(
 }
 
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn opendata_log_reader_count_with_options(
-    reader: *const opendata_log_reader_t,
-    key: *const u8,
-    key_len: usize,
-    seq_range: *const opendata_log_seq_range_t,
-    options: *const opendata_log_count_options_t,
-    out_count: *mut u64,
-) -> opendata_log_result_t {
-    if let Err(e) = require_handle(reader, "reader") {
-        return e;
-    }
-    if let Err(e) = require_handle(seq_range, "seq_range") {
-        return e;
-    }
-    if let Err(e) = require_handle(options, "options") {
-        return e;
-    }
-
-    let key_bytes = match bytes_from_ptr(key, key_len, "key") {
-        Ok(b) => Bytes::copy_from_slice(b),
-        Err(e) => return e,
-    };
-
-    let range = match convert_seq_range(&*seq_range) {
-        Ok(r) => r,
-        Err(e) => return e,
-    };
-
-    let rust_options = log::CountOptions {
-        approximate: (*options).approximate,
-    };
-
-    let handle = &*reader;
-    match handle.runtime.block_on(
-        handle
-            .reader
-            .count_with_options(key_bytes, range, rust_options),
-    ) {
-        Ok(count) => {
-            if !out_count.is_null() {
-                *out_count = count;
-            }
-            success_result()
-        }
-        Err(e) => error_from_log_error(&e),
-    }
-}
-
-#[unsafe(no_mangle)]
 pub unsafe extern "C" fn opendata_log_reader_list_keys(
     reader: *const opendata_log_reader_t,
     segment_range: *const opendata_log_segment_range_t,

--- a/log/src/config.rs
+++ b/log/src/config.rs
@@ -143,23 +143,6 @@ pub struct ScanOptions {
     // - cache_policy: control block cache behavior
 }
 
-/// Options for count operations.
-///
-/// Controls the behavior of [`LogRead::count`](crate::LogRead::count) and
-/// [`LogRead::count_with_options`](crate::LogRead::count_with_options).
-#[derive(Debug, Clone, Default)]
-pub struct CountOptions {
-    /// Whether to return an approximate count.
-    ///
-    /// When `true`, the count may be computed from index metadata without
-    /// reading individual entries, providing faster results at the cost
-    /// of accuracy. Useful for progress indicators and lag estimation.
-    ///
-    /// When `false` (the default), an exact count is computed by scanning
-    /// the relevant index entries.
-    pub approximate: bool,
-}
-
 /// Configuration for opening a [`LogDbReader`](crate::LogDbReader).
 ///
 /// This struct holds settings for read-only log access, including storage

--- a/log/src/direct.rs
+++ b/log/src/direct.rs
@@ -1,0 +1,86 @@
+//! Direct slatedb access for LogDb's count path.
+//!
+//! Mirrors slatedb's own writer/reader split: [`LogDirect`] is a
+//! read-only handle that exposes a manifest snapshot and an `SstReader`
+//! pinned to the same path + object store. Constructed independently of
+//! `SlateDbStorage` so its block cache and `DbReader` polling interval
+//! can be tuned without affecting the writer.
+//!
+//! LogDb's count flow uses [`LogDirect`] when present to walk persisted
+//! SSTs via [`common::storage::sst_blocks::count_in_range`]; without it,
+//! count falls back to a plain scan.
+
+use std::sync::Arc;
+
+use common::storage::config::{SlateDbStorageConfig, StorageConfig};
+use common::storage::factory::create_object_store;
+use common::{BytesRange, StorageError, StorageResult, storage::sst_blocks};
+use slatedb::DbReader;
+use slatedb::SstReader;
+use slatedb::config::DbReaderOptions;
+use slatedb::db_cache::DbCache;
+
+/// LogDb's slatedb-direct read handle.
+///
+/// Holds a `DbReader` (for live manifest snapshots) plus an `SstReader`
+/// (for SST-level reads). Both are independent of the writer's `Db` —
+/// they can use a separate block cache and polling interval.
+pub(crate) struct LogDirect {
+    reader: Arc<DbReader>,
+    sst_reader: SstReader,
+}
+
+impl LogDirect {
+    /// Builds a `LogDirect` backed by a fresh `DbReader` against the same
+    /// path/object store. The optional block cache is used for SST block
+    /// lookups; `None` is permitted but reads will hit object storage on
+    /// every block fetch.
+    pub(crate) async fn from_config(
+        config: &SlateDbStorageConfig,
+        block_cache: Option<Arc<dyn DbCache>>,
+    ) -> StorageResult<Self> {
+        let object_store = create_object_store(&config.object_store)?;
+        let mut builder = DbReader::builder(config.path.clone(), object_store.clone())
+            .with_options(DbReaderOptions::default());
+        if let Some(cache) = block_cache.clone() {
+            builder = builder.with_db_cache(cache);
+        }
+        let reader = builder.build().await.map_err(|e| {
+            StorageError::Storage(format!("Failed to create LogDirect DbReader: {}", e))
+        })?;
+        let sst_reader = SstReader::new(config.path.clone(), object_store, block_cache, None);
+        Ok(Self {
+            reader: Arc::new(reader),
+            sst_reader,
+        })
+    }
+
+    /// Builds a `LogDirect` only when `config` is slatedb-backed. Returns
+    /// `Ok(None)` for in-memory configs.
+    pub(crate) async fn maybe_from_storage_config(
+        config: &StorageConfig,
+    ) -> StorageResult<Option<Self>> {
+        match config {
+            StorageConfig::SlateDb(slate) => Ok(Some(Self::from_config(slate, None).await?)),
+            StorageConfig::InMemory => Ok(None),
+        }
+    }
+
+    /// Test helper: build from already-constructed slatedb components, so the
+    /// caller can share the underlying object store with another handle.
+    #[cfg(test)]
+    pub(crate) fn from_components(reader: Arc<DbReader>, sst_reader: SstReader) -> Self {
+        Self { reader, sst_reader }
+    }
+
+    /// Counts records in `range` by walking the manifest's persisted
+    /// SSTs. Returns counts plus a witness key for the highest counted
+    /// entry; callers wanting writes still in the memtable should scan
+    /// `(covered_to, range.end)` themselves.
+    pub(crate) async fn count_in_range(
+        &self,
+        range: &BytesRange,
+    ) -> StorageResult<sst_blocks::CountResult> {
+        sst_blocks::count_in_range(&self.reader.manifest(), &self.sst_reader, range).await
+    }
+}

--- a/log/src/direct.rs
+++ b/log/src/direct.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use common::storage::config::{SlateDbStorageConfig, StorageConfig};
+use common::storage::config::{ObjectStoreConfig, SlateDbStorageConfig, StorageConfig};
 use common::storage::factory::create_object_store;
 use common::{BytesRange, StorageError, StorageResult, storage::sst_blocks};
 use slatedb::DbReader;
@@ -55,13 +55,21 @@ impl LogDirect {
         })
     }
 
-    /// Builds a `LogDirect` only when `config` is slatedb-backed. Returns
-    /// `Ok(None)` for in-memory configs.
+    /// Builds a `LogDirect` only when `config` is slatedb-backed by a
+    /// persistent object store. Returns `Ok(None)` for in-memory configs
+    /// and for slatedb configs whose object store is `InMemory` —
+    /// `InMemory` instances are process-local, so a fresh one built here
+    /// would never see the writer's data (and `DbReader::build` would
+    /// fail outright on the empty store). Count falls back to scanning
+    /// the writer's storage in that case.
     pub(crate) async fn maybe_from_storage_config(
         config: &StorageConfig,
     ) -> StorageResult<Option<Self>> {
         match config {
-            StorageConfig::SlateDb(slate) => Ok(Some(Self::from_config(slate, None).await?)),
+            StorageConfig::SlateDb(slate) => match slate.object_store {
+                ObjectStoreConfig::InMemory => Ok(None),
+                _ => Ok(Some(Self::from_config(slate, None).await?)),
+            },
             StorageConfig::InMemory => Ok(None),
         }
     }

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -47,6 +47,7 @@
 //! ```
 
 mod config;
+mod direct;
 mod error;
 mod listing;
 mod log;
@@ -61,7 +62,7 @@ mod storage;
 mod view_tracker;
 mod writer;
 
-pub use config::{Config, CountOptions, ReadVisibility, ReaderConfig, ScanOptions, SegmentConfig};
+pub use config::{Config, ReadVisibility, ReaderConfig, ScanOptions, SegmentConfig};
 pub use error::{AppendError, AppendResult, Error, Result};
 pub use listing::{LogKey, LogKeyIterator};
 pub use log::{LogDb, LogDbBuilder};

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -18,7 +18,7 @@ use tokio::sync::RwLock;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
-use crate::config::{CountOptions, ReadVisibility, ScanOptions, SegmentConfig};
+use crate::config::{ReadVisibility, ScanOptions, SegmentConfig};
 use crate::error::{AppendResult, Error, Result};
 use crate::listing::ListingCache;
 use crate::listing::LogKeyIterator;
@@ -314,18 +314,47 @@ impl LogDb {
     /// Creates a LogDb from an existing storage implementation.
     #[cfg(test)]
     pub(crate) async fn new(storage: Arc<dyn common::Storage>) -> Result<Self> {
-        Self::from_storage(storage, SegmentConfig::default(), ReadVisibility::Memory).await
+        Self::from_storage(
+            storage,
+            None,
+            SegmentConfig::default(),
+            ReadVisibility::Memory,
+        )
+        .await
+    }
+
+    /// Creates a LogDb with a paired `LogDirect` handle so tests can
+    /// exercise the SST-walk count path.
+    #[cfg(test)]
+    pub(crate) async fn new_with_direct(
+        storage: Arc<dyn common::Storage>,
+        direct: Arc<crate::direct::LogDirect>,
+    ) -> Result<Self> {
+        Self::from_storage(
+            storage,
+            Some(direct),
+            SegmentConfig::default(),
+            ReadVisibility::Memory,
+        )
+        .await
     }
 
     /// Creates a LogDb with `ReadVisibility::Remote` from an existing storage implementation.
     #[cfg(test)]
     pub(crate) async fn new_durable(storage: Arc<dyn common::Storage>) -> Result<Self> {
-        Self::from_storage(storage, SegmentConfig::default(), ReadVisibility::Remote).await
+        Self::from_storage(
+            storage,
+            None,
+            SegmentConfig::default(),
+            ReadVisibility::Remote,
+        )
+        .await
     }
 
     /// Shared construction logic used by both `LogDb::new` and `LogDbBuilder::build`.
     async fn from_storage(
         storage: Arc<dyn common::Storage>,
+        direct: Option<Arc<crate::direct::LogDirect>>,
         segment_config: SegmentConfig,
         read_visibility: ReadVisibility,
     ) -> Result<Self> {
@@ -358,6 +387,7 @@ impl LogDb {
         let initial_segment_id = segment_cache.latest().map(|s| s.id());
         let read_view = Arc::new(RwLock::new(LogReadView::new(
             snapshot as Arc<dyn common::StorageRead>,
+            direct,
             segment_cache,
         )));
 
@@ -399,13 +429,11 @@ impl LogRead for LogDb {
         Ok(view.scan_with_options(key, seq_range, &options))
     }
 
-    async fn count_with_options(
-        &self,
-        _key: Bytes,
-        _seq_range: impl RangeBounds<Sequence> + Send,
-        _options: CountOptions,
-    ) -> Result<u64> {
-        todo!()
+    async fn count(&self, key: Bytes, seq_range: impl RangeBounds<Sequence> + Send) -> Result<u64> {
+        self.sync_reads().await?;
+        let seq_range = normalize_sequence(&seq_range);
+        let view = self.read_view.read().await;
+        view.count(key, seq_range).await
     }
 
     async fn list_keys(
@@ -498,8 +526,14 @@ impl LogDbBuilder {
             .await
             .map_err(|e| Error::Storage(e.to_string()))?;
 
+        let direct = crate::direct::LogDirect::maybe_from_storage_config(&self.config.storage)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?
+            .map(Arc::new);
+
         LogDb::from_storage(
             storage,
+            direct,
             self.config.segmentation,
             self.config.read_visibility,
         )
@@ -1897,6 +1931,223 @@ mod tests {
         assert_eq!(segments[0].start_seq, 0);
     }
 
+    #[tokio::test]
+    async fn count_returns_zero_for_empty_log() {
+        let log = LogDb::open(test_config()).await.unwrap();
+        let n = log.count(Bytes::from("k"), ..).await.unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[tokio::test]
+    async fn count_counts_every_entry_for_key() {
+        let log = LogDb::open(test_config()).await.unwrap();
+        log.try_append(
+            (0..10)
+                .map(|i| Record {
+                    key: Bytes::from("orders"),
+                    value: Bytes::from(format!("order-{i}")),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+        let n = log.count(Bytes::from("orders"), ..).await.unwrap();
+        assert_eq!(n, 10);
+    }
+
+    #[tokio::test]
+    async fn count_isolates_per_key() {
+        let log = LogDb::open(test_config()).await.unwrap();
+        log.try_append(vec![
+            Record {
+                key: Bytes::from("a"),
+                value: Bytes::from("1"),
+            },
+            Record {
+                key: Bytes::from("b"),
+                value: Bytes::from("1"),
+            },
+            Record {
+                key: Bytes::from("a"),
+                value: Bytes::from("2"),
+            },
+            Record {
+                key: Bytes::from("b"),
+                value: Bytes::from("2"),
+            },
+        ])
+        .await
+        .unwrap();
+        assert_eq!(log.count(Bytes::from("a"), ..).await.unwrap(), 2);
+        assert_eq!(log.count(Bytes::from("b"), ..).await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn count_respects_sequence_range() {
+        let log = LogDb::open(test_config()).await.unwrap();
+        log.try_append(
+            (0..10)
+                .map(|i| Record {
+                    key: Bytes::from("events"),
+                    value: Bytes::from(format!("event-{i}")),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+        // [3, 7) covers seqs 3,4,5,6 — 4 entries.
+        assert_eq!(log.count(Bytes::from("events"), 3..7).await.unwrap(), 4);
+        // Lower bound only.
+        assert_eq!(log.count(Bytes::from("events"), 5..).await.unwrap(), 5);
+        // Upper bound only.
+        assert_eq!(log.count(Bytes::from("events"), ..4).await.unwrap(), 4);
+        // Out-of-range upper.
+        assert_eq!(log.count(Bytes::from("events"), 100..200).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn count_sees_writes_without_flush() {
+        // Mirrors should_scan_without_flush — count's internal sync_reads must
+        // pull in unflushed writes the same way scan does.
+        let log = LogDb::open(test_config()).await.unwrap();
+        log.try_append(vec![
+            Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v0"),
+            },
+            Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v1"),
+            },
+        ])
+        .await
+        .unwrap();
+        assert_eq!(log.count(Bytes::from("k"), ..).await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn count_spans_multiple_segments() {
+        // Segments roll on a 1-byte seal_interval (effectively every write).
+        // The count path has to fan out across segments and stitch the
+        // per-segment counts back together.
+        let config = Config {
+            storage: StorageConfig::InMemory,
+            segmentation: SegmentConfig {
+                seal_interval: Some(Duration::from_nanos(1)),
+            },
+            ..Default::default()
+        };
+        let log = LogDb::open(config).await.unwrap();
+        for i in 0..5u8 {
+            log.try_append(vec![Record {
+                key: Bytes::from("k"),
+                value: Bytes::from(vec![i]),
+            }])
+            .await
+            .unwrap();
+            // Small sleep so seal_interval triggers a fresh segment.
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        let segments = log.list_segments(..).await.unwrap();
+        assert!(segments.len() >= 2, "expected multiple segments");
+        assert_eq!(log.count(Bytes::from("k"), ..).await.unwrap(), 5);
+    }
+
+    #[tokio::test]
+    async fn count_via_log_reader() {
+        // LogDbReader shares storage with LogDb; what the writer flushes,
+        // the reader counts. Mirrors `should_scan_entries_via_log_reader`.
+        let storage = StorageBuilder::new(&StorageConfig::InMemory)
+            .await
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        let log = LogDb::new(storage.clone()).await.unwrap();
+        log.try_append(
+            (0..5)
+                .map(|i| Record {
+                    key: Bytes::from("orders"),
+                    value: Bytes::from(format!("order-{i}")),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+        log.flush().await.unwrap();
+
+        let reader = LogDbReader::new(storage).await.unwrap();
+        assert_eq!(reader.count(Bytes::from("orders"), ..).await.unwrap(), 5);
+        assert_eq!(reader.count(Bytes::from("orders"), 1..4).await.unwrap(), 3);
+        assert_eq!(
+            reader.count(Bytes::from("nonexistent"), ..).await.unwrap(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn count_across_segments_via_log_reader() {
+        // The reader's fan-out across segments is the same code path as
+        // LogDb's (LogReadView::count), but this asserts that the reader's
+        // segment cache is populated correctly to see all segments.
+        let storage = StorageBuilder::new(&StorageConfig::InMemory)
+            .await
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        let log = LogDb::from_storage(
+            storage.clone(),
+            None,
+            SegmentConfig {
+                seal_interval: Some(Duration::from_nanos(1)),
+            },
+            ReadVisibility::Memory,
+        )
+        .await
+        .unwrap();
+        for i in 0..5u8 {
+            log.try_append(vec![Record {
+                key: Bytes::from("k"),
+                value: Bytes::from(vec![i]),
+            }])
+            .await
+            .unwrap();
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+        log.flush().await.unwrap();
+
+        let reader = LogDbReader::new(storage).await.unwrap();
+        let segments = reader.list_segments(..).await.unwrap();
+        assert!(segments.len() >= 2, "expected multiple segments");
+        assert_eq!(reader.count(Bytes::from("k"), ..).await.unwrap(), 5);
+    }
+
+    #[tokio::test]
+    async fn slate_reader_count_sees_flushed_data() {
+        // Slatedb-backed reader: writes go through LogDb, get flushed, then
+        // the reader's count_in_range path walks the same manifest.
+        let (storage, direct) = slate_storage_with_direct().await;
+        let log = LogDb::new_with_direct(storage.clone(), direct.clone())
+            .await
+            .unwrap();
+        log.try_append(
+            (0..10u8)
+                .map(|i| Record {
+                    key: Bytes::from("k"),
+                    value: Bytes::from(vec![i]),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+        log.flush().await.unwrap();
+
+        let reader = LogDbReader::new_with_direct(storage, direct).await.unwrap();
+        assert_eq!(reader.count(Bytes::from("k"), ..).await.unwrap(), 10);
+        assert_eq!(reader.count(Bytes::from("k"), 2..7).await.unwrap(), 5);
+    }
+
     /// Helper: creates a SlateDB-backed storage using an in-memory object store.
     /// With `start_paused = true`, SlateDB's WAL flush timer is frozen so writes
     /// remain non-durable until an explicit `flush()` call.
@@ -1905,12 +2156,48 @@ mod tests {
         use slatedb::DbBuilder;
         use slatedb::object_store::memory::InMemory;
 
+        let path = "/test/read_durable";
         let object_store = Arc::new(InMemory::new());
-        let db = DbBuilder::new("/test/read_durable", object_store)
+        let db = DbBuilder::new(path, object_store).build().await.unwrap();
+        Arc::new(SlateDbStorage::new(Arc::new(db)))
+    }
+
+    /// Same as [`slate_storage`] but also builds a [`LogDirect`] handle
+    /// sharing the same in-memory object store. `InMemory` instances are
+    /// process-local, so storage and direct must share the same `Arc` for
+    /// the direct path to see what storage writes.
+    async fn slate_storage_with_direct() -> (Arc<dyn common::Storage>, Arc<crate::direct::LogDirect>)
+    {
+        use common::storage::slate::SlateDbStorage;
+        use slatedb::config::DbReaderOptions;
+        use slatedb::object_store::memory::InMemory;
+        use slatedb::{DbBuilder, DbReader, SstReader};
+
+        let path = "/test/slate_with_direct";
+        let object_store: Arc<dyn slatedb::object_store::ObjectStore> = Arc::new(InMemory::new());
+        let db = Arc::new(
+            DbBuilder::new(path, object_store.clone())
+                .build()
+                .await
+                .unwrap(),
+        );
+        let storage: Arc<dyn common::Storage> = Arc::new(SlateDbStorage::new(db));
+
+        // Short manifest poll interval so the reader picks up freshly-
+        // flushed writes quickly — otherwise the slate count tests would
+        // race the default 1s polling tick.
+        let reader_options = DbReaderOptions {
+            manifest_poll_interval: Duration::from_millis(5),
+            ..Default::default()
+        };
+        let reader = DbReader::builder(path, object_store.clone())
+            .with_options(reader_options)
             .build()
             .await
             .unwrap();
-        Arc::new(SlateDbStorage::new(Arc::new(db)))
+        let sst_reader = SstReader::new(path, object_store, None, None);
+        let direct = crate::direct::LogDirect::from_components(Arc::new(reader), sst_reader);
+        (storage, Arc::new(direct))
     }
 
     #[tokio::test(start_paused = true)]
@@ -2042,5 +2329,50 @@ mod tests {
         let entry = iter.next().await.unwrap().unwrap();
         assert_eq!(entry.value, Bytes::from("value1"));
         assert!(iter.next().await.unwrap().is_none());
+    }
+
+    /// Exercises the count_in_range + scan split on slatedb-backed storage.
+    /// We write N entries, flush so some land in an L0 SST, then write more
+    /// without flushing — count must include both the SST-flushed prefix
+    /// (via the manifest walk) and the memtable tail (via the scan above
+    /// covered_to).
+    #[tokio::test]
+    async fn slate_count_sees_both_flushed_and_unflushed() {
+        let (storage, direct) = slate_storage_with_direct().await;
+        let log = LogDb::new_with_direct(storage, direct).await.unwrap();
+
+        // First batch — flush to put these into an L0 SST.
+        log.try_append(
+            (0..5u8)
+                .map(|i| Record {
+                    key: Bytes::from("k"),
+                    value: Bytes::from(vec![i]),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+        log.flush().await.unwrap();
+
+        // Second batch — leave in the memtable.
+        log.try_append(
+            (5..10u8)
+                .map(|i| Record {
+                    key: Bytes::from("k"),
+                    value: Bytes::from(vec![i]),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(log.count(Bytes::from("k"), ..).await.unwrap(), 10);
+        // Range that ends inside the flushed prefix — only count_in_range
+        // contributes, scan portion is empty.
+        assert_eq!(log.count(Bytes::from("k"), ..3).await.unwrap(), 3);
+        // Range that starts inside the unflushed tail — only the scan side
+        // should contribute (covered_to from count_in_range is below the
+        // range start, so scan_lo gets pulled to seg_lo).
+        assert_eq!(log.count(Bytes::from("k"), 7..).await.unwrap(), 3);
     }
 }

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -210,11 +210,7 @@ pub trait LogRead {
 /// segments come back ordered, and each segment owns sequences up to the
 /// next segment's `start_seq`. The last segment in the covering set has no
 /// successor, so its upper bound is taken from `query.end`.
-fn segment_window(
-    segments: &[LogSegment],
-    i: usize,
-    query: &Range<Sequence>,
-) -> Range<Sequence> {
+fn segment_window(segments: &[LogSegment], i: usize, query: &Range<Sequence>) -> Range<Sequence> {
     let next_start = segments
         .get(i + 1)
         .map(|s| s.meta().start_seq)
@@ -325,11 +321,9 @@ impl LogReadView {
         let mut total = result.counts.num_puts;
 
         let scan_lo = match result.covered_to {
-            Some(covered_key) => {
-                LogEntryKey::deserialize(&covered_key, segment.meta().start_seq)?
-                    .sequence
-                    .saturating_add(1)
-            }
+            Some(covered_key) => LogEntryKey::deserialize(&covered_key, segment.meta().start_seq)?
+                .sequence
+                .saturating_add(1),
             None => window.start,
         };
         if scan_lo < window.end {

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -15,12 +15,14 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio::time::MissedTickBehavior;
 
-use crate::config::{CountOptions, ReaderConfig, ScanOptions, SegmentConfig};
+use crate::config::{ReaderConfig, ScanOptions, SegmentConfig};
+use crate::direct::LogDirect;
 use crate::error::{Error, Result};
 use crate::listing::LogKeyIterator;
 use crate::model::{LogEntry, Segment, SegmentId, Sequence};
 use crate::range::{normalize_segment_id, normalize_sequence};
 use crate::segment::{LogSegment, SegmentCache};
+use crate::serde::LogEntryKey;
 use crate::storage::{LogStorageRead as _, SegmentIterator};
 use common::storage::factory::create_storage_read;
 use common::{StorageRead, StorageReaderRuntime, StorageSemantics};
@@ -109,12 +111,9 @@ pub trait LogRead {
 
     /// Counts entries for a key within a sequence number range.
     ///
-    /// Returns the number of entries in the specified range. This is useful
+    /// Returns the exact number of entries in the specified range. Useful
     /// for computing lag (how far behind a consumer is) or progress metrics.
     ///
-    /// This method uses default count options (exact count). Use
-    /// [`count_with_options`] for approximate counts.
-    ///
     /// # Arguments
     ///
     /// * `key` - The key identifying the log stream to count.
@@ -123,30 +122,7 @@ pub trait LogRead {
     /// # Errors
     ///
     /// Returns an error if the count fails due to storage issues.
-    ///
-    /// [`count_with_options`]: LogRead::count_with_options
-    async fn count(&self, key: Bytes, seq_range: impl RangeBounds<Sequence> + Send) -> Result<u64> {
-        self.count_with_options(key, seq_range, CountOptions::default())
-            .await
-    }
-
-    /// Counts entries for a key within a sequence number range with custom options.
-    ///
-    /// # Arguments
-    ///
-    /// * `key` - The key identifying the log stream to count.
-    /// * `seq_range` - The sequence number range to count.
-    /// * `options` - Count options, including whether to return an approximate count.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the count fails due to storage issues.
-    async fn count_with_options(
-        &self,
-        key: Bytes,
-        seq_range: impl RangeBounds<Sequence> + Send,
-        options: CountOptions,
-    ) -> Result<u64>;
+    async fn count(&self, key: Bytes, seq_range: impl RangeBounds<Sequence> + Send) -> Result<u64>;
 
     /// Lists distinct keys within a segment range.
     ///
@@ -227,19 +203,49 @@ pub trait LogRead {
     ) -> Result<Vec<Segment>>;
 }
 
+/// Clips `query` to the sequence window owned by `segments[i]`.
+///
+/// Relies on the tiling guarantee from
+/// [`SegmentCache::find_covering`](crate::segment::SegmentCache::find_covering):
+/// segments come back ordered, and each segment owns sequences up to the
+/// next segment's `start_seq`. The last segment in the covering set has no
+/// successor, so its upper bound is taken from `query.end`.
+fn segment_window(
+    segments: &[LogSegment],
+    i: usize,
+    query: &Range<Sequence>,
+) -> Range<Sequence> {
+    let next_start = segments
+        .get(i + 1)
+        .map(|s| s.meta().start_seq)
+        .unwrap_or(u64::MAX);
+    let lo = query.start.max(segments[i].meta().start_seq);
+    let hi = query.end.min(next_start);
+    lo..hi
+}
+
 /// Shared read component used by both `LogDb` and `LogDbReader`.
 ///
 /// Contains the storage and segment cache needed for read operations.
 /// Wrapped in `Arc<RwLock<_>>` by both consumers.
 pub(crate) struct LogReadView {
     pub(crate) storage: Arc<dyn StorageRead>,
+    pub(crate) direct: Option<Arc<LogDirect>>,
     pub(crate) segments: SegmentCache,
 }
 
 impl LogReadView {
     /// Creates a new `LogReadView`.
-    pub(crate) fn new(storage: Arc<dyn StorageRead>, segments: SegmentCache) -> Self {
-        Self { storage, segments }
+    pub(crate) fn new(
+        storage: Arc<dyn StorageRead>,
+        direct: Option<Arc<LogDirect>>,
+        segments: SegmentCache,
+    ) -> Self {
+        Self {
+            storage,
+            direct,
+            segments,
+        }
     }
 
     /// Replaces the underlying storage snapshot with a new one.
@@ -269,6 +275,71 @@ impl LogReadView {
         _options: &ScanOptions,
     ) -> LogIterator {
         LogIterator::open(Arc::clone(&self.storage), &self.segments, key, seq_range)
+    }
+
+    /// Counts entries for `key` in `seq_range`, exact.
+    ///
+    /// Fans out across overlapping segments — clipped to each segment's
+    /// window. When [`LogDirect`] is available, walks persisted SSTs via
+    /// `count_in_range` for the bulk count and scans `(covered_to, seg_hi)`
+    /// to pick up anything still in the memtable. Otherwise falls back to
+    /// a plain scan tally.
+    pub(crate) async fn count(&self, key: Bytes, seq_range: Range<Sequence>) -> Result<u64> {
+        let segments = self.segments.find_covering(&seq_range);
+        let mut total = 0u64;
+        for (i, segment) in segments.iter().enumerate() {
+            let window = segment_window(&segments, i, &seq_range);
+            if window.start >= window.end {
+                continue;
+            }
+            let n = match self.direct.as_deref() {
+                Some(direct) => {
+                    self.count_segment_via_direct(direct, segment, &key, window)
+                        .await?
+                }
+                None => self.storage.count_entries(segment, &key, window).await?,
+            };
+            total = total.saturating_add(n);
+        }
+        Ok(total)
+    }
+
+    /// Counts entries in a single segment slice using [`LogDirect`].
+    ///
+    /// Walks persisted SSTs via `count_in_range` and tops up with a tail
+    /// scan above the witness key. The tail scan covers two cases at once:
+    /// writes still in the memtable, and writes flushed since `direct`'s
+    /// manifest snapshot was taken (the DbReader polls, so its view can lag
+    /// the writer).
+    async fn count_segment_via_direct(
+        &self,
+        direct: &LogDirect,
+        segment: &LogSegment,
+        key: &Bytes,
+        window: Range<Sequence>,
+    ) -> Result<u64> {
+        let byte_range = LogEntryKey::scan_range(segment, key, window.clone());
+        let result = direct.count_in_range(&byte_range).await?;
+        // LogDb is append-only, so only puts contribute. Tombstones or
+        // merges in this byte range would indicate an unsupported op.
+        let mut total = result.counts.num_puts;
+
+        let scan_lo = match result.covered_to {
+            Some(covered_key) => {
+                LogEntryKey::deserialize(&covered_key, segment.meta().start_seq)?
+                    .sequence
+                    .saturating_add(1)
+            }
+            None => window.start,
+        };
+        if scan_lo < window.end {
+            total = total.saturating_add(
+                self.storage
+                    .count_entries(segment, key, scan_lo..window.end)
+                    .await?,
+            );
+        }
+        Ok(total)
     }
 
     /// Lists distinct keys within a segment range.
@@ -407,8 +478,12 @@ impl LogDbReader {
         )
         .await
         .map_err(|e| Error::Storage(e.to_string()))?;
+        let direct = LogDirect::maybe_from_storage_config(&config.storage)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?
+            .map(Arc::new);
         let segments = SegmentCache::open(storage.as_ref(), SegmentConfig::default()).await?;
-        let read_view = Arc::new(RwLock::new(LogReadView::new(storage, segments)));
+        let read_view = Arc::new(RwLock::new(LogReadView::new(storage, direct, segments)));
 
         let (shutdown_tx, refresh_task) =
             Self::spawn_refresh_task(Arc::clone(&read_view), config.refresh_interval);
@@ -462,8 +537,26 @@ impl LogDbReader {
     /// Creates a LogDbReader from an existing storage implementation.
     #[cfg(test)]
     pub(crate) async fn new(storage: Arc<dyn StorageRead>) -> Result<Self> {
+        Self::new_inner(storage, None).await
+    }
+
+    /// Creates a LogDbReader paired with a `LogDirect` handle so tests can
+    /// exercise the SST-walk count path through the reader.
+    #[cfg(test)]
+    pub(crate) async fn new_with_direct(
+        storage: Arc<dyn StorageRead>,
+        direct: Arc<LogDirect>,
+    ) -> Result<Self> {
+        Self::new_inner(storage, Some(direct)).await
+    }
+
+    #[cfg(test)]
+    async fn new_inner(
+        storage: Arc<dyn StorageRead>,
+        direct: Option<Arc<LogDirect>>,
+    ) -> Result<Self> {
         let segments = SegmentCache::open(storage.as_ref(), SegmentConfig::default()).await?;
-        let read_view = Arc::new(RwLock::new(LogReadView::new(storage, segments)));
+        let read_view = Arc::new(RwLock::new(LogReadView::new(storage, direct, segments)));
         let (shutdown_tx, _) = watch::channel(false);
         Ok(Self {
             read_view,
@@ -503,13 +596,10 @@ impl LogRead for LogDbReader {
         Ok(view.scan_with_options(key, seq_range, &options))
     }
 
-    async fn count_with_options(
-        &self,
-        _key: Bytes,
-        _seq_range: impl RangeBounds<Sequence> + Send,
-        _options: CountOptions,
-    ) -> Result<u64> {
-        todo!()
+    async fn count(&self, key: Bytes, seq_range: impl RangeBounds<Sequence> + Send) -> Result<u64> {
+        let seq_range = normalize_sequence(&seq_range);
+        let view = self.read_view.read().await;
+        view.count(key, seq_range).await
     }
 
     async fn list_keys(

--- a/log/src/storage.rs
+++ b/log/src/storage.rs
@@ -86,6 +86,24 @@ pub(crate) trait LogStorageRead: StorageRead {
             segment.meta().start_seq,
         ))
     }
+
+    /// Counts log entries for a key within a segment and sequence range by
+    /// scanning every record and tallying. Use this as a fallback when no
+    /// [`LogDirect`](crate::direct::LogDirect) handle is available.
+    async fn count_entries(
+        &self,
+        segment: &LogSegment,
+        key: &Bytes,
+        seq_range: Range<u64>,
+    ) -> Result<u64> {
+        let byte_range = LogEntryKey::scan_range(segment, key, seq_range);
+        let mut iter = self.scan_iter(byte_range).await?;
+        let mut total = 0u64;
+        while iter.next().await?.is_some() {
+            total = total.saturating_add(1);
+        }
+        Ok(total)
+    }
 }
 
 impl<T: StorageRead + ?Sized> LogStorageRead for T {}


### PR DESCRIPTION
Implements the count API for LogDb. I've removed the approximate count option, which I thought was kind of useless. For lag computation, it might be better to have smarter caching of intermediate results. But for a first pass, we just rely on the  block cache. Each count query is divided into one portion which uses slatedb BlockStats on the written SSTs, and one portion which scans keys in memtables and does a direct count. 
