### PR TITLE
Log: consolidate log versions

### DIFF
--- a/log/rfcs/0002-logical-segmentation.md
+++ b/log/rfcs/0002-logical-segmentation.md
@@ -235,4 +235,3 @@ This would enable use cases such as:
 |------------|-------------|
 | 2026-01-07 | Initial draft |
 | 2026-01-12 | Added link to varint implementation |
-| 2026-05-19 | Key format v2: `segment_id` precedes `record_type`; system segment (id 0) reserved for `SeqBlock` and `SegmentMeta` records; user segments start at id 1. Enables a fixed 6-byte SlateDB segment-extractor prefix that routes every per-segment record (entries + listings) to the same SlateDB segment. |

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -340,7 +340,7 @@ impl LogReadView {
     /// Lists distinct keys within a segment range.
     ///
     /// Stitches per-segment scans together by walking the segment cache —
-    /// the v2 key layout interleaves listings with log entries across
+    /// the key layout interleaves listings with log entries across
     /// segment boundaries, so a single wide-range storage scan is not safe.
     pub(crate) async fn list_keys(
         &self,

--- a/log/src/segment_extractor.rs
+++ b/log/src/segment_extractor.rs
@@ -1,6 +1,6 @@
 //! SlateDB segment extractor for the log subsystem.
 //!
-//! Implements [`slatedb::PrefixExtractor`] over the v2 log key layout, mapping
+//! Implements [`slatedb::PrefixExtractor`] over the log key layout, mapping
 //! every record to the 6-byte routing prefix `[subsystem, version, segment_id]`.
 //! When configured on the `slatedb::DbBuilder`, the extractor causes SlateDB
 //! to route writes for each LogDb segment into its own SlateDB segment, so the
@@ -37,7 +37,7 @@ const ROUTING_PREFIX_LEN: usize = 6;
 /// Stable, persisted identifier for this extractor's routing rules.
 /// Bump whenever the routing logic changes in a way that would re-route
 /// existing keys (e.g. a new `KEY_VERSION` with a different prefix shape).
-const EXTRACTOR_NAME: &str = "opendata-log/v2";
+const EXTRACTOR_NAME: &str = "opendata-log/v1";
 
 /// Prefix extractor routing log records to per-segment SlateDB segments.
 ///
@@ -128,7 +128,7 @@ mod tests {
         let extractor = LogSegmentExtractor;
 
         // when / then — must match the persisted manifest value
-        assert_eq!(extractor.name(), "opendata-log/v2");
+        assert_eq!(extractor.name(), "opendata-log/v1");
     }
 
     #[test]
@@ -341,9 +341,9 @@ mod integration_tests {
     use crate::model::Record;
     use crate::reader::LogRead;
 
-    const EXPECTED_EXTRACTOR_NAME: &str = "opendata-log/v2";
+    const EXPECTED_EXTRACTOR_NAME: &str = "opendata-log/v1";
     const LOG_SUBSYSTEM: u8 = 0x03;
-    const LOG_KEY_VERSION: u8 = 0x02;
+    const LOG_KEY_VERSION: u8 = 0x01;
     const SYSTEM_SEGMENT_ID: u32 = 0;
 
     fn slatedb_storage_config(temp_dir: &TempDir) -> (StorageConfig, SlateDbStorageConfig) {

--- a/log/src/serde.rs
+++ b/log/src/serde.rs
@@ -67,8 +67,8 @@ impl From<common::serde::DeserializeError> for Error {
     }
 }
 
-/// Key format version (currently 0x02 — segment_id precedes record_type).
-pub const KEY_VERSION: u8 = 0x02;
+/// Key format version for log storage.
+pub const KEY_VERSION: u8 = 0x01;
 
 /// Subsystem byte for log storage (see [`common::serde::subsystem`]).
 pub const SUBSYSTEM: u8 = common::serde::subsystem::LOG;
@@ -144,10 +144,10 @@ const SEGMENT_ID_OFFSET: usize = KEY_PREFIX_LEN;
 /// Offset of the record-type tag byte inside a log key, after the segment id.
 const RECORD_TYPE_OFFSET: usize = SEGMENT_ID_OFFSET + 4;
 
-/// Length of the v2 segmented key prefix: `[subsystem, version, seg_id(4), record_type]`.
+/// Length of the segmented key prefix: `[subsystem, version, seg_id(4), record_type]`.
 const SEGMENTED_PREFIX_LEN: usize = RECORD_TYPE_OFFSET + 1;
 
-/// Writes the v2 segmented prefix into `buf`:
+/// Writes the segmented prefix into `buf`:
 /// `[subsystem, version, seg_id BE, record_type]`.
 fn write_segmented_prefix(buf: &mut BytesMut, segment_id: SegmentId, record_type: u8) {
     KeyPrefix::new(SUBSYSTEM, KEY_VERSION).write_to(buf);
@@ -155,7 +155,7 @@ fn write_segmented_prefix(buf: &mut BytesMut, segment_id: SegmentId, record_type
     buf.put_u8(record_type);
 }
 
-/// Parses a v2 segmented prefix, validating the subsystem/version/tag.
+/// Parses a segmented prefix, validating the subsystem/version/tag.
 /// Returns the segment id along with the remaining (post-prefix) bytes.
 fn parse_segmented_prefix(data: &[u8], expected_tag: u8) -> Result<(SegmentId, &[u8]), Error> {
     KeyPrefix::from_bytes_with_validation(data, SUBSYSTEM, KEY_VERSION)?;
@@ -452,7 +452,7 @@ impl ListingEntryKey {
 
     /// Creates a storage key range for scanning listing entries within a
     /// single segment. Cross-segment iteration is the caller's responsibility:
-    /// the v2 layout interleaves listing records with log entries across
+    /// the key layout interleaves listing records with log entries across
     /// segment boundaries, so a wide cross-segment range scan is not safe.
     pub fn scan_range_for_segment(segment_id: SegmentId) -> BytesRange {
         BytesRange::prefix(Self::segment_prefix(segment_id))

--- a/log/src/storage.rs
+++ b/log/src/storage.rs
@@ -27,7 +27,7 @@ pub(crate) trait LogStorageRead: StorageRead {
     /// Returns the keys present in a single segment.
     ///
     /// Listing records are interleaved with log entries across segment
-    /// boundaries in the v2 layout, so cross-segment listing scans aren't
+    /// boundaries in the key layout, so cross-segment listing scans aren't
     /// safe at the storage layer. Callers wanting to enumerate keys across
     /// multiple segments stitch per-segment results together using the
     /// segment cache. See [`crate::reader::LogReadView::list_keys`].

--- a/rfcs/0001-record-key-prefix.md
+++ b/rfcs/0001-record-key-prefix.md
@@ -99,7 +99,7 @@ Two things led us away from it:
    A common byte-2 record tag is incompatible with that layout.
 
 Subsystems that want a record-type discriminator are free to keep one — they just choose where it sits.
-Timeseries, vector, and keyvalue still place a tag at byte 2; the log subsystem (v2 onwards) places its tag after a 4-byte segment id.
+Timeseries, vector, and keyvalue still place a tag at byte 2; the log subsystem places its tag after a 4-byte segment id.
 
 ### Shared prefix version
 


### PR DESCRIPTION
The previous patch which updated the Log for segmentation unnecessarily introduced a v2 bump. Since we have not actually released, we may as well keep everything on v1. 