### PR TITLE
Update common serde for changes in prefix scheme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ OpenData is a collection of deployable database systems that share common infras
 
 All databases follow these patterns (see RFCs in each crate's `rfcs/` directory):
 
-1. **Key encoding**: 2-byte prefix (version u8 + record_tag u8), big-endian for lexicographic ordering
+1. **Key encoding**: 2-byte common prefix (subsystem u8 + version u8) followed by subsystem-defined fields, big-endian for lexicographic ordering
 2. **Value encoding**: Little-endian for performance on common architectures
 3. **Common types**: `Utf8`, `Array<T>`, `FixedElementArray<T>`, `TerminatedBytes`, `RoaringBitmap/Treemap`
 4. **Sequence allocation**: Block-based `SeqBlock` for crash-safe ID generation (see `common/src/sequence.rs`)

--- a/common/AGENTS.md
+++ b/common/AGENTS.md
@@ -10,7 +10,8 @@ Shared encoding/decoding patterns used across all databases:
 
 | Module | Description |
 |--------|-------------|
-| `key_prefix.rs` | Standard 2-byte key prefix (version + record_tag) |
+| `key_prefix.rs` | Standard 2-byte key prefix (subsystem + version) — see RFC 0001 |
+| `record_tag.rs` | Optional 4+4 bit tag-byte encoding (record type + reserved); subsystems choose where to place it |
 | `terminated_bytes.rs` | Variable-length byte encoding with 0x00 terminator |
 | `sortable.rs` | Lexicographically sortable numeric encodings (sign-bit flip + big-endian) |
 | `encoding.rs` | Common value encodings (Utf8, Array, etc.) |
@@ -54,7 +55,7 @@ All databases follow this pattern for record types:
 // In database crate's src/serde/
 use common::serde::{key_prefix, terminated_bytes, encoding};
 
-// Key: version | tag | ... (big-endian)
+// Key: subsystem | version | ... subsystem-defined fields (big-endian)
 // Value: ... (little-endian)
 ```
 

--- a/common/src/serde/key_prefix.rs
+++ b/common/src/serde/key_prefix.rs
@@ -1,42 +1,40 @@
 //! Common record key prefix encoding for OpenData storage systems.
 //!
 //! This module implements RFC 0001: Record Key Prefix. All OpenData records
-//! stored in SlateDB use keys with a standardized 3-byte prefix:
+//! stored in SlateDB use keys with a standardized 2-byte prefix:
 //!
 //! ```text
-//! ┌───────────┬─────────┬────────────┬─────────────────────┐
-//! │ subsystem │ version │ record_tag │  ... record fields  │
-//! │  1 byte   │ 1 byte  │   1 byte   │    (varies)         │
-//! └───────────┴─────────┴────────────┴─────────────────────┘
+//! ┌───────────┬─────────┬─────────────────────────────────┐
+//! │ subsystem │ version │  ... subsystem-defined fields   │
+//! │  1 byte   │ 1 byte  │            (varies)             │
+//! └───────────┴─────────┴─────────────────────────────────┘
 //! ```
 //!
 //! # Subsystem Byte
 //!
 //! The first byte identifies the subsystem that owns the key.
-//! A value of 0x00 is reserved as an invalid subsystem.
+//! A value of 0x00 is reserved as an invalid subsystem. See
+//! [`super::subsystem`] for the registry of assigned subsystem bytes.
 //!
 //! # Version Byte
 //!
 //! The second byte identifies the key format version. Each subsystem manages
 //! its version independently. A version of 0x00 is reserved as an invalid version.
 //!
-//! # Record Tag Byte
-//!
-//! The third byte stores the full record tag value.
-//!
-//! - **Record Tag:** Identifies the kind of record.
-//! - `0x00` is reserved as an invalid tag when decoding serialized keys.
+//! Everything after the 2-byte prefix is defined by the subsystem, including
+//! any record-type discriminator. See [`super::record_tag`] for a reusable
+//! 4+4 bit tag-byte encoding that several subsystems opt into.
 
 use bytes::{BufMut, Bytes, BytesMut};
 
 use super::DeserializeError;
 
-/// A 3-byte key prefix containing subsystem, version, and record tag.
+/// A 2-byte key prefix containing subsystem and version.
 ///
 /// This type encapsulates the standard prefix used by all OpenData records.
 /// It provides methods for serialization, deserialization, and validation.
-/// Callers constructing a prefix directly must provide non-zero `subsystem`,
-/// `version`, and `record_tag` values.
+/// Callers constructing a prefix directly must provide non-zero `subsystem`
+/// and `version` values.
 ///
 /// # Examples
 ///
@@ -44,10 +42,9 @@ use super::DeserializeError;
 /// use common::serde::key_prefix::KeyPrefix;
 ///
 /// // Create a prefix
-/// let prefix = KeyPrefix::new(0x10, 0x01, 0x02);
+/// let prefix = KeyPrefix::new(0x10, 0x01);
 /// assert_eq!(prefix.subsystem(), 0x10);
 /// assert_eq!(prefix.version(), 0x01);
-/// assert_eq!(prefix.tag(), 0x02);
 ///
 /// // Serialize and deserialize
 /// let bytes = prefix.to_bytes();
@@ -58,24 +55,21 @@ use super::DeserializeError;
 pub struct KeyPrefix {
     subsystem: u8,
     version: u8,
-    tag: u8,
 }
 
+/// Serialized length of the key prefix in bytes.
+pub const KEY_PREFIX_LEN: usize = 2;
+
 impl KeyPrefix {
-    /// Creates a new key prefix with the given subsystem, version, and record tag.
+    /// Creates a new key prefix with the given subsystem and version.
     ///
     /// # Panics
     ///
-    /// Panics if `subsystem` is 0, `version` is 0, or `tag` is 0.
-    pub fn new(subsystem: u8, version: u8, tag: u8) -> Self {
+    /// Panics if `subsystem` is 0 or `version` is 0.
+    pub fn new(subsystem: u8, version: u8) -> Self {
         assert!(subsystem > 0, "subsystem 0 is reserved");
         assert!(version > 0, "key version 0 is reserved");
-        assert!(tag > 0, "record tag 0 is reserved");
-        Self {
-            subsystem,
-            version,
-            tag,
-        }
+        Self { subsystem, version }
     }
 
     /// Returns the subsystem byte.
@@ -88,37 +82,27 @@ impl KeyPrefix {
         self.version
     }
 
-    /// Returns the record tag.
-    pub fn tag(&self) -> u8 {
-        self.tag
-    }
-
     /// Parses a key prefix from a byte slice.
     ///
     /// # Errors
     ///
     /// Returns an error if:
-    /// - The buffer is too short (less than 3 bytes)
+    /// - The buffer is too short (less than 2 bytes)
     /// - The subsystem is 0 (reserved)
     /// - The key version is 0 (reserved)
-    /// - The record type is 0 (reserved)
     pub fn from_bytes(data: &[u8]) -> Result<Self, DeserializeError> {
-        if data.len() < 3 {
+        if data.len() < KEY_PREFIX_LEN {
             return Err(DeserializeError {
                 message: format!(
-                    "buffer too short for key prefix: need 3 bytes, got {}",
+                    "buffer too short for key prefix: need {} bytes, got {}",
+                    KEY_PREFIX_LEN,
                     data.len()
                 ),
             });
         }
         let subsystem = validate_subsystem(data[0])?;
         let version = validate_key_version(data[1])?;
-        let tag = validate_record_tag(data[2])?;
-        Ok(Self {
-            subsystem,
-            version,
-            tag,
-        })
+        Ok(Self { subsystem, version })
     }
 
     /// Parses a key prefix, validating the subsystem and version match expected values.
@@ -131,7 +115,6 @@ impl KeyPrefix {
     /// - The subsystem doesn't match `expected_subsystem`
     /// - The key version is 0
     /// - The version doesn't match `expected_version`
-    /// - The record type is 0
     pub fn from_bytes_with_validation(
         data: &[u8],
         expected_subsystem: u8,
@@ -157,16 +140,15 @@ impl KeyPrefix {
         Ok(prefix)
     }
 
-    /// Serializes the prefix to a 3-byte array.
+    /// Serializes the prefix to a 2-byte array.
     pub fn to_bytes(&self) -> Bytes {
-        Bytes::from(vec![self.subsystem, self.version, self.tag])
+        Bytes::from(vec![self.subsystem, self.version])
     }
 
     /// Writes the prefix to a buffer.
     pub fn write_to(&self, buf: &mut BytesMut) {
         buf.put_u8(self.subsystem);
         buf.put_u8(self.version);
-        buf.put_u8(self.tag);
     }
 }
 
@@ -194,15 +176,6 @@ fn validate_subsystem(byte: u8) -> Result<u8, DeserializeError> {
     Ok(byte)
 }
 
-fn validate_record_tag(byte: u8) -> Result<u8, DeserializeError> {
-    if byte == 0 {
-        return Err(DeserializeError {
-            message: format!("invalid record tag: 0x{:02x} (tag 0 is reserved)", byte),
-        });
-    }
-    Ok(byte)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -212,39 +185,31 @@ mod tests {
         // given
         let subsystem = 0x10;
         let version = 0x01;
-        let tag = 0x02;
 
         // when
-        let prefix = KeyPrefix::new(subsystem, version, tag);
+        let prefix = KeyPrefix::new(subsystem, version);
 
         // then
         assert_eq!(prefix.subsystem(), subsystem);
         assert_eq!(prefix.version(), version);
-        assert_eq!(prefix.tag(), tag);
     }
 
     #[test]
     #[should_panic(expected = "subsystem 0 is reserved")]
     fn should_panic_on_zero_subsystem() {
-        KeyPrefix::new(0, 0x01, 0x02);
+        KeyPrefix::new(0, 0x01);
     }
 
     #[test]
     #[should_panic(expected = "key version 0 is reserved")]
     fn should_panic_on_zero_version() {
-        KeyPrefix::new(0x10, 0, 0x02);
+        KeyPrefix::new(0x10, 0);
     }
 
     #[test]
-    #[should_panic(expected = "record tag 0 is reserved")]
-    fn should_panic_on_zero_record_tag() {
-        KeyPrefix::new(0x10, 0x01, 0);
-    }
-
-    #[test]
-    fn should_parse_tag_from_byte() {
+    fn should_parse_prefix_from_bytes() {
         // given
-        let bytes = [0x42, 0x17, 0x24];
+        let bytes = [0x42, 0x17];
 
         // when
         let key_prefix = KeyPrefix::from_bytes(&bytes).unwrap();
@@ -252,13 +217,25 @@ mod tests {
         // then
         assert_eq!(key_prefix.subsystem(), 0x42);
         assert_eq!(key_prefix.version(), 0x17);
-        assert_eq!(key_prefix.tag(), 0x24);
+    }
+
+    #[test]
+    fn should_parse_prefix_ignoring_trailing_bytes() {
+        // given - a buffer longer than the prefix (subsystem-defined fields follow)
+        let bytes = [0x42, 0x17, 0x99, 0xAA, 0xBB];
+
+        // when
+        let key_prefix = KeyPrefix::from_bytes(&bytes).unwrap();
+
+        // then
+        assert_eq!(key_prefix.subsystem(), 0x42);
+        assert_eq!(key_prefix.version(), 0x17);
     }
 
     #[test]
     fn should_reject_zero_subsystem_byte() {
         // given
-        let bytes = [0x00, 0x17, 0x53];
+        let bytes = [0x00, 0x17];
 
         // when
         let result = KeyPrefix::from_bytes(&bytes);
@@ -272,7 +249,7 @@ mod tests {
     #[test]
     fn should_reject_zero_version_byte() {
         // given
-        let bytes = [0x53, 0x00, 0x24];
+        let bytes = [0x53, 0x00];
 
         // when
         let result = KeyPrefix::from_bytes(&bytes);
@@ -284,23 +261,9 @@ mod tests {
     }
 
     #[test]
-    fn should_reject_zero_record_type_byte() {
-        // given
-        let bytes = [0x53, 0x17, 0x00];
-
-        // when
-        let result = KeyPrefix::from_bytes(&bytes);
-
-        // then
-        assert!(
-            matches!(result, Err(DeserializeError { message }) if  message.contains("tag 0 is reserved"))
-        );
-    }
-
-    #[test]
     fn should_write_and_read_key_prefix() {
         // given
-        let prefix = KeyPrefix::new(0x10, 0x01, 0x02);
+        let prefix = KeyPrefix::new(0x10, 0x01);
         let mut buf = BytesMut::new();
 
         // when
@@ -314,16 +277,15 @@ mod tests {
     #[test]
     fn should_serialize_key_prefix_to_bytes() {
         // given
-        let prefix = KeyPrefix::new(0x10, 0x01, 0x02);
+        let prefix = KeyPrefix::new(0x10, 0x01);
 
         // when
         let bytes = prefix.to_bytes();
 
         // then
-        assert_eq!(bytes.len(), 3);
+        assert_eq!(bytes.len(), KEY_PREFIX_LEN);
         assert_eq!(bytes[0], 0x10);
         assert_eq!(bytes[1], 0x01);
-        assert_eq!(bytes[2], 0x02);
     }
 
     #[test]
@@ -331,7 +293,7 @@ mod tests {
         // given
         let expected_subsystem = 0x10;
         let expected_version = 0x01;
-        let data = [expected_subsystem, expected_version, 0x25];
+        let data = [expected_subsystem, expected_version];
 
         // when
         let prefix =
@@ -341,13 +303,12 @@ mod tests {
         // then
         assert_eq!(prefix.subsystem(), expected_subsystem);
         assert_eq!(prefix.version(), expected_version);
-        assert_eq!(prefix.tag(), 0x25);
     }
 
     #[test]
     fn should_reject_wrong_subsystem() {
         // given
-        let data = [0x10, 0x01, 0x25];
+        let data = [0x10, 0x01];
 
         // when
         let result = KeyPrefix::from_bytes_with_validation(&data, 0x20, 0x01);
@@ -361,7 +322,7 @@ mod tests {
     #[test]
     fn should_reject_wrong_version() {
         // given
-        let data = [0x10, 0x02, 0x10]; // wrong version
+        let data = [0x10, 0x02]; // wrong version
 
         // when
         let result = KeyPrefix::from_bytes_with_validation(&data, 0x10, 0x01);
@@ -375,7 +336,7 @@ mod tests {
     #[test]
     fn should_reject_short_buffer() {
         // given
-        let data = [0x01, 0x10]; // only 2 bytes
+        let data = [0x01]; // only 1 byte
 
         // when
         let result = KeyPrefix::from_bytes(&data);

--- a/common/src/serde/mod.rs
+++ b/common/src/serde/mod.rs
@@ -5,6 +5,7 @@ pub mod key_prefix;
 pub mod record_tag;
 pub mod seq_block;
 pub mod sortable;
+pub mod subsystem;
 pub mod terminated_bytes;
 pub mod varint;
 

--- a/common/src/serde/subsystem.rs
+++ b/common/src/serde/subsystem.rs
@@ -1,0 +1,54 @@
+//! Registry of subsystem byte assignments for the RFC 0001 record key prefix.
+//!
+//! Every key stored by an OpenData subsystem begins with the subsystem byte
+//! defined here, followed by the version byte (see [`super::key_prefix`]).
+//! Centralizing the assignments in one place keeps the on-disk byte space
+//! collision-free as new subsystems are added.
+
+/// Reserved sentinel — never a valid subsystem byte.
+pub const RESERVED: u8 = 0x00;
+
+/// Timeseries database (metrics, samples).
+pub const TIMESERIES: u8 = 0x01;
+
+/// Vector database (embeddings, ANN indexes).
+pub const VECTOR: u8 = 0x02;
+
+/// Log database (Kafka-style log with sequence ordering).
+pub const LOG: u8 = 0x03;
+
+/// KeyValue database.
+pub const KEYVALUE: u8 = 0x04;
+
+/// Returns the canonical name for a known subsystem byte, or `None`.
+///
+/// Intended for diagnostics, logging, and tooling that inspects raw keys.
+pub fn name(byte: u8) -> Option<&'static str> {
+    match byte {
+        TIMESERIES => Some("timeseries"),
+        VECTOR => Some("vector"),
+        LOG => Some("log"),
+        KEYVALUE => Some("keyvalue"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_resolve_known_subsystems_by_byte() {
+        assert_eq!(name(TIMESERIES), Some("timeseries"));
+        assert_eq!(name(VECTOR), Some("vector"));
+        assert_eq!(name(LOG), Some("log"));
+        assert_eq!(name(KEYVALUE), Some("keyvalue"));
+    }
+
+    #[test]
+    fn should_return_none_for_reserved_and_unassigned_bytes() {
+        assert_eq!(name(RESERVED), None);
+        assert_eq!(name(0x42), None);
+        assert_eq!(name(0xFF), None);
+    }
+}

--- a/keyvalue/src/serde.rs
+++ b/keyvalue/src/serde.rs
@@ -16,8 +16,8 @@ use crate::error::{Error, Result};
 /// Key format version.
 pub const KEY_VERSION: u8 = 0x01;
 
-/// Subsystem-specific key prefix for KeyValue.
-pub const SUBSYSTEM: u8 = 0x04;
+/// Subsystem byte for KeyValue storage (see [`common::serde::subsystem`]).
+pub const SUBSYSTEM: u8 = common::serde::subsystem::KEYVALUE;
 
 /// Record tag: type 0x1 in high 4 bits, reserved 0x0 in low 4 bits.
 pub const RECORD_TAG: u8 = 0x10;

--- a/log/src/serde.rs
+++ b/log/src/serde.rs
@@ -52,6 +52,7 @@ use std::ops::{Bound, Range};
 
 use bytes::{BufMut, Bytes, BytesMut};
 use common::BytesRange;
+use common::serde::key_prefix::{KEY_PREFIX_LEN, KeyPrefix};
 use common::serde::record_tag::RecordTag;
 use common::serde::terminated_bytes;
 use common::serde::varint::var_u64;
@@ -69,8 +70,8 @@ impl From<common::serde::DeserializeError> for Error {
 /// Key format version (currently 0x02 — segment_id precedes record_type).
 pub const KEY_VERSION: u8 = 0x02;
 
-/// Subsystem-specific key prefix for log storage.
-pub const SUBSYSTEM: u8 = 0x03;
+/// Subsystem byte for log storage (see [`common::serde::subsystem`]).
+pub const SUBSYSTEM: u8 = common::serde::subsystem::LOG;
 
 /// Reserved segment id for system records (sequence block, per-segment
 /// metadata describing other segments). User log segments start at `1`.
@@ -136,14 +137,20 @@ impl RecordType {
     }
 }
 
+/// Offset of the segment id (u32 BE) inside a log key, immediately after the
+/// 2-byte common prefix.
+const SEGMENT_ID_OFFSET: usize = KEY_PREFIX_LEN;
+
+/// Offset of the record-type tag byte inside a log key, after the segment id.
+const RECORD_TYPE_OFFSET: usize = SEGMENT_ID_OFFSET + 4;
+
 /// Length of the v2 segmented key prefix: `[subsystem, version, seg_id(4), record_type]`.
-const SEGMENTED_PREFIX_LEN: usize = 7;
+const SEGMENTED_PREFIX_LEN: usize = RECORD_TYPE_OFFSET + 1;
 
 /// Writes the v2 segmented prefix into `buf`:
 /// `[subsystem, version, seg_id BE, record_type]`.
 fn write_segmented_prefix(buf: &mut BytesMut, segment_id: SegmentId, record_type: u8) {
-    buf.put_u8(SUBSYSTEM);
-    buf.put_u8(KEY_VERSION);
+    KeyPrefix::new(SUBSYSTEM, KEY_VERSION).write_to(buf);
     buf.put_u32(segment_id);
     buf.put_u8(record_type);
 }
@@ -151,6 +158,7 @@ fn write_segmented_prefix(buf: &mut BytesMut, segment_id: SegmentId, record_type
 /// Parses a v2 segmented prefix, validating the subsystem/version/tag.
 /// Returns the segment id along with the remaining (post-prefix) bytes.
 fn parse_segmented_prefix(data: &[u8], expected_tag: u8) -> Result<(SegmentId, &[u8]), Error> {
+    KeyPrefix::from_bytes_with_validation(data, SUBSYSTEM, KEY_VERSION)?;
     if data.len() < SEGMENTED_PREFIX_LEN {
         return Err(Error::Encoding(format!(
             "buffer too short for log key: need {} bytes, got {}",
@@ -158,23 +166,16 @@ fn parse_segmented_prefix(data: &[u8], expected_tag: u8) -> Result<(SegmentId, &
             data.len()
         )));
     }
-    if data[0] != SUBSYSTEM {
-        return Err(Error::Encoding(format!(
-            "invalid subsystem: expected 0x{:02x}, got 0x{:02x}",
-            SUBSYSTEM, data[0]
-        )));
-    }
-    if data[1] != KEY_VERSION {
-        return Err(Error::Encoding(format!(
-            "invalid key version: expected 0x{:02x}, got 0x{:02x}",
-            KEY_VERSION, data[1]
-        )));
-    }
-    let segment_id = u32::from_be_bytes([data[2], data[3], data[4], data[5]]);
-    if data[6] != expected_tag {
+    let segment_id = u32::from_be_bytes([
+        data[SEGMENT_ID_OFFSET],
+        data[SEGMENT_ID_OFFSET + 1],
+        data[SEGMENT_ID_OFFSET + 2],
+        data[SEGMENT_ID_OFFSET + 3],
+    ]);
+    if data[RECORD_TYPE_OFFSET] != expected_tag {
         return Err(Error::Encoding(format!(
             "invalid record tag: expected 0x{:02x}, got 0x{:02x}",
-            expected_tag, data[6]
+            expected_tag, data[RECORD_TYPE_OFFSET]
         )));
     }
     Ok((segment_id, &data[SEGMENTED_PREFIX_LEN..]))

--- a/rfcs/0001-record-key-prefix.md
+++ b/rfcs/0001-record-key-prefix.md
@@ -137,4 +137,5 @@ None at this time.
 |------------|--------------------------------------------|
 | 2026-01-09 | Initial draft                              |
 | 2026-03-18 | Simplify record tag and add subsystem byte |
-| 2026-05-19 | Drop the record_tag mandate from the common prefix. The common prefix is now `[subsystem, version]` (2 bytes); record-type discrimination is subsystem-defined. `common::serde::key_prefix::KeyPrefix` still ships the legacy 3-byte shape used by timeseries/vector/keyvalue; updating those callers and slimming the common codec is deferred to a follow-up. |
+| 2026-05-19 | Drop the record_tag mandate from the common prefix. The common prefix is now `[subsystem, version]` (2 bytes); record-type discrimination is subsystem-defined. |
+| 2026-05-20 | Slim `common::serde::key_prefix::KeyPrefix` to the new 2-byte shape and move tag-byte handling into the timeseries/vector subsystems. `common::serde::record_tag::RecordTag` remains as an opt-in 4+4 bit tag-byte utility for subsystems that want it. |

--- a/timeseries/src/serde/key.rs
+++ b/timeseries/src/serde/key.rs
@@ -4,8 +4,12 @@ use super::*;
 use crate::model::{BucketSize, BucketStart, SeriesFingerprint, SeriesId};
 use bytes::{Bytes, BytesMut};
 use common::BytesRange;
-use common::serde::key_prefix::KeyPrefix;
+use common::serde::key_prefix::KEY_PREFIX_LEN;
 use common::serde::terminated_bytes;
+
+/// Offset of the first subsystem-defined field after the 2-byte common prefix
+/// plus the 1-byte timeseries tag.
+const PREFIX_AND_TAG_LEN: usize = KEY_PREFIX_LEN + 1;
 
 /// BucketList key (global-scoped)
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -13,12 +17,12 @@ pub struct BucketListKey;
 
 impl BucketListKey {
     pub fn encode(&self) -> Bytes {
-        RecordType::BucketList.prefix().to_bytes()
+        RecordType::BucketList.encode_prefix()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        let prefix = KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
-        let record_type = RecordType::from_prefix(prefix)?;
+        let tag = parse_record_tag(buf)?;
+        let record_type = RecordType::from_id(tag.record_type())?;
         if record_type != RecordType::BucketList {
             return Err(EncodingError {
                 message: format!(
@@ -27,7 +31,7 @@ impl BucketListKey {
                 ),
             });
         }
-        if bucket_size_from_prefix(prefix).is_some() {
+        if bucket_size_from_tag(tag).is_some() {
             return Err(EncodingError {
                 message: "BucketListKey should be global-scoped (bucket_size should be None)"
                     .to_string(),
@@ -48,22 +52,20 @@ pub struct SeriesDictionaryKey {
 impl SeriesDictionaryKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        RecordType::SeriesDictionary
-            .prefix_with_bucket_size(self.bucket_size)
-            .write_to(&mut buf);
+        RecordType::SeriesDictionary.write_prefix_with_bucket_size(&mut buf, self.bucket_size);
         buf.extend_from_slice(&self.time_bucket.to_be_bytes());
         buf.extend_from_slice(&self.series_fingerprint.to_be_bytes());
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 3 + 4 + 16 {
+        if buf.len() < PREFIX_AND_TAG_LEN + 4 + 16 {
             return Err(EncodingError {
                 message: "Buffer too short for SeriesDictionaryKey".to_string(),
             });
         }
-        let prefix = KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
-        let record_type = RecordType::from_prefix(prefix)?;
+        let tag = parse_record_tag(buf)?;
+        let record_type = RecordType::from_id(tag.record_type())?;
         if record_type != RecordType::SeriesDictionary {
             return Err(EncodingError {
                 message: format!(
@@ -72,14 +74,16 @@ impl SeriesDictionaryKey {
                 ),
             });
         }
-        let bucket_size = bucket_size_from_prefix(prefix).ok_or_else(|| EncodingError {
+        let bucket_size = bucket_size_from_tag(tag).ok_or_else(|| EncodingError {
             message: "SeriesDictionaryKey should be bucket-scoped".to_string(),
         })?;
 
-        let time_bucket = u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
+        let suffix = &buf[PREFIX_AND_TAG_LEN..];
+        let time_bucket = u32::from_be_bytes([suffix[0], suffix[1], suffix[2], suffix[3]]);
         let series_fingerprint = u128::from_be_bytes([
-            buf[7], buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15], buf[16],
-            buf[17], buf[18], buf[19], buf[20], buf[21], buf[22],
+            suffix[4], suffix[5], suffix[6], suffix[7], suffix[8], suffix[9], suffix[10],
+            suffix[11], suffix[12], suffix[13], suffix[14], suffix[15], suffix[16], suffix[17],
+            suffix[18], suffix[19],
         ]);
 
         Ok(SeriesDictionaryKey {
@@ -114,22 +118,20 @@ pub struct ForwardIndexKey {
 impl ForwardIndexKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        RecordType::ForwardIndex
-            .prefix_with_bucket_size(self.bucket_size)
-            .write_to(&mut buf);
+        RecordType::ForwardIndex.write_prefix_with_bucket_size(&mut buf, self.bucket_size);
         buf.extend_from_slice(&self.time_bucket.to_be_bytes());
         buf.extend_from_slice(&self.series_id.to_be_bytes());
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 3 + 4 + 4 {
+        if buf.len() < PREFIX_AND_TAG_LEN + 4 + 4 {
             return Err(EncodingError {
                 message: "Buffer too short for ForwardIndexKey".to_string(),
             });
         }
-        let prefix = KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
-        let record_type = RecordType::from_prefix(prefix)?;
+        let tag = parse_record_tag(buf)?;
+        let record_type = RecordType::from_id(tag.record_type())?;
         if record_type != RecordType::ForwardIndex {
             return Err(EncodingError {
                 message: format!(
@@ -138,12 +140,13 @@ impl ForwardIndexKey {
                 ),
             });
         }
-        let bucket_size = bucket_size_from_prefix(prefix).ok_or_else(|| EncodingError {
+        let bucket_size = bucket_size_from_tag(tag).ok_or_else(|| EncodingError {
             message: "ForwardIndexKey should be bucket-scoped".to_string(),
         })?;
 
-        let time_bucket = u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
-        let series_id = u32::from_be_bytes([buf[7], buf[8], buf[9], buf[10]]);
+        let suffix = &buf[PREFIX_AND_TAG_LEN..];
+        let time_bucket = u32::from_be_bytes([suffix[0], suffix[1], suffix[2], suffix[3]]);
+        let series_id = u32::from_be_bytes([suffix[4], suffix[5], suffix[6], suffix[7]]);
 
         Ok(ForwardIndexKey {
             time_bucket,
@@ -178,9 +181,7 @@ pub struct InvertedIndexKey {
 impl InvertedIndexKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        RecordType::InvertedIndex
-            .prefix_with_bucket_size(self.bucket_size)
-            .write_to(&mut buf);
+        RecordType::InvertedIndex.write_prefix_with_bucket_size(&mut buf, self.bucket_size);
         buf.extend_from_slice(&self.time_bucket.to_be_bytes());
         // Attribute uses terminated encoding to delimit from value
         terminated_bytes::serialize(self.attribute.as_bytes(), &mut buf);
@@ -193,22 +194,20 @@ impl InvertedIndexKey {
     /// within a given bucket. This allows efficient scanning for all values of a label.
     pub fn attribute_range(bucket: &crate::model::TimeBucket, attribute: &str) -> BytesRange {
         let mut buf = BytesMut::new();
-        RecordType::InvertedIndex
-            .prefix_with_bucket_size(bucket.size)
-            .write_to(&mut buf);
+        RecordType::InvertedIndex.write_prefix_with_bucket_size(&mut buf, bucket.size);
         buf.extend_from_slice(&bucket.start.to_be_bytes());
         terminated_bytes::serialize(attribute.as_bytes(), &mut buf);
         BytesRange::prefix(buf.freeze())
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 3 + 4 {
+        if buf.len() < PREFIX_AND_TAG_LEN + 4 {
             return Err(EncodingError {
                 message: "Buffer too short for InvertedIndexKey".to_string(),
             });
         }
-        let prefix = KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
-        let record_type = RecordType::from_prefix(prefix)?;
+        let tag = parse_record_tag(buf)?;
+        let record_type = RecordType::from_id(tag.record_type())?;
         if record_type != RecordType::InvertedIndex {
             return Err(EncodingError {
                 message: format!(
@@ -217,11 +216,11 @@ impl InvertedIndexKey {
                 ),
             });
         }
-        let bucket_size = bucket_size_from_prefix(prefix).ok_or_else(|| EncodingError {
+        let bucket_size = bucket_size_from_tag(tag).ok_or_else(|| EncodingError {
             message: "InvertedIndexKey should be bucket-scoped".to_string(),
         })?;
 
-        let mut slice = &buf[3..];
+        let mut slice = &buf[PREFIX_AND_TAG_LEN..];
         let time_bucket = u32::from_be_bytes([slice[0], slice[1], slice[2], slice[3]]);
         slice = &slice[4..];
 
@@ -277,9 +276,7 @@ pub struct TimeSeriesKey {
 impl TimeSeriesKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        RecordType::TimeSeries
-            .prefix_with_bucket_size(self.bucket_size)
-            .write_to(&mut buf);
+        RecordType::TimeSeries.write_prefix_with_bucket_size(&mut buf, self.bucket_size);
         buf.extend_from_slice(&self.time_bucket.to_be_bytes());
         terminated_bytes::serialize(self.metric_name.as_bytes(), &mut buf);
         buf.extend_from_slice(&self.series_id.to_be_bytes());
@@ -287,14 +284,14 @@ impl TimeSeriesKey {
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        // Minimum: 3 (prefix) + 4 (bucket) + 1 (terminated empty metric_name = just 0x00) + 4 (series_id)
-        if buf.len() < 3 + 4 + 1 + 4 {
+        // Minimum: prefix+tag + 4 (bucket) + 1 (terminated empty metric_name = just 0x00) + 4 (series_id)
+        if buf.len() < PREFIX_AND_TAG_LEN + 4 + 1 + 4 {
             return Err(EncodingError {
                 message: "Buffer too short for TimeSeriesKey".to_string(),
             });
         }
-        let prefix = KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
-        let record_type = RecordType::from_prefix(prefix)?;
+        let tag = parse_record_tag(buf)?;
+        let record_type = RecordType::from_id(tag.record_type())?;
         if record_type != RecordType::TimeSeries {
             return Err(EncodingError {
                 message: format!(
@@ -303,13 +300,19 @@ impl TimeSeriesKey {
                 ),
             });
         }
-        let bucket_size = bucket_size_from_prefix(prefix).ok_or_else(|| EncodingError {
+        let bucket_size = bucket_size_from_tag(tag).ok_or_else(|| EncodingError {
             message: "TimeSeriesKey should be bucket-scoped".to_string(),
         })?;
 
-        let time_bucket = u32::from_be_bytes([buf[3], buf[4], buf[5], buf[6]]);
+        let bucket_offset = PREFIX_AND_TAG_LEN;
+        let time_bucket = u32::from_be_bytes([
+            buf[bucket_offset],
+            buf[bucket_offset + 1],
+            buf[bucket_offset + 2],
+            buf[bucket_offset + 3],
+        ]);
 
-        let mut slice = &buf[7..];
+        let mut slice = &buf[bucket_offset + 4..];
         let metric_name_bytes = terminated_bytes::deserialize(&mut slice)?;
         let metric_name =
             String::from_utf8(metric_name_bytes.to_vec()).map_err(|e| EncodingError {

--- a/timeseries/src/serde/mod.rs
+++ b/timeseries/src/serde/mod.rs
@@ -6,9 +6,9 @@ pub mod key;
 pub mod timeseries;
 
 use crate::model::{BucketSize, RecordTag, TimeBucket};
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use common::BytesRange;
-use common::serde::key_prefix::KeyPrefix;
+use common::serde::key_prefix::{KEY_PREFIX_LEN, KeyPrefix};
 
 // Re-export encoding utilities from common
 pub use common::serde::encoding::{
@@ -96,8 +96,8 @@ pub fn decode_fixed_element_array<T: Decode>(
 /// Key format version (currently 0x01)
 pub const KEY_VERSION: u8 = 0x01;
 
-/// Subsystem-specific key prefix for timeseries storage.
-pub const SUBSYSTEM: u8 = 0x01;
+/// Subsystem byte for timeseries storage (see [`common::serde::subsystem`]).
+pub const SUBSYSTEM: u8 = common::serde::subsystem::TIMESERIES;
 
 /// Record type enumeration for timeseries storage.
 ///
@@ -133,17 +133,11 @@ impl RecordType {
         }
     }
 
-    pub fn from_prefix(prefix: KeyPrefix) -> Result<Self, EncodingError> {
-        if prefix.subsystem() != SUBSYSTEM {
-            return Err(EncodingError {
-                message: format!(
-                    "invalid subsystem: expected 0x{:02x}, got 0x{:02x}",
-                    SUBSYSTEM,
-                    prefix.subsystem()
-                ),
-            });
-        }
-        RecordType::from_id((prefix.tag() & 0xF0) >> 4)
+    /// Decodes the record type from the tag byte that follows the 2-byte key
+    /// prefix in a timeseries key.
+    pub fn from_tag_byte(byte: u8) -> Result<Self, EncodingError> {
+        let tag = RecordTag::from_byte(byte)?;
+        RecordType::from_id(tag.record_type())
     }
 
     /// Creates a global-scoped RecordTag (reserved bits = 0).
@@ -156,26 +150,51 @@ impl RecordType {
         RecordTag::new(self.id(), bucket_size)
     }
 
-    /// Creates a global-scoped KeyPrefix with the current version.
-    pub fn prefix(&self) -> KeyPrefix {
-        KeyPrefix::new(SUBSYSTEM, KEY_VERSION, self.tag().as_byte())
+    /// Writes the 3-byte timeseries record prefix `[subsystem, version, tag]`
+    /// for a global-scoped record.
+    pub fn write_prefix(&self, buf: &mut BytesMut) {
+        write_record_prefix(buf, self.tag());
     }
 
-    /// Creates a bucket-scoped KeyPrefix with the current version.
-    pub fn prefix_with_bucket_size(&self, bucket_size: BucketSize) -> KeyPrefix {
-        KeyPrefix::new(
-            SUBSYSTEM,
-            KEY_VERSION,
-            self.tag_with_bucket_size(bucket_size).as_byte(),
-        )
+    /// Writes the 3-byte timeseries record prefix for a bucket-scoped record,
+    /// packing `bucket_size` into the low 4 bits of the tag byte.
+    pub fn write_prefix_with_bucket_size(&self, buf: &mut BytesMut, bucket_size: BucketSize) {
+        write_record_prefix(buf, self.tag_with_bucket_size(bucket_size));
+    }
+
+    /// Encodes the 3-byte timeseries record prefix for a global-scoped record
+    /// into a fresh `Bytes`.
+    pub fn encode_prefix(&self) -> Bytes {
+        let mut buf = BytesMut::with_capacity(KEY_PREFIX_LEN + 1);
+        self.write_prefix(&mut buf);
+        buf.freeze()
     }
 }
 
-/// Extracts the bucket size from a key prefix.
+/// Writes `[subsystem, version, tag]` to `buf`, where `tag` packs the record
+/// type and any subsystem-specific reserved bits (e.g. bucket size).
+fn write_record_prefix(buf: &mut BytesMut, tag: RecordTag) {
+    KeyPrefix::new(SUBSYSTEM, KEY_VERSION).write_to(buf);
+    buf.put_u8(tag.as_byte());
+}
+
+/// Reads the tag byte that follows the 2-byte key prefix, validating that the
+/// preceding 2 bytes are the timeseries subsystem and current key version.
+pub fn parse_record_tag(buf: &[u8]) -> Result<RecordTag, EncodingError> {
+    KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
+    if buf.len() < KEY_PREFIX_LEN + 1 {
+        return Err(EncodingError {
+            message: "Buffer too short for record tag".to_string(),
+        });
+    }
+    Ok(RecordTag::from_byte(buf[KEY_PREFIX_LEN])?)
+}
+
+/// Extracts the bucket size from the reserved bits of a record tag.
 ///
 /// Returns None if the reserved bits are 0 (global-scoped record).
-pub fn bucket_size_from_prefix(prefix: KeyPrefix) -> Option<BucketSize> {
-    let size = prefix.tag() & 0x0F;
+pub fn bucket_size_from_tag(tag: RecordTag) -> Option<BucketSize> {
+    let size = tag.reserved();
     if size == 0 { None } else { Some(size) }
 }
 
@@ -193,8 +212,8 @@ pub trait TimeBucketScoped: RecordKey {
     /// Decodes and validates the bucket-scoped prefix of a key.
     /// Returns the TimeBucket if the record type matches the expected type.
     fn decode_bucket_prefix(bytes: &[u8]) -> Result<TimeBucket, EncodingError> {
-        let prefix = KeyPrefix::from_bytes_with_validation(bytes, SUBSYSTEM, KEY_VERSION)?;
-        let record_type = RecordType::from_prefix(prefix)?;
+        let tag = parse_record_tag(bytes)?;
+        let record_type = RecordType::from_id(tag.record_type())?;
 
         if record_type != Self::RECORD_TYPE {
             return Err(EncodingError {
@@ -206,17 +225,23 @@ pub trait TimeBucketScoped: RecordKey {
             });
         }
 
-        let bucket_size = bucket_size_from_prefix(prefix).ok_or_else(|| EncodingError {
+        let bucket_size = bucket_size_from_tag(tag).ok_or_else(|| EncodingError {
             message: "record should be bucket-scoped".to_string(),
         })?;
 
-        if bytes.len() < 7 {
+        let bucket_offset = KEY_PREFIX_LEN + 1;
+        if bytes.len() < bucket_offset + 4 {
             return Err(EncodingError {
                 message: "buffer too short for bucket prefix".to_string(),
             });
         }
 
-        let start_epoch_min = u32::from_be_bytes([bytes[3], bytes[4], bytes[5], bytes[6]]);
+        let start_epoch_min = u32::from_be_bytes([
+            bytes[bucket_offset],
+            bytes[bucket_offset + 1],
+            bytes[bucket_offset + 2],
+            bytes[bucket_offset + 3],
+        ]);
 
         Ok(TimeBucket {
             start: start_epoch_min,
@@ -228,9 +253,7 @@ pub trait TimeBucketScoped: RecordKey {
     /// for the given time bucket.
     fn bucket_range(bucket: &TimeBucket) -> BytesRange {
         let mut buf = BytesMut::new();
-        Self::RECORD_TYPE
-            .prefix_with_bucket_size(bucket.size)
-            .write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix_with_bucket_size(&mut buf, bucket.size);
         buf.put_u32(bucket.start);
         BytesRange::prefix(buf.freeze())
     }
@@ -239,25 +262,13 @@ pub trait TimeBucketScoped: RecordKey {
 /// Helper function to write the bucket-scoped prefix to a buffer
 pub fn write_bucket_scoped_prefix<T: TimeBucketScoped>(buf: &mut BytesMut, record: &T) {
     let bucket = record.bucket();
-    T::RECORD_TYPE
-        .prefix_with_bucket_size(bucket.size)
-        .write_to(buf);
+    T::RECORD_TYPE.write_prefix_with_bucket_size(buf, bucket.size);
     buf.put_u32(bucket.start);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Extracts the RecordType from a RecordTag.
-    fn record_type_from_tag(tag: RecordTag) -> Result<RecordType, EncodingError> {
-        RecordType::from_id(tag.record_type())
-    }
-
-    fn bucket_size_from_tag(tag: RecordTag) -> Option<BucketSize> {
-        let size = tag.reserved();
-        if size == 0 { None } else { Some(size) }
-    }
 
     #[test]
     fn should_encode_and_decode_record_tag_global_scoped() {
@@ -271,7 +282,7 @@ mod tests {
         // then
         assert_eq!(decoded.as_byte(), record_tag.as_byte());
         assert_eq!(
-            record_type_from_tag(decoded).unwrap(),
+            RecordType::from_id(decoded.record_type()).unwrap(),
             RecordType::BucketList
         );
         assert_eq!(bucket_size_from_tag(decoded), None);
@@ -289,7 +300,7 @@ mod tests {
         // then
         assert_eq!(decoded.as_byte(), record_tag.as_byte());
         assert_eq!(
-            record_type_from_tag(decoded).unwrap(),
+            RecordType::from_id(decoded.record_type()).unwrap(),
             RecordType::TimeSeries
         );
         assert_eq!(bucket_size_from_tag(decoded), Some(3));

--- a/timeseries/src/storage/merge_operator.rs
+++ b/timeseries/src/storage/merge_operator.rs
@@ -1,9 +1,8 @@
 use crate::serde::bucket_list::BucketListValue;
 use crate::serde::inverted_index::InvertedIndexValue;
 use crate::serde::timeseries::merge_batch_time_series;
-use crate::serde::{EncodingError, RecordType};
+use crate::serde::{EncodingError, RecordType, parse_record_tag};
 use bytes::Bytes;
-use common::serde::key_prefix::KeyPrefix;
 use common::storage::default_merge_batch;
 
 /// Merge operator for OpenTSDB that handles merging of different record types.
@@ -15,10 +14,9 @@ pub(crate) struct OpenTsdbMergeOperator;
 impl common::storage::MergeOperator for OpenTsdbMergeOperator {
     fn merge_batch(&self, key: &Bytes, existing_value: Option<Bytes>, operands: &[Bytes]) -> Bytes {
         // Decode record type from key
-        let key_prefix = KeyPrefix::from_bytes(key.as_ref()).unwrap();
-
+        let tag = parse_record_tag(key.as_ref()).expect("Failed to parse key prefix");
         let record_type =
-            RecordType::from_prefix(key_prefix).expect("Failed to get record type from record tag");
+            RecordType::from_id(tag.record_type()).expect("Failed to decode record type");
 
         match record_type {
             RecordType::InvertedIndex => merge_batch_inverted_index(existing_value, operands)

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -467,9 +467,7 @@ impl VectorDb {
     ) -> Result<HashMap<String, VectorId>> {
         // Create prefix for all IdDictionary records
         let mut prefix_buf = bytes::BytesMut::with_capacity(3);
-        crate::serde::RecordType::IdDictionary
-            .prefix()
-            .write_to(&mut prefix_buf);
+        crate::serde::RecordType::IdDictionary.write_prefix(&mut prefix_buf);
         let prefix = prefix_buf.freeze();
 
         // Scan all IdDictionary records

--- a/vector/src/serde/key.rs
+++ b/vector/src/serde/key.rs
@@ -3,14 +3,14 @@
 //! All keys use big-endian encoding for lexicographic ordering.
 
 use super::{
-    Decode, Encode, EncodingError, FieldValue, KEY_VERSION, RecordKey, RecordType, SUBSYSTEM,
+    Decode, Encode, EncodingError, FieldValue, PREFIX_AND_TAG_LEN, RecordKey, RecordType,
+    parse_record_tag,
 };
 use crate::serde::vector_id::LEAF_LEVEL;
 use crate::serde::vector_id::{ROOT_VECTOR_ID, VectorId};
 #[allow(unused_imports)]
 use bytes::{BufMut, Bytes, BytesMut};
 use common::BytesRange;
-use common::serde::key_prefix::KeyPrefix;
 use common::serde::terminated_bytes;
 use std::ops::Bound::{Excluded, Included};
 
@@ -27,12 +27,12 @@ impl RecordKey for CollectionMetaKey {
 impl CollectionMetaKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(3);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 3 {
+        if buf.len() < PREFIX_AND_TAG_LEN {
             return Err(EncodingError {
                 message: "Buffer too short for CollectionMetaKey".to_string(),
             });
@@ -59,12 +59,12 @@ impl CentroidsKey {
 
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(3);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 3 {
+        if buf.len() < PREFIX_AND_TAG_LEN {
             return Err(EncodingError {
                 message: "Buffer too short for CentroidsKey".to_string(),
             });
@@ -100,7 +100,7 @@ impl PostingListKey {
 
     pub(crate) fn encode_prefix_for_level(level: u8) -> Bytes {
         let mut buf = BytesMut::with_capacity(4);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         VectorId::encode_level_prefix(&mut buf, level);
         buf.freeze()
     }
@@ -113,19 +113,19 @@ impl PostingListKey {
 
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(11);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         self.centroid_id.encode(&mut buf);
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 11 {
+        if buf.len() < PREFIX_AND_TAG_LEN + 8 {
             return Err(EncodingError {
                 message: "Buffer too short for PostingListKey".to_string(),
             });
         }
         validate_key_prefix::<Self>(buf)?;
-        let mut suffix = &buf[3..];
+        let mut suffix = &buf[PREFIX_AND_TAG_LEN..];
         let centroid_id = VectorId::decode(&mut suffix)?;
         Ok(PostingListKey { centroid_id })
     }
@@ -133,7 +133,7 @@ impl PostingListKey {
     /// Returns a range covering all posting list keys.
     pub fn all_posting_lists_range() -> BytesRange {
         let mut buf = BytesMut::with_capacity(3);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         BytesRange::prefix(buf.freeze())
     }
 }
@@ -159,13 +159,13 @@ impl IdDictionaryKey {
 
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         terminated_bytes::serialize(self.external_id.as_bytes(), &mut buf);
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 4 {
+        if buf.len() < PREFIX_AND_TAG_LEN + 1 {
             // At minimum: subsystem + version + tag + terminator
             return Err(EncodingError {
                 message: "Buffer too short for IdDictionaryKey".to_string(),
@@ -173,7 +173,7 @@ impl IdDictionaryKey {
         }
         validate_key_prefix::<Self>(buf)?;
 
-        let mut slice = &buf[3..];
+        let mut slice = &buf[PREFIX_AND_TAG_LEN..];
         let external_id_bytes =
             terminated_bytes::deserialize(&mut slice).map_err(|e| EncodingError {
                 message: format!("Failed to decode external_id: {}", e),
@@ -190,7 +190,7 @@ impl IdDictionaryKey {
     /// Returns a range covering all ID dictionary keys.
     pub fn all_ids_range() -> BytesRange {
         let mut buf = BytesMut::with_capacity(3);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         BytesRange::prefix(buf.freeze())
     }
 
@@ -201,7 +201,7 @@ impl IdDictionaryKey {
     /// all IDs that start with the given string prefix.
     pub fn prefix_range(prefix: &str) -> BytesRange {
         let mut buf = BytesMut::new();
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         terminated_bytes::serialize(prefix.as_bytes(), &mut buf);
         BytesRange::prefix(buf.freeze())
     }
@@ -227,20 +227,20 @@ impl VectorDataKey {
 
     pub(crate) fn encode(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(11);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         self.vector_id.encode(&mut buf);
         buf.freeze()
     }
 
     #[allow(dead_code)]
     pub(crate) fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 11 {
+        if buf.len() < PREFIX_AND_TAG_LEN + 8 {
             return Err(EncodingError {
                 message: "Buffer too short for VectorDataKey".to_string(),
             });
         }
         validate_key_prefix::<Self>(buf)?;
-        let vector_id = VectorId::decode(&mut &buf[3..])?;
+        let vector_id = VectorId::decode(&mut &buf[PREFIX_AND_TAG_LEN..])?;
         Ok(VectorDataKey { vector_id })
     }
 
@@ -248,7 +248,7 @@ impl VectorDataKey {
     #[allow(dead_code)]
     pub(crate) fn all_vectors_range() -> BytesRange {
         let mut buf = BytesMut::with_capacity(3);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         BytesRange::prefix(buf.freeze())
     }
 }
@@ -273,20 +273,20 @@ impl VectorIndexDataKey {
 
     pub(crate) fn encode(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(11);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         self.vector_id.encode(&mut buf);
         buf.freeze()
     }
 
     #[allow(dead_code)]
     pub(crate) fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 11 {
+        if buf.len() < PREFIX_AND_TAG_LEN + 8 {
             return Err(EncodingError {
                 message: "Buffer too short for VectorIndexDataKey".to_string(),
             });
         }
         validate_key_prefix::<Self>(buf)?;
-        let vector_id = VectorId::decode(&mut &buf[3..])?;
+        let vector_id = VectorId::decode(&mut &buf[PREFIX_AND_TAG_LEN..])?;
         Ok(VectorIndexDataKey { vector_id })
     }
 }
@@ -314,14 +314,14 @@ impl MetadataIndexKey {
 
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         terminated_bytes::serialize(self.field.as_bytes(), &mut buf);
         self.value.encode_sortable(&mut buf);
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 5 {
+        if buf.len() < PREFIX_AND_TAG_LEN + 2 {
             // Minimum: subsystem + version + tag + field terminator + value type
             return Err(EncodingError {
                 message: "Buffer too short for MetadataIndexKey".to_string(),
@@ -329,7 +329,7 @@ impl MetadataIndexKey {
         }
         validate_key_prefix::<Self>(buf)?;
 
-        let mut slice = &buf[3..];
+        let mut slice = &buf[PREFIX_AND_TAG_LEN..];
 
         let field_bytes = terminated_bytes::deserialize(&mut slice).map_err(|e| EncodingError {
             message: format!("Failed to decode field: {}", e),
@@ -347,7 +347,7 @@ impl MetadataIndexKey {
     /// Returns a range covering all metadata index keys for a specific field.
     pub fn field_range(field: &str) -> BytesRange {
         let mut buf = BytesMut::new();
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         terminated_bytes::serialize(field.as_bytes(), &mut buf);
         BytesRange::prefix(buf.freeze())
     }
@@ -355,7 +355,7 @@ impl MetadataIndexKey {
     /// Returns a range covering all metadata index keys.
     pub fn all_indexes_range() -> BytesRange {
         let mut buf = BytesMut::with_capacity(3);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         BytesRange::prefix(buf.freeze())
     }
 }
@@ -373,12 +373,12 @@ impl RecordKey for SeqBlockKey {
 impl SeqBlockKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(3);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 3 {
+        if buf.len() < PREFIX_AND_TAG_LEN {
             return Err(EncodingError {
                 message: "Buffer too short for SeqBlockKey".to_string(),
             });
@@ -401,12 +401,12 @@ impl RecordKey for CentroidSeqBlockKey {
 impl CentroidSeqBlockKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(3);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 3 {
+        if buf.len() < PREFIX_AND_TAG_LEN {
             return Err(EncodingError {
                 message: "Buffer too short for CentroidSeqBlockKey".to_string(),
             });
@@ -436,19 +436,19 @@ impl CentroidStatsKey {
 
     pub(crate) fn encode(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(12);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         self.centroid_id.encode(&mut buf);
         buf.freeze()
     }
 
     pub(crate) fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 11 {
+        if buf.len() < PREFIX_AND_TAG_LEN + 8 {
             return Err(EncodingError {
                 message: "Buffer too short for CentroidStatsKey".to_string(),
             });
         }
         validate_key_prefix::<Self>(buf)?;
-        let centroid_id = VectorId::decode(&mut &buf[3..])?;
+        let centroid_id = VectorId::decode(&mut &buf[PREFIX_AND_TAG_LEN..])?;
         Ok(CentroidStatsKey { centroid_id })
     }
 }
@@ -473,19 +473,19 @@ impl CentroidInfoKey {
 
     pub(crate) fn encode(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(11);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         self.centroid_id.encode(&mut buf);
         buf.freeze()
     }
 
     pub(crate) fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 11 {
+        if buf.len() < PREFIX_AND_TAG_LEN + 8 {
             return Err(EncodingError {
                 message: "Buffer too short for CentroidInfoKey".to_string(),
             });
         }
         validate_key_prefix::<Self>(buf)?;
-        let centroid_id = VectorId::decode(&mut &buf[3..])?;
+        let centroid_id = VectorId::decode(&mut &buf[PREFIX_AND_TAG_LEN..])?;
         Ok(CentroidInfoKey { centroid_id })
     }
 
@@ -493,15 +493,15 @@ impl CentroidInfoKey {
     #[allow(dead_code)]
     pub(crate) fn all_centroid_infos_range() -> BytesRange {
         let mut buf = BytesMut::with_capacity(3);
-        Self::RECORD_TYPE.prefix().write_to(&mut buf);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
         BytesRange::prefix(buf.freeze())
     }
 }
 
-/// Validates the key prefix (version and record tag).
+/// Validates the key prefix (subsystem, version) and the trailing record tag byte.
 fn validate_key_prefix<T: RecordKey>(buf: &[u8]) -> Result<(), EncodingError> {
-    let prefix = KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
-    let record_type = RecordType::from_prefix(prefix)?;
+    let tag = parse_record_tag(buf)?;
+    let record_type = RecordType::from_id(tag.record_type())?;
 
     if record_type != T::RECORD_TYPE {
         return Err(EncodingError {

--- a/vector/src/serde/mod.rs
+++ b/vector/src/serde/mod.rs
@@ -15,20 +15,24 @@ pub mod vector_data;
 pub(crate) mod vector_id;
 pub mod vector_index_data;
 
-use bytes::BytesMut;
+use bytes::{BufMut, Bytes, BytesMut};
 
 // Re-export encoding utilities from common
 pub use common::serde::encoding::{
     EncodingError, decode_optional_utf8, decode_utf8, encode_optional_utf8, encode_utf8,
 };
-use common::serde::key_prefix::KeyPrefix;
+use common::serde::key_prefix::{KEY_PREFIX_LEN, KeyPrefix};
 use common::serde::record_tag::RecordTag;
+
+/// Offset of the first subsystem-defined field after the 2-byte common prefix
+/// plus the 1-byte vector tag.
+pub const PREFIX_AND_TAG_LEN: usize = KEY_PREFIX_LEN + 1;
 
 /// Key format version (currently 0x01)
 pub const KEY_VERSION: u8 = 0x01;
 
-/// Subsystem-specific key prefix for vector storage.
-pub const SUBSYSTEM: u8 = 0x02;
+/// Subsystem byte for vector storage (see [`common::serde::subsystem`]).
+pub const SUBSYSTEM: u8 = common::serde::subsystem::VECTOR;
 
 /// Record type enumeration for vector database records.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -73,17 +77,11 @@ impl RecordType {
         }
     }
 
-    pub fn from_prefix(prefix: KeyPrefix) -> Result<Self, EncodingError> {
-        if prefix.subsystem() != SUBSYSTEM {
-            return Err(EncodingError {
-                message: format!(
-                    "invalid subsystem: expected 0x{:02x}, got 0x{:02x}",
-                    SUBSYSTEM,
-                    prefix.subsystem()
-                ),
-            });
-        }
-        RecordType::from_id((prefix.tag() & 0xF0) >> 4)
+    /// Decodes the record type from the tag byte that follows the 2-byte key
+    /// prefix in a vector key.
+    pub fn from_tag_byte(byte: u8) -> Result<Self, EncodingError> {
+        let tag = RecordTag::from_byte(byte)?;
+        RecordType::from_id(tag.record_type())
     }
 
     /// Creates a RecordTag for this record type (reserved bits = 0).
@@ -91,10 +89,30 @@ impl RecordType {
         RecordTag::new(self.id(), 0)
     }
 
-    /// Creates a KeyPrefix with the current version for this record type.
-    pub fn prefix(&self) -> KeyPrefix {
-        KeyPrefix::new(SUBSYSTEM, KEY_VERSION, self.tag().as_byte())
+    /// Writes the 3-byte vector record prefix `[subsystem, version, tag]`.
+    pub fn write_prefix(&self, buf: &mut BytesMut) {
+        KeyPrefix::new(SUBSYSTEM, KEY_VERSION).write_to(buf);
+        buf.put_u8(self.tag().as_byte());
     }
+
+    /// Encodes the 3-byte vector record prefix into a fresh `Bytes`.
+    pub fn encode_prefix(&self) -> Bytes {
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
+        self.write_prefix(&mut buf);
+        buf.freeze()
+    }
+}
+
+/// Reads the tag byte that follows the 2-byte key prefix, validating that the
+/// preceding 2 bytes are the vector subsystem and current key version.
+pub fn parse_record_tag(buf: &[u8]) -> Result<RecordTag, EncodingError> {
+    KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
+    if buf.len() < PREFIX_AND_TAG_LEN {
+        return Err(EncodingError {
+            message: "Buffer too short for record tag".to_string(),
+        });
+    }
+    Ok(RecordTag::from_byte(buf[KEY_PREFIX_LEN])?)
 }
 
 /// Trait for record keys that have a record type.

--- a/vector/src/storage/merge_operator.rs
+++ b/vector/src/storage/merge_operator.rs
@@ -6,9 +6,8 @@
 use crate::serde::centroid_stats::CentroidStatsValue;
 use crate::serde::metadata_index::MetadataIndexValue;
 use crate::serde::posting_list::merge_batch_posting_list;
-use crate::serde::{EncodingError, KEY_VERSION, RecordType, SUBSYSTEM};
+use crate::serde::{EncodingError, RecordType, parse_record_tag};
 use bytes::Bytes;
-use common::serde::key_prefix::KeyPrefix;
 use common::storage::default_merge_batch;
 
 /// Merge operator for vector database that handles merging of different record types.
@@ -29,10 +28,9 @@ impl VectorDbMergeOperator {
 
 impl common::storage::MergeOperator for VectorDbMergeOperator {
     fn merge_batch(&self, key: &Bytes, existing_value: Option<Bytes>, operands: &[Bytes]) -> Bytes {
-        let prefix = KeyPrefix::from_bytes_with_validation(key, SUBSYSTEM, KEY_VERSION)
-            .expect("Failed to decode key prefix");
+        let tag = parse_record_tag(key).expect("Failed to parse key prefix");
         let record_type =
-            RecordType::from_prefix(prefix).expect("Failed to get record type from record tag");
+            RecordType::from_id(tag.record_type()).expect("Failed to decode record type");
 
         match record_type {
             RecordType::MetadataIndex => merge_batch_metadata_index(existing_value, operands)

--- a/vector/src/storage/mod.rs
+++ b/vector/src/storage/mod.rs
@@ -156,9 +156,7 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
     #[allow(dead_code)]
     async fn scan_all_centroid_stats(&self) -> Result<Vec<(VectorId, CentroidStatsValue)>> {
         let mut prefix_buf = bytes::BytesMut::with_capacity(3);
-        crate::serde::RecordType::CentroidStats
-            .prefix()
-            .write_to(&mut prefix_buf);
+        crate::serde::RecordType::CentroidStats.write_prefix(&mut prefix_buf);
         let prefix = prefix_buf.freeze();
 
         let range = common::BytesRange::prefix(prefix);
@@ -178,9 +176,7 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
 
     async fn scan_all_centroid_info(&self) -> Result<Vec<(VectorId, CentroidInfoValue)>> {
         let mut prefix_buf = bytes::BytesMut::with_capacity(3);
-        crate::serde::RecordType::CentroidInfo
-            .prefix()
-            .write_to(&mut prefix_buf);
+        crate::serde::RecordType::CentroidInfo.write_prefix(&mut prefix_buf);
         let prefix = prefix_buf.freeze();
 
         let range = common::BytesRange::prefix(prefix);
@@ -200,9 +196,7 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
         dimensions: usize,
     ) -> Result<Vec<(VectorId, PostingListValue)>> {
         let mut prefix_buf = bytes::BytesMut::with_capacity(3);
-        crate::serde::RecordType::PostingList
-            .prefix()
-            .write_to(&mut prefix_buf);
+        crate::serde::RecordType::PostingList.write_prefix(&mut prefix_buf);
         let prefix = prefix_buf.freeze();
 
         let range = common::BytesRange::prefix(prefix);


### PR DESCRIPTION
In #450, we updated the common prefix to only specify subsystem and version. This patch updates the serde library. I've also added subsystem.rs as a common place to keep subsystem ids.