### PR TITLE
[common] add list_segments

### DIFF
--- a/common/src/storage/in_memory.rs
+++ b/common/src/storage/in_memory.rs
@@ -134,24 +134,23 @@ impl InMemoryStorage {
         self
     }
 
-    /// Records `key`'s routing prefix in the segment set, if a prefix
+    /// Records each key's routing prefix in the segment set, if a prefix
     /// extractor is configured and accepts the key.
-    fn update_segments(&self, key: &Bytes) {
+    fn update_segments(&self, keys: &[Bytes]) {
         let Some(extractor) = self.prefix_extractor.as_ref() else {
             return;
         };
-        let target = PrefixTarget::Point(key.clone());
-        let Some(len) = extractor.prefix_len(&target) else {
-            return;
-        };
-        if len == 0 || len > key.len() {
-            return;
+        let mut segments = self.segments.write().expect("segments lock poisoned");
+        for key in keys {
+            let target = PrefixTarget::Point(key.clone());
+            let Some(len) = extractor.prefix_len(&target) else {
+                continue;
+            };
+            if len == 0 || len > key.len() {
+                continue;
+            }
+            segments.insert(key.slice(..len));
         }
-        let prefix = key.slice(..len);
-        self.segments
-            .write()
-            .expect("segments lock poisoned")
-            .insert(prefix);
     }
 
     fn list_segments(&self) -> Vec<SegmentInfo> {
@@ -383,9 +382,7 @@ impl Storage for InMemoryStorage {
             }
         }
         drop(data);
-        for key in &observed_keys {
-            self.update_segments(key);
-        }
+        self.update_segments(&observed_keys);
 
         Ok(WriteResult {
             seqnum: self.next_seqnum(),
@@ -421,9 +418,7 @@ impl Storage for InMemoryStorage {
             );
         }
         drop(data);
-        for key in &observed_keys {
-            self.update_segments(key);
-        }
+        self.update_segments(&observed_keys);
 
         Ok(WriteResult {
             seqnum: self.next_seqnum(),
@@ -479,9 +474,7 @@ impl Storage for InMemoryStorage {
             );
         }
         drop(data);
-        for key in &observed_keys {
-            self.update_segments(key);
-        }
+        self.update_segments(&observed_keys);
 
         Ok(WriteResult {
             seqnum: self.next_seqnum(),

--- a/common/src/storage/in_memory.rs
+++ b/common/src/storage/in_memory.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ops::RangeBounds;
 use std::sync::{Arc, RwLock};
 
@@ -8,11 +8,12 @@ use bytes::Bytes;
 use super::{
     MergeOperator, MergeRecordOp, PutRecordOp, Storage, StorageSnapshot, WriteOptions, WriteResult,
 };
-use crate::storage::RecordOp;
+use crate::storage::{RecordOp, SegmentInfo};
 use crate::{
     BytesRange, CheckpointInfo, Record, StorageError, StorageIterator, StorageRead, StorageResult,
     Ttl,
 };
+use slatedb::{PrefixExtractor, PrefixTarget};
 
 /// Trait for providing the current time.
 pub trait Clock: Send + Sync {
@@ -69,6 +70,8 @@ pub struct InMemoryStorage {
     written_seq: std::sync::atomic::AtomicU64,
     durable_seq: std::sync::atomic::AtomicU64,
     durable_tx: tokio::sync::watch::Sender<u64>,
+    prefix_extractor: Option<Arc<dyn PrefixExtractor>>,
+    segments: Arc<RwLock<BTreeSet<Bytes>>>,
     defer_durability: bool,
 }
 
@@ -84,6 +87,8 @@ impl InMemoryStorage {
             written_seq: std::sync::atomic::AtomicU64::new(0),
             durable_seq: std::sync::atomic::AtomicU64::new(0),
             durable_tx,
+            prefix_extractor: None,
+            segments: Arc::new(RwLock::new(BTreeSet::new())),
             defer_durability: false,
         }
     }
@@ -103,6 +108,8 @@ impl InMemoryStorage {
             written_seq: std::sync::atomic::AtomicU64::new(0),
             durable_seq: std::sync::atomic::AtomicU64::new(0),
             durable_tx,
+            prefix_extractor: None,
+            segments: Arc::new(RwLock::new(BTreeSet::new())),
             defer_durability: false,
         }
     }
@@ -117,6 +124,43 @@ impl InMemoryStorage {
     pub fn with_default_ttl(mut self, ttl: u64) -> Self {
         self.default_ttl = Some(ttl);
         self
+    }
+
+    /// Installs a prefix extractor used to populate the segment list returned
+    /// by [`StorageRead::list_segments`]. Used by tests that exercise
+    /// segment-based bucket discovery without a real SlateDB manifest.
+    pub fn with_prefix_extractor(mut self, extractor: Arc<dyn PrefixExtractor>) -> Self {
+        self.prefix_extractor = Some(extractor);
+        self
+    }
+
+    /// Records `key`'s routing prefix in the segment set, if a prefix
+    /// extractor is configured and accepts the key.
+    fn update_segments(&self, key: &Bytes) {
+        let Some(extractor) = self.prefix_extractor.as_ref() else {
+            return;
+        };
+        let target = PrefixTarget::Point(key.clone());
+        let Some(len) = extractor.prefix_len(&target) else {
+            return;
+        };
+        if len == 0 || len > key.len() {
+            return;
+        }
+        let prefix = key.slice(..len);
+        self.segments
+            .write()
+            .expect("segments lock poisoned")
+            .insert(prefix);
+    }
+
+    fn list_segments(&self) -> Vec<SegmentInfo> {
+        self.segments
+            .read()
+            .expect("segments lock poisoned")
+            .iter()
+            .map(|p| SegmentInfo { prefix: p.clone() })
+            .collect()
     }
 
     /// Enables deferred durability mode.
@@ -215,6 +259,10 @@ impl StorageRead for InMemoryStorage {
 
         Ok(Box::new(InMemoryIterator { records, index: 0 }))
     }
+
+    fn list_segments(&self) -> Vec<SegmentInfo> {
+        InMemoryStorage::list_segments(self)
+    }
 }
 
 struct InMemoryIterator {
@@ -243,6 +291,7 @@ impl StorageIterator for InMemoryIterator {
 pub struct InMemoryStorageSnapshot {
     data: Arc<BTreeMap<Bytes, StoredValue>>,
     clock: Arc<dyn Clock>,
+    segments: Arc<Vec<SegmentInfo>>,
 }
 
 #[async_trait]
@@ -272,6 +321,10 @@ impl StorageRead for InMemoryStorageSnapshot {
 
         Ok(Box::new(InMemoryIterator { records, index: 0 }))
     }
+
+    fn list_segments(&self) -> Vec<SegmentInfo> {
+        (*self.segments).clone()
+    }
 }
 
 #[async_trait]
@@ -290,10 +343,12 @@ impl Storage for InMemoryStorage {
             .map_err(|e| StorageError::Internal(format!("Failed to acquire write lock: {}", e)))?;
 
         let now = self.clock.now();
+        let mut observed_keys: Vec<Bytes> = Vec::new();
         for record in records {
             match record {
                 RecordOp::Put(op) => {
                     let expire_ts = compute_expire_ts(now, op.options.ttl, self.default_ttl);
+                    observed_keys.push(op.record.key.clone());
                     data.insert(
                         op.record.key,
                         StoredValue {
@@ -313,6 +368,7 @@ impl Storage for InMemoryStorage {
                         &[op.record.value],
                     );
                     let expire_ts = compute_expire_ts(now, op.options.ttl, self.default_ttl);
+                    observed_keys.push(op.record.key.clone());
                     data.insert(
                         op.record.key,
                         StoredValue {
@@ -325,6 +381,10 @@ impl Storage for InMemoryStorage {
                     data.remove(&key);
                 }
             }
+        }
+        drop(data);
+        for key in &observed_keys {
+            self.update_segments(key);
         }
 
         Ok(WriteResult {
@@ -348,8 +408,10 @@ impl Storage for InMemoryStorage {
             .map_err(|e| StorageError::Internal(format!("Failed to acquire write lock: {}", e)))?;
 
         let now = self.clock.now();
+        let mut observed_keys: Vec<Bytes> = Vec::with_capacity(records.len());
         for op in records {
             let expire_ts = compute_expire_ts(now, op.options.ttl, self.default_ttl);
+            observed_keys.push(op.record.key.clone());
             data.insert(
                 op.record.key,
                 StoredValue {
@@ -357,6 +419,10 @@ impl Storage for InMemoryStorage {
                     expire_ts,
                 },
             );
+        }
+        drop(data);
+        for key in &observed_keys {
+            self.update_segments(key);
         }
 
         Ok(WriteResult {
@@ -394,6 +460,7 @@ impl Storage for InMemoryStorage {
             .map_err(|e| StorageError::Internal(format!("Failed to acquire write lock: {}", e)))?;
 
         let now = self.clock.now();
+        let mut observed_keys: Vec<Bytes> = Vec::with_capacity(records.len());
         for op in records {
             let existing_value = data
                 .get(&op.record.key)
@@ -402,6 +469,7 @@ impl Storage for InMemoryStorage {
             let merged_value =
                 merge_op.merge_batch(&op.record.key, existing_value, &[op.record.value]);
             let expire_ts = compute_expire_ts(now, op.options.ttl, self.default_ttl);
+            observed_keys.push(op.record.key.clone());
             data.insert(
                 op.record.key,
                 StoredValue {
@@ -409,6 +477,10 @@ impl Storage for InMemoryStorage {
                     expire_ts,
                 },
             );
+        }
+        drop(data);
+        for key in &observed_keys {
+            self.update_segments(key);
         }
 
         Ok(WriteResult {
@@ -428,10 +500,11 @@ impl Storage for InMemoryStorage {
             .map_err(|e| StorageError::Internal(format!("Failed to acquire read lock: {}", e)))?;
 
         let snapshot_data = Arc::new(data.clone());
-
+        let segments = Arc::new(InMemoryStorage::list_segments(self));
         Ok(Arc::new(InMemoryStorageSnapshot {
             data: snapshot_data,
             clock: self.clock.clone(),
+            segments,
         }))
     }
 
@@ -595,6 +668,10 @@ impl super::StorageRead for FailingStorage {
     ) -> super::StorageResult<Box<dyn super::StorageIterator + Send + 'static>> {
         self.inner.scan_iter(range).await
     }
+
+    fn list_segments(&self) -> Vec<SegmentInfo> {
+        self.inner.list_segments()
+    }
 }
 
 #[cfg(feature = "test-utils")]
@@ -672,6 +749,109 @@ mod tests {
                     result.freeze()
                 })
         }
+    }
+
+    #[tokio::test]
+    async fn list_segments_returns_empty_list() {
+        // given
+        let storage = InMemoryStorage::new();
+
+        // when
+        let live = storage.list_segments();
+        let snapshot = storage.snapshot().await.unwrap();
+        let frozen = snapshot.list_segments();
+
+        // then
+        assert!(live.is_empty());
+        assert!(frozen.is_empty());
+    }
+
+    /// 4-byte prefix extractor used by the segment-tracking tests below.
+    #[derive(Debug)]
+    struct FirstFourBytesExtractor;
+
+    impl PrefixExtractor for FirstFourBytesExtractor {
+        fn name(&self) -> &str {
+            "test-first-four"
+        }
+
+        fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+            let bytes: &[u8] = match target {
+                PrefixTarget::Point(b) => b.as_ref(),
+                PrefixTarget::Prefix(b) => b.as_ref(),
+            };
+            if bytes.len() >= 4 { Some(4) } else { None }
+        }
+    }
+
+    #[tokio::test]
+    async fn list_segments_tracks_distinct_written_prefixes() {
+        // given
+        let storage =
+            InMemoryStorage::new().with_prefix_extractor(Arc::new(FirstFourBytesExtractor));
+
+        // when
+        storage
+            .put(vec![
+                Record::new(Bytes::from_static(b"AAAA_one"), Bytes::from("v1")).into(),
+                Record::new(Bytes::from_static(b"AAAA_two"), Bytes::from("v2")).into(),
+                Record::new(Bytes::from_static(b"BBBB_one"), Bytes::from("v3")).into(),
+            ])
+            .await
+            .unwrap();
+
+        // then
+        let segments = storage.list_segments();
+        let prefixes: Vec<&[u8]> = segments.iter().map(|s| s.prefix.as_ref()).collect();
+        assert_eq!(prefixes, vec![b"AAAA".as_ref(), b"BBBB".as_ref()]);
+        let snapshot = storage.snapshot().await.unwrap();
+        assert_eq!(snapshot.list_segments().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn snapshot_segment_view_is_frozen_at_creation() {
+        // given
+        let storage =
+            InMemoryStorage::new().with_prefix_extractor(Arc::new(FirstFourBytesExtractor));
+        storage
+            .put(vec![
+                Record::new(Bytes::from_static(b"AAAA_one"), Bytes::from("v")).into(),
+            ])
+            .await
+            .unwrap();
+
+        // when
+        let snapshot = storage.snapshot().await.unwrap();
+        storage
+            .put(vec![
+                Record::new(Bytes::from_static(b"BBBB_one"), Bytes::from("v")).into(),
+            ])
+            .await
+            .unwrap();
+
+        // then
+        assert_eq!(storage.list_segments().len(), 2);
+        let frozen = snapshot.list_segments();
+        assert_eq!(frozen.len(), 1);
+        assert_eq!(frozen[0].prefix.as_ref(), b"AAAA");
+    }
+
+    #[tokio::test]
+    async fn list_segments_ignores_keys_without_extracted_prefix() {
+        // given
+        let storage =
+            InMemoryStorage::new().with_prefix_extractor(Arc::new(FirstFourBytesExtractor));
+
+        // when
+        storage
+            .put(vec![
+                Record::new(Bytes::from_static(b"abc"), Bytes::from("short")).into(),
+            ])
+            .await
+            .unwrap();
+
+        // then
+        assert!(storage.list_segments().is_empty());
     }
 
     #[tokio::test]

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -219,6 +219,18 @@ pub trait StorageIterator {
     async fn next(&mut self) -> StorageResult<Option<Record>>;
 }
 
+/// Routing-prefix view of a SlateDB segment in the manifest.
+///
+/// SlateDB partitions the LSM by a configurable [`slatedb::PrefixExtractor`];
+/// each resulting segment is identified by its routing prefix. Subsystems use
+/// this to derive logical entities (e.g. timeseries buckets, log segments)
+/// from the current manifest without scanning record keys.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SegmentInfo {
+    /// The segment's routing prefix.
+    pub prefix: Bytes,
+}
+
 /// Common read operations supported by both Storage and StorageSnapshot.
 ///
 /// This trait provides the core read methods that are shared between full storage
@@ -239,6 +251,22 @@ pub trait StorageRead: Send + Sync {
         &self,
         range: BytesRange,
     ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>>;
+
+    /// Lists the segments currently visible to this handle.
+    ///
+    /// For SlateDB-backed live storage this is projected from `Db::manifest()`
+    /// on each call. `StorageSnapshot` implementations capture the list at
+    /// snapshot creation. Backends without a real segment concept return an
+    /// empty list.
+    ///
+    /// SlateDB does not let us pin a `DbSnapshot` to a specific sequence
+    /// number, so a snapshot's segment list is an upper bound: it always
+    /// covers every prefix of every flushed record the snapshot can read, but
+    /// may include extra segments registered between `Db::snapshot()` and the
+    /// manifest read. In-memtable writes visible to the snapshot have no
+    /// corresponding segment yet (segments are manifest-level); callers
+    /// needing complete in-memtable coverage must augment separately.
+    fn list_segments(&self) -> Vec<SegmentInfo>;
 
     /// Collects all records in the range into a Vec.
     #[tracing::instrument(level = "trace", skip_all)]

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::storage::factory::OwnedHybridCache;
-use crate::storage::{MergeOptions, PutOptions};
+use crate::storage::{MergeOptions, PutOptions, SegmentInfo};
 use crate::{
     BytesRange, CheckpointInfo, Record, StorageError, StorageIterator, StorageRead, StorageResult,
     Ttl,
@@ -68,6 +68,18 @@ fn default_scan_options() -> ScanOptions {
         order: IterationOrder::Ascending,
         filter_context: None,
     }
+}
+
+/// Projects the segment list from a SlateDB `VersionedManifest` into the
+/// `common` `SegmentInfo` shape.
+fn manifest_segments(manifest: &slatedb::manifest::VersionedManifest) -> Vec<SegmentInfo> {
+    manifest
+        .segments()
+        .iter()
+        .map(|s| SegmentInfo {
+            prefix: s.prefix().clone(),
+        })
+        .collect()
 }
 
 /// SlateDB-backed implementation of the Storage trait.
@@ -171,6 +183,10 @@ impl StorageRead for SlateDbStorage {
         Ok(Box::new(SlateDbIterator { iter }))
     }
 
+    fn list_segments(&self) -> Vec<SegmentInfo> {
+        manifest_segments(&self.db.manifest())
+    }
+
     async fn close(&self) -> StorageResult<()> {
         // Stop durable bridge first so no status subscriber outlives DB close.
         self.durable_bridge_abort.abort();
@@ -205,9 +221,12 @@ impl StorageIterator for SlateDbIterator {
 
 /// SlateDB snapshot wrapper that implements StorageSnapshot.
 ///
-/// Provides a consistent read-only view of the database at the time the snapshot was created.
+/// Provides a consistent read-only view of the database at the time the
+/// snapshot was created. `segments` is captured at snapshot creation and
+/// returned by [`StorageRead::list_segments`] for the snapshot's lifetime.
 pub struct SlateDbStorageSnapshot {
     snapshot: Arc<DbSnapshot>,
+    segments: Arc<Vec<SegmentInfo>>,
 }
 
 #[async_trait]
@@ -237,6 +256,10 @@ impl StorageRead for SlateDbStorageSnapshot {
             .await
             .map_err(StorageError::from_storage)?;
         Ok(Box::new(SlateDbIterator { iter }))
+    }
+
+    fn list_segments(&self) -> Vec<SegmentInfo> {
+        (*self.segments).clone()
     }
 }
 
@@ -341,7 +364,8 @@ impl Storage for SlateDbStorage {
             .snapshot()
             .await
             .map_err(StorageError::from_storage)?;
-        Ok(Arc::new(SlateDbStorageSnapshot { snapshot }))
+        let segments = Arc::new(manifest_segments(&self.db.manifest()));
+        Ok(Arc::new(SlateDbStorageSnapshot { snapshot, segments }))
     }
 
     async fn flush(&self) -> StorageResult<()> {
@@ -448,6 +472,10 @@ impl StorageRead for SlateDbStorageReader {
         Ok(Box::new(SlateDbIterator { iter }))
     }
 
+    fn list_segments(&self) -> Vec<SegmentInfo> {
+        manifest_segments(&self.reader.manifest())
+    }
+
     async fn close(&self) -> StorageResult<()> {
         self.reader
             .close()
@@ -469,7 +497,7 @@ mod tests {
     use super::*;
     use crate::BytesRange;
     use slatedb::DbBuilder;
-    use slatedb::config::Settings;
+    use slatedb::config::{FlushOptions, FlushType, Settings};
     use slatedb::object_store::memory::InMemory;
     use slatedb_common::clock::MockSystemClock;
 
@@ -919,6 +947,109 @@ mod tests {
         assert!(
             reader_can_see_with_merge_op(path, object_store.clone(), "k1", Some(reader_merge_op),)
                 .await
+        );
+
+        storage.close().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_segments_returns_empty_for_unsegmented_db() {
+        // given
+        let object_store = Arc::new(InMemory::new());
+        let path = "/test/segments_empty";
+        let db = DbBuilder::new(path, object_store.clone())
+            .build()
+            .await
+            .unwrap();
+        let storage = SlateDbStorage::new(Arc::new(db));
+
+        // when
+        let initial = storage.list_segments();
+
+        // then
+        assert!(initial.is_empty());
+
+        storage.close().await.unwrap();
+    }
+
+    /// 2-byte prefix extractor for snapshot-contract tests.
+    #[derive(Debug)]
+    struct TwoBytePrefixExtractor;
+
+    impl slatedb::PrefixExtractor for TwoBytePrefixExtractor {
+        fn name(&self) -> &str {
+            "test-two-byte"
+        }
+
+        fn prefix_len(&self, target: &slatedb::PrefixTarget) -> Option<usize> {
+            let bytes: &[u8] = match target {
+                slatedb::PrefixTarget::Point(b) => b.as_ref(),
+                slatedb::PrefixTarget::Prefix(b) => b.as_ref(),
+            };
+            if bytes.len() >= 2 { Some(2) } else { None }
+        }
+    }
+
+    #[tokio::test]
+    async fn snapshot_segments_cover_flushed_visible_data_across_concurrent_writes() {
+        // given
+        let object_store = Arc::new(InMemory::new());
+        let path = "/test/segments_race";
+        let db = DbBuilder::new(path, object_store.clone())
+            .with_segment_extractor(Arc::new(TwoBytePrefixExtractor))
+            .build()
+            .await
+            .unwrap();
+        let storage = SlateDbStorage::new(Arc::new(db));
+        storage
+            .put(vec![
+                Record::new(Bytes::from_static(b"AA_one"), Bytes::from("v1")).into(),
+            ])
+            .await
+            .unwrap();
+        storage
+            .db
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .unwrap();
+
+        // when
+        let snapshot = storage.snapshot().await.unwrap();
+        storage
+            .put(vec![
+                Record::new(Bytes::from_static(b"BB_two"), Bytes::from("v2")).into(),
+            ])
+            .await
+            .unwrap();
+        storage
+            .db
+            .flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .unwrap();
+
+        // then
+        let visible = snapshot
+            .get(Bytes::from_static(b"AA_one"))
+            .await
+            .unwrap()
+            .expect("snapshot must see pre-snapshot record");
+        assert_eq!(visible.value, Bytes::from("v1"));
+        assert!(
+            snapshot
+                .get(Bytes::from_static(b"BB_two"))
+                .await
+                .unwrap()
+                .is_none()
+        );
+        let segments = snapshot.list_segments();
+        let prefixes: Vec<&[u8]> = segments.iter().map(|s| s.prefix.as_ref()).collect();
+        assert!(
+            prefixes.contains(&b"AA".as_ref()),
+            "snapshot segments must cover the prefix of visible flushed data; got {prefixes:?}"
         );
 
         storage.close().await.unwrap();

--- a/log/src/server/handlers.rs
+++ b/log/src/server/handlers.rs
@@ -344,6 +344,10 @@ mod tests {
                 self.check_failure()?;
                 Ok(Box::new(EmptyIterator))
             }
+
+            fn list_segments(&self) -> Vec<common::storage::SegmentInfo> {
+                Vec::new()
+            }
         }
 
         impl StorageSnapshot for ToggleFailStorage {}


### PR DESCRIPTION
## Summary

Adds accessors to the storage exposing the SlateDB manifest's segment list to subsystems that need bucket-style discovery (e.g. timeseries buckets) without re-scanning record keys. On SlateDB-backed storage the list of segments is read from the manifest subscription on each call. Snapshots capture the list at snapshot creation, returning a frozen view — SlateDB does not let us pin a DbSnapshot to a specific sequence number, so the snapshot's segment list is documented as an upper bound on segments containing flushed visible data.

InMemoryStorage takes an optional slatedb::PrefixExtractor via with_prefix_extractor(...), runs it over every written key, and reads the resulting prefixes from a BTreeSet.

## Test Plan

- unit tests

## Checklist

- [ ] Tests added/updated
- [ ] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
