### PR TITLE
Log: integration with slatedb segments

### DIFF
--- a/log/rfcs/0002-logical-segmentation.md
+++ b/log/rfcs/0002-logical-segmentation.md
@@ -115,7 +115,9 @@ Living in the system segment decouples metadata from the per-segment
 SlateDB lifecycle: when a user segment is drained and pruned from the
 SlateDB manifest, the `SegmentMeta` record for it is not automatically
 removed and must be deleted by the writer as it observes the manifest
-update. See [Retention](#segment-retention-future) below.
+update. The exact cleanup mechanism is out of scope for this RFC and is
+called out under [Segment-Based Deletion](#segment-based-deletion) as
+future work.
 
 #### Metadata Lifecycle
 

--- a/log/rfcs/0002-logical-segmentation.md
+++ b/log/rfcs/0002-logical-segmentation.md
@@ -46,11 +46,22 @@ Key properties of segments:
 
 ### Key Encoding with Segments
 
-The log entry key format is extended to include the segment ID:
+Every log storage key — log entries, listings, segment metadata, and the
+global sequence block — shares a 7-byte segmented prefix:
+
+```
+| subsystem (u8) | version (u8) | segment_id (u32 BE) | record_type (u8) | ... record-specific fields ... |
+```
+
+Placing `segment_id` before `record_type` keeps every record for a given
+segment contiguous in storage regardless of record type. This is the
+property a SlateDB segment extractor relies on: with a fixed 6-byte prefix
+`[subsystem, version, segment_id]`, all records for a segment land in the
+same SlateDB segment.
 
 ```
 Log Entry:
-  | version (u8) | type (u8) | segment_id (u32 BE) | key (TerminatedBytes) | relative_seq (varint u64) |
+  | sub | ver | segment_id (u32 BE) | record_type=0x10 | key (TerminatedBytes) | relative_seq (varint u64) |
 ```
 
 The `segment_id` is a 32-bit identifier, allowing up to ~4 billion segments. Future versions can expand this to 64 bits if needed.
@@ -64,13 +75,33 @@ This encoding ensures:
 - Within a key, entries are ordered by sequence number
 - Prefix scans can be constrained to specific segments
 
+### The system segment
+
+Segment id `0` is reserved as the **system segment**: it never holds user
+log entries. The records that aren't bound to a specific user segment live
+there, sharing the same 7-byte prefix layout (with `segment_id = 0`):
+
+- **`SeqBlock`** (`record_type = 0x20`): the global block-based sequence
+  allocator's persisted state. There is exactly one record.
+- **`SegmentMeta`** (`record_type = 0x30`): per-segment metadata describing
+  user segments. The described segment id is encoded as a 4-byte suffix
+  after `record_type`, so all `SegmentMeta` records sit in a contiguous
+  range and can be scanned with a single prefix scan.
+
+User log segments are numbered from `1`. A custom SlateDB compactor can
+recognize the system segment by its `segment_id = 0` prefix and exempt it
+from any retention-driven drains, while still allowing regular user
+segments to be retired via `CompactionSpec::DrainSegment` and pruned from
+the manifest.
+
 ### Segment Metadata
 
-Each segment has associated metadata stored in a separate record:
+Each user segment has associated metadata stored as a single record in the
+system segment. The described segment's id is the suffix:
 
 ```
 SegmentMeta Record:
-  Key:   | version (u8) | type (u8=0x03) | segment_id (u32 BE) |
+  Key:   | sub | ver | segment_id=0 (u32 BE) | record_type=0x30 | described_segment_id (u32 BE) |
   Value: | start_seq (u64 BE) | start_time_ms (i64 BE) |
 ```
 
@@ -79,6 +110,12 @@ The metadata tracks:
 - **start_time_ms**: Wall-clock time when the segment was created
 
 End boundaries (end sequence, end time) are derived from the next segment's start values, or from the current log state for the active segment.
+
+Living in the system segment decouples metadata from the per-segment
+SlateDB lifecycle: when a user segment is drained and pruned from the
+SlateDB manifest, the `SegmentMeta` record for it is not automatically
+removed and must be deleted by the writer as it observes the manifest
+update. See [Retention](#segment-retention-future) below.
 
 #### Metadata Lifecycle
 
@@ -196,3 +233,4 @@ This would enable use cases such as:
 |------------|-------------|
 | 2026-01-07 | Initial draft |
 | 2026-01-12 | Added link to varint implementation |
+| 2026-05-19 | Key format v2: `segment_id` precedes `record_type`; system segment (id 0) reserved for `SeqBlock` and `SegmentMeta` records; user segments start at id 1. Enables a fixed 6-byte SlateDB segment-extractor prefix that routes every per-segment record (entries + listings) to the same SlateDB segment. |

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -55,6 +55,7 @@ mod model;
 mod range;
 mod reader;
 mod segment;
+mod segment_extractor;
 mod serde;
 #[cfg(feature = "http-server")]
 pub mod server;

--- a/log/src/listing.rs
+++ b/log/src/listing.rs
@@ -154,18 +154,9 @@ mod tests {
         }
 
         #[storage_test]
-        async fn should_return_empty_for_empty_range(storage: Arc<dyn Storage>) {
-            // when
-            let keys = storage.list_keys(0..0).await.unwrap();
-
-            // then
-            assert!(keys.is_empty());
-        }
-
-        #[storage_test]
         async fn should_return_empty_when_no_listing_entries(storage: Arc<dyn Storage>) {
             // when
-            let keys = storage.list_keys(0..10).await.unwrap();
+            let keys = storage.list_keys_in_segment(1).await.unwrap();
 
             // then
             assert!(keys.is_empty());
@@ -174,12 +165,17 @@ mod tests {
         #[storage_test]
         async fn should_iterate_keys_in_single_segment(storage: Arc<dyn Storage>) {
             // given
-            write_listing_entry(&*storage, 0, b"key-a").await;
-            write_listing_entry(&*storage, 0, b"key-b").await;
-            write_listing_entry(&*storage, 0, b"key-c").await;
+            write_listing_entry(&*storage, 1, b"key-a").await;
+            write_listing_entry(&*storage, 1, b"key-b").await;
+            write_listing_entry(&*storage, 1, b"key-c").await;
 
             // when
-            let keys: Vec<Bytes> = storage.list_keys(0..1).await.unwrap().into_iter().collect();
+            let keys: Vec<Bytes> = storage
+                .list_keys_in_segment(1)
+                .await
+                .unwrap()
+                .into_iter()
+                .collect();
 
             // then - keys returned in lexicographic order
             assert_eq!(keys.len(), 3);
@@ -189,60 +185,66 @@ mod tests {
         }
 
         #[storage_test]
-        async fn should_iterate_keys_across_multiple_segments(storage: Arc<dyn Storage>) {
-            // given
-            write_listing_entry(&*storage, 0, b"key-a").await;
-            write_listing_entry(&*storage, 1, b"key-b").await;
-            write_listing_entry(&*storage, 2, b"key-c").await;
+        async fn should_isolate_listings_to_their_segment(storage: Arc<dyn Storage>) {
+            // given — listing entries in multiple segments
+            write_listing_entry(&*storage, 1, b"in-segment-1").await;
+            write_listing_entry(&*storage, 2, b"in-segment-2").await;
 
             // when
-            let keys = storage.list_keys(0..3).await.unwrap();
+            let seg1 = storage.list_keys_in_segment(1).await.unwrap();
+            let seg2 = storage.list_keys_in_segment(2).await.unwrap();
 
-            // then
-            assert_eq!(keys.len(), 3);
+            // then — each segment scan returns only its own listing entries
+            assert_eq!(seg1.len(), 1);
+            assert!(seg1.contains(&Bytes::from("in-segment-1")));
+            assert_eq!(seg2.len(), 1);
+            assert!(seg2.contains(&Bytes::from("in-segment-2")));
         }
 
         #[storage_test]
-        async fn should_deduplicate_keys_across_segments(storage: Arc<dyn Storage>) {
-            // given - same key in multiple segments
-            write_listing_entry(&*storage, 0, b"shared-key").await;
-            write_listing_entry(&*storage, 1, b"shared-key").await;
-            write_listing_entry(&*storage, 2, b"shared-key").await;
+        async fn should_skip_log_entries_when_scanning_listings(storage: Arc<dyn Storage>) {
+            use crate::segment::LogSegment;
+            use crate::serde::LogEntryKey;
+            use crate::serde::SegmentMeta;
+
+            // given — listing records alongside log entries in the same segment
+            let segment_id = 1u32;
+            let segment = LogSegment::new(segment_id, SegmentMeta::new(0, 1000));
+            write_listing_entry(&*storage, segment_id, b"alpha").await;
+            // Write a log entry that would lex-sort before listings (tag 0x10 < 0x40).
+            let entry_key = LogEntryKey::new(segment_id, Bytes::from("alpha"), 1).serialize(0);
+            storage
+                .put_with_options(
+                    vec![common::Record::new(entry_key, Bytes::from("v")).into()],
+                    common::WriteOptions::default(),
+                )
+                .await
+                .unwrap();
+            // Anchor used for the segment metadata so deserialization is sane.
+            let _ = segment;
 
             // when
-            let keys = storage.list_keys(0..3).await.unwrap();
+            let keys = storage.list_keys_in_segment(segment_id).await.unwrap();
 
-            // then - only one instance of the key
+            // then — listing scan only sees listing records, not log entries
             assert_eq!(keys.len(), 1);
-            assert!(keys.contains(&Bytes::from("shared-key")));
-        }
-
-        #[storage_test]
-        async fn should_respect_segment_range(storage: Arc<dyn Storage>) {
-            // given
-            write_listing_entry(&*storage, 0, b"key-0").await;
-            write_listing_entry(&*storage, 1, b"key-1").await;
-            write_listing_entry(&*storage, 2, b"key-2").await;
-            write_listing_entry(&*storage, 3, b"key-3").await;
-
-            // when - only query segments 1..3
-            let keys: Vec<Bytes> = storage.list_keys(1..3).await.unwrap().into_iter().collect();
-
-            // then - only keys from segments 1 and 2
-            assert_eq!(keys.len(), 2);
-            assert_eq!(keys[0], Bytes::from("key-1"));
-            assert_eq!(keys[1], Bytes::from("key-2"));
+            assert!(keys.contains(&Bytes::from("alpha")));
         }
 
         #[storage_test]
         async fn should_return_keys_in_lexicographic_order(storage: Arc<dyn Storage>) {
             // given - keys inserted out of order
-            write_listing_entry(&*storage, 0, b"zebra").await;
-            write_listing_entry(&*storage, 0, b"apple").await;
-            write_listing_entry(&*storage, 0, b"mango").await;
+            write_listing_entry(&*storage, 1, b"zebra").await;
+            write_listing_entry(&*storage, 1, b"apple").await;
+            write_listing_entry(&*storage, 1, b"mango").await;
 
             // when
-            let keys: Vec<Bytes> = storage.list_keys(0..1).await.unwrap().into_iter().collect();
+            let keys: Vec<Bytes> = storage
+                .list_keys_in_segment(1)
+                .await
+                .unwrap()
+                .into_iter()
+                .collect();
 
             // then - keys returned in lexicographic order
             assert_eq!(keys[0], Bytes::from("apple"));

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -319,6 +319,7 @@ impl LogDb {
             None,
             SegmentConfig::default(),
             ReadVisibility::Memory,
+            Arc::new(SystemClock),
         )
         .await
     }
@@ -335,6 +336,7 @@ impl LogDb {
             Some(direct),
             SegmentConfig::default(),
             ReadVisibility::Memory,
+            Arc::new(SystemClock),
         )
         .await
     }
@@ -347,6 +349,7 @@ impl LogDb {
             None,
             SegmentConfig::default(),
             ReadVisibility::Remote,
+            Arc::new(SystemClock),
         )
         .await
     }
@@ -357,9 +360,8 @@ impl LogDb {
         direct: Option<Arc<crate::direct::LogDirect>>,
         segment_config: SegmentConfig,
         read_visibility: ReadVisibility,
+        clock: Arc<dyn Clock>,
     ) -> Result<Self> {
-        let clock: Arc<dyn Clock> = Arc::new(SystemClock);
-
         let seq_key = Bytes::from_static(&SEQ_BLOCK_KEY);
         let sequence_allocator = common::SequenceAllocator::load(storage.as_ref(), seq_key)
             .await
@@ -493,6 +495,7 @@ impl LogRead for LogDb {
 pub struct LogDbBuilder {
     config: crate::config::Config,
     storage_builder: Option<StorageBuilder>,
+    clock: Option<Arc<dyn Clock>>,
 }
 
 impl LogDbBuilder {
@@ -501,6 +504,7 @@ impl LogDbBuilder {
         Self {
             config,
             storage_builder: None,
+            clock: None,
         }
     }
 
@@ -513,6 +517,18 @@ impl LogDbBuilder {
         self
     }
 
+    /// Overrides the wall-clock source. Test-only — production callers always
+    /// use the default [`common::clock::SystemClock`].
+    ///
+    /// LogDb consults this clock to timestamp segment metadata and to decide
+    /// when the configured `seal_interval` has elapsed. Tests pass a
+    /// [`common::clock::MockClock`] to drive segment rolls deterministically.
+    #[cfg(test)]
+    pub(crate) fn with_clock(mut self, clock: Arc<dyn Clock>) -> Self {
+        self.clock = Some(clock);
+        self
+    }
+
     /// Builds the LogDb instance.
     pub async fn build(self) -> Result<LogDb> {
         let sb = match self.storage_builder {
@@ -521,6 +537,13 @@ impl LogDbBuilder {
                 .await
                 .map_err(|e| Error::Storage(e.to_string()))?,
         };
+        // Route every log record to a SlateDB segment keyed by the 6-byte
+        // routing prefix `[subsystem, version, segment_id]`. No-op for the
+        // in-memory backend; for slatedb-backed storage this installs the
+        // extractor on the underlying `DbBuilder` (see RFC 0024).
+        let sb = sb.map_slatedb(|db| {
+            db.with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())
+        });
         let storage = sb
             .build()
             .await
@@ -531,11 +554,14 @@ impl LogDbBuilder {
             .map_err(|e| Error::Storage(e.to_string()))?
             .map(Arc::new);
 
+        let clock: Arc<dyn Clock> = self.clock.unwrap_or_else(|| Arc::new(SystemClock));
+
         LogDb::from_storage(
             storage,
             direct,
             self.config.segmentation,
             self.config.read_visibility,
+            clock,
         )
         .await
     }
@@ -1534,24 +1560,8 @@ mod tests {
 
     #[tokio::test]
     async fn should_list_keys_respects_segment_range() {
-        // given - entries in different segments
+        // given - entries in different segments. First user segment is id 1.
         let log = LogDb::open(test_config()).await.unwrap();
-
-        // segment 0
-        log.try_append(vec![
-            Record {
-                key: Bytes::from("key-seg0"),
-                value: Bytes::from("value"),
-            },
-            Record {
-                key: Bytes::from("key-seg0-b"),
-                value: Bytes::from("value"),
-            },
-        ])
-        .await
-        .unwrap();
-
-        log.seal_segment().await.unwrap();
 
         // segment 1
         log.try_append(vec![
@@ -1583,17 +1593,33 @@ mod tests {
         .await
         .unwrap();
 
-        // when - list only keys from segment 1
-        let mut iter = log.list_keys(1..2).await.unwrap();
+        log.seal_segment().await.unwrap();
+
+        // segment 3
+        log.try_append(vec![
+            Record {
+                key: Bytes::from("key-seg3"),
+                value: Bytes::from("value"),
+            },
+            Record {
+                key: Bytes::from("key-seg3-b"),
+                value: Bytes::from("value"),
+            },
+        ])
+        .await
+        .unwrap();
+
+        // when - list only keys from segment 2
+        let mut iter = log.list_keys(2..3).await.unwrap();
         let mut keys = vec![];
         while let Some(key) = iter.next().await.unwrap() {
             keys.push(key.key);
         }
 
-        // then - only keys from segment 1
+        // then - only keys from segment 2
         assert_eq!(keys.len(), 2);
-        assert_eq!(keys[0], Bytes::from("key-seg1"));
-        assert_eq!(keys[1], Bytes::from("key-seg1-b"));
+        assert_eq!(keys[0], Bytes::from("key-seg2"));
+        assert_eq!(keys[1], Bytes::from("key-seg2-b"));
     }
 
     #[tokio::test]
@@ -1622,9 +1648,9 @@ mod tests {
         // when
         let segments = log.list_segments(..).await.unwrap();
 
-        // then
+        // then — first user segment is id 1 (id 0 is reserved system segment)
         assert_eq!(segments.len(), 1);
-        assert_eq!(segments[0].id, 0);
+        assert_eq!(segments[0].id, 1);
         assert_eq!(segments[0].start_seq, 0);
     }
 
@@ -1633,7 +1659,7 @@ mod tests {
         // given
         let log = LogDb::open(test_config()).await.unwrap();
 
-        // segment 0
+        // first user segment (id 1)
         log.try_append(vec![Record {
             key: Bytes::from("key"),
             value: Bytes::from("value-0"),
@@ -1643,7 +1669,7 @@ mod tests {
 
         log.seal_segment().await.unwrap();
 
-        // segment 1
+        // segment 2
         log.try_append(vec![Record {
             key: Bytes::from("key"),
             value: Bytes::from("value-1"),
@@ -1653,7 +1679,7 @@ mod tests {
 
         log.seal_segment().await.unwrap();
 
-        // segment 2
+        // segment 3
         log.try_append(vec![Record {
             key: Bytes::from("key"),
             value: Bytes::from("value-2"),
@@ -1666,11 +1692,11 @@ mod tests {
 
         // then
         assert_eq!(segments.len(), 3);
-        assert_eq!(segments[0].id, 0);
+        assert_eq!(segments[0].id, 1);
         assert_eq!(segments[0].start_seq, 0);
-        assert_eq!(segments[1].id, 1);
+        assert_eq!(segments[1].id, 2);
         assert_eq!(segments[1].start_seq, 1);
-        assert_eq!(segments[2].id, 2);
+        assert_eq!(segments[2].id, 3);
         assert_eq!(segments[2].start_seq, 2);
     }
 
@@ -1725,12 +1751,12 @@ mod tests {
         .await
         .unwrap();
 
-        // when - query range that spans segment 1
+        // when - query range that spans the middle segment (id 2)
         let segments = log.list_segments(2..4).await.unwrap();
 
-        // then - only segment 1 matches
+        // then - only segment 2 matches
         assert_eq!(segments.len(), 1);
-        assert_eq!(segments[0].id, 1);
+        assert_eq!(segments[0].id, 2);
         assert_eq!(segments[0].start_seq, 2);
     }
 
@@ -1768,8 +1794,8 @@ mod tests {
 
         // then
         assert_eq!(segments.len(), 2);
-        assert_eq!(segments[0].id, 0);
-        assert_eq!(segments[1].id, 1);
+        assert_eq!(segments[0].id, 1);
+        assert_eq!(segments[1].id, 2);
     }
 
     #[tokio::test]
@@ -1927,7 +1953,7 @@ mod tests {
         // when/then - reads see unflushed data via sync_to_flushed
         let segments = log.list_segments(..).await.unwrap();
         assert_eq!(segments.len(), 1);
-        assert_eq!(segments[0].id, 0);
+        assert_eq!(segments[0].id, 1);
         assert_eq!(segments[0].start_seq, 0);
     }
 
@@ -2103,6 +2129,7 @@ mod tests {
                 seal_interval: Some(Duration::from_nanos(1)),
             },
             ReadVisibility::Memory,
+            Arc::new(SystemClock),
         )
         .await
         .unwrap();

--- a/log/src/range.rs
+++ b/log/src/range.rs
@@ -14,6 +14,7 @@
 use std::ops::{Bound, Range, RangeBounds};
 
 use crate::model::{SegmentId, Sequence};
+use crate::serde::FIRST_USER_SEGMENT_ID;
 
 /// Converts any `RangeBounds<Sequence>` to a normalized `Range<Sequence>`.
 pub(crate) fn normalize_sequence<R: RangeBounds<Sequence>>(range: &R) -> Range<Sequence> {
@@ -31,11 +32,14 @@ pub(crate) fn normalize_sequence<R: RangeBounds<Sequence>>(range: &R) -> Range<S
 }
 
 /// Converts any `RangeBounds<SegmentId>` to a normalized `Range<SegmentId>`.
+///
+/// An unbounded start resolves to [`FIRST_USER_SEGMENT_ID`] (1), skipping the
+/// reserved system segment (id `0`).
 pub(crate) fn normalize_segment_id<R: RangeBounds<SegmentId>>(range: &R) -> Range<SegmentId> {
     let start = match range.start_bound() {
         Bound::Included(&s) => s,
         Bound::Excluded(&s) => s.saturating_add(1),
-        Bound::Unbounded => 0,
+        Bound::Unbounded => FIRST_USER_SEGMENT_ID,
     };
     let end = match range.end_bound() {
         Bound::Included(&e) => e.saturating_add(1),
@@ -100,12 +104,12 @@ mod tests {
     }
 
     #[test]
-    fn should_normalize_segment_id_full_range() {
+    fn should_normalize_segment_id_full_range_skips_system_segment() {
         // given/when
         let range = normalize_segment_id(&(..));
 
-        // then
-        assert_eq!(range, 0..u32::MAX);
+        // then — unbounded start resolves to FIRST_USER_SEGMENT_ID (1)
+        assert_eq!(range, FIRST_USER_SEGMENT_ID..u32::MAX);
     }
 
     #[test]
@@ -118,12 +122,12 @@ mod tests {
     }
 
     #[test]
-    fn should_normalize_segment_id_range_to() {
+    fn should_normalize_segment_id_range_to_skips_system_segment() {
         // given/when
         let range = normalize_segment_id(&(..100u32));
 
-        // then
-        assert_eq!(range, 0..100);
+        // then — unbounded start resolves to FIRST_USER_SEGMENT_ID (1)
+        assert_eq!(range, FIRST_USER_SEGMENT_ID..100);
     }
 
     #[test]
@@ -149,13 +153,14 @@ mod tests {
         // given/when
         let range = normalize_segment_id(&(..=10u32));
 
-        // then
-        assert_eq!(range, 0..11);
+        // then — unbounded start resolves to FIRST_USER_SEGMENT_ID (1)
+        assert_eq!(range, FIRST_USER_SEGMENT_ID..11);
     }
 
     #[test]
     fn should_normalize_segment_id_handle_max_value_inclusive() {
-        // given/when
+        // given/when — explicit start of 0 is preserved (callers can opt in
+        // to scanning the system segment by passing it explicitly)
         let range = normalize_segment_id(&(0..=u32::MAX));
 
         // then - saturating_add prevents overflow

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -4,6 +4,7 @@
 //! - [`LogRead`]: The trait defining read operations on the log.
 //! - [`LogDbReader`]: A read-only view of the log that implements `LogRead`.
 
+use std::collections::BTreeSet;
 use std::ops::{Range, RangeBounds};
 use std::sync::Arc;
 use std::time::Duration;
@@ -337,11 +338,22 @@ impl LogReadView {
     }
 
     /// Lists distinct keys within a segment range.
+    ///
+    /// Stitches per-segment scans together by walking the segment cache —
+    /// the v2 key layout interleaves listings with log entries across
+    /// segment boundaries, so a single wide-range storage scan is not safe.
     pub(crate) async fn list_keys(
         &self,
         segment_range: Range<SegmentId>,
     ) -> Result<LogKeyIterator> {
-        let keys = self.storage.list_keys(segment_range).await?;
+        let mut keys = BTreeSet::new();
+        for segment in self.segments.all() {
+            if !segment_range.contains(&segment.id()) {
+                continue;
+            }
+            let per_segment = self.storage.list_keys_in_segment(segment.id()).await?;
+            keys.extend(per_segment);
+        }
         Ok(LogKeyIterator::from_keys(keys))
     }
 

--- a/log/src/segment.rs
+++ b/log/src/segment.rs
@@ -14,7 +14,7 @@ use crate::config::SegmentConfig;
 use crate::error::Result;
 use crate::model::Segment;
 use crate::model::SegmentId;
-use crate::serde::{SegmentMeta, SegmentMetaKey};
+use crate::serde::{FIRST_USER_SEGMENT_ID, SegmentMeta, SegmentMetaKey};
 use crate::storage::LogStorageRead as _;
 use common::storage::PutOptions;
 use common::{PutRecordOp, Record, StorageRead, Ttl};
@@ -84,7 +84,9 @@ pub(crate) struct SegmentCache {
 impl SegmentCache {
     /// Creates a new cache by loading all segments from storage.
     pub(crate) async fn open(storage: &dyn StorageRead, config: SegmentConfig) -> Result<Self> {
-        let loaded = storage.scan_segments(0..u32::MAX).await?;
+        let loaded = storage
+            .scan_segments(FIRST_USER_SEGMENT_ID..SegmentId::MAX)
+            .await?;
 
         let mut segments = BTreeMap::new();
         for segment in loaded {
@@ -153,14 +155,11 @@ impl SegmentCache {
         storage: &dyn StorageRead,
         after_segment_id: Option<SegmentId>,
     ) -> Result<()> {
-        let loaded = match after_segment_id {
-            Some(id) => {
-                storage
-                    .scan_segments(id.saturating_add(1)..u32::MAX)
-                    .await?
-            }
-            None => storage.scan_segments(0..u32::MAX).await?,
+        let scan_start = match after_segment_id {
+            Some(id) => id.saturating_add(1).max(FIRST_USER_SEGMENT_ID),
+            None => FIRST_USER_SEGMENT_ID,
         };
+        let loaded = storage.scan_segments(scan_start..SegmentId::MAX).await?;
 
         if after_segment_id.is_none() {
             self.segments.clear();
@@ -190,7 +189,7 @@ impl SegmentCache {
             || Self::should_roll(self.config.seal_interval, current_time_ms, latest.as_ref());
 
         if needs_new_segment {
-            let segment_id = latest.map(|s| s.id + 1).unwrap_or(0);
+            let segment_id = latest.map(|s| s.id + 1).unwrap_or(FIRST_USER_SEGMENT_ID);
             let meta = SegmentMeta::new(start_seq, current_time_ms);
             let key = SegmentMetaKey::new(segment_id).serialize();
             let value = meta.serialize();
@@ -243,7 +242,8 @@ mod tests {
     use common::Storage;
     use opendata_macros::storage_test;
 
-    // Helper to create a segment and write it to storage + cache
+    // Helper to create a segment and write it to storage + cache. Segment ids
+    // start at [`FIRST_USER_SEGMENT_ID`] (1) — segment 0 is the system segment.
     async fn write_segment(
         storage: &dyn common::Storage,
         cache: &mut SegmentCache,
@@ -251,7 +251,7 @@ mod tests {
     ) -> LogSegment {
         let segment_id = match cache.latest() {
             Some(latest) => latest.id + 1,
-            None => 0,
+            None => FIRST_USER_SEGMENT_ID,
         };
         let segment = LogSegment::new(segment_id, meta);
         storage.write_segment(&segment).await.unwrap();
@@ -274,7 +274,7 @@ mod tests {
     }
 
     #[storage_test]
-    async fn should_write_first_segment_with_id_zero(storage: Arc<dyn Storage>) {
+    async fn should_write_first_segment_with_first_user_id(storage: Arc<dyn Storage>) {
         // given
         let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
             .await
@@ -284,8 +284,8 @@ mod tests {
         // when
         let segment = write_segment(storage.as_ref(), &mut cache, meta.clone()).await;
 
-        // then
-        assert_eq!(segment.id(), 0);
+        // then — segment 0 is reserved (system), first user segment is 1
+        assert_eq!(segment.id(), FIRST_USER_SEGMENT_ID);
         assert_eq!(segment.meta(), &meta);
     }
 
@@ -297,14 +297,14 @@ mod tests {
             .unwrap();
 
         // when
-        let seg0 = write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
-        let seg1 = write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(100, 2000)).await;
-        let seg2 = write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(200, 3000)).await;
+        let seg_a = write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
+        let seg_b = write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(100, 2000)).await;
+        let seg_c = write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(200, 3000)).await;
 
         // then
-        assert_eq!(seg0.id(), 0);
-        assert_eq!(seg1.id(), 1);
-        assert_eq!(seg2.id(), 2);
+        assert_eq!(seg_a.id(), 1);
+        assert_eq!(seg_b.id(), 2);
+        assert_eq!(seg_c.id(), 3);
     }
 
     #[storage_test]
@@ -320,7 +320,7 @@ mod tests {
         let latest = cache.latest();
 
         // then
-        assert_eq!(latest.unwrap().id(), 1);
+        assert_eq!(latest.unwrap().id(), 2);
     }
 
     #[storage_test]
@@ -338,9 +338,9 @@ mod tests {
 
         // then
         assert_eq!(segments.len(), 3);
-        assert_eq!(segments[0].id(), 0);
-        assert_eq!(segments[1].id(), 1);
-        assert_eq!(segments[2].id(), 2);
+        assert_eq!(segments[0].id(), 1);
+        assert_eq!(segments[1].id(), 2);
+        assert_eq!(segments[2].id(), 3);
     }
 
     #[storage_test]
@@ -360,9 +360,9 @@ mod tests {
 
         // then
         assert_eq!(segments.len(), 2);
-        assert_eq!(segments[0].id(), 0);
+        assert_eq!(segments[0].id(), 1);
         assert_eq!(segments[0].meta().start_seq, 0);
-        assert_eq!(segments[1].id(), 1);
+        assert_eq!(segments[1].id(), 2);
         assert_eq!(segments[1].meta().start_seq, 100);
     }
 
@@ -385,7 +385,7 @@ mod tests {
 
     #[storage_test]
     async fn should_find_segments_by_seq_range_single(storage: Arc<dyn Storage>) {
-        // given: segments at seq 0, 100, 200
+        // given: segments at seq 0, 100, 200 (ids 1, 2, 3)
         let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
             .await
             .unwrap();
@@ -398,12 +398,12 @@ mod tests {
 
         // then: only first segment matches
         assert_eq!(segments.len(), 1);
-        assert_eq!(segments[0].id(), 0);
+        assert_eq!(segments[0].id(), 1);
     }
 
     #[storage_test]
     async fn should_find_segments_by_seq_range_spanning(storage: Arc<dyn Storage>) {
-        // given: segments at seq 0, 100, 200
+        // given: segments at seq 0, 100, 200 (ids 1, 2, 3)
         let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
             .await
             .unwrap();
@@ -416,13 +416,13 @@ mod tests {
 
         // then: first two segments match
         assert_eq!(segments.len(), 2);
-        assert_eq!(segments[0].id(), 0);
-        assert_eq!(segments[1].id(), 1);
+        assert_eq!(segments[0].id(), 1);
+        assert_eq!(segments[1].id(), 2);
     }
 
     #[storage_test]
     async fn should_find_segments_by_seq_range_unbounded_end(storage: Arc<dyn Storage>) {
-        // given: segments at seq 0, 100, 200
+        // given: segments at seq 0, 100, 200 (ids 1, 2, 3)
         let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
             .await
             .unwrap();
@@ -435,8 +435,8 @@ mod tests {
 
         // then: second and third segments match
         assert_eq!(segments.len(), 2);
-        assert_eq!(segments[0].id(), 1);
-        assert_eq!(segments[1].id(), 2);
+        assert_eq!(segments[0].id(), 2);
+        assert_eq!(segments[1].id(), 3);
     }
 
     #[storage_test]
@@ -470,7 +470,7 @@ mod tests {
 
     #[storage_test]
     async fn should_find_last_segment_when_range_after_all(storage: Arc<dyn Storage>) {
-        // given: segments at seq 0, 100, 200
+        // given: segments at seq 0, 100, 200 (ids 1, 2, 3)
         let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
             .await
             .unwrap();
@@ -483,12 +483,12 @@ mod tests {
 
         // then: last segment matches (it could contain seqs 200+)
         assert_eq!(segments.len(), 1);
-        assert_eq!(segments[0].id(), 2);
+        assert_eq!(segments[0].id(), 3);
     }
 
     #[storage_test]
     async fn should_find_segment_when_query_starts_at_boundary(storage: Arc<dyn Storage>) {
-        // given: segments at seq 0, 100, 200
+        // given: segments at seq 0, 100, 200 (ids 1, 2, 3)
         let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
             .await
             .unwrap();
@@ -501,12 +501,12 @@ mod tests {
 
         // then: only the segment starting at 100 matches
         assert_eq!(segments.len(), 1);
-        assert_eq!(segments[0].id(), 1);
+        assert_eq!(segments[0].id(), 2);
     }
 
     #[storage_test]
     async fn should_find_segments_with_unbounded_start(storage: Arc<dyn Storage>) {
-        // given: segments at seq 0, 100, 200
+        // given: segments at seq 0, 100, 200 (ids 1, 2, 3)
         let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
             .await
             .unwrap();
@@ -519,8 +519,8 @@ mod tests {
 
         // then: first two segments match
         assert_eq!(segments.len(), 2);
-        assert_eq!(segments[0].id(), 0);
-        assert_eq!(segments[1].id(), 1);
+        assert_eq!(segments[0].id(), 1);
+        assert_eq!(segments[1].id(), 2);
     }
 
     #[tokio::test]
@@ -548,7 +548,7 @@ mod tests {
     async fn should_roll_returns_false_when_within_interval() {
         // given: segment created at time 1000, seal interval 1 hour
         let seal_interval = Some(Duration::from_secs(3600));
-        let segment = LogSegment::new(0, SegmentMeta::new(0, 1000));
+        let segment = LogSegment::new(FIRST_USER_SEGMENT_ID, SegmentMeta::new(0, 1000));
 
         // when: current time is 1000 + 30 minutes
         let current_time_ms = 1000 + 30 * 60 * 1000;
@@ -562,7 +562,7 @@ mod tests {
     async fn should_roll_returns_true_when_interval_exceeded() {
         // given: segment created at time 1000, seal interval 1 hour
         let seal_interval = Some(Duration::from_secs(3600));
-        let segment = LogSegment::new(0, SegmentMeta::new(0, 1000));
+        let segment = LogSegment::new(FIRST_USER_SEGMENT_ID, SegmentMeta::new(0, 1000));
 
         // when: current time is 1000 + 2 hours
         let current_time_ms = 1000 + 2 * 60 * 60 * 1000;
@@ -576,7 +576,7 @@ mod tests {
     async fn should_roll_returns_true_when_exactly_at_interval() {
         // given: segment created at time 1000, seal interval 1 hour
         let seal_interval = Some(Duration::from_secs(3600));
-        let segment = LogSegment::new(0, SegmentMeta::new(0, 1000));
+        let segment = LogSegment::new(FIRST_USER_SEGMENT_ID, SegmentMeta::new(0, 1000));
 
         // when: current time is exactly at the interval boundary
         let current_time_ms = 1000 + 60 * 60 * 1000;
@@ -589,7 +589,7 @@ mod tests {
     #[tokio::test]
     async fn should_roll_returns_false_without_seal_interval_when_segment_exists() {
         // given: no seal interval, segment exists
-        let segment = LogSegment::new(0, SegmentMeta::new(0, 1000));
+        let segment = LogSegment::new(FIRST_USER_SEGMENT_ID, SegmentMeta::new(0, 1000));
 
         // when
         let should_roll = SegmentCache::should_roll(None, 999999999, Some(&segment));
@@ -609,14 +609,14 @@ mod tests {
         // when
         let assignment = cache.assign_segment(1000, 0, &mut records, false);
 
-        // then
+        // then — first user segment is FIRST_USER_SEGMENT_ID (1), not 0
         assert!(assignment.is_new);
-        assert_eq!(assignment.segment.id(), 0);
+        assert_eq!(assignment.segment.id(), FIRST_USER_SEGMENT_ID);
         assert_eq!(assignment.segment.meta().start_seq, 0);
         assert_eq!(assignment.segment.meta().start_time_ms, 1000);
         assert_eq!(records.len(), 1); // segment meta record added
         // cache is updated
-        assert_eq!(cache.latest().unwrap().id(), 0);
+        assert_eq!(cache.latest().unwrap().id(), FIRST_USER_SEGMENT_ID);
     }
 
     #[storage_test]
@@ -637,7 +637,7 @@ mod tests {
 
         // then: returns existing segment, no new record
         assert!(!assignment.is_new);
-        assert_eq!(assignment.segment.id(), 0);
+        assert_eq!(assignment.segment.id(), FIRST_USER_SEGMENT_ID);
         assert_eq!(records.len(), 0);
         // still only one segment in cache
         assert_eq!(cache.all().len(), 1);
@@ -659,7 +659,7 @@ mod tests {
 
         // then: creates new segment and updates cache
         assert!(assignment.is_new);
-        assert_eq!(assignment.segment.id(), 1);
+        assert_eq!(assignment.segment.id(), FIRST_USER_SEGMENT_ID + 1);
         assert_eq!(assignment.segment.meta().start_seq, 100);
         assert_eq!(records.len(), 1);
         assert_eq!(cache.all().len(), 2);
@@ -681,7 +681,7 @@ mod tests {
 
         // then: new segment created despite being within interval
         assert!(assignment.is_new);
-        assert_eq!(assignment.segment.id(), 1);
+        assert_eq!(assignment.segment.id(), FIRST_USER_SEGMENT_ID + 1);
         assert_eq!(cache.all().len(), 2);
     }
 
@@ -724,8 +724,8 @@ mod tests {
 
         fresh.refresh(storage.as_ref(), None).await.unwrap();
         assert_eq!(fresh.all().len(), 2);
-        assert_eq!(fresh.all()[0].id(), 0);
-        assert_eq!(fresh.all()[1].id(), 1);
+        assert_eq!(fresh.all()[0].id(), 1);
+        assert_eq!(fresh.all()[1].id(), 2);
     }
 
     #[storage_test]
@@ -737,21 +737,21 @@ mod tests {
         write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(100, 2000)).await;
         write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(200, 3000)).await;
 
-        // Start a cache that only knows about segment 0
+        // Start a cache that only knows about segment 1 (the first user segment)
         let mut partial = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
             .await
             .unwrap();
-        partial.segments.retain(|_, seg| seg.id() == 0);
+        partial.segments.retain(|_, seg| seg.id() == 1);
         assert_eq!(partial.all().len(), 1);
 
-        // Refresh loading only segments after id 0
-        partial.refresh(storage.as_ref(), Some(0)).await.unwrap();
+        // Refresh loading only segments after id 1
+        partial.refresh(storage.as_ref(), Some(1)).await.unwrap();
 
         // Should now have all 3 segments
         assert_eq!(partial.all().len(), 3);
-        assert_eq!(partial.all()[0].id(), 0);
-        assert_eq!(partial.all()[1].id(), 1);
-        assert_eq!(partial.all()[2].id(), 2);
+        assert_eq!(partial.all()[0].id(), 1);
+        assert_eq!(partial.all()[1].id(), 2);
+        assert_eq!(partial.all()[2].id(), 3);
     }
 
     #[storage_test]
@@ -763,7 +763,7 @@ mod tests {
         write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(100, 2000)).await;
 
         // Refresh after the latest segment — nothing new
-        cache.refresh(storage.as_ref(), Some(1)).await.unwrap();
+        cache.refresh(storage.as_ref(), Some(2)).await.unwrap();
         assert_eq!(cache.all().len(), 2);
     }
 
@@ -781,7 +781,7 @@ mod tests {
         // Full refresh should clear the bogus entry
         cache.refresh(storage.as_ref(), None).await.unwrap();
         assert_eq!(cache.all().len(), 1);
-        assert_eq!(cache.all()[0].id(), 0);
+        assert_eq!(cache.all()[0].id(), 1);
     }
 
     #[storage_test]
@@ -796,7 +796,7 @@ mod tests {
         cache.insert(LogSegment::new(99, SegmentMeta::new(9999, 9999)));
         assert_eq!(cache.all().len(), 3);
 
-        cache.refresh(storage.as_ref(), Some(1)).await.unwrap();
+        cache.refresh(storage.as_ref(), Some(2)).await.unwrap();
         // Bogus entry persists because incremental refresh only appends
         assert_eq!(cache.all().len(), 3);
     }

--- a/log/src/segment_extractor.rs
+++ b/log/src/segment_extractor.rs
@@ -1,0 +1,460 @@
+//! SlateDB segment extractor for the log subsystem.
+//!
+//! Implements [`slatedb::PrefixExtractor`] over the v2 log key layout, mapping
+//! every record to the 6-byte routing prefix `[subsystem, version, segment_id]`.
+//! When configured on the `slatedb::DbBuilder`, the extractor causes SlateDB
+//! to route writes for each LogDb segment into its own SlateDB segment, so the
+//! per-LogDb-segment LSM state can be compacted (and eventually drained) as a
+//! unit.
+//!
+//! See `log/rfcs/0002-logical-segmentation.md` for the layout this extractor
+//! relies on, and `slatedb::prefix_extractor::PrefixExtractor` for the contract
+//! the impl satisfies.
+//!
+//! # Naming
+//!
+//! The extractor's [`name`](slatedb::PrefixExtractor::name) is persisted in
+//! the SlateDB manifest and validated on open. Changes to the routing logic
+//! (including any future bump of the log's `KEY_VERSION`) must change the
+//! name as well, so a database created under different routing rules is
+//! rejected with `SlateDBError::SegmentExtractorMismatch` rather than silently
+//! mis-routed.
+
+use std::sync::Arc;
+
+use slatedb::{PrefixExtractor, PrefixTarget};
+
+use crate::serde::{KEY_VERSION, SUBSYSTEM};
+
+/// Routing prefix length: `[subsystem(1), version(1), segment_id(4 BE)]`.
+///
+/// The `record_type` byte at position 6 deliberately sits *outside* the
+/// extracted prefix so all record types for a given segment (entries,
+/// listings, and — for the system segment — metadata and the seq block)
+/// share one routing prefix and land in the same SlateDB segment.
+const ROUTING_PREFIX_LEN: usize = 6;
+
+/// Stable, persisted identifier for this extractor's routing rules.
+/// Bump whenever the routing logic changes in a way that would re-route
+/// existing keys (e.g. a new `KEY_VERSION` with a different prefix shape).
+const EXTRACTOR_NAME: &str = "opendata-log/v2";
+
+/// Prefix extractor routing log records to per-segment SlateDB segments.
+///
+/// Returns `Some(6)` for any key whose first two bytes are `[SUBSYSTEM,
+/// KEY_VERSION]` and whose total length is at least 6 bytes — i.e. every
+/// well-formed log key. Returns `None` otherwise, so unrelated keys
+/// (shouldn't occur in a LogDb-owned database, but treated defensively)
+/// stay in the root tree.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct LogSegmentExtractor;
+
+impl LogSegmentExtractor {
+    /// Returns a shared `Arc<dyn PrefixExtractor>` for handing to
+    /// `slatedb::DbBuilder::with_segment_extractor`.
+    pub(crate) fn shared() -> Arc<dyn PrefixExtractor> {
+        Arc::new(Self)
+    }
+}
+
+impl PrefixExtractor for LogSegmentExtractor {
+    fn name(&self) -> &str {
+        EXTRACTOR_NAME
+    }
+
+    fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+        // The `Point` and `Prefix` variants share the same answer here: the
+        // extracted bytes are determined entirely by positions 0..6, which
+        // both variants observe directly.
+        let bytes: &[u8] = match target {
+            PrefixTarget::Point(b) | PrefixTarget::Prefix(b) => b.as_ref(),
+        };
+        if bytes.len() < ROUTING_PREFIX_LEN {
+            return None;
+        }
+        if bytes[0] != SUBSYSTEM || bytes[1] != KEY_VERSION {
+            return None;
+        }
+        Some(ROUTING_PREFIX_LEN)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+
+    use crate::serde::{FIRST_USER_SEGMENT_ID, LogEntryKey, SEQ_BLOCK_KEY, SegmentMetaKey};
+
+    fn point(bytes: &[u8]) -> PrefixTarget {
+        PrefixTarget::Point(Bytes::copy_from_slice(bytes))
+    }
+
+    fn prefix(bytes: &[u8]) -> PrefixTarget {
+        PrefixTarget::Prefix(Bytes::copy_from_slice(bytes))
+    }
+
+    #[test]
+    fn should_return_stable_name() {
+        // given
+        let extractor = LogSegmentExtractor;
+
+        // when / then — must match the persisted manifest value
+        assert_eq!(extractor.name(), "opendata-log/v2");
+    }
+
+    #[test]
+    fn should_extract_six_bytes_from_well_formed_log_entry_key() {
+        // given
+        let extractor = LogSegmentExtractor;
+        let key = LogEntryKey::new(FIRST_USER_SEGMENT_ID, Bytes::from("user-key"), 0).serialize(0);
+
+        // when
+        let n = extractor.prefix_len(&PrefixTarget::Point(key.clone()));
+
+        // then
+        assert_eq!(n, Some(6));
+        // routing prefix is [SUBSYSTEM, KEY_VERSION, segment_id BE]
+        let extracted = &key[..n.unwrap()];
+        assert_eq!(extracted[0], SUBSYSTEM);
+        assert_eq!(extracted[1], KEY_VERSION);
+        assert_eq!(
+            &extracted[2..6],
+            &FIRST_USER_SEGMENT_ID.to_be_bytes(),
+            "bytes 2..6 should encode the segment id"
+        );
+    }
+
+    #[test]
+    fn should_route_seq_block_to_system_segment() {
+        // given — SeqBlock is a 7-byte key in the system segment (id 0)
+        let extractor = LogSegmentExtractor;
+        let key = Bytes::from_static(&SEQ_BLOCK_KEY);
+
+        // when
+        let n = extractor.prefix_len(&PrefixTarget::Point(key.clone()));
+
+        // then — extracted prefix has segment_id 0 (the system segment)
+        assert_eq!(n, Some(6));
+        assert_eq!(&key[2..6], &0u32.to_be_bytes());
+    }
+
+    #[test]
+    fn should_route_segment_meta_to_system_segment() {
+        // given — SegmentMeta records live in the system segment regardless of
+        // which user segment they describe
+        let extractor = LogSegmentExtractor;
+        let described_segment = 42u32;
+        let key = SegmentMetaKey::new(described_segment).serialize();
+
+        // when
+        let n = extractor.prefix_len(&PrefixTarget::Point(key.clone()));
+
+        // then — extracted prefix routes by storage seg_id (0), NOT the
+        // described seg_id which appears later in the key
+        assert_eq!(n, Some(6));
+        assert_eq!(&key[2..6], &0u32.to_be_bytes());
+    }
+
+    #[test]
+    fn should_route_keys_for_different_segments_to_different_prefixes() {
+        // given
+        let extractor = LogSegmentExtractor;
+        let key1 = LogEntryKey::new(1, Bytes::from("k"), 0).serialize(0);
+        let key2 = LogEntryKey::new(2, Bytes::from("k"), 0).serialize(0);
+
+        // when
+        let n1 = extractor
+            .prefix_len(&PrefixTarget::Point(key1.clone()))
+            .unwrap();
+        let n2 = extractor
+            .prefix_len(&PrefixTarget::Point(key2.clone()))
+            .unwrap();
+
+        // then — both extract 6-byte prefixes, but the prefixes differ
+        assert_eq!(n1, 6);
+        assert_eq!(n2, 6);
+        assert_ne!(&key1[..n1], &key2[..n2]);
+    }
+
+    #[test]
+    fn should_return_none_for_keys_shorter_than_routing_prefix() {
+        // given
+        let extractor = LogSegmentExtractor;
+        let short = [SUBSYSTEM, KEY_VERSION, 0, 0, 0]; // 5 bytes
+
+        // when / then
+        assert_eq!(extractor.prefix_len(&point(&short)), None);
+        assert_eq!(extractor.prefix_len(&prefix(&short)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_keys_with_wrong_subsystem() {
+        // given
+        let extractor = LogSegmentExtractor;
+        let bad = [0xFF, KEY_VERSION, 0, 0, 0, 1, 0x10];
+
+        // when / then
+        assert_eq!(extractor.prefix_len(&point(&bad)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_keys_with_wrong_version() {
+        // given
+        let extractor = LogSegmentExtractor;
+        let bad = [SUBSYSTEM, 0xFF, 0, 0, 0, 1, 0x10];
+
+        // when / then
+        assert_eq!(extractor.prefix_len(&point(&bad)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_empty_key() {
+        // given
+        let extractor = LogSegmentExtractor;
+
+        // when / then
+        assert_eq!(extractor.prefix_len(&point(&[])), None);
+        assert_eq!(extractor.prefix_len(&prefix(&[])), None);
+    }
+
+    #[test]
+    fn should_satisfy_prefix_extension_invariant_for_well_formed_prefix() {
+        // given — a 6-byte scan prefix that targets segment 1
+        let extractor = LogSegmentExtractor;
+        let mut scan_prefix = vec![SUBSYSTEM, KEY_VERSION];
+        scan_prefix.extend_from_slice(&1u32.to_be_bytes());
+        assert_eq!(scan_prefix.len(), 6);
+
+        // when
+        let n = extractor.prefix_len(&prefix(&scan_prefix)).unwrap();
+        assert_eq!(n, 6);
+
+        // then — any extension q of scan_prefix must satisfy Point(q) = Some(n)
+        // and q[..n] == scan_prefix[..n].
+        let extension: Vec<u8> = scan_prefix
+            .iter()
+            .copied()
+            .chain([0x10, b'k', 0x00, 0x05])
+            .collect();
+        let point_n = extractor.prefix_len(&point(&extension)).unwrap();
+        assert_eq!(point_n, n);
+        assert_eq!(&extension[..point_n], &scan_prefix[..n]);
+    }
+}
+
+/// End-to-end tests that exercise the extractor against a real SlateDB on a
+/// temp dir: open LogDb, write across segments, drop the writer, then open a
+/// `DbReader` and inspect the manifest. Lives inside the crate (rather than
+/// under `tests/`) because the deterministic variant uses
+/// [`crate::log::LogDbBuilder::with_clock`], which is `pub(crate)`.
+///
+/// Manifest inspection uses `DbReader::manifest()` after the writer drops —
+/// SlateDB's writer fence prevents peeking at the live manifest, but the
+/// reader sees the durable state.
+#[cfg(test)]
+mod integration_tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use common::StorageConfig;
+    use common::clock::MockClock;
+    use common::storage::config::{LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig};
+    use common::storage::factory::create_object_store;
+    use slatedb::DbReader;
+    use tempfile::TempDir;
+
+    use crate::config::{Config, SegmentConfig};
+    use crate::log::{LogDb, LogDbBuilder};
+    use crate::model::Record;
+    use crate::reader::LogRead;
+
+    const EXPECTED_EXTRACTOR_NAME: &str = "opendata-log/v2";
+    const LOG_SUBSYSTEM: u8 = 0x03;
+    const LOG_KEY_VERSION: u8 = 0x02;
+    const SYSTEM_SEGMENT_ID: u32 = 0;
+
+    fn slatedb_storage_config(temp_dir: &TempDir) -> (StorageConfig, SlateDbStorageConfig) {
+        let slate = SlateDbStorageConfig {
+            path: "log-data".to_string(),
+            object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
+                path: temp_dir.path().to_string_lossy().to_string(),
+            }),
+            settings_path: None,
+            block_cache: None,
+        };
+        (StorageConfig::SlateDb(slate.clone()), slate)
+    }
+
+    fn segment_id_from_prefix(prefix: &[u8]) -> u32 {
+        assert_eq!(prefix.len(), 6, "routing prefix should be 6 bytes");
+        assert_eq!(prefix[0], LOG_SUBSYSTEM);
+        assert_eq!(prefix[1], LOG_KEY_VERSION);
+        u32::from_be_bytes([prefix[2], prefix[3], prefix[4], prefix[5]])
+    }
+
+    /// Reopens the SlateDB path as a `DbReader` and returns the segment ids
+    /// (decoded from each segment's routing prefix) present in the manifest.
+    async fn manifest_segment_ids(slate: &SlateDbStorageConfig) -> Vec<u32> {
+        let object_store = create_object_store(&slate.object_store).expect("object store");
+        let reader = DbReader::builder(slate.path.clone(), object_store)
+            .build()
+            .await
+            .expect("open DbReader");
+        let manifest = reader.manifest();
+
+        // Sanity-check that the extractor name was persisted.
+        assert_eq!(
+            manifest.segment_extractor_name(),
+            Some(EXPECTED_EXTRACTOR_NAME),
+            "segment_extractor_name should round-trip through the manifest"
+        );
+
+        let mut ids: Vec<u32> = manifest
+            .segments()
+            .iter()
+            .map(|seg| segment_id_from_prefix(seg.prefix().as_ref()))
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+
+    #[tokio::test]
+    async fn opens_and_persists_extractor_name_in_manifest() {
+        // given
+        let temp_dir = TempDir::new().expect("tempdir");
+        let (storage, slate) = slatedb_storage_config(&temp_dir);
+
+        // when — open + close a LogDb so the manifest is written out
+        {
+            let log = LogDb::open(Config {
+                storage: storage.clone(),
+                ..Default::default()
+            })
+            .await
+            .expect("open LogDb");
+            log.try_append(vec![Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v"),
+            }])
+            .await
+            .expect("append");
+            log.flush().await.expect("flush");
+            log.close().await.expect("close");
+        }
+
+        // then — reopen as a DbReader and verify the extractor name is persisted
+        let object_store = create_object_store(&slate.object_store).expect("object store");
+        let reader = DbReader::builder(slate.path.clone(), object_store)
+            .build()
+            .await
+            .expect("open DbReader");
+        let manifest = reader.manifest();
+        assert_eq!(
+            manifest.segment_extractor_name(),
+            Some(EXPECTED_EXTRACTOR_NAME)
+        );
+    }
+
+    #[tokio::test]
+    async fn routes_each_user_segment_to_its_own_slatedb_segment() {
+        // given — LogDb driven by a MockClock so segment rolls are deterministic.
+        // Each clock advance past the seal interval forces a new user segment on
+        // the next append.
+        let temp_dir = TempDir::new().expect("tempdir");
+        let (storage, slate) = slatedb_storage_config(&temp_dir);
+        let clock = Arc::new(MockClock::new());
+        let log = LogDbBuilder::new(Config {
+            storage: storage.clone(),
+            segmentation: SegmentConfig {
+                seal_interval: Some(Duration::from_secs(1)),
+            },
+            ..Default::default()
+        })
+        .with_clock(clock.clone())
+        .build()
+        .await
+        .expect("open LogDb");
+
+        // when — three appends, with the mock clock advanced past the seal
+        // interval between each. No real-time sleeps.
+        for i in 0..3 {
+            log.try_append(vec![Record {
+                key: Bytes::from(format!("k-{i}")),
+                value: Bytes::from(format!("v-{i}")),
+            }])
+            .await
+            .expect("append");
+            log.flush().await.expect("flush");
+            clock.advance(Duration::from_secs(2));
+        }
+
+        // confirm via the LogDb API that three user segments exist
+        let segments = log.list_segments(..).await.expect("list_segments");
+        assert_eq!(segments.len(), 3, "expected three user segments");
+        let user_ids: Vec<u32> = segments.iter().map(|s| s.id).collect();
+        assert_eq!(user_ids, vec![1, 2, 3]);
+
+        log.close().await.expect("close");
+
+        // then — manifest contains a SlateDB segment per LogDb segment, plus
+        // the system segment for the SeqBlock and SegmentMeta records
+        let manifest_ids = manifest_segment_ids(&slate).await;
+        assert!(
+            manifest_ids.contains(&SYSTEM_SEGMENT_ID),
+            "system segment (id 0) should hold SeqBlock + SegmentMeta records; \
+             manifest segment ids: {:?}",
+            manifest_ids
+        );
+        for user_id in &user_ids {
+            assert!(
+                manifest_ids.contains(user_id),
+                "user segment {} should have its own SlateDB segment; \
+                 manifest segment ids: {:?}",
+                user_id,
+                manifest_ids
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn reopens_existing_database_with_matching_extractor_name() {
+        // given — create a database, write, close
+        let temp_dir = TempDir::new().expect("tempdir");
+        let (storage, _slate) = slatedb_storage_config(&temp_dir);
+        {
+            let log = LogDb::open(Config {
+                storage: storage.clone(),
+                ..Default::default()
+            })
+            .await
+            .expect("open LogDb");
+            log.try_append(vec![Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v"),
+            }])
+            .await
+            .expect("append");
+            log.flush().await.expect("flush");
+            log.close().await.expect("close");
+        }
+
+        // when / then — reopening with the same config (same extractor name)
+        // must succeed. A mismatched name would surface as a
+        // SegmentExtractorMismatch SlateDB error during build().
+        let log = LogDb::open(Config {
+            storage,
+            ..Default::default()
+        })
+        .await
+        .expect("reopen LogDb with matching extractor name");
+
+        // Reader should see the previously appended record.
+        let mut iter = log.scan(Bytes::from("k"), ..).await.expect("scan");
+        let entry = iter.next().await.expect("read").expect("entry present");
+        assert_eq!(entry.value, Bytes::from("v"));
+
+        log.close().await.expect("close");
+    }
+}

--- a/log/src/segment_extractor.rs
+++ b/log/src/segment_extractor.rs
@@ -260,7 +260,9 @@ mod integration_tests {
     use bytes::Bytes;
     use common::StorageConfig;
     use common::clock::MockClock;
-    use common::storage::config::{LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig};
+    use common::storage::config::{
+        LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig,
+    };
     use common::storage::factory::create_object_store;
     use slatedb::DbReader;
     use tempfile::TempDir;

--- a/log/src/segment_extractor.rs
+++ b/log/src/segment_extractor.rs
@@ -41,11 +41,19 @@ const EXTRACTOR_NAME: &str = "opendata-log/v2";
 
 /// Prefix extractor routing log records to per-segment SlateDB segments.
 ///
-/// Returns `Some(6)` for any key whose first two bytes are `[SUBSYSTEM,
-/// KEY_VERSION]` and whose total length is at least 6 bytes — i.e. every
-/// well-formed log key. Returns `None` otherwise, so unrelated keys
-/// (shouldn't occur in a LogDb-owned database, but treated defensively)
-/// stay in the root tree.
+/// Every well-formed log key has the shape `[SUBSYSTEM, KEY_VERSION,
+/// segment_id(4 BE), ...]` by construction, so this extractor returns
+/// `Some(6)` for any well-formed `PrefixTarget::Point` and for any 6+ byte
+/// `PrefixTarget::Prefix` matching the same leading two bytes.
+///
+/// **Point inputs that don't match are a bug.** SlateDB rejects writes whose
+/// segment extractor returns `None` (or `Some(0)`) with
+/// `SlateDBError::EmptySegmentPrefix` at write time, so a malformed key
+/// would surface as a confusing downstream error rather than a clear
+/// failure at the origin. We panic on mismatched `Point` inputs to make
+/// the bug obvious. Short or non-conforming `Prefix` scan inputs are
+/// permitted to return `None` — the trait contract allows it and slatedb
+/// simply skips prefix-based filtering in that case.
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct LogSegmentExtractor;
 
@@ -63,19 +71,39 @@ impl PrefixExtractor for LogSegmentExtractor {
     }
 
     fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
-        // The `Point` and `Prefix` variants share the same answer here: the
-        // extracted bytes are determined entirely by positions 0..6, which
-        // both variants observe directly.
-        let bytes: &[u8] = match target {
-            PrefixTarget::Point(b) | PrefixTarget::Prefix(b) => b.as_ref(),
-        };
-        if bytes.len() < ROUTING_PREFIX_LEN {
-            return None;
+        match target {
+            // Stored keys and point-read targets must be well-formed log
+            // keys. A mismatch is a LogDb bug; panic with the offending bytes
+            // rather than letting slatedb reject the write later with an
+            // opaque EmptySegmentPrefix error.
+            PrefixTarget::Point(b) => {
+                let bytes = b.as_ref();
+                assert!(
+                    bytes.len() >= ROUTING_PREFIX_LEN
+                        && bytes[0] == SUBSYSTEM
+                        && bytes[1] == KEY_VERSION,
+                    "LogSegmentExtractor: malformed log key (subsystem/version mismatch \
+                     or under {} bytes): {:02x?}",
+                    ROUTING_PREFIX_LEN,
+                    bytes
+                );
+                Some(ROUTING_PREFIX_LEN)
+            }
+            // Scan prefixes are caller-supplied; a too-short or non-matching
+            // prefix is benign — return `None` so any prefix-based filter is
+            // skipped (no false negatives, per the trait contract).
+            PrefixTarget::Prefix(b) => {
+                let bytes = b.as_ref();
+                if bytes.len() < ROUTING_PREFIX_LEN
+                    || bytes[0] != SUBSYSTEM
+                    || bytes[1] != KEY_VERSION
+                {
+                    None
+                } else {
+                    Some(ROUTING_PREFIX_LEN)
+                }
+            }
         }
-        if bytes[0] != SUBSYSTEM || bytes[1] != KEY_VERSION {
-            return None;
-        }
-        Some(ROUTING_PREFIX_LEN)
     }
 }
 
@@ -178,44 +206,85 @@ mod tests {
     }
 
     #[test]
-    fn should_return_none_for_keys_shorter_than_routing_prefix() {
-        // given
+    fn should_return_none_for_prefix_shorter_than_routing_prefix() {
+        // given — a 5-byte scan prefix
         let extractor = LogSegmentExtractor;
-        let short = [SUBSYSTEM, KEY_VERSION, 0, 0, 0]; // 5 bytes
+        let short = [SUBSYSTEM, KEY_VERSION, 0, 0, 0];
 
-        // when / then
-        assert_eq!(extractor.prefix_len(&point(&short)), None);
+        // when / then — short Prefix returns None (scan-side, benign)
         assert_eq!(extractor.prefix_len(&prefix(&short)), None);
     }
 
     #[test]
-    fn should_return_none_for_keys_with_wrong_subsystem() {
+    fn should_return_none_for_prefix_with_wrong_subsystem() {
+        // given
+        let extractor = LogSegmentExtractor;
+        let bad = [0xFF, KEY_VERSION, 0, 0, 0, 1, 0x10];
+
+        // when / then — non-log Prefix returns None
+        assert_eq!(extractor.prefix_len(&prefix(&bad)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_prefix_with_wrong_version() {
+        // given
+        let extractor = LogSegmentExtractor;
+        let bad = [SUBSYSTEM, 0xFF, 0, 0, 0, 1, 0x10];
+
+        // when / then — Prefix with wrong version returns None
+        assert_eq!(extractor.prefix_len(&prefix(&bad)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_empty_prefix() {
+        // given
+        let extractor = LogSegmentExtractor;
+
+        // when / then — empty Prefix returns None (scan-side, benign)
+        assert_eq!(extractor.prefix_len(&prefix(&[])), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed log key")]
+    fn should_panic_on_point_shorter_than_routing_prefix() {
+        // given
+        let extractor = LogSegmentExtractor;
+        let short = [SUBSYSTEM, KEY_VERSION, 0, 0, 0];
+
+        // when / then — short Point is a LogDb bug; panic
+        let _ = extractor.prefix_len(&point(&short));
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed log key")]
+    fn should_panic_on_point_with_wrong_subsystem() {
         // given
         let extractor = LogSegmentExtractor;
         let bad = [0xFF, KEY_VERSION, 0, 0, 0, 1, 0x10];
 
         // when / then
-        assert_eq!(extractor.prefix_len(&point(&bad)), None);
+        let _ = extractor.prefix_len(&point(&bad));
     }
 
     #[test]
-    fn should_return_none_for_keys_with_wrong_version() {
+    #[should_panic(expected = "malformed log key")]
+    fn should_panic_on_point_with_wrong_version() {
         // given
         let extractor = LogSegmentExtractor;
         let bad = [SUBSYSTEM, 0xFF, 0, 0, 0, 1, 0x10];
 
         // when / then
-        assert_eq!(extractor.prefix_len(&point(&bad)), None);
+        let _ = extractor.prefix_len(&point(&bad));
     }
 
     #[test]
-    fn should_return_none_for_empty_key() {
+    #[should_panic(expected = "malformed log key")]
+    fn should_panic_on_empty_point() {
         // given
         let extractor = LogSegmentExtractor;
 
         // when / then
-        assert_eq!(extractor.prefix_len(&point(&[])), None);
-        assert_eq!(extractor.prefix_len(&prefix(&[])), None);
+        let _ = extractor.prefix_len(&point(&[]));
     }
 
     #[test]

--- a/log/src/serde.rs
+++ b/log/src/serde.rs
@@ -8,16 +8,30 @@
 //!
 //! # Key Format
 //!
-//! All keys start with a subsystem byte, version byte, and record type discriminator:
+//! All log storage keys share a 7-byte segmented prefix:
 //!
 //! ```text
-//! | subsystem (u8) | version (u8) | type (u8) | ... record-specific fields ... |
+//! | subsystem (u8) | version (u8) | segment_id (u32 BE) | record_type (u8) | ... |
 //! ```
+//!
+//! Placing `segment_id` before `record_type` lets a SlateDB segment extractor
+//! recognize the segment boundary with a fixed 6-byte prefix
+//! `[subsystem, version, segment_id]`, routing all records for a given
+//! segment to the same SlateDB segment regardless of record type.
+//!
+//! # System Segment
+//!
+//! Segment id `0` is reserved as the **system segment**: it never holds user
+//! log entries. Records that are not bound to a specific user segment (the
+//! global sequence block, and per-segment metadata records describing other
+//! segments) live in segment `0`. Real user segments are numbered from `1`.
 //!
 //! # Record Types
 //!
-//! - `LogEntry` (0x10): User data entries with key and sequence number
-//! - `SeqBlock` (0x20): Sequence number block allocation tracking (value type in `common` crate)
+//! - `LogEntry`     (`0x10`): user data entry, in its owning segment
+//! - `SeqBlock`     (`0x20`): global sequence block, in the system segment
+//! - `SegmentMeta`  (`0x30`): per-segment metadata, in the system segment
+//! - `ListingEntry` (`0x40`): per-segment key listing, in its owning segment
 //!
 //! # TerminatedBytes Encoding
 //!
@@ -38,7 +52,6 @@ use std::ops::{Bound, Range};
 
 use bytes::{BufMut, Bytes, BytesMut};
 use common::BytesRange;
-use common::serde::key_prefix::KeyPrefix;
 use common::serde::record_tag::RecordTag;
 use common::serde::terminated_bytes;
 use common::serde::varint::var_u64;
@@ -53,14 +66,30 @@ impl From<common::serde::DeserializeError> for Error {
     }
 }
 
-/// Key format version (currently 0x01)
-pub const KEY_VERSION: u8 = 0x01;
+/// Key format version (currently 0x02 — segment_id precedes record_type).
+pub const KEY_VERSION: u8 = 0x02;
 
 /// Subsystem-specific key prefix for log storage.
 pub const SUBSYSTEM: u8 = 0x03;
 
-/// Storage key for the SeqBlock record.
-pub const SEQ_BLOCK_KEY: [u8; 3] = [SUBSYSTEM, KEY_VERSION, 0x20]; // RecordType::SeqBlock
+/// Reserved segment id for system records (sequence block, per-segment
+/// metadata describing other segments). User log segments start at `1`.
+pub const SYSTEM_SEGMENT_ID: SegmentId = 0;
+
+/// First segment id assigned to user log data. Segment `0` is reserved as the
+/// system segment.
+pub const FIRST_USER_SEGMENT_ID: SegmentId = 1;
+
+/// Storage key for the SeqBlock record (lives in the system segment).
+pub const SEQ_BLOCK_KEY: [u8; 7] = [
+    SUBSYSTEM,
+    KEY_VERSION,
+    0,
+    0,
+    0,
+    0,    // SYSTEM_SEGMENT_ID encoded as u32 BE
+    0x20, // RecordType::SeqBlock tag byte
+];
 
 /// Record type discriminators for log storage.
 ///
@@ -99,28 +128,56 @@ impl RecordType {
         }
     }
 
-    pub fn from_prefix(prefix: KeyPrefix) -> Result<Self, Error> {
-        if prefix.subsystem() != SUBSYSTEM {
-            return Err(Error::Encoding(format!(
-                "invalid subsystem: expected 0x{:02x}, got 0x{:02x}",
-                SUBSYSTEM,
-                prefix.subsystem()
-            )));
-        }
-        RecordType::from_id((prefix.tag() & 0xF0) >> 4)
-    }
-
     /// Creates a RecordTag for this record type.
     ///
     /// Log records use 0 for the reserved bits.
     pub fn tag(&self) -> RecordTag {
         RecordTag::new(self.id(), 0)
     }
+}
 
-    /// Creates a KeyPrefix for this record type with the current version.
-    pub fn prefix(&self) -> KeyPrefix {
-        KeyPrefix::new(SUBSYSTEM, KEY_VERSION, self.tag().as_byte())
+/// Length of the v2 segmented key prefix: `[subsystem, version, seg_id(4), record_type]`.
+const SEGMENTED_PREFIX_LEN: usize = 7;
+
+/// Writes the v2 segmented prefix into `buf`:
+/// `[subsystem, version, seg_id BE, record_type]`.
+fn write_segmented_prefix(buf: &mut BytesMut, segment_id: SegmentId, record_type: u8) {
+    buf.put_u8(SUBSYSTEM);
+    buf.put_u8(KEY_VERSION);
+    buf.put_u32(segment_id);
+    buf.put_u8(record_type);
+}
+
+/// Parses a v2 segmented prefix, validating the subsystem/version/tag.
+/// Returns the segment id along with the remaining (post-prefix) bytes.
+fn parse_segmented_prefix(data: &[u8], expected_tag: u8) -> Result<(SegmentId, &[u8]), Error> {
+    if data.len() < SEGMENTED_PREFIX_LEN {
+        return Err(Error::Encoding(format!(
+            "buffer too short for log key: need {} bytes, got {}",
+            SEGMENTED_PREFIX_LEN,
+            data.len()
+        )));
     }
+    if data[0] != SUBSYSTEM {
+        return Err(Error::Encoding(format!(
+            "invalid subsystem: expected 0x{:02x}, got 0x{:02x}",
+            SUBSYSTEM, data[0]
+        )));
+    }
+    if data[1] != KEY_VERSION {
+        return Err(Error::Encoding(format!(
+            "invalid key version: expected 0x{:02x}, got 0x{:02x}",
+            KEY_VERSION, data[1]
+        )));
+    }
+    let segment_id = u32::from_be_bytes([data[2], data[3], data[4], data[5]]);
+    if data[6] != expected_tag {
+        return Err(Error::Encoding(format!(
+            "invalid record tag: expected 0x{:02x}, got 0x{:02x}",
+            expected_tag, data[6]
+        )));
+    }
+    Ok((segment_id, &data[SEGMENTED_PREFIX_LEN..]))
 }
 
 /// Key for a log entry record.
@@ -129,7 +186,7 @@ impl RecordType {
 /// that preserves lexicographic ordering:
 ///
 /// ```text
-/// | subsystem (u8) | version (u8) | type (u8) | segment_id (u32 BE) | terminated_key | relative_seq (var_u64) |
+/// | subsystem (u8) | version (u8) | segment_id (u32 BE) | record_type (u8=0x10) | terminated_key | relative_seq (var_u64) |
 /// ```
 ///
 /// The `relative_seq` is the entry's sequence number relative to the segment's `start_seq`
@@ -137,8 +194,9 @@ impl RecordType {
 /// relative offsets within a segment are small. The sequence number uses variable-length
 /// encoding (see [`common::serde::varint::var_u64`]).
 ///
-/// The ordering (segment_id before key) ensures entries are grouped by segment,
-/// enabling efficient scans within a single segment.
+/// Placing `segment_id` before `record_type` keeps every record for a given segment
+/// contiguous in storage, regardless of record type — the property a fixed-length
+/// SlateDB segment extractor relies on.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LogEntryKey {
     /// The segment this entry belongs to
@@ -166,8 +224,11 @@ impl LogEntryKey {
     pub fn serialize(&self, segment_start_seq: u64) -> Bytes {
         let relative_seq = self.sequence - segment_start_seq;
         let mut buf = BytesMut::new();
-        RecordType::LogEntry.prefix().write_to(&mut buf);
-        buf.put_u32(self.segment_id);
+        write_segmented_prefix(
+            &mut buf,
+            self.segment_id,
+            RecordType::LogEntry.tag().as_byte(),
+        );
         terminated_bytes::serialize(&self.key, &mut buf);
         var_u64::serialize(relative_seq, &mut buf);
         buf.freeze()
@@ -179,26 +240,10 @@ impl LogEntryKey {
     /// caller must provide the segment's start sequence to recover the absolute
     /// sequence number.
     pub fn deserialize(data: &[u8], segment_start_seq: u64) -> Result<Self, Error> {
-        let prefix = KeyPrefix::from_bytes_with_validation(data, SUBSYSTEM, KEY_VERSION)?;
-        let record_type = RecordType::from_prefix(prefix)?;
-        if record_type != RecordType::LogEntry {
-            return Err(Error::Encoding(format!(
-                "invalid record type: expected LogEntry, got {:?}",
-                record_type
-            )));
-        }
-
-        if data.len() < 7 {
-            return Err(Error::Encoding(
-                "buffer too short for log entry key".to_string(),
-            ));
-        }
-
-        let segment_id = u32::from_be_bytes([data[3], data[4], data[5], data[6]]);
-
-        let mut buf = &data[7..];
-        let key = terminated_bytes::deserialize(&mut buf)?;
-        let relative_seq = var_u64::deserialize(&mut buf)?;
+        let (segment_id, mut rest) =
+            parse_segmented_prefix(data, RecordType::LogEntry.tag().as_byte())?;
+        let key = terminated_bytes::deserialize(&mut rest)?;
+        let relative_seq = var_u64::deserialize(&mut rest)?;
         let sequence = segment_start_seq + relative_seq;
 
         Ok(LogEntryKey {
@@ -223,8 +268,7 @@ impl LogEntryKey {
     fn build_scan_key(segment: &LogSegment, key: &[u8], seq: u64) -> Bytes {
         let relative_seq = seq.saturating_sub(segment.meta().start_seq);
         let mut buf = BytesMut::new();
-        RecordType::LogEntry.prefix().write_to(&mut buf);
-        buf.put_u32(segment.id());
+        write_segmented_prefix(&mut buf, segment.id(), RecordType::LogEntry.tag().as_byte());
         terminated_bytes::serialize(key, &mut buf);
         var_u64::serialize(relative_seq, &mut buf);
         buf.freeze()
@@ -233,12 +277,16 @@ impl LogEntryKey {
 
 /// Key for a segment metadata record.
 ///
+/// `SegmentMeta` records describe user log segments. They are written into the
+/// system segment (seg_id `0`), with the described segment's id encoded as a
+/// suffix so the records sort by described segment:
+///
 /// ```text
-/// | subsystem (u8) | version (u8) | type (u8=0x30) | segment_id (u32 BE) |
+/// | subsystem (u8) | version (u8) | SYSTEM_SEGMENT_ID (u32 BE) | record_type (u8=0x30) | described_segment_id (u32 BE) |
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SegmentMetaKey {
-    /// The segment identifier
+    /// The user segment this metadata record describes.
     pub segment_id: SegmentId,
 }
 
@@ -250,35 +298,48 @@ impl SegmentMetaKey {
 
     /// Encodes the key to bytes for storage
     pub fn serialize(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(7);
-        RecordType::SegmentMeta.prefix().write_to(&mut buf);
+        let mut buf = BytesMut::with_capacity(SEGMENTED_PREFIX_LEN + 4);
+        write_segmented_prefix(
+            &mut buf,
+            SYSTEM_SEGMENT_ID,
+            RecordType::SegmentMeta.tag().as_byte(),
+        );
         buf.put_u32(self.segment_id);
         buf.freeze()
     }
 
-    /// Decodes a segment metadata key from bytes
+    /// Decodes a segment metadata key from bytes.
+    ///
+    /// Strict: rejects keys that aren't routed to the system segment, and
+    /// rejects trailing bytes past the described-segment-id suffix. The
+    /// caller has already validated subsystem / version / tag via
+    /// [`parse_segmented_prefix`].
     pub fn deserialize(data: &[u8]) -> Result<Self, Error> {
-        let prefix = KeyPrefix::from_bytes_with_validation(data, SUBSYSTEM, KEY_VERSION)?;
-        let record_type = RecordType::from_prefix(prefix)?;
-        if record_type != RecordType::SegmentMeta {
+        let (storage_segment_id, rest) =
+            parse_segmented_prefix(data, RecordType::SegmentMeta.tag().as_byte())?;
+        if storage_segment_id != SYSTEM_SEGMENT_ID {
             return Err(Error::Encoding(format!(
-                "invalid record type: expected SegmentMeta, got {:?}",
-                record_type
+                "SegmentMeta records must live in the system segment (got seg_id {})",
+                storage_segment_id
             )));
         }
-
-        if data.len() < 7 {
-            return Err(Error::Encoding(
-                "buffer too short for SegmentMeta key".to_string(),
-            ));
+        if rest.len() != 4 {
+            return Err(Error::Encoding(format!(
+                "SegmentMeta key has wrong described-segment-id suffix length: expected 4 bytes, got {}",
+                rest.len()
+            )));
         }
-
-        let segment_id = u32::from_be_bytes([data[3], data[4], data[5], data[6]]);
-
+        let segment_id = u32::from_be_bytes([rest[0], rest[1], rest[2], rest[3]]);
         Ok(SegmentMetaKey { segment_id })
     }
 
-    /// Creates a storage key range for scanning segment metadata within a segment ID range.
+    /// Creates a storage key range for scanning `SegmentMeta` records whose
+    /// *described* segment id falls in `range`.
+    ///
+    /// All records live in the system segment (storage seg_id `0`); the
+    /// described segment id is the fixed-width 4-byte suffix, so the range
+    /// endpoints encode `seg_id=0` at the front and the described range at
+    /// the back. The scan is contiguous within the system segment.
     pub fn scan_range(range: Range<SegmentId>) -> BytesRange {
         let start = Bound::Included(SegmentMetaKey::new(range.start).serialize());
         let end = Bound::Excluded(SegmentMetaKey::new(range.end).serialize());
@@ -342,15 +403,18 @@ impl SegmentMeta {
 /// Key for a listing entry record.
 ///
 /// Tracks key presence within a segment for efficient key enumeration.
-/// The key format places segment_id before the user key, ensuring all
-/// listing records for a segment are contiguous for efficient prefix scans.
+/// Listing records share the segment's 6-byte prefix `[sub, ver, segment_id]`
+/// with log entries, so they land in the same SlateDB segment under a
+/// segment extractor.
 ///
 /// ```text
-/// | subsystem (u8) | version (u8) | type (u8=0x40) | segment_id (u32 BE) | key (Bytes) |
+/// | subsystem (u8) | version (u8) | segment_id (u32 BE) | record_type (u8=0x40) | key (Bytes) |
 /// ```
 ///
 /// Unlike log entry keys, the user key is stored as raw bytes without
-/// terminated encoding since it occupies the suffix position.
+/// terminated encoding since it occupies the suffix position. Listings for a
+/// given segment are enumerated with a single contiguous prefix scan; cross-
+/// segment listings are stitched together by walking the segment cache.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListingEntryKey {
     /// The segment this listing entry belongs to
@@ -368,50 +432,40 @@ impl ListingEntryKey {
     /// Serializes the key to bytes for storage.
     pub fn serialize(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        RecordType::ListingEntry.prefix().write_to(&mut buf);
-        buf.put_u32(self.segment_id);
+        write_segmented_prefix(
+            &mut buf,
+            self.segment_id,
+            RecordType::ListingEntry.tag().as_byte(),
+        );
         buf.put_slice(&self.key);
         buf.freeze()
     }
 
     /// Deserializes a listing entry key from bytes.
     pub fn deserialize(data: &[u8]) -> Result<Self, Error> {
-        let prefix = KeyPrefix::from_bytes_with_validation(data, SUBSYSTEM, KEY_VERSION)?;
-        let record_type = RecordType::from_prefix(prefix)?;
-        if record_type != RecordType::ListingEntry {
-            return Err(Error::Encoding(format!(
-                "invalid record type: expected ListingEntry, got {:?}",
-                record_type
-            )));
-        }
-
-        if data.len() < 7 {
-            return Err(Error::Encoding(
-                "buffer too short for listing entry key".to_string(),
-            ));
-        }
-
-        let segment_id = u32::from_be_bytes([data[3], data[4], data[5], data[6]]);
-        let key = Bytes::copy_from_slice(&data[7..]);
-
+        let (segment_id, rest) =
+            parse_segmented_prefix(data, RecordType::ListingEntry.tag().as_byte())?;
+        let key = Bytes::copy_from_slice(rest);
         Ok(ListingEntryKey { segment_id, key })
     }
 
-    /// Creates a storage key range for scanning listing entries across segments.
-    ///
-    /// Returns a range that matches all listing entries for segments within
-    /// the specified range [start, end).
-    pub fn scan_range(range: Range<SegmentId>) -> BytesRange {
-        let start = Bound::Included(Self::segment_prefix(range.start));
-        let end = Bound::Excluded(Self::segment_prefix(range.end));
-        BytesRange::new(start, end)
+    /// Creates a storage key range for scanning listing entries within a
+    /// single segment. Cross-segment iteration is the caller's responsibility:
+    /// the v2 layout interleaves listing records with log entries across
+    /// segment boundaries, so a wide cross-segment range scan is not safe.
+    pub fn scan_range_for_segment(segment_id: SegmentId) -> BytesRange {
+        BytesRange::prefix(Self::segment_prefix(segment_id))
     }
 
-    /// Returns the prefix key for a segment (smallest possible key for segment).
+    /// Returns the listing prefix for a segment (the smallest valid listing key
+    /// for that segment).
     fn segment_prefix(segment_id: SegmentId) -> Bytes {
-        let mut buf = BytesMut::with_capacity(7);
-        RecordType::ListingEntry.prefix().write_to(&mut buf);
-        buf.put_u32(segment_id);
+        let mut buf = BytesMut::with_capacity(SEGMENTED_PREFIX_LEN);
+        write_segmented_prefix(
+            &mut buf,
+            segment_id,
+            RecordType::ListingEntry.tag().as_byte(),
+        );
         buf.freeze()
     }
 }
@@ -508,15 +562,15 @@ mod tests {
         let serialized = key.serialize(segment_start_seq);
 
         // then
-        // subsystem (1) + version (1) + tag (1) + segment_id (4) + key "k" (1) + terminator (1) + relative_seq (varint, 2 bytes for 100) = 11
+        // subsystem (1) + version (1) + segment_id (4) + tag (1) + key "k" (1) + terminator (1) + relative_seq (varint, 2 bytes for 100) = 11
         assert_eq!(serialized.len(), 11);
         assert_eq!(serialized[0], SUBSYSTEM);
         assert_eq!(serialized[1], KEY_VERSION);
-        // Record tag: type 0x01 in high nibble, reserved 0x00 in low nibble = 0x10
-        assert_eq!(serialized[2], RecordType::LogEntry.tag().as_byte());
-        assert_eq!(serialized[2], 0x10);
         // segment_id = 1 in big endian
-        assert_eq!(&serialized[3..7], &[0, 0, 0, 1]);
+        assert_eq!(&serialized[2..6], &[0, 0, 0, 1]);
+        // Record tag: type 0x01 in high nibble, reserved 0x00 in low nibble = 0x10
+        assert_eq!(serialized[6], RecordType::LogEntry.tag().as_byte());
+        assert_eq!(serialized[6], 0x10);
         // key "k" + terminator
         assert_eq!(serialized[7], b'k');
         assert_eq!(serialized[8], 0x00); // terminator
@@ -537,7 +591,7 @@ mod tests {
 
         // then
         // relative_seq = 5 fits in 1 byte (length code 0)
-        // subsystem (1) + version (1) + type (1) + segment_id (4) + key "k" (1) + terminator (1) + relative_seq (1) = 10
+        // subsystem (1) + version (1) + segment_id (4) + tag (1) + key "k" (1) + terminator (1) + relative_seq (1) = 10
         assert_eq!(serialized.len(), 10);
         // relative_seq = 5 as varint: length code 0, value 5
         assert_eq!(serialized[9], 0x05);
@@ -545,25 +599,25 @@ mod tests {
 
     #[test]
     fn should_order_log_entries_by_segment_then_key_then_sequence() {
-        // given - all in segment 0 with start_seq 0
-        let segment_start_seq = 0;
-        let key1 = LogEntryKey::new(0, Bytes::from("a"), 1);
-        let key2 = LogEntryKey::new(0, Bytes::from("a"), 2);
-        let key3 = LogEntryKey::new(0, Bytes::from("b"), 1);
-        // segment 1 has its own start_seq
-        let segment1_start_seq = 100;
-        let key4 = LogEntryKey::new(1, Bytes::from("a"), 101);
+        // given - all in segment 1 with start_seq 0
+        let seg1_start_seq = 0;
+        let key1 = LogEntryKey::new(1, Bytes::from("a"), 1);
+        let key2 = LogEntryKey::new(1, Bytes::from("a"), 2);
+        let key3 = LogEntryKey::new(1, Bytes::from("b"), 1);
+        // segment 2 has its own start_seq
+        let seg2_start_seq = 100;
+        let key4 = LogEntryKey::new(2, Bytes::from("a"), 101);
 
         // when
-        let s1 = key1.serialize(segment_start_seq);
-        let s2 = key2.serialize(segment_start_seq);
-        let s3 = key3.serialize(segment_start_seq);
-        let s4 = key4.serialize(segment1_start_seq);
+        let s1 = key1.serialize(seg1_start_seq);
+        let s2 = key2.serialize(seg1_start_seq);
+        let s3 = key3.serialize(seg1_start_seq);
+        let s4 = key4.serialize(seg2_start_seq);
 
         // then - segment_id ordering takes precedence
         assert!(s1 < s2, "same segment/key, seq 1 < seq 2");
         assert!(s2 < s3, "same segment, key 'a' < key 'b'");
-        assert!(s3 < s4, "segment 0 < segment 1");
+        assert!(s3 < s4, "segment 1 < segment 2");
     }
 
     #[test]
@@ -583,15 +637,8 @@ mod tests {
 
     #[test]
     fn should_fail_deserialize_log_entry_key_too_short() {
-        // given
-        let data = vec![
-            SUBSYSTEM,
-            KEY_VERSION,
-            RecordType::LogEntry.tag().as_byte(),
-            0,
-            0,
-            0,
-        ]; // only 6 bytes
+        // given — 6 bytes (one short of the 7-byte segmented prefix)
+        let data = vec![SUBSYSTEM, KEY_VERSION, 0, 0, 0, 1];
 
         // when
         let result = LogEntryKey::deserialize(&data, 0);
@@ -623,15 +670,15 @@ mod tests {
         let serialized = key.serialize();
 
         // then
-        // subsystem (1) + version (1) + tag (1) + segment_id (4) + key "k" (1) = 8
+        // subsystem (1) + version (1) + segment_id (4) + tag (1) + key "k" (1) = 8
         assert_eq!(serialized.len(), 8);
         assert_eq!(serialized[0], SUBSYSTEM);
         assert_eq!(serialized[1], KEY_VERSION);
-        // Record tag: type 0x04 in high nibble, reserved 0x00 in low nibble = 0x40
-        assert_eq!(serialized[2], RecordType::ListingEntry.tag().as_byte());
-        assert_eq!(serialized[2], 0x40);
         // segment_id = 1 in big endian
-        assert_eq!(&serialized[3..7], &[0, 0, 0, 1]);
+        assert_eq!(&serialized[2..6], &[0, 0, 0, 1]);
+        // Record tag: type 0x04 in high nibble, reserved 0x00 in low nibble = 0x40
+        assert_eq!(serialized[6], RecordType::ListingEntry.tag().as_byte());
+        assert_eq!(serialized[6], 0x40);
         // key "k" (raw bytes, no terminator)
         assert_eq!(serialized[7], b'k');
     }
@@ -646,7 +693,7 @@ mod tests {
         let deserialized = ListingEntryKey::deserialize(&serialized).unwrap();
 
         // then
-        assert_eq!(serialized.len(), 7); // subsystem + version + tag + segment_id only
+        assert_eq!(serialized.len(), SEGMENTED_PREFIX_LEN); // sub + ver + segment_id + tag, no user key
         assert_eq!(deserialized.segment_id, 1);
         assert_eq!(deserialized.key, Bytes::new());
     }
@@ -654,9 +701,9 @@ mod tests {
     #[test]
     fn should_order_listing_entries_by_segment_then_key() {
         // given
-        let key1 = ListingEntryKey::new(0, Bytes::from("a"));
-        let key2 = ListingEntryKey::new(0, Bytes::from("b"));
-        let key3 = ListingEntryKey::new(1, Bytes::from("a"));
+        let key1 = ListingEntryKey::new(1, Bytes::from("a"));
+        let key2 = ListingEntryKey::new(1, Bytes::from("b"));
+        let key3 = ListingEntryKey::new(2, Bytes::from("a"));
 
         // when
         let s1 = key1.serialize();
@@ -665,24 +712,27 @@ mod tests {
 
         // then
         assert!(s1 < s2, "same segment, key 'a' < key 'b'");
-        assert!(s2 < s3, "segment 0 < segment 1");
+        assert!(s2 < s3, "segment 1 < segment 2");
     }
 
     #[test]
-    fn should_create_listing_entry_scan_range() {
+    fn should_create_listing_entry_scan_range_for_segment() {
         // given
-        let range = 1..3;
+        let segment_id = 7;
 
         // when
-        let scan_range = ListingEntryKey::scan_range(range);
+        let scan_range = ListingEntryKey::scan_range_for_segment(segment_id);
 
-        // then
-        let start_key = ListingEntryKey::new(1, Bytes::new()).serialize();
-        let end_key = ListingEntryKey::new(3, Bytes::new()).serialize();
-
-        // Range should be [segment 1 prefix, segment 3 prefix)
+        // then — start is the segment's listing prefix (= empty-key listing key)
+        let start_key = ListingEntryKey::new(segment_id, Bytes::new()).serialize();
         assert_eq!(scan_range.start_bound(), Bound::Included(&start_key));
-        assert_eq!(scan_range.end_bound(), Bound::Excluded(&end_key));
+        // end is the lex-incremented prefix — non-empty for a non-0xFF prefix
+        match scan_range.end_bound() {
+            Bound::Excluded(b) => {
+                assert!(b > &start_key, "end bound must be strictly after start");
+            }
+            other => panic!("expected Excluded end bound, got {:?}", other),
+        }
     }
 
     #[test]
@@ -713,15 +763,8 @@ mod tests {
 
     #[test]
     fn should_fail_deserialize_listing_entry_key_too_short() {
-        // given
-        let data = vec![
-            SUBSYSTEM,
-            KEY_VERSION,
-            RecordType::ListingEntry.tag().as_byte(),
-            0,
-            0,
-            0,
-        ]; // only 6 bytes
+        // given — 6 bytes, one short of the segmented prefix
+        let data = vec![SUBSYSTEM, KEY_VERSION, 0, 0, 0, 1];
 
         // when
         let result = ListingEntryKey::deserialize(&data);
@@ -739,8 +782,8 @@ mod tests {
             #[test]
             fn should_preserve_sequence_ordering(a: u64, b: u64) {
                 let segment_start_seq = 0;
-                let key_a = LogEntryKey::new(0, Bytes::from("key"), a);
-                let key_b = LogEntryKey::new(0, Bytes::from("key"), b);
+                let key_a = LogEntryKey::new(1, Bytes::from("key"), a);
+                let key_b = LogEntryKey::new(1, Bytes::from("key"), b);
 
                 let enc_a = key_a.serialize(segment_start_seq);
                 let enc_b = key_b.serialize(segment_start_seq);
@@ -754,28 +797,42 @@ mod tests {
             }
 
             #[test]
-            fn should_include_listing_entry_in_scan_range(
-                start in 0u32..1000,
-                range_size in 1u32..100,
-                offset in 0u32..100,
+            fn should_include_listing_entry_in_per_segment_scan_range(
+                segment_id in 1u32..100_000,
                 key_bytes in prop::collection::vec(any::<u8>(), 1..100),
             ) {
-                let end = start.saturating_add(range_size);
-                let segment_id = start.saturating_add(offset % range_size);
-
                 let key = ListingEntryKey::new(segment_id, Bytes::from(key_bytes));
                 let serialized = key.serialize();
 
-                let scan_range = ListingEntryKey::scan_range(start..end);
+                let scan_range = ListingEntryKey::scan_range_for_segment(segment_id);
 
                 prop_assert!(
                     scan_range.contains(&serialized),
-                    "listing entry for segment {} with key should be in range {}..{}, \
+                    "listing entry for segment {} should be in its per-segment range, \
                      serialized={:?}, range_start={:?}, range_end={:?}",
-                    segment_id, start, end,
+                    segment_id,
                     serialized.as_ref(),
                     scan_range.start_bound(),
                     scan_range.end_bound()
+                );
+            }
+
+            #[test]
+            fn should_exclude_other_segments_from_per_segment_scan_range(
+                segment_id in 1u32..100_000,
+                other_segment_id in 1u32..100_000,
+                key_bytes in prop::collection::vec(any::<u8>(), 0..100),
+            ) {
+                prop_assume!(segment_id != other_segment_id);
+                let key = ListingEntryKey::new(other_segment_id, Bytes::from(key_bytes));
+                let serialized = key.serialize();
+
+                let scan_range = ListingEntryKey::scan_range_for_segment(segment_id);
+
+                prop_assert!(
+                    !scan_range.contains(&serialized),
+                    "listing entry for segment {} should NOT be in segment {}'s range",
+                    other_segment_id, segment_id
                 );
             }
         }

--- a/log/src/storage.rs
+++ b/log/src/storage.rs
@@ -24,16 +24,15 @@ use common::{StorageIterator, StorageRead};
 /// Automatically available on all `StorageRead` types via a blanket impl.
 #[async_trait]
 pub(crate) trait LogStorageRead: StorageRead {
-    /// Returns keys present in the given segment range.
+    /// Returns the keys present in a single segment.
     ///
-    /// Keys are deduplicated and returned in a sorted `BTreeSet`.
-    /// The segment range is half-open: [start, end).
-    async fn list_keys(&self, segment_range: Range<SegmentId>) -> Result<BTreeSet<Bytes>> {
-        if segment_range.start >= segment_range.end {
-            return Ok(BTreeSet::new());
-        }
-
-        let scan_range = ListingEntryKey::scan_range(segment_range);
+    /// Listing records are interleaved with log entries across segment
+    /// boundaries in the v2 layout, so cross-segment listing scans aren't
+    /// safe at the storage layer. Callers wanting to enumerate keys across
+    /// multiple segments stitch per-segment results together using the
+    /// segment cache. See [`crate::reader::LogReadView::list_keys`].
+    async fn list_keys_in_segment(&self, segment_id: SegmentId) -> Result<BTreeSet<Bytes>> {
+        let scan_range = ListingEntryKey::scan_range_for_segment(segment_id);
         let mut iter = self
             .scan_iter(scan_range)
             .await
@@ -193,10 +192,9 @@ pub(crate) trait LogStorageWrite: Storage {
         Ok(())
     }
 
-    /// Writes a SeqBlock record to storage.
+    /// Writes a SeqBlock record to storage at the canonical [`crate::serde::SEQ_BLOCK_KEY`].
     async fn write_seq_block(&self, block: &common::SeqBlock) -> Result<()> {
-        use crate::serde::{KEY_VERSION, RecordType};
-        let key = Bytes::from(vec![KEY_VERSION, RecordType::SeqBlock.id()]);
+        let key = Bytes::from_static(&crate::serde::SEQ_BLOCK_KEY);
         let value = block.serialize();
         self.put(vec![common::Record::new(key, value).into()])
             .await?;
@@ -242,34 +240,16 @@ mod tests {
 
     #[storage_test]
     async fn should_scan_segments_in_order(storage: Arc<dyn Storage>) {
-        // given
-        let seg0 = LogSegment::new(0, SegmentMeta::new(0, 100));
-        let seg1 = LogSegment::new(1, SegmentMeta::new(100, 200));
-        let seg2 = LogSegment::new(2, SegmentMeta::new(200, 300));
-        storage.write_segment(&seg0).await.unwrap();
-        storage.write_segment(&seg2).await.unwrap(); // write out of order
+        // given — user segments start at id 1
+        let seg1 = LogSegment::new(1, SegmentMeta::new(0, 100));
+        let seg2 = LogSegment::new(2, SegmentMeta::new(100, 200));
+        let seg3 = LogSegment::new(3, SegmentMeta::new(200, 300));
         storage.write_segment(&seg1).await.unwrap();
+        storage.write_segment(&seg3).await.unwrap(); // write out of order
+        storage.write_segment(&seg2).await.unwrap();
 
         // when
-        let segments = storage.scan_segments(0..u32::MAX).await.unwrap();
-
-        // then
-        assert_eq!(segments.len(), 3);
-        assert_eq!(segments[0].id(), 0);
-        assert_eq!(segments[1].id(), 1);
-        assert_eq!(segments[2].id(), 2);
-    }
-
-    #[storage_test]
-    async fn should_scan_segments_with_range(storage: Arc<dyn Storage>) {
-        // given
-        for i in 0u32..5 {
-            let seg = LogSegment::new(i, SegmentMeta::new(i as u64 * 100, i as i64 * 100));
-            storage.write_segment(&seg).await.unwrap();
-        }
-
-        // when
-        let segments = storage.scan_segments(1..4).await.unwrap();
+        let segments = storage.scan_segments(1..u32::MAX).await.unwrap();
 
         // then
         assert_eq!(segments.len(), 3);
@@ -279,9 +259,27 @@ mod tests {
     }
 
     #[storage_test]
+    async fn should_scan_segments_with_range(storage: Arc<dyn Storage>) {
+        // given
+        for i in 1u32..=5 {
+            let seg = LogSegment::new(i, SegmentMeta::new(i as u64 * 100, i as i64 * 100));
+            storage.write_segment(&seg).await.unwrap();
+        }
+
+        // when
+        let segments = storage.scan_segments(2..5).await.unwrap();
+
+        // then
+        assert_eq!(segments.len(), 3);
+        assert_eq!(segments[0].id(), 2);
+        assert_eq!(segments[1].id(), 3);
+        assert_eq!(segments[2].id(), 4);
+    }
+
+    #[storage_test]
     async fn should_scan_entries_for_key(storage: Arc<dyn Storage>) {
         // given
-        let segment = LogSegment::new(0, SegmentMeta::new(0, 100));
+        let segment = LogSegment::new(1, SegmentMeta::new(0, 100));
         storage.write_segment(&segment).await.unwrap();
 
         let key = Bytes::from("key1");
@@ -314,7 +312,7 @@ mod tests {
     #[storage_test]
     async fn should_filter_entries_by_sequence_range(storage: Arc<dyn Storage>) {
         // given
-        let segment = LogSegment::new(0, SegmentMeta::new(0, 100));
+        let segment = LogSegment::new(1, SegmentMeta::new(0, 100));
         storage.write_segment(&segment).await.unwrap();
 
         let key = Bytes::from("key1");
@@ -343,7 +341,7 @@ mod tests {
     #[storage_test]
     async fn should_return_empty_iterator_for_unknown_key(storage: Arc<dyn Storage>) {
         // given
-        let segment = LogSegment::new(0, SegmentMeta::new(0, 100));
+        let segment = LogSegment::new(1, SegmentMeta::new(0, 100));
         storage.write_segment(&segment).await.unwrap();
 
         // when
@@ -365,8 +363,7 @@ mod tests {
         storage.write_seq_block(&block).await.unwrap();
 
         // then
-        use crate::serde::{KEY_VERSION, RecordType};
-        let key = Bytes::from(vec![KEY_VERSION, RecordType::SeqBlock.id()]);
+        let key = Bytes::from_static(&crate::serde::SEQ_BLOCK_KEY);
         let record = storage.get(key).await.unwrap().unwrap();
         let read_block = common::SeqBlock::deserialize(&record.value).unwrap();
         assert_eq!(read_block.base_sequence, 1000);

--- a/log/src/writer.rs
+++ b/log/src/writer.rs
@@ -521,26 +521,26 @@ mod tests {
         let (writer, mut handle, storage) = create_writer().await;
         let _task = handle.spawn(writer);
 
-        // Append something to create segment 0
+        // Append something to create the first user segment (id 1)
         handle
             .try_append(make_write(&["key1"], 1000))
             .await
             .unwrap();
         assert_eq!(handle.written_epoch(), 1);
 
-        // Force seal — should create segment 1
+        // Force seal — should create segment 2
         handle.force_seal(2000).await.unwrap();
         assert_eq!(handle.written_epoch(), 2);
 
-        // Verify two segments exist in storage
+        // Verify two user segments exist in storage
         handle.flush().await.unwrap();
         use crate::storage::LogStorageRead as _;
-        let segments = storage.scan_segments(0..u32::MAX).await.unwrap();
+        let segments = storage.scan_segments(1..u32::MAX).await.unwrap();
         assert_eq!(segments.len(), 2);
-        assert_eq!(segments[0].id(), 0);
-        assert_eq!(segments[1].id(), 1);
+        assert_eq!(segments[0].id(), 1);
+        assert_eq!(segments[1].id(), 2);
 
-        // Subsequent append goes to segment 1
+        // Subsequent append goes to segment 2
         let result = handle
             .try_append(make_write(&["key2"], 3000))
             .await
@@ -562,7 +562,7 @@ mod tests {
 
         // Verify entries are readable from storage
         use crate::storage::LogStorageRead as _;
-        let segments = storage.scan_segments(0..u32::MAX).await.unwrap();
+        let segments = storage.scan_segments(1..u32::MAX).await.unwrap();
         assert_eq!(segments.len(), 1);
 
         let key = Bytes::from("mykey");

--- a/log/tests/http_api_formats.rs
+++ b/log/tests/http_api_formats.rs
@@ -257,8 +257,8 @@ async fn test_list_segments_json_response() {
     let segments = json["segments"].as_array().unwrap();
     assert_eq!(segments.len(), 1);
 
-    // Check camelCase field names
-    assert_eq!(segments[0]["id"], 0);
+    // Check camelCase field names — first user segment is id 1 (id 0 is reserved system segment)
+    assert_eq!(segments[0]["id"], 1);
     assert_eq!(segments[0]["startSeq"], 0);
     assert!(segments[0]["startTimeMs"].as_i64().unwrap() > 0);
 }
@@ -492,7 +492,8 @@ async fn test_list_segments_protobuf_response() {
 
     assert_eq!(proto_response.status, "success");
     assert_eq!(proto_response.segments.len(), 1);
-    assert_eq!(proto_response.segments[0].id, 0);
+    // First user segment is id 1; id 0 is the reserved system segment.
+    assert_eq!(proto_response.segments[0].id, 1);
     assert_eq!(proto_response.segments[0].start_seq, 0);
     assert!(proto_response.segments[0].start_time_ms > 0);
 }

--- a/log/tests/http_server.rs
+++ b/log/tests/http_server.rs
@@ -158,7 +158,8 @@ async fn test_list_segments_returns_all_segments() {
     let segments = log.list_segments(..).await.unwrap();
 
     assert_eq!(segments.len(), 1);
-    assert_eq!(segments[0].id, 0);
+    // First user segment is id 1; id 0 is reserved system segment.
+    assert_eq!(segments[0].id, 1);
     assert_eq!(segments[0].start_seq, 0);
 }
 
@@ -199,7 +200,7 @@ async fn test_list_keys_empty_when_no_keys_in_segment_range() {
 async fn test_list_keys_in_specific_segment_range() {
     let log = setup_test_log().await;
 
-    // Append records to segment 0
+    // Append records to the first user segment (id 1)
     log.try_append(vec![
         Record {
             key: Bytes::from("key-a"),
@@ -214,8 +215,8 @@ async fn test_list_keys_in_specific_segment_range() {
     .unwrap();
     log.flush().await.unwrap();
 
-    // List keys only in segment 0
-    let mut iter = log.list_keys(0..1).await.unwrap();
+    // List keys only in segment 1
+    let mut iter = log.list_keys(1..2).await.unwrap();
     let mut keys = Vec::new();
     while let Some(key_entry) = iter.next().await.unwrap() {
         keys.push(key_entry.key);
@@ -367,7 +368,7 @@ async fn test_list_keys_only_first_segment() {
     // Use a very short seal interval to force multiple segments
     let log = setup_test_log_with_segment_interval(Duration::from_millis(1)).await;
 
-    // Append key-a to segment 0
+    // Append key-a to the first user segment (id 1)
     log.try_append(vec![Record {
         key: Bytes::from("key-a"),
         value: Bytes::from("value-a"),
@@ -379,7 +380,7 @@ async fn test_list_keys_only_first_segment() {
     // Wait to exceed seal interval
     tokio::time::sleep(Duration::from_millis(10)).await;
 
-    // Append key-b to segment 1
+    // Append key-b to segment 2
     log.try_append(vec![Record {
         key: Bytes::from("key-b"),
         value: Bytes::from("value-b"),
@@ -388,14 +389,14 @@ async fn test_list_keys_only_first_segment() {
     .unwrap();
     log.flush().await.unwrap();
 
-    // List keys only from segment 0
-    let mut iter = log.list_keys(0..1).await.unwrap();
+    // List keys only from segment 1
+    let mut iter = log.list_keys(1..2).await.unwrap();
     let mut keys = Vec::new();
     while let Some(key_entry) = iter.next().await.unwrap() {
         keys.push(key_entry.key);
     }
 
-    // Should only have key-a from segment 0
+    // Should only have key-a from segment 1
     assert_eq!(keys.len(), 1);
     assert_eq!(keys[0], Bytes::from("key-a"));
 }
@@ -405,7 +406,7 @@ async fn test_list_segments_filters_by_sequence_range() {
     // Use a very short seal interval to force multiple segments
     let log = setup_test_log_with_segment_interval(Duration::from_millis(1)).await;
 
-    // Append to create segment 0 (sequences start at 0)
+    // Append to create the first user segment, id 1 (sequence 0)
     log.try_append(vec![Record {
         key: Bytes::from("key-a"),
         value: Bytes::from("value-a"),
@@ -417,7 +418,7 @@ async fn test_list_segments_filters_by_sequence_range() {
     // Wait to exceed seal interval
     tokio::time::sleep(Duration::from_millis(10)).await;
 
-    // Append to create segment 1 (sequences start at 1)
+    // Append to create segment 2 (sequence 1)
     log.try_append(vec![Record {
         key: Bytes::from("key-b"),
         value: Bytes::from("value-b"),
@@ -433,7 +434,7 @@ async fn test_list_segments_filters_by_sequence_range() {
     // List segments overlapping only the first sequence
     let segments = log.list_segments(0..1).await.unwrap();
 
-    // Should only include segment 0
+    // Should only include segment 1 (the first user segment)
     assert_eq!(segments.len(), 1);
-    assert_eq!(segments[0].id, 0);
+    assert_eq!(segments[0].id, 1);
 }

--- a/rfcs/0001-record-key-prefix.md
+++ b/rfcs/0001-record-key-prefix.md
@@ -7,35 +7,32 @@
 
 ## Summary
 
-This RFC defines a common record key prefix format for OpenData storage systems built on SlateDB.
-All records use a standardized 3-byte prefix consisting of a subsystem byte, a version byte, and a record tag byte.
-The record tag stores the record type as a full byte.
-This enables forward compatibility and consistent key organization across Opendata systems.
+This RFC defines a common 2-byte record key prefix for OpenData storage systems built on SlateDB.
+All records begin with a subsystem byte and a version byte; everything after that is subsystem-defined.
+The shared prefix gives each subsystem an isolated keyspace and a path for schema evolution without dictating any further key layout.
 
 ## Motivation
 
-OpenData comprises multiple storage subsystems (e.g. log, timeseries) that share a common foundation on SlateDB. Each subsystem defines its own record types with distinct key structures, but they follow a similar pattern: a version prefix for forward compatibility and a type discriminator to distinguish record kinds.
+OpenData comprises multiple storage subsystems (e.g. log, timeseries, vector, keyvalue) that share a common foundation on SlateDB.
+Each subsystem defines its own record types with distinct key structures, but they all benefit from a couple of shared invariants:
 
-Formalizing this pattern as a common specification provides several benefits:
+1. **Subsystem isolation** — a shared keyspace needs a way to namespace records by subsystem.
+2. **Forward compatibility** — schema evolution needs an explicit version signal.
 
-1. **Consistency** — New subsystems and record types follow a predictable structure, making the codebase easier to understand and maintain.
-
-2. **Forward compatibility** — The version byte allows schema evolution without breaking existing data.
-
-3. **Documentation** — A single source of truth for the encoding conventions used across OpenData.
+Formalizing those two bytes as a common prefix gives every subsystem the same foundation without coupling them to a specific key layout.
+Earlier drafts of this RFC also reserved a third "record tag" byte at byte position 2.
+That mandate has been removed (see [Alternatives](#common-record-tag-at-byte-2)) — record-type discrimination is now left entirely to each subsystem to design.
 
 ## Goals
 
-- Define the 3-byte record key prefix format
-- Specify the record tag encoding
+- Define a minimal common prefix shared by every subsystem
 - Document the versioning strategy for schema evolution
-- Establish conventions for big-endian key encoding
 
 ## Non-Goals
 
 - Subsystem-specific record definitions (covered by individual RFCs)
 - Value encoding conventions (covered by individual RFCs)
-- Key components beyond the 3-byte prefix
+- Record-type discrimination — left to each subsystem
 
 ## Design
 
@@ -44,13 +41,14 @@ Formalizing this pattern as a common specification provides several benefits:
 All OpenData records stored in SlateDB use keys with the following prefix:
 
 ```
-┌───────────┬─────────┬────────────┬─────────────────────┐
-│ subsystem │ version │ record_tag │  ... record fields  │
-│  1 byte   │ 1 byte  │   1 byte   │    (varies)         │
-└───────────┴─────────┴────────────┴─────────────────────┘
+┌───────────┬─────────┬─────────────────────────────────┐
+│ subsystem │ version │  ... subsystem-defined fields   │
+│  1 byte   │ 1 byte  │            (varies)             │
+└───────────┴─────────┴─────────────────────────────────┘
 ```
 
-The 3-byte prefix is followed by record-specific fields that vary by subsystem and record type.
+The 2-byte prefix is followed by subsystem-defined fields that vary by subsystem and record type.
+Subsystems typically include a record-type discriminator somewhere after the prefix to distinguish record kinds within their keyspace; the exact position and semantics are at each subsystem's discretion.
 
 ### Subsystem Byte
 
@@ -63,19 +61,17 @@ The first byte identifies the subsystem that owns the key.
 | `0x02`        | Vector             |
 | `0x03`        | Log                |
 | `0x04`        | KeyValue           |
-| `0x01`–`0xFF` | Subsystem-defined  |
-
+| `0x05`–`0xFF` | Available          |
 
 ### Version Byte
 
 The second byte identifies the key format version.
-Each subsystem manages its version independently—bumping the version in one subsystem does not affect others.
+Each subsystem manages its version independently — bumping the version in one subsystem does not affect others.
 
-| Value  | Description |
-|--------|-------------|
-| `0x00` | Reserved (invalid) |
-| `0x01` | Current version (all subsystems) |
-| `0x02`–`0xFF` | Reserved for future versions |
+| Value         | Description       |
+|---------------|-------------------|
+| `0x00`        | Reserved (invalid)|
+| `0x01`–`0xFF` | Subsystem-defined |
 
 The version byte enables schema migration.
 When the key format changes in a backwards-incompatible way, the subsystem increments its version.
@@ -86,70 +82,31 @@ Readers encountering an unknown version can reject the record or apply version-s
 - New record types do not require a version bump
 - Changes to existing key field layouts require a version bump
 
-### Record Tag Byte
-
-The third byte stores the record tag as a full byte value.
-
-**Record Tag:** Identifies the kind of record. Values `0x01`–`0xFF` are available.
-Tag `0x00` is reserved in all subsystems.
-
-### Record Type Allocation
-
-Record types are allocated per-subsystem.
-Since subsystems are stored in separate SlateDB instances, the same type value may be reused across subsystems without collision.
-Type `0x0` is reserved in all subsystems.
-
-See the following RFCs for subsystem-specific record type definitions:
-
-- **Log:** [RFC 0001: Log Storage](../log/rfcs/0001-storage.md)
-- **Timeseries:** [RFC 0001: TSDB Storage](../timeseries/rfcs/0001-tsdb-storage.md)
-
-### Prefix Queries
-
-The standardized prefix enables efficient filtering by record type:
-
-```rust
-// Build a 3-byte prefix
-fn key_prefix(subsystem: u8, version: u8, record_tag: u8) -> [u8; 3] {
-    [subsystem, version, record_tag]
-}
-```
-
-### Record Type Ordering
-
-Placing the record type in the key prefix means that records of different types are stored in separate key ranges and cannot be interleaved. This is a deliberate design choice with tradeoffs:
-
-**Benefits:**
-- Simpler access model — queries for a single record type are contiguous range scans
-- Predictable key ordering — easier to reason about compaction and caching behavior
-- Clean separation — different record types can evolve independently
-
-**Limitations:**
-- Rules out key designs that optimize for locality across record types. For example, a system that wants to co-locate metadata and data records for the same entity (e.g., `entity_id:metadata` adjacent to `entity_id:data`) cannot do so with this prefix structure.
-
-This tradeoff favors simplicity and type-scoped access patterns over flexible cross-type locality. Subsystems requiring tight co-location of heterogeneous records would need to encode them as a single record type with internal discrimination.
-
 ## Alternatives
 
-### Split Record Tag Byte
+### Common record tag at byte 2
 
-An earlier design split the second byte into a high-nibble record type and a low-nibble reserved field:
+Earlier drafts of this RFC mandated a third "record tag" byte at position 2, available `0x01`–`0xFF`.
+The intent was to enable cross-subsystem introspection tooling that could classify records by type without parsing subsystem-specific fields.
 
-```
-| version | record_tag | ... |
-```
+Two things led us away from it:
 
-That approach reduced the record-type space to 15 values and baked subsystem-specific concerns into a shared encoding.
-Using the full byte for the record tag keeps the common prefix simpler and gives each subsystem the full `0x01`-`0xFF` tag range.
-Each subsystem can encode additional information in the record type.
-For example, timeseries encodes time bucket granularity in the lower 4 bits of the record tag.
+1. **No common tooling materialized.**
+   No introspection tools came to rely on the position, so the constraint paid no rent.
 
-### Shared Prefix Version
+2. **Subsystem needs evolved past it.**
+   The log subsystem's prefix-routed segmentation (see [`log/rfcs/0002`](../log/rfcs/0002-logical-segmentation.md)) requires a routing identifier (segment id) immediately after the version byte, ahead of any record-type discriminator.
+   A common byte-2 record tag is incompatible with that layout.
+
+Subsystems that want a record-type discriminator are free to keep one — they just choose where it sits.
+Timeseries, vector, and keyvalue still place a tag at byte 2; the log subsystem (v2 onwards) places its tag after a 4-byte segment id.
+
+### Shared prefix version
 
 An alternative would use a shared version across all subsystems, requiring coordinated bumps when the prefix format changes:
 
 ```
-| subsystem | prefix_version | record_tag | ... |
+| subsystem | prefix_version | ... |
 ```
 
 A hybrid approach could reserve one bit (e.g., the high bit) to indicate prefix-level changes, leaving 7 bits for subsystem-specific versioning:
@@ -166,7 +123,7 @@ These approaches were deferred because:
 
 1. **Coordination overhead** — Requiring all subsystems to bump versions together is inconvenient and slows development.
 
-2. **Unlikely need** — The 3-byte prefix structure is simple and stable. Changes requiring cross-subsystem coordination are unlikely.
+2. **Unlikely need** — The 2-byte prefix is simple and stable. Changes requiring cross-subsystem coordination are unlikely.
 
 3. **Simplicity** — Independent versioning is easier to reason about and implement.
 
@@ -180,3 +137,4 @@ None at this time.
 |------------|--------------------------------------------|
 | 2026-01-09 | Initial draft                              |
 | 2026-03-18 | Simplify record tag and add subsystem byte |
+| 2026-05-19 | Drop the record_tag mandate from the common prefix. The common prefix is now `[subsystem, version]` (2 bytes); record-type discrimination is subsystem-defined. `common::serde::key_prefix::KeyPrefix` still ships the legacy 3-byte shape used by timeseries/vector/keyvalue; updating those callers and slimming the common codec is deferred to a follow-up. |


### PR DESCRIPTION
Since segments in Slatedb are prefix-based, this patch required some rejiggering of Logdb paths. The prior structure didn't work because record type came before segment_id in the key schema. This means that listing records and log records would be divided into separate segments. To fix it, I had to move segment_id ahead of the record type. Since `SeqBlock` keys do not fall within a segment, I decided to use a sentinel system segment (0x0). This gives all keys in LogDb, a common segment prefix. Within the compaction scheduler (deferred for subsequent work), the system segment will not be eligible for draining.

These changes put LogDb at odds with the common key structure, which specifies a record tag in the shared prefix. My feeling is that the common prefix was going a little too far by getting into the record type structure. We take some of the flexibility out of systems without getting much in return. In any case, timeseries is going to face the same problem with the key structure, so some change there is inevitable. If the change makes sense, a follow-up can revise the common key codec library.