### PR TITLE
Implement log retention/compaction (RFC 5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2550,6 +2550,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "ulid",
 ]
 
 [[package]]

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -33,6 +33,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 slatedb.workspace = true
 tokio.workspace = true
+ulid.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
 

--- a/log/c/src/db.rs
+++ b/log/c/src/db.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
-use common::storage::config::StorageConfig;
-use log::{LogDbBuilder, LogRead};
+use log::{LogDb, LogRead};
 
 use crate::ffi::*;
 
@@ -30,58 +29,12 @@ pub unsafe extern "C" fn opendata_log_open(
         Err(e) => return e,
     };
 
-    // Separate compaction runtime to prevent block_on deadlock
-    let compaction_runtime = match tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(2)
-        .thread_name("od-compaction")
-        .enable_all()
-        .build()
-    {
-        Ok(r) => r,
-        Err(e) => {
-            return error_result(
-                opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INTERNAL,
-                &format!("failed to create compaction runtime: {e}"),
-            );
-        }
-    };
-
-    let log = match runtime.block_on(async {
-        let sb = match common::StorageBuilder::new(&rust_config.storage).await {
-            Ok(sb) => sb,
-            Err(e) => {
-                return Err(log::Error::Storage(format!(
-                    "failed to create storage builder: {e}"
-                )));
-            }
-        };
-        let sb = sb.map_slatedb(|db| {
-            // Re-extract SlateDB config fields for the CompactorBuilder.
-            // Called inside block_on because CompactorBuilder::new requires a Tokio runtime.
-            if let StorageConfig::SlateDb(ref slate_config) = rust_config.storage {
-                let obj_store = common::create_object_store(&slate_config.object_store).unwrap();
-                db.with_compactor_builder(
-                    common::CompactorBuilder::new(slate_config.path.clone(), obj_store)
-                        .with_runtime(compaction_runtime.handle().clone()),
-                )
-            } else {
-                db
-            }
-        });
-        LogDbBuilder::new(rust_config)
-            .with_storage_builder(sb)
-            .build()
-            .await
-    }) {
+    let log = match runtime.block_on(LogDb::open(rust_config)) {
         Ok(log) => log,
         Err(e) => return error_from_log_error(&e),
     };
 
-    *out_log = Box::into_raw(Box::new(opendata_log_t {
-        log,
-        runtime,
-        _compaction_runtime: compaction_runtime,
-    }));
+    *out_log = Box::into_raw(Box::new(opendata_log_t { log, runtime }));
     success_result()
 }
 

--- a/log/c/src/ffi.rs
+++ b/log/c/src/ffi.rs
@@ -10,8 +10,6 @@ use tokio::runtime::Runtime;
 pub struct opendata_log_t {
     pub(crate) log: log::LogDb,
     pub(crate) runtime: Arc<Runtime>,
-    // Kept alive so compaction tasks continue running; never read directly.
-    pub(crate) _compaction_runtime: Runtime,
 }
 
 pub struct opendata_log_reader_t {
@@ -306,6 +304,8 @@ pub(crate) unsafe fn build_config(
                 ));
             }
         },
+        retention: Default::default(),
+        compaction: Default::default(),
     })
 }
 

--- a/log/rfcs/0005-compaction-and-retention.md
+++ b/log/rfcs/0005-compaction-and-retention.md
@@ -159,8 +159,10 @@ Benefits:
                   │                                          │
                   │  LogCompactionScheduler                  │
                   │      │                                   │
-                  │      ├─ background refresh: scan         │
-                  │      │   SegmentMeta → live_set cache    │
+                  │      ├─ tracks the current live segment  │
+                  │      │   set (sourced from the writer    │
+                  │      │   in-process; from storage in     │
+                  │      │   a future standalone compactor)  │
                   │      │                                   │
                   │      └─ propose():                       │
                   │           active: L0→fresh SR on         │
@@ -168,7 +170,7 @@ Benefits:
                   │           sealed: one-shot final         │
                   │             compaction to single SR      │
                   │           orphaned: drain (segment in    │
-                  │             manifest but not in cache)   │
+                  │             manifest but not in live set)│
                   └──────────────────────────────────────────┘
 ```
 
@@ -176,9 +178,10 @@ Two components: a writer-side `RetentionTask` that decides when segments
 have expired and asks the single writer task to delete their
 `SegmentMeta` records, and a `LogCompactionScheduler` inside SlateDB's
 compactor that proposes active/sealed compactions plus drains for any
-segment in the manifest but not in the live set. The scheduler owns a
-background refresh task that re-reads the live set from storage on a
-coarse cadence.
+segment in the manifest but not in the live set. How the scheduler
+learns the current live set depends on whether the compactor is
+in-process with the writer or runs standalone — see
+[Live set propagation](#live-set-propagation).
 
 ### Configuration
 
@@ -216,20 +219,19 @@ struct LogCompactionOptions {
     /// L0 SST count at which the active-segment policy proposes an L0
     /// compaction. Sized as a fraction of SlateDB's `l0_max_ssts` so
     /// the scheduler triggers before backpressure hits.
-    pub l0_high_water: usize,
+    pub min_l0_per_compaction: usize,
 
     /// Maximum number of L0 SSTs to roll into one fresh SR per
     /// active-segment compaction.
     pub max_l0_per_compaction: usize,
-
-    /// How often the live-set cache is refreshed by scanning
-    /// `SegmentMeta` records. Coarse cadence is fine; the live set
-    /// changes slowly and staleness only delays drains.
-    ///
-    /// Default: 30 seconds.
-    pub live_set_refresh_interval: Duration,
 }
 ```
+
+In the embedded case, the scheduler subscribes to the writer's
+`WrittenView` watch channel and derives the live segment range from
+the two segment-id watermarks already published there, so no polling
+cadence is configured here. A future standalone-compactor RFC will
+introduce a polling interval for the read side it owns.
 
 #### Granularity and precision
 
@@ -320,15 +322,15 @@ therefore the canonical seal moment of its predecessor.
 Compaction work is bounded by ~2× ingest under sustained load: a byte
 flushed to L0 is rewritten at most once during the active phase
 (L0-relief into a fresh SR) and once at seal (final compaction). Light
-loads that never cross the L0 high-water do only the seal-time
+loads that never reach `min_l0_per_compaction` do only the seal-time
 rewrite. Either way, there's no per-tier write amplification.
 
 #### Active segment
 
-**Backpressure-only**: when L0 SST count rises above an L0 high-water
-mark (a configurable fraction of SlateDB's `l0_max_ssts`), merge some L0
-SSTs into a fresh SR. Otherwise do nothing — no SR-to-SR merging, no
-read-amp work.
+**Backpressure-only**: when L0 SST count reaches `min_l0_per_compaction`
+(a configurable fraction of SlateDB's `l0_max_ssts`), merge some L0 SSTs
+into a fresh SR. Otherwise do nothing — no SR-to-SR merging, no read-amp
+work.
 
 SR count grows linearly with active-segment age. We accept this because
 tip reads are served from memory and sealed-segment compaction repairs
@@ -396,7 +398,7 @@ On each `propose()` tick, for every segment in the manifest:
   `drain_segment`. Skipped entirely while the live set is `None`,
   otherwise an empty cache at startup would orphan every segment.
 - **Active** (largest segment id that's both in the manifest and in
-  the live set): emit an L0 compaction when L0 ≥ `l0_high_water`.
+  the live set): emit an L0 compaction when L0 ≥ `min_l0_per_compaction`.
 - **Sealed** (any other segment in the live set): emit a one-shot
   final compaction unless it's already in single-SR steady state
   (L0 = 0 and at most one SR).
@@ -424,15 +426,25 @@ Standard hygiene applies throughout: skip any segment with an
 already-active compaction or drain in `CompactorStateView` to avoid
 duplicate proposals.
 
-#### Background refresh
+#### Live set propagation
 
-A background refresh mechanism periodically scans `SegmentMeta` and
-publishes a new live-set view when a scan succeeds. Until the first
-successful refresh, the live set remains uninitialized and orphan
-drains stay suppressed.
+The scheduler needs an up-to-date view of the live segment set to
+classify manifest segments correctly. How that view reaches the
+scheduler depends on the deployment shape:
 
-The scan is cheap, and a coarse refresh cadence is sufficient because
-staleness only delays drain.
+- **Embedded with the writer (initial release).** The writer is the
+  authoritative source for the live set — it owns the `SegmentMeta`
+  records — and it runs in the same process as the compactor. It
+  notifies the in-process scheduler whenever the live set changes (on
+  segment roll and on retention deletes). No storage scan is needed.
+- **Standalone compactor (future).** A standalone process can't observe
+  the writer's in-memory state, so the scheduler maintains the live set
+  by periodically scanning `SegmentMeta` records from storage. The scan
+  is cheap and a coarse cadence is sufficient because staleness only
+  delays drain.
+
+Either way, until the scheduler has observed a live set at least once,
+it leaves it uninitialized and orphan drains stay suppressed.
 
 ### RetentionTask
 
@@ -476,11 +488,12 @@ The exact startup sequencing is an implementation detail, but two
 requirements are part of the design:
 
 - The scheduler must not act on an uninitialized live-set view.
-- Orphan drains remain suppressed until the first successful live-set
-  refresh from `SegmentMeta`.
+- Orphan drains remain suppressed until the scheduler has observed the
+  live set at least once (see [Live set propagation](#live-set-propagation)).
 
-For a future standalone compactor, the scheduler's read side can be
-backed by a `DbReader` opened by the standalone process; the retention
+For a future standalone compactor, the scheduler's read side would be
+backed by a `DbReader` opened by the standalone process and a polling
+task that refreshes the live set from `SegmentMeta`; the retention
 protocol itself does not change.
 
 If `retention` is `None`, no `RetentionTask` runs, no `SegmentMeta`
@@ -546,7 +559,6 @@ The implementation exposes the following Prometheus metrics:
 | `logdb_segment_oldest_age_seconds`           | gauge   | Age of the oldest live segment's start time                     |
 | `logdb_retention_meta_deletes_total`         | counter | `SegmentMeta` records deleted by the `RetentionTask`            |
 | `logdb_retention_meta_delete_errors_total`   | counter | Failed `SegmentMeta` deletes by the `RetentionTask`             |
-| `logdb_compaction_live_set_refresh_errors_total` | counter | Failed live-set refresh scans in the scheduler              |
 
 ## Alternatives
 
@@ -576,3 +588,4 @@ compactor rather than keeping them with the writer.
 | Date       | Description |
 |------------|-------------|
 | 2026-05-20 | Initial draft. SegmentMeta-as-source-of-truth protocol: writer deletes SegmentMeta on expiry, compactor garbage-collects orphaned SlateDB segments. |
+| 2026-05-22 | Implementation: rename `l0_high_water` → `min_l0_per_compaction`; drop `live_set_refresh_interval` (deferred to standalone-compactor RFC); restate live-set propagation as a shape-dependent concern (in-process notification for embedded, storage polling for future standalone). |

--- a/log/src/compaction.rs
+++ b/log/src/compaction.rs
@@ -1,0 +1,726 @@
+//! Compaction scheduling for LogDb.
+//!
+//! Implements the policy described in RFC 0005. The scheduler classifies each
+//! SlateDB-level segment in the manifest as system / active / sealed /
+//! orphaned and proposes compactions or drains accordingly. See
+//! [`propose_compactions`] for the per-state behaviour.
+//!
+//! The scheduler doesn't read storage. It subscribes to a compactor-facing
+//! view (via a [`std::sync::OnceLock`] installed after the writer is created)
+//! and derives the live user-segment range from the two segment-id watermarks
+//! published there. Because retention only deletes from the low end of the
+//! log (RFC 0005), the live set is always a contiguous id range, so two
+//! integers fully describe it.
+
+use std::collections::HashSet;
+use std::sync::{Arc, OnceLock};
+
+use bytes::Bytes;
+use slatedb::compactor::{
+    CompactionScheduler, CompactionSchedulerSupplier, CompactionSpec, CompactorStateView, SourceId,
+};
+use slatedb::config::CompactorOptions;
+use slatedb::manifest::Segment;
+use tokio::sync::watch;
+use ulid::Ulid;
+
+use crate::config::LogCompactionOptions;
+use crate::model::SegmentId;
+use crate::segment_extractor::ROUTING_PREFIX_LEN;
+use crate::serde::FIRST_USER_SEGMENT_ID;
+/// Compactor-facing view of the user-segment live set.
+///
+/// `last_segment_id` advances at written latency so active/sealed segment
+/// compactions can respond quickly to new segments. `last_deleted_segment_id`
+/// advances only once the corresponding writer operation is durable, so drain
+/// proposals never run ahead of durable `SegmentMeta` deletion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct CompactorView {
+    pub last_segment_id: Option<SegmentId>,
+    pub last_deleted_segment_id: Option<SegmentId>,
+}
+
+/// Cell shared between the builder and the supplier; the writer's
+/// `CompactorView` receiver is installed here once the writer exists. While
+/// empty the scheduler treats the live set as uninitialized.
+pub(crate) type CompactorViewCell = Arc<OnceLock<watch::Receiver<CompactorView>>>;
+
+/// L0 SST count at or above which the system segment is consolidated.
+const SYSTEM_SEGMENT_L0_THRESHOLD: usize = 2;
+
+/// Bounds of the contiguous live user-segment range, `first_id..=last_id`.
+/// Contiguity holds because retention only deletes from the low end (RFC 0005).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LiveSetBounds {
+    pub first_id: SegmentId,
+    pub last_id: SegmentId,
+}
+
+impl LiveSetBounds {
+    /// Returns true if `id` is in the live range.
+    pub(crate) fn contains(&self, id: SegmentId) -> bool {
+        id >= self.first_id && id <= self.last_id
+    }
+}
+
+/// Hands a [`LogCompactionScheduler`] to SlateDB at compactor construction time.
+pub(crate) struct LogCompactionSchedulerSupplier {
+    pub(crate) cell: CompactorViewCell,
+    pub(crate) options: LogCompactionOptions,
+}
+
+impl CompactionSchedulerSupplier for LogCompactionSchedulerSupplier {
+    fn compaction_scheduler(
+        &self,
+        _options: &CompactorOptions,
+    ) -> Box<dyn CompactionScheduler + Send + Sync> {
+        Box::new(LogCompactionScheduler {
+            cell: Arc::clone(&self.cell),
+            options: self.options.clone(),
+        })
+    }
+}
+
+/// LogDb's `CompactionScheduler` impl. Reads the writer's live-set watermarks
+/// from a shared `OnceLock`-gated watch receiver; never touches storage.
+pub(crate) struct LogCompactionScheduler {
+    cell: CompactorViewCell,
+    options: LogCompactionOptions,
+}
+
+impl CompactionScheduler for LogCompactionScheduler {
+    fn propose(&self, state: &CompactorStateView) -> Vec<CompactionSpec> {
+        let bounds = self.cell.get().and_then(|rx| {
+            let view = rx.borrow();
+            compute_bounds(view.last_segment_id, view.last_deleted_segment_id)
+        });
+        let active = collect_active_compactions(state);
+        let segments: Vec<SegmentSnapshot> = state
+            .manifest()
+            .segments()
+            .iter()
+            .map(SegmentSnapshot::from_segment)
+            .collect();
+        propose_compactions(&segments, bounds, &active, &self.options)
+    }
+}
+
+/// View of the compactor's in-flight work. Used to (1) skip segments that
+/// already have a compaction running and (2) pick a destination SR id that
+/// doesn't collide with one already in flight.
+#[derive(Debug, Default)]
+pub(crate) struct ActiveCompactionsView {
+    pub segment_prefixes: HashSet<Bytes>,
+    pub max_destination: Option<u32>,
+}
+
+/// Per-segment fields the policy reads. Decoupled from slatedb's `Segment`
+/// so tests can construct one without building a real slatedb manifest.
+#[derive(Debug, Clone)]
+pub(crate) struct SegmentSnapshot {
+    pub prefix: Bytes,
+    pub l0_ids: Vec<Ulid>,
+    pub sr_ids: Vec<u32>,
+}
+
+impl SegmentSnapshot {
+    fn from_segment(segment: &Segment) -> Self {
+        Self {
+            prefix: segment.prefix().clone(),
+            l0_ids: segment.l0().iter().map(|sst| sst.id).collect(),
+            sr_ids: segment.compacted().iter().map(|sr| sr.id).collect(),
+        }
+    }
+
+    /// L0 SSTs as `SourceId::SstView`s.
+    fn l0_sources(&self) -> impl Iterator<Item = SourceId> + '_ {
+        self.l0_ids.iter().copied().map(SourceId::SstView)
+    }
+
+    /// Sorted runs as `SourceId::SortedRun`s.
+    fn sr_sources(&self) -> impl Iterator<Item = SourceId> + '_ {
+        self.sr_ids.iter().copied().map(SourceId::SortedRun)
+    }
+
+    /// All sources (L0 SSTs followed by sorted runs).
+    fn all_sources(&self) -> impl Iterator<Item = SourceId> + '_ {
+        self.l0_sources().chain(self.sr_sources())
+    }
+}
+
+/// Allocates the current `next_sr` and bumps the counter.
+fn alloc_sr_id(next_sr: &mut u32) -> u32 {
+    let id = *next_sr;
+    *next_sr += 1;
+    id
+}
+
+/// Collects the segment prefixes with an in-flight compaction and the max
+/// destination SR id among in-flight tiered compactions. Drain specs have no
+/// destination and contribute nothing.
+fn collect_active_compactions(state: &CompactorStateView) -> ActiveCompactionsView {
+    let Some(compactions) = state.compactions() else {
+        return ActiveCompactionsView::default();
+    };
+    let mut prefixes = HashSet::new();
+    let mut max_dst: Option<u32> = None;
+    for compaction in compactions.recent_compactions().filter(|c| c.active()) {
+        prefixes.insert(compaction.spec().segment().clone());
+        if let Some(dst) = compaction.spec().destination() {
+            max_dst = Some(max_dst.map_or(dst, |cur| cur.max(dst)));
+        }
+    }
+    ActiveCompactionsView {
+        segment_prefixes: prefixes,
+        max_destination: max_dst,
+    }
+}
+
+/// Decodes a SegmentId from a 6-byte routing prefix
+/// (`[SUBSYSTEM, KEY_VERSION, seg_id(4 BE)]`).
+fn decode_segment_id(prefix: &[u8]) -> Option<SegmentId> {
+    if prefix.len() != ROUTING_PREFIX_LEN {
+        return None;
+    }
+    Some(u32::from_be_bytes([
+        prefix[2], prefix[3], prefix[4], prefix[5],
+    ]))
+}
+
+/// Returns a sorted-run id safe to use as a fresh compaction destination.
+/// SR ids are globally unique across trees (SlateDB RFC-0024), so the
+/// counter must skip past every committed run and every in-flight destination.
+fn next_fresh_sr_id(segments: &[SegmentSnapshot], max_in_flight_dst: Option<u32>) -> u32 {
+    let max_committed = segments
+        .iter()
+        .flat_map(|seg| seg.sr_ids.iter().copied())
+        .max();
+    [max_committed, max_in_flight_dst]
+        .into_iter()
+        .flatten()
+        .max()
+        .map(|id| id.saturating_add(1))
+        .unwrap_or(0)
+}
+
+/// Pure policy function. See module docs and RFC 0005 for the policy.
+///
+/// - **System segment** (id 0): consolidate when L0 ≥ 2.
+/// - **Active** (largest live id, or largest manifest id when bounds is None):
+///   propose an L0-relief compaction when L0 ≥ `min_l0_per_compaction`.
+/// - **Sealed** (live, not active): one-shot final consolidation into a single
+///   SR unless already in steady state. Suppressed when bounds is `None`.
+/// - **Orphaned** (in manifest but not in live set): drain. Suppressed when
+///   bounds is `None`.
+/// - **Invariant**: panics if a manifest segment has id > max live id (writer
+///   protocol violation per RFC 0005).
+pub(crate) fn propose_compactions(
+    segments: &[SegmentSnapshot],
+    bounds: Option<LiveSetBounds>,
+    active: &ActiveCompactionsView,
+    options: &LogCompactionOptions,
+) -> Vec<CompactionSpec> {
+    let mut next_sr = next_fresh_sr_id(segments, active.max_destination);
+    let mut out = Vec::new();
+
+    // Determine "what id we treat as active" — either the published max live
+    // id, or the manifest-derived fallback when bounds is None.
+    let manifest_max_user = segments
+        .iter()
+        .filter_map(|s| decode_segment_id(&s.prefix))
+        .filter(|id| *id > 0)
+        .max();
+    let active_id_for_policy = bounds.map(|b| b.last_id).or(manifest_max_user);
+
+    for segment in segments {
+        if active.segment_prefixes.contains(&segment.prefix) {
+            continue;
+        }
+        let Some(id) = decode_segment_id(&segment.prefix) else {
+            // `LogSegmentExtractor` only produces 6-byte prefixes, so an
+            // undecodable prefix indicates a manifest from a different
+            // extractor configuration. Skip it rather than misclassify.
+            tracing::warn!(
+                "compaction scheduler: undecodable segment prefix (len {}), skipping",
+                segment.prefix.len(),
+            );
+            continue;
+        };
+
+        if id == 0 {
+            if segment.l0_ids.len() >= SYSTEM_SEGMENT_L0_THRESHOLD
+                && let Some(spec) = build_consolidation_spec(segment, &mut next_sr)
+            {
+                out.push(spec);
+            }
+            continue;
+        }
+
+        if let Some(b) = bounds {
+            if id > b.last_id {
+                panic!(
+                    "LogCompactionScheduler invariant violated: manifest has \
+                     segment id {id} > max live id {} (writer protocol broken)",
+                    b.last_id
+                );
+            }
+            if !b.contains(id) {
+                out.push(build_drain_spec(segment));
+                continue;
+            }
+        }
+
+        match active_id_for_policy {
+            Some(active_id) if id == active_id => {
+                if segment.l0_ids.len() >= options.min_l0_per_compaction
+                    && let Some(spec) =
+                        build_active_l0_spec(segment, &mut next_sr, options.max_l0_per_compaction)
+                {
+                    out.push(spec);
+                }
+            }
+            _ => {
+                if bounds.is_some()
+                    && !is_single_sr_steady(segment)
+                    && let Some(spec) = build_consolidation_spec(segment, &mut next_sr)
+                {
+                    out.push(spec);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// True when a segment is already in single-SR steady state: empty L0 and at
+/// most one compacted SR.
+fn is_single_sr_steady(segment: &SegmentSnapshot) -> bool {
+    segment.l0_ids.is_empty() && segment.sr_ids.len() <= 1
+}
+
+/// Builds an L0-relief compaction spec for an active segment.
+fn build_active_l0_spec(
+    segment: &SegmentSnapshot,
+    next_sr: &mut u32,
+    max_l0: usize,
+) -> Option<CompactionSpec> {
+    let sources: Vec<SourceId> = segment.l0_sources().take(max_l0).collect();
+    if sources.is_empty() {
+        return None;
+    }
+    Some(CompactionSpec::for_segment(
+        segment.prefix.clone(),
+        sources,
+        alloc_sr_id(next_sr),
+    ))
+}
+
+/// Full consolidation: merge L0 + all SRs into the lowest-id SR among them,
+/// or a fresh SR if none exist.
+fn build_consolidation_spec(
+    segment: &SegmentSnapshot,
+    next_sr: &mut u32,
+) -> Option<CompactionSpec> {
+    let sources: Vec<SourceId> = segment.all_sources().collect();
+    if sources.is_empty() {
+        return None;
+    }
+    let dst = segment
+        .sr_ids
+        .iter()
+        .copied()
+        .min()
+        .unwrap_or_else(|| alloc_sr_id(next_sr));
+    Some(CompactionSpec::for_segment(
+        segment.prefix.clone(),
+        sources,
+        dst,
+    ))
+}
+
+/// Drain spec retiring all SSTs/SRs in the segment.
+fn build_drain_spec(segment: &SegmentSnapshot) -> CompactionSpec {
+    CompactionSpec::drain_segment(segment.prefix.clone(), segment.all_sources().collect())
+}
+
+/// Derives the live user-segment range from the two watermarks on
+/// `CompactorView`. Returns `None` if no user segment has been created, or if
+/// the inferred range is empty.
+pub(crate) fn compute_bounds(
+    last_segment_id: Option<SegmentId>,
+    last_deleted_segment_id: Option<SegmentId>,
+) -> Option<LiveSetBounds> {
+    let last = last_segment_id?;
+    let first = last_deleted_segment_id
+        .map(|d| d + 1)
+        .unwrap_or(FIRST_USER_SEGMENT_ID);
+    if first > last {
+        return None;
+    }
+    Some(LiveSetBounds {
+        first_id: first,
+        last_id: last,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn contains_includes_endpoints() {
+        let bounds = LiveSetBounds {
+            first_id: 3,
+            last_id: 5,
+        };
+        assert!(bounds.contains(3));
+        assert!(bounds.contains(4));
+        assert!(bounds.contains(5));
+    }
+
+    #[test]
+    fn contains_excludes_outside() {
+        let bounds = LiveSetBounds {
+            first_id: 3,
+            last_id: 5,
+        };
+        assert!(!bounds.contains(2));
+        assert!(!bounds.contains(6));
+    }
+
+    #[test]
+    fn singleton_range_contains_only_self() {
+        let bounds = LiveSetBounds {
+            first_id: 7,
+            last_id: 7,
+        };
+        assert!(bounds.contains(7));
+        assert!(!bounds.contains(6));
+        assert!(!bounds.contains(8));
+    }
+
+    #[test]
+    fn compute_bounds_returns_none_when_no_segments_created() {
+        assert_eq!(compute_bounds(None, None), None);
+        assert_eq!(compute_bounds(None, Some(2)), None);
+    }
+
+    #[test]
+    fn compute_bounds_starts_at_first_user_segment_when_no_deletes() {
+        let bounds = compute_bounds(Some(5), None).unwrap();
+        assert_eq!(bounds.first_id, FIRST_USER_SEGMENT_ID);
+        assert_eq!(bounds.last_id, 5);
+    }
+
+    #[test]
+    fn compute_bounds_starts_one_past_last_deleted() {
+        let bounds = compute_bounds(Some(7), Some(3)).unwrap();
+        assert_eq!(bounds.first_id, 4);
+        assert_eq!(bounds.last_id, 7);
+    }
+
+    #[test]
+    fn compute_bounds_returns_none_when_range_is_empty() {
+        // Hypothetical: last_segment_id <= last_deleted_segment_id (unreachable
+        // under writer protocol since the active segment can't be deleted).
+        assert_eq!(compute_bounds(Some(3), Some(3)), None);
+        assert_eq!(compute_bounds(Some(3), Some(5)), None);
+    }
+
+    // ---- propose_compactions tests ----
+
+    use crate::serde::{KEY_VERSION, SUBSYSTEM};
+
+    fn prefix_for(id: SegmentId) -> Bytes {
+        let bytes = id.to_be_bytes();
+        Bytes::from(vec![
+            SUBSYSTEM,
+            KEY_VERSION,
+            bytes[0],
+            bytes[1],
+            bytes[2],
+            bytes[3],
+        ])
+    }
+
+    fn snapshot(id: SegmentId, l0: usize, srs: &[u32]) -> SegmentSnapshot {
+        SegmentSnapshot {
+            prefix: prefix_for(id),
+            l0_ids: (0..l0).map(|_| Ulid::new()).collect(),
+            sr_ids: srs.to_vec(),
+        }
+    }
+
+    fn default_options() -> LogCompactionOptions {
+        LogCompactionOptions::default()
+    }
+
+    fn bounds(first: SegmentId, last: SegmentId) -> Option<LiveSetBounds> {
+        Some(LiveSetBounds {
+            first_id: first,
+            last_id: last,
+        })
+    }
+
+    #[test]
+    fn propose_is_noop_on_empty_manifest() {
+        let specs = propose_compactions(
+            &[],
+            bounds(1, 1),
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn propose_consolidates_system_segment_when_l0_threshold_reached() {
+        let segments = vec![snapshot(0, 2, &[])];
+        let specs = propose_compactions(
+            &segments,
+            None,
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].segment(), &prefix_for(0));
+        assert_eq!(specs[0].sources().len(), 2);
+        assert!(!specs[0].is_drain());
+    }
+
+    #[test]
+    fn propose_leaves_system_segment_below_threshold_alone() {
+        let segments = vec![snapshot(0, 1, &[])];
+        let specs = propose_compactions(
+            &segments,
+            None,
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn propose_l0_compacts_active_when_threshold_reached() {
+        // active = id 3, L0 = min_l0_per_compaction (default 4) → compact.
+        // L0 count is below max_l0_per_compaction, so all L0s are folded in.
+        let segments = vec![snapshot(3, 4, &[])];
+        let opts = default_options();
+        let specs = propose_compactions(
+            &segments,
+            bounds(1, 3),
+            &ActiveCompactionsView::default(),
+            &opts,
+        );
+
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].segment(), &prefix_for(3));
+        assert_eq!(specs[0].sources().len(), 4);
+        assert!(!specs[0].is_drain());
+    }
+
+    #[test]
+    fn propose_l0_caps_at_max_l0_per_compaction() {
+        // active = id 3 with more L0s than `max_l0_per_compaction` (default 8).
+        // The spec must include exactly the cap.
+        let segments = vec![snapshot(3, 12, &[])];
+        let opts = default_options();
+        let specs = propose_compactions(
+            &segments,
+            bounds(1, 3),
+            &ActiveCompactionsView::default(),
+            &opts,
+        );
+
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].sources().len(), opts.max_l0_per_compaction);
+    }
+
+    #[test]
+    fn propose_skips_active_when_l0_below_threshold() {
+        let segments = vec![snapshot(3, 3, &[])]; // 3 < default 4
+        let specs = propose_compactions(
+            &segments,
+            bounds(1, 3),
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn propose_consolidates_sealed_when_not_in_steady_state() {
+        // Sealed id 2, with 1 L0 and 2 SRs → needs consolidation.
+        // Active id 3 with no work; we expect only the sealed work emitted.
+        let segments = vec![snapshot(2, 1, &[10, 11]), snapshot(3, 0, &[])];
+        let specs = propose_compactions(
+            &segments,
+            bounds(1, 3),
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].segment(), &prefix_for(2));
+        assert!(!specs[0].is_drain());
+        // Destination is min existing SR id.
+        assert_eq!(specs[0].destination(), Some(10));
+    }
+
+    #[test]
+    fn propose_skips_sealed_already_in_steady_state() {
+        // Sealed id 2 has L0=0 and exactly 1 SR → steady state, no work.
+        let segments = vec![snapshot(2, 0, &[5]), snapshot(3, 0, &[])];
+        let specs = propose_compactions(
+            &segments,
+            bounds(1, 3),
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn propose_drains_orphaned_segment() {
+        // Live range [3,4], but manifest also has id 2 → orphaned.
+        let segments = vec![
+            snapshot(2, 0, &[7]),
+            snapshot(3, 0, &[]),
+            snapshot(4, 0, &[]),
+        ];
+        let specs = propose_compactions(
+            &segments,
+            bounds(3, 4),
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].segment(), &prefix_for(2));
+        assert!(specs[0].is_drain());
+    }
+
+    #[test]
+    fn propose_suppresses_orphan_drains_when_bounds_uninitialized() {
+        // Without bounds, anything that looks orphaned would otherwise be a
+        // false positive (we just haven't seen the writer's view yet).
+        let segments = vec![snapshot(2, 0, &[]), snapshot(3, 0, &[])];
+        let specs = propose_compactions(
+            &segments,
+            None,
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn propose_treats_largest_manifest_id_as_active_when_bounds_uninitialized() {
+        // Without bounds, fallback: largest manifest id (3) is active, and we
+        // only do L0 work — sealed (2) is left alone.
+        let segments = vec![snapshot(2, 5, &[]), snapshot(3, 5, &[])];
+        let specs = propose_compactions(
+            &segments,
+            None,
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].segment(), &prefix_for(3));
+    }
+
+    #[test]
+    fn propose_skips_segments_with_active_compactions() {
+        // Active id 3 needs L0 compaction, but it's already being compacted.
+        let segments = vec![snapshot(3, 4, &[])];
+        let mut active = ActiveCompactionsView::default();
+        active.segment_prefixes.insert(prefix_for(3));
+        let specs = propose_compactions(&segments, bounds(1, 3), &active, &default_options());
+        assert!(specs.is_empty());
+    }
+
+    #[test]
+    fn next_fresh_sr_id_skips_past_in_flight_destinations() {
+        // Committed SR id 5; in-flight compaction targeting 10. The next
+        // fresh id must be 11, not 6.
+        let segments = vec![snapshot(2, 0, &[5])];
+        let active = ActiveCompactionsView {
+            max_destination: Some(10),
+            ..ActiveCompactionsView::default()
+        };
+        assert_eq!(next_fresh_sr_id(&segments, active.max_destination), 11);
+    }
+
+    #[test]
+    fn next_fresh_sr_id_uses_committed_when_no_in_flight() {
+        let segments = vec![snapshot(2, 0, &[5])];
+        assert_eq!(next_fresh_sr_id(&segments, None), 6);
+    }
+
+    #[test]
+    fn next_fresh_sr_id_is_zero_for_empty_state() {
+        assert_eq!(next_fresh_sr_id(&[], None), 0);
+    }
+
+    #[test]
+    fn propose_uses_fresh_destination_above_in_flight() {
+        // Active id 3 needs L0 compaction. Committed max SR=5; in-flight
+        // compaction targets 10. The new spec must target 11.
+        let segments = vec![snapshot(3, 4, &[5])];
+        let active = ActiveCompactionsView {
+            // Note: only the destination is in flight; the segment isn't, so
+            // we still propose work for it.
+            max_destination: Some(10),
+            ..ActiveCompactionsView::default()
+        };
+        let specs = propose_compactions(&segments, bounds(1, 3), &active, &default_options());
+        assert_eq!(specs.len(), 1);
+        assert_eq!(specs[0].destination(), Some(11));
+    }
+
+    #[test]
+    #[should_panic(expected = "invariant violated")]
+    fn propose_panics_when_manifest_has_id_above_max_live() {
+        // Manifest has id 5 but writer's max is 3 → broken writer protocol.
+        let segments = vec![snapshot(5, 0, &[])];
+        let _ = propose_compactions(
+            &segments,
+            bounds(1, 3),
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+    }
+
+    #[test]
+    fn propose_handles_mixed_states_in_one_tick() {
+        // System (consolidate) + sealed (consolidate) + orphan (drain) +
+        // active (L0 compact, threshold reached).
+        let segments = vec![
+            snapshot(0, 2, &[]),  // system needs consolidation
+            snapshot(1, 0, &[]),  // orphan: not in [2..=4]
+            snapshot(2, 1, &[8]), // sealed, not steady-state → consolidate
+            snapshot(3, 0, &[9]), // sealed, steady-state (0 L0 + 1 SR) → skip
+            snapshot(4, 4, &[]),  // active, L0 at threshold → compact
+        ];
+        let specs = propose_compactions(
+            &segments,
+            bounds(2, 4),
+            &ActiveCompactionsView::default(),
+            &default_options(),
+        );
+
+        let kinds: Vec<_> = specs
+            .iter()
+            .map(|s| (s.segment().clone(), s.is_drain()))
+            .collect();
+        assert!(kinds.contains(&(prefix_for(0), false)));
+        assert!(kinds.contains(&(prefix_for(1), true)));
+        assert!(kinds.contains(&(prefix_for(2), false)));
+        assert!(kinds.contains(&(prefix_for(4), false)));
+        // Sealed id 3 was steady — must not be in the output.
+        assert!(!kinds.iter().any(|(p, _)| p == &prefix_for(3)));
+        assert_eq!(kinds.len(), 4);
+    }
+}

--- a/log/src/config.rs
+++ b/log/src/config.rs
@@ -9,6 +9,8 @@ use common::StorageConfig;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_with::{DurationMilliSeconds, serde_as};
 
+use crate::error::Error;
+
 /// Configuration for opening a [`LogDb`](crate::LogDb).
 ///
 /// This struct holds all the settings needed to initialize a log instance,
@@ -60,6 +62,55 @@ pub struct Config {
         deserialize_with = "deserialize_read_visibility"
     )]
     pub read_visibility: ReadVisibility,
+
+    /// Retention policy; see [`RetentionConfig`] and RFC 0005.
+    #[serde(default)]
+    pub retention: RetentionConfig,
+
+    /// Compaction policy; see [`LogCompactionOptions`] and RFC 0005.
+    #[serde(default)]
+    pub compaction: LogCompactionOptions,
+}
+
+impl Config {
+    /// Validates the retention/segmentation relationship per RFC 0005.
+    ///
+    /// Returns `Err(Error::InvalidInput)` if `retention` is set without a
+    /// `seal_interval`, or if `retention` is smaller than `seal_interval`.
+    pub fn validate_retention(&self) -> crate::error::Result<()> {
+        let Some(retention) = self.retention.retention else {
+            return Ok(());
+        };
+        let Some(seal_interval) = self.segmentation.seal_interval else {
+            return Err(Error::InvalidInput(
+                "retention requires segmentation.seal_interval to be set.".into(),
+            ));
+        };
+        if retention < seal_interval {
+            return Err(Error::InvalidInput(format!(
+                "retention ({retention:?}) must be at least as large as \
+                 segmentation.seal_interval ({seal_interval:?}).",
+            )));
+        }
+        Ok(())
+    }
+
+    /// Validates that compaction thresholds are internally consistent.
+    ///
+    /// Returns `Err(Error::InvalidInput)` if `min_l0_per_compaction` exceeds
+    /// `max_l0_per_compaction` — a config that would silently disable L0
+    /// compactions on active segments.
+    pub fn validate_compaction(&self) -> crate::error::Result<()> {
+        let min = self.compaction.min_l0_per_compaction;
+        let max = self.compaction.max_l0_per_compaction;
+        if min > max {
+            return Err(Error::InvalidInput(format!(
+                "compaction.min_l0_per_compaction ({min}) must be \
+                 <= compaction.max_l0_per_compaction ({max}).",
+            )));
+        }
+        Ok(())
+    }
 }
 
 /// Read visibility levels.
@@ -129,6 +180,90 @@ pub struct SegmentConfig {
     #[serde_as(as = "Option<DurationMilliSeconds<u64>>")]
     #[serde(default)]
     pub seal_interval: Option<Duration>,
+}
+
+/// Retention policy configuration.
+///
+/// Retention is enforced at segment granularity: a sealed segment becomes
+/// eligible for reclamation when its end time (its successor's
+/// `start_time_ms`) is older than `now() - retention`. See RFC 0005 for the
+/// full protocol.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RetentionConfig {
+    /// Segment retention duration.
+    ///
+    /// Segments whose end time is older than `now() - retention` are eligible
+    /// for deletion. `None` disables retention (segments live forever).
+    ///
+    /// When set, [`SegmentConfig::seal_interval`] must also be set and must
+    /// be `<= retention`; otherwise [`Config::validate_retention`] fails.
+    #[serde_as(as = "Option<DurationMilliSeconds<u64>>")]
+    #[serde(default)]
+    pub retention: Option<Duration>,
+
+    /// How often the writer's retention task re-evaluates segment expiry and
+    /// deletes any `SegmentMeta` records past the retention bound.
+    ///
+    /// Smaller values reduce the lag between expiry and the segment becoming
+    /// invisible to readers. Defaults to 60 seconds.
+    #[serde_as(as = "DurationMilliSeconds<u64>")]
+    #[serde(default = "default_retention_check_interval")]
+    pub check_interval: Duration,
+}
+
+fn default_retention_check_interval() -> Duration {
+    Duration::from_secs(60)
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            retention: None,
+            check_interval: default_retention_check_interval(),
+        }
+    }
+}
+
+/// Compaction policy configuration.
+///
+/// Tunes the compaction scheduler that operates on LogDb's per-segment
+/// SlateDB layout. See RFC 0005 for the policy this configures.
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LogCompactionOptions {
+    /// Minimum number of L0 SSTs required to trigger an active-segment
+    /// compaction.
+    ///
+    /// Should be a fraction of SlateDB's `l0_max_ssts` so the scheduler
+    /// triggers before backpressure hits. Defaults to 4 (half of SlateDB's
+    /// default `l0_max_ssts` of 8).
+    #[serde(default = "default_min_l0_per_compaction")]
+    pub min_l0_per_compaction: usize,
+
+    /// Maximum number of L0 SSTs to roll into one fresh SR per active-segment
+    /// compaction.
+    ///
+    /// Defaults to 8.
+    #[serde(default = "default_max_l0_per_compaction")]
+    pub max_l0_per_compaction: usize,
+}
+
+fn default_min_l0_per_compaction() -> usize {
+    4
+}
+
+fn default_max_l0_per_compaction() -> usize {
+    8
+}
+
+impl Default for LogCompactionOptions {
+    fn default() -> Self {
+        Self {
+            min_l0_per_compaction: default_min_l0_per_compaction(),
+            max_l0_per_compaction: default_max_l0_per_compaction(),
+        }
+    }
 }
 
 /// Options for scan operations.
@@ -247,5 +382,160 @@ mod tests {
 
         // then
         assert_eq!(cfg.read_visibility, ReadVisibility::Remote);
+    }
+
+    fn config_with(retention: Option<Duration>, seal_interval: Option<Duration>) -> Config {
+        Config {
+            segmentation: SegmentConfig { seal_interval },
+            retention: RetentionConfig {
+                retention,
+                ..RetentionConfig::default()
+            },
+            ..Config::default()
+        }
+    }
+
+    #[test]
+    fn should_accept_retention_disabled() {
+        // given
+        let cfg = config_with(None, None);
+
+        // when / then
+        cfg.validate_retention().unwrap();
+    }
+
+    #[test]
+    fn should_accept_retention_disabled_with_seal_interval() {
+        // given
+        let cfg = config_with(None, Some(Duration::from_secs(60)));
+
+        // when / then
+        cfg.validate_retention().unwrap();
+    }
+
+    #[test]
+    fn should_accept_retention_equal_to_seal_interval() {
+        // given
+        let cfg = config_with(Some(Duration::from_secs(60)), Some(Duration::from_secs(60)));
+
+        // when / then
+        cfg.validate_retention().unwrap();
+    }
+
+    #[test]
+    fn should_reject_retention_without_seal_interval() {
+        // given
+        let cfg = config_with(Some(Duration::from_secs(60)), None);
+
+        // when
+        let err = cfg.validate_retention().unwrap_err();
+
+        // then
+        assert!(
+            matches!(&err, Error::InvalidInput(msg) if msg.contains("seal_interval")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn should_reject_retention_smaller_than_seal_interval() {
+        // given
+        let cfg = config_with(Some(Duration::from_secs(30)), Some(Duration::from_secs(60)));
+
+        // when
+        let err = cfg.validate_retention().unwrap_err();
+
+        // then
+        assert!(
+            matches!(&err, Error::InvalidInput(msg) if msg.contains("at least as large")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn should_reject_min_l0_above_max_l0() {
+        // given
+        let cfg = Config {
+            compaction: LogCompactionOptions {
+                min_l0_per_compaction: 10,
+                max_l0_per_compaction: 5,
+            },
+            ..Config::default()
+        };
+
+        // when
+        let err = cfg.validate_compaction().unwrap_err();
+
+        // then
+        assert!(
+            matches!(&err, Error::InvalidInput(msg)
+                if msg.contains("min_l0_per_compaction") && msg.contains("max_l0_per_compaction")),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn should_accept_min_l0_equal_to_max_l0() {
+        let cfg = Config {
+            compaction: LogCompactionOptions {
+                min_l0_per_compaction: 4,
+                max_l0_per_compaction: 4,
+            },
+            ..Config::default()
+        };
+        cfg.validate_compaction().unwrap();
+    }
+
+    #[test]
+    fn should_use_documented_defaults_for_retention_config() {
+        let cfg = RetentionConfig::default();
+        assert_eq!(cfg.retention, None);
+        assert_eq!(cfg.check_interval, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn should_use_documented_defaults_for_compaction_options() {
+        let cfg = LogCompactionOptions::default();
+        assert_eq!(cfg.min_l0_per_compaction, 4);
+        assert_eq!(cfg.max_l0_per_compaction, 8);
+    }
+
+    #[test]
+    fn should_deserialize_retention_config_with_defaults() {
+        // given
+        let json = "{}";
+
+        // when
+        let cfg: RetentionConfig = serde_json::from_str(json).unwrap();
+
+        // then
+        assert_eq!(cfg.retention, None);
+        assert_eq!(cfg.check_interval, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn should_deserialize_retention_config_with_durations_in_ms() {
+        // given
+        let json = r#"{"retention": 3600000, "check_interval": 5000}"#;
+
+        // when
+        let cfg: RetentionConfig = serde_json::from_str(json).unwrap();
+
+        // then
+        assert_eq!(cfg.retention, Some(Duration::from_secs(3600)));
+        assert_eq!(cfg.check_interval, Duration::from_secs(5));
+    }
+
+    #[test]
+    fn should_deserialize_compaction_options_with_defaults() {
+        // given
+        let json = "{}";
+
+        // when
+        let cfg: LogCompactionOptions = serde_json::from_str(json).unwrap();
+
+        // then
+        assert_eq!(cfg.min_l0_per_compaction, 4);
+        assert_eq!(cfg.max_l0_per_compaction, 8);
     }
 }

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -46,6 +46,7 @@
 //! # }
 //! ```
 
+mod compaction;
 mod config;
 mod direct;
 mod error;
@@ -63,7 +64,10 @@ mod storage;
 mod view_tracker;
 mod writer;
 
-pub use config::{Config, ReadVisibility, ReaderConfig, ScanOptions, SegmentConfig};
+pub use config::{
+    Config, LogCompactionOptions, ReadVisibility, ReaderConfig, RetentionConfig, ScanOptions,
+    SegmentConfig,
+};
 pub use error::{AppendError, AppendResult, Error, Result};
 pub use listing::{LogKey, LogKeyIterator};
 pub use log::{LogDb, LogDbBuilder};

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -5,20 +5,26 @@
 //! ([`try_append`](LogDb::try_append), [`append_timeout`](LogDb::append_timeout))
 //! and read operations ([`scan`], [`count`]) via the [`LogRead`] trait.
 
+use std::collections::VecDeque;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use common::StorageBuilder;
+use std::sync::OnceLock;
+
 use common::clock::{Clock, SystemClock};
 use common::coordinator::{Durability, EpochWatcher, EpochWatermarks};
+use common::storage::config::StorageConfig;
+use common::{CompactorBuilder, StorageBuilder, create_object_store};
+use slatedb::compactor::CompactionSchedulerSupplier;
 use tokio::sync::RwLock;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
-use crate::config::{ReadVisibility, ScanOptions, SegmentConfig};
+use crate::compaction::{CompactorView, CompactorViewCell, LogCompactionSchedulerSupplier};
+use crate::config::{ReadVisibility, RetentionConfig, ScanOptions, SegmentConfig};
 use crate::error::{AppendResult, Error, Result};
 use crate::listing::ListingCache;
 use crate::listing::LogKeyIterator;
@@ -28,7 +34,9 @@ use crate::reader::{LogIterator, LogRead, LogReadView};
 use crate::segment::SegmentCache;
 use crate::serde::SEQ_BLOCK_KEY;
 use crate::view_tracker::{ViewEntry, ViewTracker};
-use crate::writer::{LogWrite, LogWriteHandle, LogWriter, LogWriterConfig, WrittenView};
+use crate::writer::{
+    LogWrite, LogWriteHandle, LogWriter, LogWriterConfig, RetentionPolicy, WrittenView,
+};
 
 /// The main log interface providing read and write operations.
 ///
@@ -102,6 +110,7 @@ pub struct LogDb {
     read_view: Arc<RwLock<LogReadView>>,
     epoch_watcher: EpochWatcher,
     read_subscriber_task: JoinHandle<()>,
+    compactor_view_task: Option<JoinHandle<()>>,
     read_visibility: ReadVisibility,
 }
 
@@ -270,6 +279,12 @@ impl LogDb {
         Ok(())
     }
 
+    /// Test-only delete of a sealed segment's `SegmentMeta` record.
+    #[cfg(test)]
+    pub(crate) async fn delete_segment_meta(&self, segment_id: SegmentId) -> Result<()> {
+        self.handle.delete_segment_meta(segment_id).await
+    }
+
     /// Flushes all pending writes to durable storage.
     ///
     /// This method ensures that all acknowledged writes are durably persisted
@@ -304,6 +319,9 @@ impl LogDb {
         drop(self.handle);
         let _ = self.writer_task.await;
         self.read_subscriber_task.abort();
+        if let Some(task) = self.compactor_view_task {
+            task.abort();
+        }
         self.storage
             .close()
             .await
@@ -318,8 +336,10 @@ impl LogDb {
             storage,
             None,
             SegmentConfig::default(),
+            RetentionConfig::default(),
             ReadVisibility::Memory,
             Arc::new(SystemClock),
+            None,
         )
         .await
     }
@@ -335,8 +355,10 @@ impl LogDb {
             storage,
             Some(direct),
             SegmentConfig::default(),
+            RetentionConfig::default(),
             ReadVisibility::Memory,
             Arc::new(SystemClock),
+            None,
         )
         .await
     }
@@ -348,19 +370,26 @@ impl LogDb {
             storage,
             None,
             SegmentConfig::default(),
+            RetentionConfig::default(),
             ReadVisibility::Remote,
             Arc::new(SystemClock),
+            None,
         )
         .await
     }
 
-    /// Shared construction logic used by both `LogDb::new` and `LogDbBuilder::build`.
+    /// Shared construction logic used by `LogDb::new` and `LogDbBuilder::build`.
+    /// When `compactor_view_cell` is `Some`, a durable-gated compactor view
+    /// receiver is installed there so the embedded compaction scheduler can
+    /// track the live set.
     async fn from_storage(
         storage: Arc<dyn common::Storage>,
         direct: Option<Arc<crate::direct::LogDirect>>,
         segment_config: SegmentConfig,
+        retention_config: RetentionConfig,
         read_visibility: ReadVisibility,
         clock: Arc<dyn Clock>,
+        compactor_view_cell: Option<crate::compaction::CompactorViewCell>,
     ) -> Result<Self> {
         let seq_key = Bytes::from_static(&SEQ_BLOCK_KEY);
         let sequence_allocator = common::SequenceAllocator::load(storage.as_ref(), seq_key)
@@ -373,20 +402,45 @@ impl LogDb {
         let segment_cache = SegmentCache::open(snapshot.as_ref(), segment_config).await?;
         let listing_cache = ListingCache::new();
 
+        let writer_config = LogWriterConfig {
+            retention: retention_config.retention.map(|retention| RetentionPolicy {
+                retention,
+                check_interval: retention_config.check_interval,
+            }),
+            ..LogWriterConfig::default()
+        };
         let (writer, mut handle) = LogWriter::new(
             storage.clone(),
             sequence_allocator,
             segment_cache.clone(),
             listing_cache,
-            LogWriterConfig::default(),
+            Arc::clone(&clock),
+            writer_config,
         )
         .await
         .map_err(Error::Storage)?;
 
         let written_rx = handle.written_rx();
+        let initial_segment_id = segment_cache.latest().map(|s| s.id());
+        let initial_deleted_segment_id = segment_cache.initial_deleted_segment_id();
+        let compactor_view_task = if let Some(cell) = compactor_view_cell.as_ref() {
+            let (compactor_rx, task) = spawn_compactor_view_publisher(
+                written_rx.clone(),
+                &storage,
+                initial_segment_id,
+                initial_deleted_segment_id,
+            );
+            // Err from `set` would mean the cell was already initialised — that
+            // never happens on our paths, so log it loudly rather than swallow.
+            if cell.set(compactor_rx).is_err() {
+                tracing::warn!("compactor view cell was already initialised");
+            }
+            Some(task)
+        } else {
+            None
+        };
         let writer_task = handle.spawn(writer);
 
-        let initial_segment_id = segment_cache.latest().map(|s| s.id());
         let read_view = Arc::new(RwLock::new(LogReadView::new(
             snapshot as Arc<dyn common::StorageRead>,
             direct,
@@ -399,9 +453,15 @@ impl LogDb {
                 Arc::clone(&read_view),
                 &storage,
                 initial_segment_id,
+                initial_deleted_segment_id,
             )
         } else {
-            spawn_written_subscriber(written_rx, Arc::clone(&read_view), initial_segment_id)
+            spawn_written_subscriber(
+                written_rx,
+                Arc::clone(&read_view),
+                initial_segment_id,
+                initial_deleted_segment_id,
+            )
         };
 
         Ok(Self {
@@ -412,6 +472,7 @@ impl LogDb {
             read_view,
             epoch_watcher,
             read_subscriber_task,
+            compactor_view_task,
             read_visibility,
         })
     }
@@ -461,40 +522,9 @@ impl LogRead for LogDb {
 
 /// Builder for creating LogDb instances with custom options.
 ///
-/// This builder provides a fluent API for configuring a LogDb, including
-/// low-level SlateDB knobs via [`StorageBuilder::map_slatedb`].
-///
-/// # Example
-///
-/// ```ignore
-/// use log::LogDbBuilder;
-/// use log::Config;
-/// use common::{StorageBuilder, CompactorBuilder, create_object_store};
-///
-/// // Create a separate runtime for compaction (important for sync/JNI usage)
-/// let compaction_runtime = tokio::runtime::Builder::new_multi_thread()
-///     .worker_threads(2)
-///     .enable_all()
-///     .build()
-///     .unwrap();
-///
-/// let mut sb = StorageBuilder::new(&config.storage).await.unwrap();
-/// sb = sb.map_slatedb(|db| {
-///     let obj_store = create_object_store(&slate_config.object_store).unwrap();
-///     db.with_compactor_builder(
-///         CompactorBuilder::new(slate_config.path.clone(), obj_store)
-///             .with_runtime(compaction_runtime.handle().clone())
-///     )
-/// });
-///
-/// let log = LogDbBuilder::new(config)
-///     .with_storage_builder(sb)
-///     .build()
-///     .await?;
-/// ```
+/// This builder provides configuration validation and LogDb construction.
 pub struct LogDbBuilder {
     config: crate::config::Config,
-    storage_builder: Option<StorageBuilder>,
     clock: Option<Arc<dyn Clock>>,
 }
 
@@ -503,18 +533,8 @@ impl LogDbBuilder {
     pub fn new(config: crate::config::Config) -> Self {
         Self {
             config,
-            storage_builder: None,
             clock: None,
         }
-    }
-
-    /// Sets a pre-configured [`StorageBuilder`].
-    ///
-    /// Use this to configure low-level SlateDB knobs like compaction runtime.
-    /// If not called, a default `StorageBuilder` is created from the config.
-    pub fn with_storage_builder(mut self, builder: StorageBuilder) -> Self {
-        self.storage_builder = Some(builder);
-        self
     }
 
     /// Overrides the wall-clock source. Test-only — production callers always
@@ -531,12 +551,11 @@ impl LogDbBuilder {
 
     /// Builds the LogDb instance.
     pub async fn build(self) -> Result<LogDb> {
-        let sb = match self.storage_builder {
-            Some(sb) => sb,
-            None => StorageBuilder::new(&self.config.storage)
-                .await
-                .map_err(|e| Error::Storage(e.to_string()))?,
-        };
+        self.config.validate_retention()?;
+        self.config.validate_compaction()?;
+        let sb = StorageBuilder::new(&self.config.storage)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
         // Route every log record to a SlateDB segment keyed by the 6-byte
         // routing prefix `[subsystem, version, segment_id]`. No-op for the
         // in-memory backend; for slatedb-backed storage this installs the
@@ -544,6 +563,25 @@ impl LogDbBuilder {
         let sb = sb.map_slatedb(|db| {
             db.with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())
         });
+        // Install the LogDb compaction scheduler for every SlateDB-backed log.
+        let compactor_view_cell: CompactorViewCell = Arc::new(OnceLock::new());
+        let sb = if let StorageConfig::SlateDb(ref slate_config) = self.config.storage {
+            let path = slate_config.path.clone();
+            let object_store = create_object_store(&slate_config.object_store)
+                .map_err(|e| Error::Storage(e.to_string()))?;
+            let supplier: Arc<dyn CompactionSchedulerSupplier> =
+                Arc::new(LogCompactionSchedulerSupplier {
+                    cell: Arc::clone(&compactor_view_cell),
+                    options: self.config.compaction.clone(),
+                });
+            sb.map_slatedb(move |db| {
+                db.with_compactor_builder(
+                    CompactorBuilder::new(path, object_store).with_scheduler_supplier(supplier),
+                )
+            })
+        } else {
+            sb
+        };
         let storage = sb
             .build()
             .await
@@ -556,24 +594,113 @@ impl LogDbBuilder {
 
         let clock: Arc<dyn Clock> = self.clock.unwrap_or_else(|| Arc::new(SystemClock));
 
+        // Hand the cell to `from_storage` only when we installed the supplier.
+        let cell_for_writer =
+            matches!(self.config.storage, StorageConfig::SlateDb(_)).then_some(compactor_view_cell);
+
         LogDb::from_storage(
             storage,
             direct,
             self.config.segmentation,
+            self.config.retention,
             self.config.read_visibility,
             clock,
+            cell_for_writer,
         )
         .await
     }
 }
 
+fn spawn_compactor_view_publisher(
+    mut written_rx: watch::Receiver<WrittenView>,
+    storage: &Arc<dyn common::Storage>,
+    initial_segment_id: Option<SegmentId>,
+    initial_deleted_segment_id: Option<SegmentId>,
+) -> (watch::Receiver<CompactorView>, JoinHandle<()>) {
+    let (compactor_tx, compactor_rx) = watch::channel(CompactorView {
+        last_segment_id: initial_segment_id,
+        last_deleted_segment_id: initial_deleted_segment_id,
+    });
+    let mut durable_rx = storage.subscribe_durable();
+
+    let task = tokio::spawn(async move {
+        let mut pending_deletes: VecDeque<(u64, Option<SegmentId>)> = VecDeque::new();
+        let mut last_durable_seq = *durable_rx.borrow();
+
+        loop {
+            tokio::select! {
+                result = written_rx.changed() => {
+                    if result.is_err() {
+                        break;
+                    }
+                    let view = written_rx.borrow_and_update().clone();
+                    pending_deletes.push_back((view.seqnum, view.last_deleted_segment_id));
+                    compactor_tx.send_modify(|state| {
+                        state.last_segment_id = view.last_segment_id;
+                    });
+                    drain_compactor_deletes(
+                        &mut pending_deletes,
+                        last_durable_seq,
+                        &compactor_tx,
+                    );
+                }
+                result = durable_rx.changed() => {
+                    if result.is_err() {
+                        break;
+                    }
+                    last_durable_seq = *durable_rx.borrow_and_update();
+                    drain_compactor_deletes(
+                        &mut pending_deletes,
+                        last_durable_seq,
+                        &compactor_tx,
+                    );
+                }
+            }
+        }
+    });
+
+    (compactor_rx, task)
+}
+
+fn drain_compactor_deletes(
+    pending_deletes: &mut VecDeque<(u64, Option<SegmentId>)>,
+    durable_seq: u64,
+    compactor_tx: &watch::Sender<CompactorView>,
+) {
+    let mut latest_durable_delete = None;
+    while pending_deletes
+        .front()
+        .is_some_and(|(seqnum, _)| *seqnum <= durable_seq)
+    {
+        latest_durable_delete = pending_deletes
+            .pop_front()
+            .map(|(_, deleted_id)| deleted_id);
+    }
+
+    if let Some(last_deleted_segment_id) = latest_durable_delete {
+        compactor_tx.send_modify(|state| {
+            state.last_deleted_segment_id = last_deleted_segment_id;
+        });
+    }
+}
+
 /// Tries to advance the tracker and, on success, applies the new snapshot
-/// to the shared read view and refreshes segments if needed.
+/// to the shared read view and reconciles the local segment cache against
+/// the writer's published watermarks.
+///
+/// Two independent reconciliations happen on a tick:
+///
+/// - **Adds.** When `last_segment_id` advanced, scan storage for the new
+///   segments and append them.
+/// - **Drops.** When `last_deleted_segment_id` advanced, drop every
+///   locally-cached segment with id `<= new value`. Sound because retention
+///   only deletes from the low end of the log (RFC 0005).
 async fn try_advance_read_view(
     tracker: &mut ViewTracker,
     read_view: &RwLock<LogReadView>,
     watermarks: &EpochWatermarks,
     known_segment_id: &mut Option<SegmentId>,
+    known_deleted_segment_id: &mut Option<SegmentId>,
     durability: Durability,
     through_seq: u64,
 ) {
@@ -593,6 +720,15 @@ async fn try_advance_read_view(
             }
         }
 
+        // Drop segments that have been deleted off the low end since our
+        // last observation.
+        if advanced.last_deleted_segment_id > *known_deleted_segment_id {
+            if let Some(through_id) = advanced.last_deleted_segment_id {
+                rv.drop_segments_through(through_id);
+            }
+            *known_deleted_segment_id = advanced.last_deleted_segment_id;
+        }
+
         match durability {
             Durability::Written => watermarks.update_written(advanced.epoch),
             Durability::Durable | Durability::Applied => watermarks.update_durable(advanced.epoch),
@@ -604,10 +740,12 @@ fn spawn_written_subscriber(
     mut written_rx: watch::Receiver<WrittenView>,
     read_view: Arc<RwLock<LogReadView>>,
     initial_segment_id: Option<SegmentId>,
+    initial_deleted_segment_id: Option<SegmentId>,
 ) -> (EpochWatcher, JoinHandle<()>) {
     let (watermarks, watcher) = EpochWatermarks::new();
     let mut tracker = ViewTracker::new();
     let mut known_segment_id = initial_segment_id;
+    let mut known_deleted_segment_id = initial_deleted_segment_id;
     let task = tokio::spawn(async move {
         while written_rx.changed().await.is_ok() {
             let view = written_rx.borrow_and_update().clone();
@@ -617,6 +755,7 @@ fn spawn_written_subscriber(
                 epoch: view.epoch,
                 snapshot: view.snapshot,
                 last_segment_id: view.last_segment_id,
+                last_deleted_segment_id: view.last_deleted_segment_id,
             });
 
             try_advance_read_view(
@@ -624,6 +763,7 @@ fn spawn_written_subscriber(
                 &read_view,
                 &watermarks,
                 &mut known_segment_id,
+                &mut known_deleted_segment_id,
                 Durability::Written,
                 seqnum,
             )
@@ -645,11 +785,13 @@ fn spawn_durable_subscriber(
     read_view: Arc<RwLock<LogReadView>>,
     storage: &Arc<dyn common::Storage>,
     initial_segment_id: Option<SegmentId>,
+    initial_deleted_segment_id: Option<SegmentId>,
 ) -> (EpochWatcher, JoinHandle<()>) {
     let (watermarks, watcher) = EpochWatermarks::new();
     let mut durable_rx = storage.subscribe_durable();
     let mut tracker = ViewTracker::new();
     let mut known_segment_id = initial_segment_id;
+    let mut known_deleted_segment_id = initial_deleted_segment_id;
 
     let task = tokio::spawn(async move {
         // Track the latest known durable_seq so we can re-check after new
@@ -669,12 +811,14 @@ fn spawn_durable_subscriber(
                         epoch: view.epoch,
                         snapshot: view.snapshot,
                         last_segment_id: view.last_segment_id,
+                        last_deleted_segment_id: view.last_deleted_segment_id,
                     });
                     watermarks.update_written(view.epoch);
 
                     // Re-check: the durable watermark may already cover this entry
                     try_advance_read_view(
-                        &mut tracker, &read_view, &watermarks, &mut known_segment_id,
+                        &mut tracker, &read_view, &watermarks,
+                        &mut known_segment_id, &mut known_deleted_segment_id,
                         Durability::Durable, last_durable_seq,
                     )
                     .await;
@@ -685,7 +829,8 @@ fn spawn_durable_subscriber(
                     }
                     last_durable_seq = *durable_rx.borrow_and_update();
                     try_advance_read_view(
-                        &mut tracker, &read_view, &watermarks, &mut known_segment_id,
+                        &mut tracker, &read_view, &watermarks,
+                        &mut known_segment_id, &mut known_deleted_segment_id,
                         Durability::Durable, last_durable_seq,
                     )
                     .await;
@@ -699,8 +844,10 @@ fn spawn_durable_subscriber(
 
 #[cfg(test)]
 mod tests {
+    use common::Storage;
     use common::StorageBuilder;
     use common::StorageConfig;
+    use common::storage::in_memory::InMemoryStorage;
 
     use super::*;
     use crate::config::Config;
@@ -711,6 +858,93 @@ mod tests {
             storage: StorageConfig::InMemory,
             ..Default::default()
         }
+    }
+
+    async fn make_written_view(
+        storage: &Arc<dyn common::Storage>,
+        seqnum: u64,
+        last_segment_id: Option<SegmentId>,
+        last_deleted_segment_id: Option<SegmentId>,
+    ) -> WrittenView {
+        WrittenView {
+            epoch: seqnum,
+            snapshot: storage.snapshot().await.unwrap(),
+            seqnum,
+            last_segment_id,
+            last_deleted_segment_id,
+        }
+    }
+
+    #[tokio::test]
+    async fn compactor_view_should_publish_new_segments_at_written_latency() {
+        let storage = Arc::new(InMemoryStorage::new().with_deferred_durability());
+        let storage_dyn = storage.clone() as Arc<dyn common::Storage>;
+        let initial_view = make_written_view(&storage_dyn, 0, None, None).await;
+        let (written_tx, written_rx) = watch::channel(initial_view);
+        let (mut compactor_rx, task) =
+            spawn_compactor_view_publisher(written_rx, &storage_dyn, None, None);
+
+        let write_result = storage
+            .apply(vec![common::storage::RecordOp::Delete(Bytes::from_static(
+                b"segment-meta-1",
+            ))])
+            .await
+            .unwrap();
+        written_tx.send_replace(
+            make_written_view(&storage_dyn, write_result.seqnum, Some(3), None).await,
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), compactor_rx.changed())
+            .await
+            .expect("timed out waiting for compactor view")
+            .expect("compactor view channel closed");
+        let view = *compactor_rx.borrow_and_update();
+        assert_eq!(view.last_segment_id, Some(3));
+        assert_eq!(view.last_deleted_segment_id, None);
+
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn compactor_view_should_delay_deleted_segments_until_durable() {
+        let storage = Arc::new(InMemoryStorage::new().with_deferred_durability());
+        let storage_dyn = storage.clone() as Arc<dyn common::Storage>;
+        let initial_view = make_written_view(&storage_dyn, 0, Some(2), None).await;
+        let (written_tx, written_rx) = watch::channel(initial_view);
+        let (mut compactor_rx, task) =
+            spawn_compactor_view_publisher(written_rx, &storage_dyn, Some(2), None);
+
+        let write_result = storage
+            .apply(vec![common::storage::RecordOp::Delete(Bytes::from_static(
+                b"segment-meta-1",
+            ))])
+            .await
+            .unwrap();
+        written_tx.send_replace(
+            make_written_view(&storage_dyn, write_result.seqnum, Some(2), Some(1)).await,
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), compactor_rx.changed())
+            .await
+            .expect("timed out waiting for written compactor update")
+            .expect("compactor view channel closed");
+        let view = *compactor_rx.borrow_and_update();
+        assert_eq!(view.last_segment_id, Some(2));
+        assert_eq!(
+            view.last_deleted_segment_id, None,
+            "delete should remain hidden until durable",
+        );
+
+        storage.flush_to(write_result.seqnum);
+
+        tokio::time::timeout(Duration::from_secs(1), compactor_rx.changed())
+            .await
+            .expect("timed out waiting for durable compactor update")
+            .expect("compactor view channel closed");
+        let view = *compactor_rx.borrow_and_update();
+        assert_eq!(view.last_deleted_segment_id, Some(1));
+
+        task.abort();
     }
 
     #[tokio::test]
@@ -1939,6 +2173,135 @@ mod tests {
         assert_eq!(keys, vec![Bytes::from("alpha"), Bytes::from("beta")]);
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn should_delete_expired_segments_via_periodic_retention_loop() {
+        // Drives the writer's `run`-loop `select!` branch end-to-end through
+        // the public API, reached via the periodic `tokio::time::interval`
+        // inside `LogWriter::run` (rather than calling `tick_retention`
+        // directly).
+        use crate::Config;
+        use common::clock::MockClock;
+        use std::time::SystemTime;
+
+        let t0_secs: u64 = 10_000;
+        let retention = Duration::from_secs(60);
+        let seal_interval = Duration::from_secs(60);
+        let check_interval = Duration::from_millis(10);
+
+        let clock = Arc::new(MockClock::with_time(
+            SystemTime::UNIX_EPOCH + Duration::from_secs(t0_secs),
+        ));
+        let config = Config {
+            storage: StorageConfig::InMemory,
+            segmentation: SegmentConfig {
+                seal_interval: Some(seal_interval),
+            },
+            retention: RetentionConfig {
+                retention: Some(retention),
+                check_interval,
+            },
+            ..Config::default()
+        };
+        let log = LogDbBuilder::new(config)
+            .with_clock(Arc::clone(&clock) as Arc<dyn Clock>)
+            .build()
+            .await
+            .unwrap();
+
+        // Create segment 1 at T=t0, then seal it (segment 2 also starts at t0).
+        // Segment 1's effective end_time is segment 2's start_time_ms = t0_ms.
+        log.try_append(vec![Record {
+            key: Bytes::from("k"),
+            value: Bytes::from("v"),
+        }])
+        .await
+        .unwrap();
+        log.seal_segment().await.unwrap();
+
+        let before: Vec<_> = log
+            .list_segments(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+        assert_eq!(before, vec![1, 2]);
+
+        // Move the writer's wall-clock past the retention cutoff for segment 1.
+        clock.set_time(SystemTime::UNIX_EPOCH + Duration::from_secs(t0_secs + 70));
+
+        // Advance `tokio::time` past one `check_interval` so the writer's
+        // interval branch in `select!` fires. Under `start_paused`, sleeping
+        // both bumps virtual time and yields, giving the spawned writer
+        // task room to run `tick_retention` to completion.
+        tokio::time::sleep(check_interval + Duration::from_millis(1)).await;
+        // tick_retention has several internal `.await` points (apply +
+        // snapshot + broadcast); a few extra yields drain them before we
+        // check the public surface.
+        for _ in 0..16 {
+            tokio::task::yield_now().await;
+        }
+
+        // Local reader should now see segment 1 dropped from the view.
+        let after: Vec<_> = log
+            .list_segments(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+        assert_eq!(after, vec![2]);
+    }
+
+    #[tokio::test]
+    async fn should_drop_deleted_segment_from_local_reader_view() {
+        // given: three sealed user segments
+        let log = LogDb::open(test_config()).await.unwrap();
+        log.try_append(vec![Record {
+            key: Bytes::from("k"),
+            value: Bytes::from("v0"),
+        }])
+        .await
+        .unwrap();
+        log.seal_segment().await.unwrap();
+        log.try_append(vec![Record {
+            key: Bytes::from("k"),
+            value: Bytes::from("v1"),
+        }])
+        .await
+        .unwrap();
+        log.seal_segment().await.unwrap();
+        log.try_append(vec![Record {
+            key: Bytes::from("k"),
+            value: Bytes::from("v2"),
+        }])
+        .await
+        .unwrap();
+
+        let before: Vec<_> = log
+            .list_segments(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+        assert_eq!(before, vec![1, 2, 3]);
+
+        // when: retention deletes the oldest segment's metadata
+        log.delete_segment_meta(1).await.unwrap();
+
+        // then: local readers converge — segment 1 is no longer visible
+        // without reopening the LogDb.
+        let after: Vec<_> = log
+            .list_segments(..)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|s| s.id)
+            .collect();
+        assert_eq!(after, vec![2, 3]);
+    }
+
     #[tokio::test]
     async fn should_list_segments_without_flush() {
         // given
@@ -2128,8 +2491,10 @@ mod tests {
             SegmentConfig {
                 seal_interval: Some(Duration::from_nanos(1)),
             },
+            RetentionConfig::default(),
             ReadVisibility::Memory,
             Arc::new(SystemClock),
+            None,
         )
         .await
         .unwrap();

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -250,11 +250,12 @@ impl LogReadView {
         self.storage = snapshot;
     }
 
-    /// Incrementally loads new segments from the current storage snapshot.
+    /// Reloads segments from the current storage snapshot.
     ///
-    /// Only loads segments with ID > `after_segment_id`. This is used by
-    /// subscriber tasks to refresh segments without needing segments propagated
-    /// through the watch channel.
+    /// When `after_segment_id` is `Some`, only newer segments are appended.
+    /// When `None`, the segment cache is fully replaced from storage. The
+    /// standalone reader uses the full-reload path so it converges on both
+    /// newly-created and deleted segments.
     pub(crate) async fn refresh_segments(
         &mut self,
         after_segment_id: Option<SegmentId>,
@@ -262,6 +263,12 @@ impl LogReadView {
         self.segments
             .refresh(self.storage.as_ref(), after_segment_id)
             .await
+    }
+
+    /// Drops every cached segment with id `<= through_id`. Used by subscriber
+    /// tasks to converge to the writer's published deletion watermark.
+    pub(crate) fn drop_segments_through(&mut self, through_id: SegmentId) {
+        self.segments.drop_through(through_id);
     }
 
     /// Scans entries for a key within a sequence number range with custom options.
@@ -502,6 +509,10 @@ impl LogDbReader {
     }
 
     /// Spawns a background task that periodically refreshes the segment cache.
+    ///
+    /// This path fully reloads segments from storage on each tick so a
+    /// standalone reader observes retention-driven `SegmentMeta` deletes as
+    /// well as newly created segments.
     fn spawn_refresh_task(
         read_view: Arc<RwLock<LogReadView>>,
         interval: Duration,
@@ -515,16 +526,9 @@ impl LogDbReader {
             loop {
                 tokio::select! {
                     _ = ticker.tick() => {
-                        // Get the latest segment ID for incremental refresh
-                        let after_segment_id = {
-                            let view = read_view.read().await;
-                            view.segments.latest().map(|s| s.id())
-                        };
-
-                        // Refresh the cache
                         let mut view = read_view.write().await;
                         let storage = Arc::clone(&view.storage);
-                        if let Err(e) = view.segments.refresh(storage.as_ref(), after_segment_id).await {
+                        if let Err(e) = view.segments.refresh(storage.as_ref(), None).await {
                             tracing::warn!("Failed to refresh segment cache: {}", e);
                         }
                     }

--- a/log/src/segment.rs
+++ b/log/src/segment.rs
@@ -110,6 +110,40 @@ impl SegmentCache {
         self.segments.values().next_back().cloned()
     }
 
+    /// Returns the id of the oldest (lowest-id) live segment, if any.
+    ///
+    /// Combined with [`SegmentCache::latest`], this characterises the live
+    /// range. Retention removes only from the low end of the log (see RFC
+    /// 0005), so the gap below this id implies a deletion watermark.
+    pub(crate) fn oldest_id(&self) -> Option<SegmentId> {
+        self.segments.values().next().map(|s| s.id())
+    }
+
+    /// Returns the deletion watermark implied by the current cache contents:
+    /// `Some(oldest_id - 1)` when the oldest live id is above
+    /// [`FIRST_USER_SEGMENT_ID`] (i.e., earlier segments must have been
+    /// deleted), or `None` when no deletions are observable from the cache.
+    pub(crate) fn initial_deleted_segment_id(&self) -> Option<SegmentId> {
+        self.oldest_id()
+            .filter(|oldest| *oldest > FIRST_USER_SEGMENT_ID)
+            .map(|oldest| oldest - 1)
+    }
+
+    /// Removes the segment with the given id, if present, and returns it.
+    pub(crate) fn remove(&mut self, segment_id: SegmentId) -> Option<LogSegment> {
+        let start_seq = self
+            .segments
+            .iter()
+            .find_map(|(seq, seg)| (seg.id() == segment_id).then_some(*seq))?;
+        self.segments.remove(&start_seq)
+    }
+
+    /// Drops every segment with id `<= through_id`. Used by readers to
+    /// converge to the writer's published deletion watermark.
+    pub(crate) fn drop_through(&mut self, through_id: SegmentId) {
+        self.segments.retain(|_, seg| seg.id() > through_id);
+    }
+
     /// Returns all segments ordered by start sequence.
     pub(crate) fn all(&self) -> Vec<LogSegment> {
         self.segments.values().cloned().collect()
@@ -782,6 +816,82 @@ mod tests {
         cache.refresh(storage.as_ref(), None).await.unwrap();
         assert_eq!(cache.all().len(), 1);
         assert_eq!(cache.all()[0].id(), 1);
+    }
+
+    #[storage_test]
+    async fn oldest_id_returns_none_when_empty(storage: Arc<dyn Storage>) {
+        let cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
+            .await
+            .unwrap();
+        assert!(cache.oldest_id().is_none());
+    }
+
+    #[storage_test]
+    async fn oldest_id_tracks_lowest_segment_id(storage: Arc<dyn Storage>) {
+        let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
+            .await
+            .unwrap();
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(100, 2000)).await;
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(200, 3000)).await;
+        assert_eq!(cache.oldest_id(), Some(1));
+
+        // After removing the first segment the next-oldest takes its place.
+        cache.remove(1);
+        assert_eq!(cache.oldest_id(), Some(2));
+    }
+
+    #[storage_test]
+    async fn remove_drops_segment_by_id(storage: Arc<dyn Storage>) {
+        let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
+            .await
+            .unwrap();
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(100, 2000)).await;
+
+        let removed = cache.remove(1).expect("segment 1 should be present");
+        assert_eq!(removed.id(), 1);
+        let all = cache.all();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id(), 2);
+    }
+
+    #[storage_test]
+    async fn remove_is_noop_for_missing_id(storage: Arc<dyn Storage>) {
+        let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
+            .await
+            .unwrap();
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
+
+        assert!(cache.remove(99).is_none());
+        assert_eq!(cache.all().len(), 1);
+    }
+
+    #[storage_test]
+    async fn drop_through_removes_low_end_segments(storage: Arc<dyn Storage>) {
+        let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
+            .await
+            .unwrap();
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(100, 2000)).await;
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(200, 3000)).await;
+
+        cache.drop_through(2);
+
+        let remaining: Vec<_> = cache.all().into_iter().map(|s| s.id()).collect();
+        assert_eq!(remaining, vec![3]);
+    }
+
+    #[storage_test]
+    async fn drop_through_is_noop_when_threshold_below_oldest(storage: Arc<dyn Storage>) {
+        let mut cache = SegmentCache::open(storage.as_ref(), SegmentConfig::default())
+            .await
+            .unwrap();
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(100, 2000)).await;
+
+        cache.drop_through(0);
+        assert_eq!(cache.all().len(), 2);
     }
 
     #[storage_test]

--- a/log/src/segment_extractor.rs
+++ b/log/src/segment_extractor.rs
@@ -32,7 +32,7 @@ use crate::serde::{KEY_VERSION, SUBSYSTEM};
 /// extracted prefix so all record types for a given segment (entries,
 /// listings, and — for the system segment — metadata and the seq block)
 /// share one routing prefix and land in the same SlateDB segment.
-const ROUTING_PREFIX_LEN: usize = 6;
+pub(crate) const ROUTING_PREFIX_LEN: usize = 6;
 
 /// Stable, persisted identifier for this extractor's routing rules.
 /// Bump whenever the routing logic changes in a way that would re-route

--- a/log/src/view_tracker.rs
+++ b/log/src/view_tracker.rs
@@ -17,6 +17,7 @@ pub(crate) struct ViewEntry {
     pub epoch: u64,
     pub snapshot: Arc<dyn StorageSnapshot>,
     pub last_segment_id: Option<SegmentId>,
+    pub last_deleted_segment_id: Option<SegmentId>,
 }
 
 /// Buffers pending writes and produces read views when a watermark advances.
@@ -80,6 +81,7 @@ mod tests {
             epoch: 10,
             snapshot: snap.clone(),
             last_segment_id: Some(7),
+            last_deleted_segment_id: None,
         });
 
         let result = tracker.advance(1);
@@ -99,6 +101,7 @@ mod tests {
             epoch: 1,
             snapshot: snap,
             last_segment_id: Some(9),
+            last_deleted_segment_id: None,
         });
 
         let result = tracker.advance(3);
@@ -116,18 +119,21 @@ mod tests {
             epoch: 1,
             snapshot: make_snapshot().await,
             last_segment_id: Some(0),
+            last_deleted_segment_id: None,
         });
         tracker.push(ViewEntry {
             seqnum: 3,
             epoch: 2,
             snapshot: make_snapshot().await,
             last_segment_id: Some(1),
+            last_deleted_segment_id: None,
         });
         tracker.push(ViewEntry {
             seqnum: 5,
             epoch: 3,
             snapshot: make_snapshot().await,
             last_segment_id: Some(2),
+            last_deleted_segment_id: None,
         });
 
         let result = tracker.advance(3);

--- a/log/src/writer.rs
+++ b/log/src/writer.rs
@@ -325,7 +325,13 @@ impl LogWriter {
         let ops = vec![RecordOp::Delete(key)];
         let write_result = self.apply(ops).await?;
         self.segment_cache.remove(segment_id);
-        // Deletion watermark is monotonic — only advance.
+        // Deletion watermark is monotonic — only advance. Advancing here is
+        // safe even though `apply` doesn't tell us whether the key existed:
+        // SlateDB transitions to a terminal error state on any write failure
+        // (see `Db::check_closed`), so a successful `apply` implies every
+        // prior `apply` on this writer also succeeded. Retention's caller
+        // (`tick_retention`) iterates expired ids in ascending order, so
+        // successful advances are contiguous from the low end.
         if self
             .last_deleted_segment_id
             .is_none_or(|prev| prev < segment_id)

--- a/log/src/writer.rs
+++ b/log/src/writer.rs
@@ -19,8 +19,9 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use common::Ttl::NoExpiry;
+use common::clock::Clock;
 use common::coordinator::{EpochWatcher, EpochWatermarks};
-use common::storage::PutOptions;
+use common::storage::{PutOptions, RecordOp};
 use common::{PutRecordOp, SequenceAllocator, WriteOptions};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
@@ -29,20 +30,25 @@ use crate::error::AppendError;
 use crate::listing::ListingCache;
 use crate::model::{AppendOutput, Record as UserRecord, SegmentId};
 use crate::segment::{LogSegment, SegmentAssignment, SegmentCache};
-use crate::serde::LogEntryKey;
+use crate::serde::{LogEntryKey, SegmentMetaKey};
 
 /// Snapshot of writer state broadcast to subscribers after each write.
+///
+/// The two segment-id watermarks below are monotonic and (combined with
+/// RFC 0005's "retention only deletes from the low end" invariant) fully
+/// describe the live user-segment range. Safe under `watch` coalescing.
 #[derive(Clone)]
 pub(crate) struct WrittenView {
     pub epoch: u64,
     pub snapshot: Arc<dyn common::storage::StorageSnapshot>,
     /// Storage engine sequence number for this write.
     pub seqnum: u64,
-    /// ID of the most recently created segment, if any.
-    /// Subscribers compare this against their local state to detect new segments
-    /// and reload them from the snapshot. This is safe under watch coalescing
-    /// because it is a monotonic watermark, not an incremental delta.
+    /// Id of the largest user segment created so far. `None` before the first
+    /// segment is created.
     pub last_segment_id: Option<SegmentId>,
+    /// Id of the largest user segment whose `SegmentMeta` has been deleted.
+    /// `None` until the first delete is observed.
+    pub last_deleted_segment_id: Option<SegmentId>,
 }
 
 /// The write type for the log writer.
@@ -64,6 +70,11 @@ pub(crate) enum WriterCommand {
         timestamp_ms: i64,
         result_tx: oneshot::Sender<Result<(), String>>,
     },
+    #[cfg(test)]
+    DeleteSegmentMeta {
+        segment_id: SegmentId,
+        result_tx: oneshot::Sender<Result<(), String>>,
+    },
     Flush {
         result_tx: oneshot::Sender<Result<u64, String>>,
     },
@@ -72,14 +83,28 @@ pub(crate) enum WriterCommand {
 /// Configuration for the log writer.
 pub(crate) struct LogWriterConfig {
     pub queue_capacity: usize,
+    /// Retention policy. When `Some`, the writer's main loop runs a periodic
+    /// retention check that deletes `SegmentMeta` records for expired sealed
+    /// segments. `None` disables the check entirely.
+    pub retention: Option<RetentionPolicy>,
 }
 
 impl Default for LogWriterConfig {
     fn default() -> Self {
         Self {
             queue_capacity: 10_000,
+            retention: None,
         }
     }
+}
+
+/// Retention policy controlling the writer's periodic expiry check.
+#[derive(Debug, Clone)]
+pub(crate) struct RetentionPolicy {
+    /// Segments whose end time is older than `now() - retention` expire.
+    pub retention: Duration,
+    /// How often the writer evaluates expiry.
+    pub check_interval: Duration,
 }
 
 /// The log writer task. Owns all write-side state and runs as a spawned async task.
@@ -92,6 +117,9 @@ pub(crate) struct LogWriter {
     written_tx: watch::Sender<WrittenView>,
     watermarks: EpochWatermarks,
     last_segment_id: Option<SegmentId>,
+    last_deleted_segment_id: Option<SegmentId>,
+    clock: Arc<dyn Clock>,
+    retention: Option<RetentionPolicy>,
 }
 
 impl LogWriter {
@@ -101,17 +129,20 @@ impl LogWriter {
         sequence_allocator: SequenceAllocator,
         segment_cache: SegmentCache,
         listing_cache: ListingCache,
+        clock: Arc<dyn Clock>,
         config: LogWriterConfig,
     ) -> Result<(Self, LogWriteHandle), String> {
         let (cmd_tx, cmd_rx) = mpsc::channel(config.queue_capacity);
 
         let initial_snapshot = storage.snapshot().await.map_err(|e| e.to_string())?;
         let last_segment_id = segment_cache.latest().map(|s| s.id());
+        let last_deleted_segment_id = segment_cache.initial_deleted_segment_id();
         let initial_view = WrittenView {
             epoch: 0,
             snapshot: initial_snapshot,
             seqnum: 0,
             last_segment_id,
+            last_deleted_segment_id,
         };
         let (written_tx, written_rx) = watch::channel(initial_view);
         let (watermarks, watcher) = EpochWatermarks::new();
@@ -125,6 +156,9 @@ impl LogWriter {
             written_tx,
             watermarks,
             last_segment_id,
+            last_deleted_segment_id,
+            clock,
+            retention: config.retention,
         };
 
         let handle = LogWriteHandle {
@@ -137,26 +171,88 @@ impl LogWriter {
         Ok((writer, handle))
     }
 
-    /// Runs the writer loop, processing commands from the receiver.
+    /// Runs the writer loop, processing commands and periodic retention
+    /// ticks when retention is configured.
     pub(crate) async fn run(mut self, mut rx: mpsc::Receiver<WriterCommand>) {
-        while let Some(cmd) = rx.recv().await {
-            match cmd {
-                WriterCommand::Append { write, result_tx } => {
-                    let result = self.handle_append(write).await;
-                    let _ = result_tx.send(result);
+        let mut retention_tick = self
+            .retention
+            .as_ref()
+            .map(|p| tokio::time::interval(p.check_interval));
+        loop {
+            tokio::select! {
+                cmd = rx.recv() => {
+                    let Some(cmd) = cmd else { break };
+                    self.handle_command(cmd).await;
                 }
-                #[cfg(test)]
-                WriterCommand::ForceSeal {
-                    timestamp_ms,
-                    result_tx,
+                _ = async {
+                    match retention_tick.as_mut() {
+                        Some(t) => { t.tick().await; }
+                        None => std::future::pending::<()>().await,
+                    }
                 } => {
-                    let result = self.handle_force_seal(timestamp_ms).await;
-                    let _ = result_tx.send(result);
+                    self.tick_retention().await;
                 }
-                WriterCommand::Flush { result_tx } => {
-                    let result = self.handle_flush().await;
-                    let _ = result_tx.send(result);
-                }
+            }
+        }
+    }
+
+    async fn handle_command(&mut self, cmd: WriterCommand) {
+        match cmd {
+            WriterCommand::Append { write, result_tx } => {
+                let result = self.handle_append(write).await;
+                let _ = result_tx.send(result);
+            }
+            #[cfg(test)]
+            WriterCommand::ForceSeal {
+                timestamp_ms,
+                result_tx,
+            } => {
+                let result = self.handle_force_seal(timestamp_ms).await;
+                let _ = result_tx.send(result);
+            }
+            #[cfg(test)]
+            WriterCommand::DeleteSegmentMeta {
+                segment_id,
+                result_tx,
+            } => {
+                let result = self.handle_delete_segment_meta(segment_id).await;
+                let _ = result_tx.send(result);
+            }
+            WriterCommand::Flush { result_tx } => {
+                let result = self.handle_flush().await;
+                let _ = result_tx.send(result);
+            }
+        }
+    }
+
+    /// Periodic retention check: deletes `SegmentMeta` for any sealed segment
+    /// whose end time (the successor's `start_time_ms`) is past
+    /// `now - retention`. Per-segment failures log and are retried next tick.
+    async fn tick_retention(&mut self) {
+        let Some(policy) = self.retention.clone() else {
+            return;
+        };
+        let now_ms = match self.clock.now().duration_since(std::time::UNIX_EPOCH) {
+            Ok(d) => d.as_millis() as i64,
+            Err(e) => {
+                // Falling back to 0 would silently disable retention; skip
+                // the tick and retry once the clock is sane again.
+                tracing::warn!("retention: clock before UNIX_EPOCH, skipping tick: {e}");
+                return;
+            }
+        };
+        let cutoff = now_ms - policy.retention.as_millis() as i64;
+
+        let segments = self.segment_cache.all();
+        let expired: Vec<SegmentId> = segments
+            .windows(2)
+            .filter(|w| w[1].meta().start_time_ms < cutoff)
+            .map(|w| w[0].id())
+            .collect();
+
+        for id in expired {
+            if let Err(e) = self.handle_delete_segment_meta(id).await {
+                tracing::warn!("retention: failed to delete SegmentMeta for segment {id}: {e}");
             }
         }
     }
@@ -169,12 +265,12 @@ impl LogWriter {
             return Ok(None);
         }
 
-        let mut records = Vec::new();
+        let mut puts = Vec::new();
 
         // 1. Allocate sequences
         let (base_seq, maybe_block_record) = self.sequence_allocator.allocate(count);
         if let Some(r) = maybe_block_record {
-            records.push(PutRecordOp::new_with_options(
+            puts.push(PutRecordOp::new_with_options(
                 r,
                 PutOptions { ttl: NoExpiry },
             ));
@@ -183,18 +279,19 @@ impl LogWriter {
         // 2. Assign segment (appends segment metadata record if new)
         let assignment =
             self.segment_cache
-                .assign_segment(write.timestamp_ms, base_seq, &mut records, false);
+                .assign_segment(write.timestamp_ms, base_seq, &mut puts, false);
 
         // 3. Assign listing entries for new keys
         let keys: Vec<Bytes> = write.records.iter().map(|r| r.key.clone()).collect();
         self.listing_cache
-            .assign_new_keys(assignment.segment.id(), &keys, &mut records);
+            .assign_new_keys(assignment.segment.id(), &keys, &mut puts);
 
         // 4. Build log entry records
-        self.add_entries(&assignment.segment, base_seq, &write.records, &mut records);
+        self.add_entries(&assignment.segment, base_seq, &write.records, &mut puts);
 
         // 5. Write to storage and broadcast
-        self.write_and_broadcast(records, &assignment).await?;
+        let ops: Vec<RecordOp> = puts.into_iter().map(RecordOp::Put).collect();
+        self.apply_and_broadcast(ops, Some(&assignment)).await?;
 
         Ok(Some(AppendOutput {
             start_sequence: base_seq,
@@ -205,44 +302,82 @@ impl LogWriter {
     #[cfg(test)]
     async fn handle_force_seal(&mut self, timestamp_ms: i64) -> Result<(), String> {
         let next_seq = self.sequence_allocator.peek_next_sequence();
-        let mut records = Vec::new();
-        let assignment =
-            self.segment_cache
-                .assign_segment(timestamp_ms, next_seq, &mut records, true);
+        let mut puts = Vec::new();
+        let assignment = self
+            .segment_cache
+            .assign_segment(timestamp_ms, next_seq, &mut puts, true);
 
-        if !records.is_empty() {
-            self.write_and_broadcast(records, &assignment).await?;
+        if !puts.is_empty() {
+            let ops: Vec<RecordOp> = puts.into_iter().map(RecordOp::Put).collect();
+            self.apply_and_broadcast(ops, Some(&assignment)).await?;
         }
 
         Ok(())
     }
 
-    /// Writes records to storage, updates the segments snapshot if needed,
-    /// takes a new storage snapshot, bumps the epoch, and broadcasts.
-    async fn write_and_broadcast(
+    /// Deletes a sealed segment's `SegmentMeta` record.
+    ///
+    /// Idempotent at the storage layer: a missing key in SlateDB is a harmless
+    /// no-op. The local cache is updated only after the storage write succeeds,
+    /// so a failed delete leaves the segment live (retention will retry).
+    async fn handle_delete_segment_meta(&mut self, segment_id: SegmentId) -> Result<(), String> {
+        let key = SegmentMetaKey::new(segment_id).serialize();
+        let ops = vec![RecordOp::Delete(key)];
+        let write_result = self.apply(ops).await?;
+        self.segment_cache.remove(segment_id);
+        // Deletion watermark is monotonic — only advance.
+        if self
+            .last_deleted_segment_id
+            .is_none_or(|prev| prev < segment_id)
+        {
+            self.last_deleted_segment_id = Some(segment_id);
+        }
+        self.broadcast(write_result.seqnum).await
+    }
+
+    /// Writes ops to storage and broadcasts the resulting view.
+    ///
+    /// Used by the append/seal paths where no post-write state change is
+    /// needed before the broadcast. For deletes, prefer the explicit
+    /// `apply` + `broadcast` pair so cache/watermark updates can happen
+    /// between them.
+    async fn apply_and_broadcast(
         &mut self,
-        records: Vec<PutRecordOp>,
-        assignment: &SegmentAssignment,
+        ops: Vec<RecordOp>,
+        assignment: Option<&SegmentAssignment>,
     ) -> Result<(), String> {
+        let write_result = self.apply(ops).await?;
+        if let Some(assignment) = assignment
+            && assignment.is_new
+        {
+            self.last_segment_id = Some(assignment.segment.id());
+        }
+        self.broadcast(write_result.seqnum).await
+    }
+
+    /// Writes ops to storage. Returns the resulting `WriteResult`.
+    async fn apply(&mut self, ops: Vec<RecordOp>) -> Result<common::storage::WriteResult, String> {
         let options = WriteOptions {
             await_durable: false,
         };
-        let write_result = self
-            .storage
-            .put_with_options(records, options)
+        self.storage
+            .apply_with_options(ops, options)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| e.to_string())
+    }
 
+    /// Takes a fresh storage snapshot, bumps the epoch, and broadcasts a
+    /// new `WrittenView` using current watermarks. Must be called after a
+    /// successful `apply` (and any post-write state updates).
+    async fn broadcast(&mut self, seqnum: u64) -> Result<(), String> {
         let snapshot = self.storage.snapshot().await.map_err(|e| e.to_string())?;
         self.epoch += 1;
-        if assignment.is_new {
-            self.last_segment_id = Some(assignment.segment.id());
-        }
         self.written_tx.send_replace(WrittenView {
             epoch: self.epoch,
             snapshot,
-            seqnum: write_result.seqnum,
+            seqnum,
             last_segment_id: self.last_segment_id,
+            last_deleted_segment_id: self.last_deleted_segment_id,
         });
         self.watermarks.update_written(self.epoch);
         Ok(())
@@ -385,6 +520,24 @@ impl LogWriteHandle {
         Self::recv_epoch(result_rx).await
     }
 
+    /// Test-only command-driven delete of a sealed segment's `SegmentMeta`
+    /// record. Production deletes go through `LogWriter::tick_retention`.
+    #[cfg(test)]
+    pub(crate) async fn delete_segment_meta(
+        &self,
+        segment_id: SegmentId,
+    ) -> Result<(), crate::error::Error> {
+        let (result_tx, result_rx) = oneshot::channel();
+        self.cmd_tx
+            .send(WriterCommand::DeleteSegmentMeta {
+                segment_id,
+                result_tx,
+            })
+            .await
+            .map_err(|_| crate::error::Error::Internal("writer shut down".into()))?;
+        Self::recv_cmd(result_rx).await
+    }
+
     /// The highest epoch that has reached written visibility.
     pub(crate) fn written_epoch(&self) -> u64 {
         *self.watcher.written_rx.borrow()
@@ -427,6 +580,15 @@ mod tests {
         storage: Arc<dyn common::Storage>,
         config: LogWriterConfig,
     ) -> (LogWriter, LogWriteHandle, Arc<dyn common::Storage>) {
+        let clock: Arc<dyn Clock> = Arc::new(common::clock::SystemClock);
+        create_writer_with_storage_and_clock(storage, clock, config).await
+    }
+
+    async fn create_writer_with_storage_and_clock(
+        storage: Arc<dyn common::Storage>,
+        clock: Arc<dyn Clock>,
+        config: LogWriterConfig,
+    ) -> (LogWriter, LogWriteHandle, Arc<dyn common::Storage>) {
         let seq_key = Bytes::from_static(&SEQ_BLOCK_KEY);
         let sequence_allocator = SequenceAllocator::load(storage.as_ref(), seq_key)
             .await
@@ -441,6 +603,7 @@ mod tests {
             sequence_allocator,
             segment_cache,
             listing_cache,
+            clock,
             config,
         )
         .await
@@ -635,8 +798,9 @@ mod tests {
             create_writer_with_storage(failing.clone(), LogWriterConfig::default()).await;
         let _task = handle.spawn(writer);
 
-        // Enable put failure after writer is running
-        failing.fail_put(common::StorageError::Storage("test put error".into()));
+        // Enable apply failure after writer is running. Appends flow through
+        // Storage::apply_with_options so we fail at that seam.
+        failing.fail_apply(common::StorageError::Storage("test put error".into()));
 
         let result = handle.try_append(make_write(&["key1"], 1000)).await;
         assert!(
@@ -701,8 +865,8 @@ mod tests {
             create_writer_with_storage(failing.clone(), LogWriterConfig::default()).await;
         let _task = handle.spawn(writer);
 
-        // First append fails
-        failing.fail_put_once(common::StorageError::Storage("test put error".into()));
+        // First append fails. Appends go through Storage::apply_with_options.
+        failing.fail_apply_once(common::StorageError::Storage("test put error".into()));
         let result = handle.try_append(make_write(&["key1"], 1000)).await;
         assert!(result.is_err());
 
@@ -729,6 +893,359 @@ mod tests {
             "expected Shutdown, got: {:?}",
             result,
         );
+    }
+
+    #[tokio::test]
+    async fn should_delete_segment_meta_and_advance_watermarks() {
+        // given: writer has produced two user segments
+        let (writer, mut handle, storage) = create_writer().await;
+        let mut written_rx = handle.written_rx();
+        let _task = handle.spawn(writer);
+
+        handle.try_append(make_write(&["k1"], 1000)).await.unwrap();
+        handle.force_seal(2000).await.unwrap();
+        handle.flush().await.unwrap();
+
+        use crate::storage::LogStorageRead as _;
+        let segs_before = storage.scan_segments(1..u32::MAX).await.unwrap();
+        assert_eq!(
+            segs_before.iter().map(|s| s.id()).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+
+        let epoch_before = handle.written_epoch();
+
+        // when: delete segment 1's SegmentMeta
+        handle.delete_segment_meta(1).await.unwrap();
+
+        // then: storage scan no longer sees segment 1
+        handle.flush().await.unwrap();
+        let segs_after = storage.scan_segments(1..u32::MAX).await.unwrap();
+        assert_eq!(
+            segs_after.iter().map(|s| s.id()).collect::<Vec<_>>(),
+            vec![2]
+        );
+
+        // and: the broadcast carries the deletion watermark
+        let view = written_rx.borrow_and_update().clone();
+        assert_eq!(view.last_deleted_segment_id, Some(1));
+        assert_eq!(view.last_segment_id, Some(2));
+        assert!(handle.written_epoch() > epoch_before);
+    }
+
+    #[tokio::test]
+    async fn should_be_idempotent_when_deleting_unknown_segment() {
+        // given: writer with no segments yet
+        let (writer, mut handle, _storage) = create_writer().await;
+        let mut written_rx = handle.written_rx();
+        let _task = handle.spawn(writer);
+
+        // when: delete a never-created segment
+        handle.delete_segment_meta(42).await.unwrap();
+
+        // then: the watermark still advances (subscribers can converge),
+        // and no error is surfaced
+        let view = written_rx.borrow_and_update().clone();
+        assert_eq!(view.last_deleted_segment_id, Some(42));
+    }
+
+    #[tokio::test]
+    async fn should_not_regress_deletion_watermark() {
+        // given: a writer with two sealed segments deleted out of order
+        let (writer, mut handle, _storage) = create_writer().await;
+        let mut written_rx = handle.written_rx();
+        let _task = handle.spawn(writer);
+        handle.try_append(make_write(&["k1"], 1000)).await.unwrap();
+        handle.force_seal(2000).await.unwrap();
+        handle.force_seal(3000).await.unwrap();
+
+        // when: delete the higher id first, then the lower id
+        handle.delete_segment_meta(2).await.unwrap();
+        handle.delete_segment_meta(1).await.unwrap();
+
+        // then: watermark is the max of the two, not the most recent
+        let view = written_rx.borrow_and_update().clone();
+        assert_eq!(view.last_deleted_segment_id, Some(2));
+    }
+
+    #[storage_test]
+    async fn should_propagate_storage_error_on_delete(storage: Arc<dyn Storage>) {
+        let failing = FailingStorage::wrap(storage);
+        let (writer, mut handle, _) =
+            create_writer_with_storage(failing.clone(), LogWriterConfig::default()).await;
+        let _task = handle.spawn(writer);
+
+        // Force the next apply call to fail.
+        failing.fail_apply(common::StorageError::Storage("delete failed".into()));
+
+        let result = handle.delete_segment_meta(1).await;
+        assert!(
+            matches!(&result, Err(crate::error::Error::Storage(msg)) if msg.contains("delete failed")),
+            "expected Storage error, got: {:?}",
+            result,
+        );
+    }
+
+    // ---- Retention tick tests ----
+    //
+    // These tests drive `tick_retention` directly on a non-spawned writer.
+    // That tests the policy logic in isolation; the periodic interval that
+    // calls into it from `run()` is tokio's responsibility.
+
+    use common::clock::MockClock;
+
+    fn retention_policy(secs: u64) -> RetentionPolicy {
+        RetentionPolicy {
+            retention: Duration::from_secs(secs),
+            check_interval: Duration::from_millis(1),
+        }
+    }
+
+    async fn create_writer_for_retention(
+        clock: Arc<MockClock>,
+        retention_secs: u64,
+    ) -> (LogWriter, LogWriteHandle, Arc<dyn common::Storage>) {
+        let storage = Arc::new(InMemoryStorage::default());
+        let config = LogWriterConfig {
+            retention: Some(retention_policy(retention_secs)),
+            ..LogWriterConfig::default()
+        };
+        create_writer_with_storage_and_clock(storage, clock, config).await
+    }
+
+    fn ms_after_epoch(secs: u64) -> i64 {
+        (secs as i64) * 1000
+    }
+
+    fn epoch_plus(secs: u64) -> std::time::SystemTime {
+        std::time::UNIX_EPOCH + Duration::from_secs(secs)
+    }
+
+    #[tokio::test]
+    async fn tick_retention_is_noop_when_no_segments() {
+        let clock = Arc::new(MockClock::with_time(epoch_plus(10_000)));
+        let (mut writer, _h, storage) = create_writer_for_retention(Arc::clone(&clock), 60).await;
+
+        writer.tick_retention().await;
+
+        use crate::storage::LogStorageRead as _;
+        let segs = storage.scan_segments(1..u32::MAX).await.unwrap();
+        assert_eq!(segs.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn tick_retention_skips_the_active_segment() {
+        // Active segment alone has no successor → no end-time → never expires.
+        let clock = Arc::new(MockClock::with_time(epoch_plus(10_000)));
+        let (mut writer, _h, storage) = create_writer_for_retention(Arc::clone(&clock), 60).await;
+
+        writer
+            .handle_append(LogWrite {
+                records: vec![UserRecord {
+                    key: Bytes::from("k"),
+                    value: Bytes::from("v"),
+                }],
+                timestamp_ms: ms_after_epoch(1_000),
+            })
+            .await
+            .unwrap();
+
+        clock.set_time(epoch_plus(100_000)); // far past any plausible retention
+        writer.tick_retention().await;
+
+        use crate::storage::LogStorageRead as _;
+        let segs = storage.scan_segments(1..u32::MAX).await.unwrap();
+        assert_eq!(segs.iter().map(|s| s.id()).collect::<Vec<_>>(), vec![1]);
+    }
+
+    #[tokio::test]
+    async fn tick_retention_keeps_sealed_segment_within_retention() {
+        // Segment 1 sealed at T=2000s, segment 2 active. At T=2030s with 60s
+        // retention, segment 1's end (2000s) is not yet older than 1970s.
+        let clock = Arc::new(MockClock::with_time(epoch_plus(2_030)));
+        let (mut writer, _h, storage) = create_writer_for_retention(Arc::clone(&clock), 60).await;
+        writer
+            .handle_append(LogWrite {
+                records: vec![UserRecord {
+                    key: Bytes::from("k"),
+                    value: Bytes::from("v"),
+                }],
+                timestamp_ms: ms_after_epoch(1_000),
+            })
+            .await
+            .unwrap();
+        writer
+            .handle_force_seal(ms_after_epoch(2_000))
+            .await
+            .unwrap();
+
+        writer.tick_retention().await;
+
+        use crate::storage::LogStorageRead as _;
+        let segs = storage.scan_segments(1..u32::MAX).await.unwrap();
+        assert_eq!(segs.iter().map(|s| s.id()).collect::<Vec<_>>(), vec![1, 2]);
+    }
+
+    #[tokio::test]
+    async fn tick_retention_deletes_expired_sealed_segment() {
+        // Segment 1 sealed at T=2000s (its successor's start). At T=10_000s
+        // with 60s retention, the cutoff is 9940s; segment 1's end (2000s)
+        // is well past expiry.
+        let clock = Arc::new(MockClock::with_time(epoch_plus(10_000)));
+        let (mut writer, _h, storage) = create_writer_for_retention(Arc::clone(&clock), 60).await;
+        writer
+            .handle_append(LogWrite {
+                records: vec![UserRecord {
+                    key: Bytes::from("k"),
+                    value: Bytes::from("v"),
+                }],
+                timestamp_ms: ms_after_epoch(1_000),
+            })
+            .await
+            .unwrap();
+        writer
+            .handle_force_seal(ms_after_epoch(2_000))
+            .await
+            .unwrap();
+
+        writer.tick_retention().await;
+
+        use crate::storage::LogStorageRead as _;
+        let segs = storage.scan_segments(1..u32::MAX).await.unwrap();
+        assert_eq!(segs.iter().map(|s| s.id()).collect::<Vec<_>>(), vec![2]);
+    }
+
+    #[tokio::test]
+    async fn tick_retention_deletes_all_expired_segments_in_one_tick() {
+        let clock = Arc::new(MockClock::with_time(epoch_plus(10_000)));
+        let (mut writer, _h, storage) = create_writer_for_retention(Arc::clone(&clock), 60).await;
+        writer
+            .handle_append(LogWrite {
+                records: vec![UserRecord {
+                    key: Bytes::from("k"),
+                    value: Bytes::from("v0"),
+                }],
+                timestamp_ms: ms_after_epoch(1_000),
+            })
+            .await
+            .unwrap();
+        writer
+            .handle_force_seal(ms_after_epoch(2_000))
+            .await
+            .unwrap();
+        writer
+            .handle_append(LogWrite {
+                records: vec![UserRecord {
+                    key: Bytes::from("k"),
+                    value: Bytes::from("v1"),
+                }],
+                timestamp_ms: ms_after_epoch(2_000),
+            })
+            .await
+            .unwrap();
+        writer
+            .handle_force_seal(ms_after_epoch(3_000))
+            .await
+            .unwrap();
+
+        writer.tick_retention().await;
+
+        use crate::storage::LogStorageRead as _;
+        let segs = storage.scan_segments(1..u32::MAX).await.unwrap();
+        // Both seg 1 (end 2000s) and seg 2 (end 3000s) are well past expiry.
+        assert_eq!(segs.iter().map(|s| s.id()).collect::<Vec<_>>(), vec![3]);
+    }
+
+    #[tokio::test]
+    async fn tick_retention_is_idempotent_across_ticks() {
+        let clock = Arc::new(MockClock::with_time(epoch_plus(10_000)));
+        let (mut writer, _h, storage) = create_writer_for_retention(Arc::clone(&clock), 60).await;
+        writer
+            .handle_append(LogWrite {
+                records: vec![UserRecord {
+                    key: Bytes::from("k"),
+                    value: Bytes::from("v"),
+                }],
+                timestamp_ms: ms_after_epoch(1_000),
+            })
+            .await
+            .unwrap();
+        writer
+            .handle_force_seal(ms_after_epoch(2_000))
+            .await
+            .unwrap();
+
+        writer.tick_retention().await;
+        writer.tick_retention().await; // second tick: cache no longer has seg 1
+
+        use crate::storage::LogStorageRead as _;
+        let segs = storage.scan_segments(1..u32::MAX).await.unwrap();
+        assert_eq!(segs.iter().map(|s| s.id()).collect::<Vec<_>>(), vec![2]);
+    }
+
+    #[tokio::test]
+    async fn tick_retention_advances_deletion_watermark() {
+        let clock = Arc::new(MockClock::with_time(epoch_plus(10_000)));
+        let (mut writer, handle, _storage) =
+            create_writer_for_retention(Arc::clone(&clock), 60).await;
+        let mut written_rx = handle.written_rx();
+        writer
+            .handle_append(LogWrite {
+                records: vec![UserRecord {
+                    key: Bytes::from("k"),
+                    value: Bytes::from("v"),
+                }],
+                timestamp_ms: ms_after_epoch(1_000),
+            })
+            .await
+            .unwrap();
+        writer
+            .handle_force_seal(ms_after_epoch(2_000))
+            .await
+            .unwrap();
+
+        writer.tick_retention().await;
+
+        let view = written_rx.borrow_and_update().clone();
+        assert_eq!(view.last_deleted_segment_id, Some(1));
+    }
+
+    #[tokio::test]
+    async fn tick_retention_does_nothing_when_disabled() {
+        // Build writer with retention = None. Even after segments are sealed,
+        // tick_retention should be a no-op (run() never calls it in this case,
+        // but invoking it directly should still be safe).
+        let storage = Arc::new(InMemoryStorage::default());
+        let clock: Arc<dyn Clock> = Arc::new(MockClock::with_time(epoch_plus(10_000)));
+        let (mut writer, _h, _storage) = create_writer_with_storage_and_clock(
+            storage.clone() as Arc<dyn common::Storage>,
+            clock,
+            LogWriterConfig::default(),
+        )
+        .await;
+        writer
+            .handle_append(LogWrite {
+                records: vec![UserRecord {
+                    key: Bytes::from("k"),
+                    value: Bytes::from("v"),
+                }],
+                timestamp_ms: ms_after_epoch(1_000),
+            })
+            .await
+            .unwrap();
+        writer
+            .handle_force_seal(ms_after_epoch(2_000))
+            .await
+            .unwrap();
+
+        writer.tick_retention().await;
+
+        use crate::storage::LogStorageRead as _;
+        let segs = (storage as Arc<dyn common::Storage>)
+            .scan_segments(1..u32::MAX)
+            .await
+            .unwrap();
+        assert_eq!(segs.iter().map(|s| s.id()).collect::<Vec<_>>(), vec![1, 2]);
     }
 
     #[tokio::test]

--- a/log/tests/reader_writer.rs
+++ b/log/tests/reader_writer.rs
@@ -3,12 +3,15 @@
 //! These tests verify that a LogDbReader can discover data written by a
 //! separate LogDb instance when using persistent storage.
 
-use std::time::Duration;
+use std::future::Future;
+use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use common::StorageConfig;
 use common::storage::config::{LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig};
-use log::{Config, LogDb, LogDbReader, LogRead, ReaderConfig, Record};
+use log::{
+    Config, LogDb, LogDbReader, LogRead, ReaderConfig, Record, RetentionConfig, SegmentConfig,
+};
 use tempfile::TempDir;
 
 fn local_storage_config(dir: &TempDir) -> StorageConfig {
@@ -20,6 +23,25 @@ fn local_storage_config(dir: &TempDir) -> StorageConfig {
         settings_path: None,
         block_cache: None,
     })
+}
+
+async fn wait_until<F, Fut>(timeout: Duration, interval: Duration, mut predicate: F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let deadline = Instant::now() + timeout;
+    loop {
+        if predicate().await {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "condition was not satisfied within {:?}",
+            timeout
+        );
+        tokio::time::sleep(interval).await;
+    }
 }
 
 #[tokio::test]
@@ -143,6 +165,119 @@ async fn reader_discovers_new_data_after_initial_open() {
     assert_eq!(entry.value, Bytes::from("event-1"));
 
     // Clean up
+    reader.close().await;
+    writer.close().await.expect("Failed to close writer");
+}
+
+#[tokio::test]
+async fn reader_drops_expired_segments_after_retention_deletes_metadata() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage = local_storage_config(&temp_dir);
+
+    let writer = LogDb::open(Config {
+        storage: storage.clone(),
+        segmentation: SegmentConfig {
+            seal_interval: Some(Duration::from_millis(100)),
+        },
+        retention: RetentionConfig {
+            retention: Some(Duration::from_millis(100)),
+            check_interval: Duration::from_millis(20),
+        },
+        ..Default::default()
+    })
+    .await
+    .expect("Failed to open writer");
+
+    let key = Bytes::from("retained-key");
+    writer
+        .try_append(vec![Record {
+            key: key.clone(),
+            value: Bytes::from("value-0"),
+        }])
+        .await
+        .expect("Failed to append first record");
+    writer.flush().await.expect("Failed to flush first record");
+
+    tokio::time::sleep(Duration::from_millis(120)).await;
+
+    writer
+        .try_append(vec![Record {
+            key: key.clone(),
+            value: Bytes::from("value-1"),
+        }])
+        .await
+        .expect("Failed to append second record");
+    writer.flush().await.expect("Failed to flush second record");
+
+    let reader = LogDbReader::open(ReaderConfig {
+        storage,
+        refresh_interval: Duration::from_millis(20),
+    })
+    .await
+    .expect("Failed to open reader");
+
+    wait_until(
+        Duration::from_secs(2),
+        Duration::from_millis(20),
+        || async {
+            reader
+                .list_segments(..)
+                .await
+                .map(|segments| segments.len() == 2)
+                .unwrap_or(false)
+        },
+    )
+    .await;
+
+    let mut iter = reader
+        .scan(key.clone(), ..)
+        .await
+        .expect("Failed to scan before retention");
+    let first = iter
+        .next()
+        .await
+        .expect("Failed to read first entry")
+        .expect("Expected first entry");
+    let second = iter
+        .next()
+        .await
+        .expect("Failed to read second entry")
+        .expect("Expected second entry");
+    assert_eq!(first.value, Bytes::from("value-0"));
+    assert_eq!(second.value, Bytes::from("value-1"));
+    assert!(iter.next().await.expect("Failed to finish scan").is_none());
+
+    wait_until(
+        Duration::from_secs(2),
+        Duration::from_millis(20),
+        || async {
+            reader
+                .list_segments(..)
+                .await
+                .map(|segments| segments.len() == 1)
+                .unwrap_or(false)
+        },
+    )
+    .await;
+
+    let mut iter = reader
+        .scan(key, ..)
+        .await
+        .expect("Failed to scan after retention");
+    let remaining = iter
+        .next()
+        .await
+        .expect("Failed to read retained entry")
+        .expect("Expected retained entry");
+    assert_eq!(remaining.sequence, 1);
+    assert_eq!(remaining.value, Bytes::from("value-1"));
+    assert!(
+        iter.next()
+            .await
+            .expect("Failed to finish retained scan")
+            .is_none()
+    );
+
     reader.close().await;
     writer.close().await.expect("Failed to close writer");
 }

--- a/log/tests/retention_config.rs
+++ b/log/tests/retention_config.rs
@@ -1,0 +1,95 @@
+//! End-to-end validation that retention/segmentation config rules from
+//! RFC 0005 surface as `Error::InvalidInput` through `LogDb::open`.
+
+use std::time::Duration;
+
+use common::StorageConfig;
+use log::{Config, Error, LogCompactionOptions, LogDb, RetentionConfig, SegmentConfig};
+
+fn in_memory_with(retention: Option<Duration>, seal_interval: Option<Duration>) -> Config {
+    Config {
+        storage: StorageConfig::InMemory,
+        segmentation: SegmentConfig { seal_interval },
+        retention: RetentionConfig {
+            retention,
+            ..RetentionConfig::default()
+        },
+        ..Config::default()
+    }
+}
+
+#[tokio::test]
+async fn open_rejects_retention_without_seal_interval() {
+    // given
+    let config = in_memory_with(Some(Duration::from_secs(60)), None);
+
+    // when
+    let err = match LogDb::open(config).await {
+        Ok(_) => panic!("expected Err"),
+        Err(e) => e,
+    };
+
+    // then
+    assert!(
+        matches!(&err, Error::InvalidInput(msg) if msg.contains("seal_interval")),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn open_rejects_retention_smaller_than_seal_interval() {
+    // given
+    let config = in_memory_with(Some(Duration::from_secs(30)), Some(Duration::from_secs(60)));
+
+    // when
+    let err = match LogDb::open(config).await {
+        Ok(_) => panic!("expected Err"),
+        Err(e) => e,
+    };
+
+    // then
+    assert!(
+        matches!(&err, Error::InvalidInput(msg) if msg.contains("at least as large")),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn open_accepts_retention_equal_to_seal_interval() {
+    let config = in_memory_with(Some(Duration::from_secs(60)), Some(Duration::from_secs(60)));
+    let log = LogDb::open(config)
+        .await
+        .expect("retention == seal_interval should be accepted");
+    log.close().await.expect("close failed");
+}
+
+#[tokio::test]
+async fn open_rejects_min_l0_above_max_l0() {
+    let config = Config {
+        storage: StorageConfig::InMemory,
+        compaction: LogCompactionOptions {
+            min_l0_per_compaction: 10,
+            max_l0_per_compaction: 5,
+        },
+        ..Config::default()
+    };
+
+    let err = match LogDb::open(config).await {
+        Ok(_) => panic!("expected Err"),
+        Err(e) => e,
+    };
+
+    assert!(
+        matches!(&err, Error::InvalidInput(msg) if msg.contains("min_l0_per_compaction")),
+        "unexpected error: {err}"
+    );
+}
+
+#[tokio::test]
+async fn open_accepts_retention_disabled() {
+    // Default config: no retention, no seal_interval. Must build cleanly.
+    let log = LogDb::open(Config::default())
+        .await
+        .expect("default config should open");
+    log.close().await.expect("close failed");
+}

--- a/log/tests/retention_slatedb_smoke.rs
+++ b/log/tests/retention_slatedb_smoke.rs
@@ -1,0 +1,75 @@
+//! Smoke test confirming the SlateDB-backed `LogDbBuilder` path doesn't
+//! crash with retention + compaction options configured. Does not observe
+//! drains — policy correctness is covered by the unit tests in `compaction.rs`.
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use common::StorageConfig;
+use common::storage::config::{LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig};
+use log::{Config, LogCompactionOptions, LogDb, LogRead, Record, RetentionConfig, SegmentConfig};
+use tempfile::TempDir;
+
+fn local_storage_config(dir: &TempDir) -> StorageConfig {
+    StorageConfig::SlateDb(SlateDbStorageConfig {
+        path: "log-data".to_string(),
+        object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
+            path: dir.path().to_string_lossy().to_string(),
+        }),
+        settings_path: None,
+        block_cache: None,
+    })
+}
+
+#[tokio::test]
+async fn slatedb_open_with_retention_and_compaction_options() {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let config = Config {
+        storage: local_storage_config(&temp_dir),
+        segmentation: SegmentConfig {
+            seal_interval: Some(Duration::from_secs(3600)),
+        },
+        retention: RetentionConfig {
+            retention: Some(Duration::from_secs(86400)),
+            check_interval: Duration::from_secs(60),
+        },
+        compaction: LogCompactionOptions::default(),
+        ..Config::default()
+    };
+
+    let log = LogDb::open(config).await.expect("LogDb::open failed");
+
+    log.try_append(vec![Record {
+        key: Bytes::from("k"),
+        value: Bytes::from("v"),
+    }])
+    .await
+    .expect("append failed");
+    log.flush().await.expect("flush failed");
+
+    let segments = log.list_segments(..).await.expect("list_segments failed");
+    assert_eq!(segments.len(), 1);
+
+    log.close().await.expect("close failed");
+}
+
+#[tokio::test]
+async fn slatedb_open_without_retention_still_wires_compactor() {
+    // Compaction strategy runs unconditionally (RFC 0005), so the scheduler
+    // must still wire cleanly when retention is disabled.
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let config = Config {
+        storage: local_storage_config(&temp_dir),
+        ..Config::default()
+    };
+
+    let log = LogDb::open(config).await.expect("LogDb::open failed");
+    log.try_append(vec![Record {
+        key: Bytes::from("k"),
+        value: Bytes::from("v"),
+    }])
+    .await
+    .expect("append failed");
+    log.flush().await.expect("flush failed");
+    log.close().await.expect("close failed");
+}


### PR DESCRIPTION
Implements compaction/retention semantics according to the specification in [RFC 5](https://github.com/opendata-oss/opendata/blob/main/log/rfcs/0005-compaction-and-retention.md). Mostly a mechanical implementation. The main notable detail that is worth reviewing is the path to propagate segment changes from the writer to the compactor. We make use of the same durable epoch bookkeeping that the reader uses, but we need a separate task to decouple it from the reader's visibility configuration.