### PR TITLE
Log: use prefix bloom filters

### DIFF
--- a/common/src/serde/terminated_bytes.rs
+++ b/common/src/serde/terminated_bytes.rs
@@ -121,6 +121,41 @@ pub fn deserialize(buf: &mut &[u8]) -> Result<Bytes, DeserializeError> {
     })
 }
 
+/// Returns the position just past the terminator that closes a
+/// terminated-bytes-encoded segment within `bytes`, starting the scan at
+/// `start`.
+///
+/// Walks the encoded stream byte-by-byte, treating `ESCAPE_BYTE` (`0x01`)
+/// as an escape that consumes the following byte regardless of value, and
+/// stopping at the first `TERMINATOR_BYTE` (`0x00`) outside an escape
+/// sequence. Returns `None` if the input ends before the terminator is
+/// reached, including the case where the last byte is the start of an
+/// escape sequence (truncation-unsafe — the next byte could shift the
+/// terminator's position).
+///
+/// Unlike [`deserialize`], this function does not decode the payload — it
+/// only locates the boundary. Callers that need just the end offset (e.g.
+/// a prefix extractor sizing a hashable prefix) can use this without
+/// allocating.
+pub fn find_terminator_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut i = start;
+    while i < bytes.len() {
+        match bytes[i] {
+            TERMINATOR_BYTE => return Some(i + 1),
+            ESCAPE_BYTE => {
+                // Escape byte consumes the next byte. If the stream ends
+                // mid-escape we cannot decide where the terminator lands.
+                i += 2;
+                if i > bytes.len() {
+                    return None;
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    None
+}
+
 /// Creates a [`BytesRange`] for scanning all keys with the given logical prefix.
 ///
 /// The prefix is first incremented using `lex_increment`, then both bounds
@@ -258,6 +293,83 @@ mod tests {
 
         assert_eq!(decoded.as_ref(), b"a");
         assert_eq!(slice, &[0xDE, 0xAD]);
+    }
+
+    #[test]
+    fn should_find_terminator_end_on_simple_input() {
+        // given — serialize "abc" so we know exactly where the terminator lands
+        let mut buf = BytesMut::new();
+        serialize(b"abc", &mut buf);
+        // expected layout: 'a' 'b' 'c' 0x00 (4 bytes)
+
+        // when / then — the terminator end sits one byte past the terminator
+        assert_eq!(find_terminator_end(&buf, 0), Some(4));
+    }
+
+    #[test]
+    fn should_find_terminator_end_skipping_escaped_zero_byte() {
+        // given — payload contains 0x00 which encodes to 0x01 0x01, then "x",
+        // then the real terminator. The inner 0x01 must NOT be mistaken for
+        // the terminator.
+        let mut buf = BytesMut::new();
+        serialize(&[0x00, b'x'], &mut buf);
+        // layout: 0x01 0x01 'x' 0x00 (4 bytes)
+
+        // when / then
+        assert_eq!(find_terminator_end(&buf, 0), Some(4));
+    }
+
+    #[test]
+    fn should_find_terminator_end_skipping_escaped_escape_byte() {
+        // given — payload contains 0x01 which encodes to 0x01 0x02. The 0x02
+        // looks innocuous but the escape pair must be consumed atomically so
+        // the position is correctly tracked.
+        let mut buf = BytesMut::new();
+        serialize(&[0x01, b'x'], &mut buf);
+        // layout: 0x01 0x02 'x' 0x00 (4 bytes)
+
+        // when / then
+        assert_eq!(find_terminator_end(&buf, 0), Some(4));
+    }
+
+    #[test]
+    fn should_find_terminator_end_from_offset_start() {
+        // given — a synthetic header followed by an encoded payload. Searching
+        // from offset 3 skips past the header bytes (which may legally contain
+        // 0x00).
+        let mut buf = BytesMut::from(&[0x00, 0xFF, 0x42][..]);
+        serialize(b"key", &mut buf);
+        // layout: [00 FF 42] [k e y 00]; payload terminator at index 6, end at 7
+
+        // when / then
+        assert_eq!(find_terminator_end(&buf, 3), Some(7));
+    }
+
+    #[test]
+    fn should_return_none_when_terminator_absent() {
+        // given — bytes without a terminator
+        let bytes: &[u8] = b"abc";
+
+        // when / then
+        assert_eq!(find_terminator_end(bytes, 0), None);
+    }
+
+    #[test]
+    fn should_return_none_when_input_ends_mid_escape() {
+        // given — last byte is the escape byte itself
+        let bytes: &[u8] = &[b'a', ESCAPE_BYTE];
+
+        // when / then
+        assert_eq!(find_terminator_end(bytes, 0), None);
+    }
+
+    #[test]
+    fn should_return_none_when_start_is_past_end() {
+        // given
+        let bytes: &[u8] = &[0x00];
+
+        // when / then
+        assert_eq!(find_terminator_end(bytes, 5), None);
     }
 
     #[test]

--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -10,7 +10,6 @@ use super::in_memory::InMemoryStorage;
 use super::metrics_recorder::{MetricsRsRecorder, MixtricsBridge as MetricsRsRegistry};
 use super::slate::{SlateDbStorage, SlateDbStorageReader};
 use super::{MergeOperator, Storage, StorageError, StorageRead, StorageResult};
-use slatedb::DbReader;
 use slatedb::config::Settings;
 pub use slatedb::db_cache::CachedEntry;
 pub use slatedb::db_cache::foyer::{FoyerCache, FoyerCacheOptions};
@@ -18,6 +17,7 @@ pub use slatedb::db_cache::foyer_hybrid::FoyerHybridCache;
 use slatedb::db_cache::{CachedKey, DbCache};
 use slatedb::object_store::{self, ObjectStore};
 pub use slatedb::{CompactorBuilder, DbBuilder};
+use slatedb::{DbReader, FilterPolicy};
 use tracing::info;
 use uuid::Uuid;
 
@@ -162,6 +162,9 @@ impl StorageBuilder {
                     let adapter = SlateDbStorage::merge_operator_adapter(op);
                     db_builder = db_builder.with_merge_operator(Arc::new(adapter));
                 }
+                if let Some(policies) = self.semantics.filter_policies {
+                    db_builder = db_builder.with_filter_policies(policies);
+                }
                 let db = db_builder.build().await.map_err(|e| {
                     StorageError::Storage(format!("Failed to create SlateDB: {}", e))
                 })?;
@@ -247,6 +250,7 @@ impl StorageReaderRuntime {
 #[derive(Default)]
 pub struct StorageSemantics {
     pub(crate) merge_operator: Option<Arc<dyn MergeOperator>>,
+    pub(crate) filter_policies: Option<Vec<Arc<dyn FilterPolicy>>>,
 }
 
 impl StorageSemantics {
@@ -261,6 +265,15 @@ impl StorageSemantics {
     /// Each system (timeseries, vector) defines its own merge semantics.
     pub fn with_merge_operator(mut self, op: Arc<dyn MergeOperator>) -> Self {
         self.merge_operator = Some(op);
+        self
+    }
+
+    /// Sets the filter policies for SlateDB writers and readers.
+    ///
+    /// System crates use this to keep the writer, compactor, and standalone
+    /// reader paths aligned on SST filter encoding/decoding behavior.
+    pub fn with_filter_policies(mut self, policies: Vec<Arc<dyn FilterPolicy>>) -> Self {
+        self.filter_policies = Some(policies);
         self
     }
 }
@@ -346,6 +359,9 @@ pub async fn create_storage_read(
             if let Some(op) = semantics.merge_operator {
                 let adapter = SlateDbStorage::merge_operator_adapter(op);
                 builder = builder.with_merge_operator(Arc::new(adapter));
+            }
+            if let Some(policies) = semantics.filter_policies {
+                builder = builder.with_filter_policies(policies);
             }
             // Prefer runtime-provided cache, fall back to config. The
             // runtime-provided cache is owned by the caller, so we don't hold

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -240,6 +240,24 @@ pub trait StorageRead: Send + Sync {
         range: BytesRange,
     ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>>;
 
+    /// Returns an iterator over records whose key starts with `prefix`.
+    ///
+    /// Backends that support prefix-aware bloom filters (e.g. SlateDB with a
+    /// configured `PrefixExtractor`) consult those filters here, allowing
+    /// SSTs that contain no matching keys to be skipped without a block
+    /// read. Backends without such filters fall back to a range scan over
+    /// the prefix.
+    ///
+    /// The default implementation delegates to [`Self::scan_iter`] with
+    /// the range derived from the prefix, which preserves correctness for
+    /// any backend; backends that can do better should override this.
+    async fn scan_prefix_iter(
+        &self,
+        prefix: Bytes,
+    ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>> {
+        self.scan_iter(BytesRange::prefix(prefix)).await
+    }
+
     /// Collects all records in the range into a Vec.
     #[tracing::instrument(level = "trace", skip_all)]
     async fn scan(&self, range: BytesRange) -> StorageResult<Vec<Record>> {

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -171,6 +171,22 @@ impl StorageRead for SlateDbStorage {
         Ok(Box::new(SlateDbIterator { iter }))
     }
 
+    /// Slatedb consults its SST-level filters on `scan_prefix` but not on
+    /// `scan`, so routing prefix scans through this path is what lets a
+    /// configured `PrefixExtractor` actually skip SSTs.
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn scan_prefix_iter(
+        &self,
+        prefix: Bytes,
+    ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>> {
+        let iter = self
+            .db
+            .scan_prefix_with_options(prefix, &default_scan_options())
+            .await
+            .map_err(StorageError::from_storage)?;
+        Ok(Box::new(SlateDbIterator { iter }))
+    }
+
     async fn close(&self) -> StorageResult<()> {
         // Stop durable bridge first so no status subscriber outlives DB close.
         self.durable_bridge_abort.abort();
@@ -234,6 +250,19 @@ impl StorageRead for SlateDbStorageSnapshot {
         let iter = self
             .snapshot
             .scan_with_options(range, &default_scan_options())
+            .await
+            .map_err(StorageError::from_storage)?;
+        Ok(Box::new(SlateDbIterator { iter }))
+    }
+
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn scan_prefix_iter(
+        &self,
+        prefix: Bytes,
+    ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>> {
+        let iter = self
+            .snapshot
+            .scan_prefix_with_options(prefix, &default_scan_options())
             .await
             .map_err(StorageError::from_storage)?;
         Ok(Box::new(SlateDbIterator { iter }))
@@ -443,6 +472,19 @@ impl StorageRead for SlateDbStorageReader {
         let iter = self
             .reader
             .scan_with_options(range, &default_scan_options())
+            .await
+            .map_err(StorageError::from_storage)?;
+        Ok(Box::new(SlateDbIterator { iter }))
+    }
+
+    #[tracing::instrument(level = "trace", skip_all)]
+    async fn scan_prefix_iter(
+        &self,
+        prefix: Bytes,
+    ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>> {
+        let iter = self
+            .reader
+            .scan_prefix_with_options(prefix, &default_scan_options())
             .await
             .map_err(StorageError::from_storage)?;
         Ok(Box::new(SlateDbIterator { iter }))

--- a/log/src/filter_prefix.rs
+++ b/log/src/filter_prefix.rs
@@ -53,7 +53,7 @@
 use std::sync::Arc;
 
 use common::serde::terminated_bytes;
-use slatedb::{PrefixExtractor, PrefixTarget};
+use slatedb::{BloomFilterPolicy, FilterPolicy, PrefixExtractor, PrefixTarget};
 
 use crate::serde::{
     KEY_VERSION, RECORD_TYPE_OFFSET, RecordType, SEGMENT_META_KEY_LEN, SEGMENTED_PREFIX_LEN,
@@ -91,6 +91,16 @@ impl LogKeyPrefixExtractor {
     pub(crate) fn shared() -> Arc<dyn PrefixExtractor> {
         Arc::new(Self)
     }
+}
+
+/// Returns the filter policy set that must be shared by LogDb writers,
+/// compactors, and standalone readers.
+pub(crate) fn bloom_filter_policies() -> Vec<Arc<dyn FilterPolicy>> {
+    vec![Arc::new(
+        BloomFilterPolicy::new(10)
+            .with_prefix_extractor(LogKeyPrefixExtractor::shared())
+            .with_whole_key_filtering(false),
+    )]
 }
 
 /// Returns true if the buffer is a syntactically well-formed log key

--- a/log/src/key_extractor.rs
+++ b/log/src/key_extractor.rs
@@ -1,0 +1,790 @@
+//! Bloom-filter prefix extractor for the log key space.
+//!
+//! Implements [`slatedb::PrefixExtractor`] over the v2 log key layout to
+//! drive a prefix-aware [`slatedb::filter_policy::BloomFilterPolicy`]. The
+//! filter hashes every LogDb logical key (the `(segment, user_key)` pair)
+//! without the trailing `var_u64(relative_seq)`, so that SSTs containing no
+//! entries for a queried `(segment, user_key)` can be skipped without a
+//! block read. Slatedb dedups consecutive same-prefix hashes during SST
+//! construction, so a segment containing N entries for the same user key
+//! contributes a single stored hash to the filter.
+//!
+//! See `slatedb::prefix_extractor::PrefixExtractor` for the contract this
+//! impl satisfies, and `log/src/segment_extractor.rs` for the *segment*
+//! extractor — a separate slatedb axis that partitions the LSM physically
+//! and uses a different (shorter) prefix.
+//!
+//! # Properties this extractor must satisfy
+//!
+//! 1. **Length cap.** `prefix_len` returning `Some(n)` requires `n <=
+//!    input.len()`. Slatedb asserts this at SST-build time; violation
+//!    panics inside the SST builder.
+//!
+//! 2. **Truncation invariant for `Prefix` targets.** If
+//!    `prefix_len(Prefix(p)) = Some(n)`, then for every extension `q` of
+//!    `p`, `prefix_len(Point(q)) = Some(n)` and `q[..n] == p[..n]`. When
+//!    this cannot be guaranteed (e.g., the terminator hasn't been seen
+//!    yet, or the record type has no delimiter at all) we return `None`
+//!    so slatedb skips the filter for that scan — correct, just no
+//!    skip-benefit. Violating this would surface as a filter false
+//!    negative for stored keys.
+//!
+//! 3. **No false negatives on stored keys.** A corollary of (2): every
+//!    key fed to `add_key` must, on a `might_match(Point(k))` probe
+//!    afterward, report "might match". With `whole_key_filtering=false`
+//!    the probe uses the extracted prefix, so this reduces to "the
+//!    extractor returns the same `n` for build-time `Point(k)` and
+//!    query-time `Point(k)` calls" — i.e., the extractor is
+//!    deterministic on identical inputs. Trivially satisfied here.
+//!
+//! See [`tests::proptests`] for these properties exercised against random
+//! `(segment, user_key, seq)` triples.
+//!
+//! # Naming
+//!
+//! The extractor's [`name`](slatedb::PrefixExtractor::name) is encoded into
+//! every filter block via the `BloomFilterPolicy`'s composite name. Readers
+//! match the persisted name against the configured policy before decoding;
+//! a mismatch causes the filter sub-block to be ignored and the SST is
+//! scanned without filter help (correct, just slower). Bump the name
+//! whenever the LogEntry key shape changes in a way that would alter the
+//! extracted bytes.
+
+use std::sync::Arc;
+
+use common::serde::terminated_bytes;
+use slatedb::{PrefixExtractor, PrefixTarget};
+
+use crate::serde::{
+    KEY_VERSION, RECORD_TYPE_OFFSET, RecordType, SEGMENT_META_KEY_LEN, SEGMENTED_PREFIX_LEN,
+    SUBSYSTEM,
+};
+
+/// Stable, persisted identifier for the bytes this extractor produces.
+/// Distinct from the segment extractor's `"opendata-log/v2"` because they
+/// are independent slatedb features (filter policy vs. segment routing).
+const EXTRACTOR_NAME: &str = "opendata-log/v2/key-prefix";
+
+/// Extracts the prefix of a log key up to and including the user key.
+///
+/// Dispatches on the record-type byte at offset 6:
+///
+/// - `LogEntry (0x10)` — variable region is `[terminated_user_key,
+///   var_u64(relative_seq)]`. The extractor finds the first unescaped
+///   `0x00` (the terminator that closes the user key) starting at offset
+///   `SEGMENTED_PREFIX_LEN` and returns its position + 1. Removing the
+///   sequence varint from the hashed prefix lets the SST builder dedupe
+///   all entries for a given `(segment, user_key)` down to a single
+///   stored hash.
+/// - `SeqBlock (0x20)` — fixed 7-byte key, no variable suffix; the prefix
+///   *is* the whole key.
+/// - `SegmentMeta (0x30)` — fixed 11-byte key (segmented prefix + 4-byte
+///   described-segment-id suffix); whole key.
+/// - `ListingEntry (0x40)` — variable suffix without a terminator. Whole
+///   key for `Point`; `None` for `Prefix` (truncation-unsafe — any
+///   extension is a strictly longer key with a longer extracted length,
+///   violating the trait's prefix-extension invariant).
+///
+/// Unknown or malformed inputs panic for `Point` (LogDb bug) and return
+/// `None` for `Prefix` (caller-supplied, benign).
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct LogKeyPrefixExtractor;
+
+impl LogKeyPrefixExtractor {
+    /// Returns a shared `Arc<dyn PrefixExtractor>` for handing to
+    /// `slatedb::filter_policy::BloomFilterPolicy::with_prefix_extractor`.
+    pub(crate) fn shared() -> Arc<dyn PrefixExtractor> {
+        Arc::new(Self)
+    }
+}
+
+/// Returns true if the buffer is a syntactically well-formed log key
+/// prefix up to (and including) the record-type byte: matches `SUBSYSTEM`,
+/// `KEY_VERSION`, and has the segment id + tag bytes present.
+fn has_segmented_prefix(bytes: &[u8]) -> bool {
+    bytes.len() >= SEGMENTED_PREFIX_LEN && bytes[0] == SUBSYSTEM && bytes[1] == KEY_VERSION
+}
+
+/// Decodes the record-type byte at offset 6 into a [`RecordType`]. The high
+/// nibble holds the type id; the low nibble is reserved (currently 0 for
+/// every log record). Returns `None` if the id is unknown.
+fn decode_record_type(tag_byte: u8) -> Option<RecordType> {
+    RecordType::from_id((tag_byte & 0xF0) >> 4).ok()
+}
+
+/// Computes the prefix length for a `Point` target — a stored key or
+/// point-lookup target. Panics on malformed inputs: an SST builder reaching
+/// here with a non-log key is a LogDb bug, and surfacing it as a panic
+/// gives a useful stack trace at the bug's origin.
+fn prefix_len_for_point(bytes: &[u8]) -> usize {
+    assert!(
+        has_segmented_prefix(bytes),
+        "LogKeyPrefixExtractor: malformed log key (subsystem/version mismatch \
+         or under {} bytes): {:02x?}",
+        SEGMENTED_PREFIX_LEN,
+        bytes,
+    );
+
+    let tag = bytes[RECORD_TYPE_OFFSET];
+    let record_type = decode_record_type(tag).unwrap_or_else(|| {
+        panic!(
+            "LogKeyPrefixExtractor: unknown record-type tag 0x{:02x} in key: {:02x?}",
+            tag, bytes,
+        )
+    });
+    match record_type {
+        RecordType::LogEntry => terminated_bytes::find_terminator_end(bytes, SEGMENTED_PREFIX_LEN)
+            .expect("LogKeyPrefixExtractor: LogEntry key missing terminated_bytes terminator"),
+        RecordType::SeqBlock => SEGMENTED_PREFIX_LEN,
+        RecordType::SegmentMeta => {
+            assert!(
+                bytes.len() >= SEGMENT_META_KEY_LEN,
+                "LogKeyPrefixExtractor: SegmentMeta key shorter than {} bytes: {:02x?}",
+                SEGMENT_META_KEY_LEN,
+                bytes,
+            );
+            SEGMENT_META_KEY_LEN
+        }
+        RecordType::ListingEntry => bytes.len(),
+    }
+}
+
+/// Computes the prefix length for a `Prefix` target — a caller-supplied
+/// scan prefix. Returns `None` for any case where the truncation invariant
+/// (`prefix_len(Prefix(p)) = Some(n)` ⇒ every extension `q` has
+/// `prefix_len(Point(q)) = Some(n)` and `q[..n] == p[..n]`) cannot be
+/// guaranteed.
+fn prefix_len_for_prefix(bytes: &[u8]) -> Option<usize> {
+    if !has_segmented_prefix(bytes) {
+        return None;
+    }
+
+    let tag = bytes[RECORD_TYPE_OFFSET];
+    match decode_record_type(tag)? {
+        // Terminator-bounded variable region. Returning `Some(pos+1)` only
+        // when the terminator is present in `bytes` means every extension
+        // `q` of `p` has its terminator at the same position (the encoding
+        // can't move it) — invariant satisfied.
+        RecordType::LogEntry => terminated_bytes::find_terminator_end(bytes, SEGMENTED_PREFIX_LEN),
+        // Fixed-length keys: extracted length is constant for every valid
+        // extension. Safe to return as long as the prefix already contains
+        // the full key.
+        RecordType::SeqBlock => Some(SEGMENTED_PREFIX_LEN),
+        RecordType::SegmentMeta => {
+            (bytes.len() >= SEGMENT_META_KEY_LEN).then_some(SEGMENT_META_KEY_LEN)
+        }
+        // Variable suffix with no delimiter. For any candidate `n`, an
+        // extension `q` longer than `p` would extract `q.len() != n`, so
+        // returning `Some(_)` would lie about future extensions and could
+        // produce false negatives. Disable the filter for these scans.
+        RecordType::ListingEntry => None,
+    }
+}
+
+impl PrefixExtractor for LogKeyPrefixExtractor {
+    fn name(&self) -> &str {
+        EXTRACTOR_NAME
+    }
+
+    fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+        match target {
+            PrefixTarget::Point(b) => Some(prefix_len_for_point(b.as_ref())),
+            PrefixTarget::Prefix(b) => prefix_len_for_prefix(b.as_ref()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+
+    use crate::serde::{FIRST_USER_SEGMENT_ID, ListingEntryKey, LogEntryKey, SegmentMetaKey};
+
+    fn point(bytes: &[u8]) -> PrefixTarget {
+        PrefixTarget::Point(Bytes::copy_from_slice(bytes))
+    }
+
+    fn prefix(bytes: &[u8]) -> PrefixTarget {
+        PrefixTarget::Prefix(Bytes::copy_from_slice(bytes))
+    }
+
+    #[test]
+    fn should_return_stable_name() {
+        let extractor = LogKeyPrefixExtractor;
+        assert_eq!(extractor.name(), "opendata-log/v2/key-prefix");
+    }
+
+    #[test]
+    fn should_extract_through_terminator_for_log_entry_key() {
+        // given
+        let extractor = LogKeyPrefixExtractor;
+        let user_key = Bytes::from("orders");
+        let key = LogEntryKey::new(FIRST_USER_SEGMENT_ID, user_key.clone(), 42).serialize(0);
+
+        // when
+        let n = extractor
+            .prefix_len(&PrefixTarget::Point(key.clone()))
+            .unwrap();
+
+        // then — extracted bytes are [segmented_prefix | terminated_user_key],
+        // ending at the terminator. The trailing var_u64(42) is excluded.
+        let expected_end = SEGMENTED_PREFIX_LEN + user_key.len() + 1; // +1 terminator
+        assert_eq!(n, expected_end);
+        assert_eq!(key[n - 1], 0x00); // terminated_bytes terminator
+    }
+
+    #[test]
+    fn should_dedup_extracted_prefix_across_sequences() {
+        // given — same (segment, user_key), different sequence numbers
+        let extractor = LogKeyPrefixExtractor;
+        let key_a = LogEntryKey::new(2, Bytes::from("k"), 5).serialize(0);
+        let key_b = LogEntryKey::new(2, Bytes::from("k"), 999).serialize(0);
+
+        // when
+        let n_a = extractor
+            .prefix_len(&PrefixTarget::Point(key_a.clone()))
+            .unwrap();
+        let n_b = extractor
+            .prefix_len(&PrefixTarget::Point(key_b.clone()))
+            .unwrap();
+
+        // then — both extract the same bytes; this is what lets slatedb's
+        // consecutive-prefix dedup collapse them to a single filter hash.
+        assert_eq!(n_a, n_b);
+        assert_eq!(&key_a[..n_a], &key_b[..n_b]);
+    }
+
+    #[test]
+    fn should_handle_user_key_containing_escaped_zero_byte() {
+        // given — terminated_bytes encodes 0x00 inside the user key as
+        // 0x01 0x01, so the extractor must NOT stop at that inner byte.
+        let extractor = LogKeyPrefixExtractor;
+        let user_key = Bytes::from_static(&[b'a', 0x00, b'b']);
+        let key = LogEntryKey::new(1, user_key.clone(), 0).serialize(0);
+
+        // when
+        let n = extractor
+            .prefix_len(&PrefixTarget::Point(key.clone()))
+            .unwrap();
+
+        // then — the encoded user key is 'a' 0x01 0x01 'b', then a 0x00
+        // terminator, then the relative_seq varint. Extracted length =
+        // SEGMENTED_PREFIX_LEN + 4 (encoded user key) + 1 (terminator) = 12.
+        assert_eq!(n, SEGMENTED_PREFIX_LEN + 5);
+        assert_eq!(key[n - 1], 0x00); // terminated_bytes terminator
+    }
+
+    #[test]
+    fn should_handle_user_key_containing_escape_byte() {
+        // given — 0x01 inside the user key is encoded as 0x01 0x02. The
+        // 0x02 must not be confused with a terminator candidate.
+        let extractor = LogKeyPrefixExtractor;
+        let user_key = Bytes::from_static(&[0x01, b'x']);
+        let key = LogEntryKey::new(1, user_key.clone(), 0).serialize(0);
+
+        // when
+        let n = extractor
+            .prefix_len(&PrefixTarget::Point(key.clone()))
+            .unwrap();
+
+        // then — encoded user key is 0x01 0x02 'x', then a 0x00 terminator.
+        assert_eq!(n, SEGMENTED_PREFIX_LEN + 4);
+        assert_eq!(key[n - 1], 0x00); // terminated_bytes terminator
+    }
+
+    #[test]
+    fn should_extract_whole_key_for_seq_block() {
+        // given
+        let extractor = LogKeyPrefixExtractor;
+        let key = Bytes::from_static(&crate::serde::SEQ_BLOCK_KEY);
+        assert_eq!(key.len(), SEGMENTED_PREFIX_LEN);
+
+        // when
+        let n = extractor
+            .prefix_len(&PrefixTarget::Point(key.clone()))
+            .unwrap();
+
+        // then
+        assert_eq!(n, SEGMENTED_PREFIX_LEN);
+    }
+
+    #[test]
+    fn should_extract_whole_key_for_segment_meta() {
+        // given
+        let extractor = LogKeyPrefixExtractor;
+        let key = SegmentMetaKey::new(42).serialize();
+        assert_eq!(key.len(), SEGMENT_META_KEY_LEN);
+
+        // when
+        let n = extractor
+            .prefix_len(&PrefixTarget::Point(key.clone()))
+            .unwrap();
+
+        // then
+        assert_eq!(n, SEGMENT_META_KEY_LEN);
+    }
+
+    #[test]
+    fn should_extract_whole_key_for_listing_entry_point() {
+        // given
+        let extractor = LogKeyPrefixExtractor;
+        let user_key = Bytes::from("some-key");
+        let key = ListingEntryKey::new(1, user_key.clone()).serialize();
+
+        // when
+        let n = extractor
+            .prefix_len(&PrefixTarget::Point(key.clone()))
+            .unwrap();
+
+        // then — listing entries have a raw user-key suffix with no
+        // terminator; the whole-key hash is what slatedb stores in the
+        // filter (since whole_key_filtering is disabled and we substitute
+        // the full bytes here).
+        assert_eq!(n, key.len());
+    }
+
+    #[test]
+    fn should_return_none_for_listing_entry_prefix() {
+        // given — even a syntactically valid listing prefix returns None,
+        // because the truncation invariant cannot hold for a variable
+        // suffix with no delimiter: a one-byte extension would extract a
+        // longer prefix than the input.
+        let extractor = LogKeyPrefixExtractor;
+        let key = ListingEntryKey::new(1, Bytes::from("anything")).serialize();
+
+        // when / then
+        assert_eq!(extractor.prefix_len(&PrefixTarget::Prefix(key)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_log_entry_prefix_without_terminator() {
+        // given — a scan prefix that stops mid-user-key, before the
+        // terminator. The terminator could land anywhere in an extension,
+        // so we cannot promise a stable extracted length.
+        let extractor = LogKeyPrefixExtractor;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&[SUBSYSTEM, KEY_VERSION]);
+        buf.extend_from_slice(&1u32.to_be_bytes());
+        buf.push(RecordType::LogEntry.tag().as_byte());
+        buf.extend_from_slice(b"par"); // start of user key, no terminator yet
+
+        // when / then
+        assert_eq!(extractor.prefix_len(&prefix(&buf)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_log_entry_prefix_ending_mid_escape() {
+        // given — prefix ends on the escape byte itself, so we don't know
+        // what byte follows (could be 0x01 → encoded 0x00, or 0x02 →
+        // encoded 0x01). No safe answer.
+        let extractor = LogKeyPrefixExtractor;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&[SUBSYSTEM, KEY_VERSION]);
+        buf.extend_from_slice(&1u32.to_be_bytes());
+        buf.push(RecordType::LogEntry.tag().as_byte());
+        buf.extend_from_slice(b"a");
+        buf.push(0x01); // terminated_bytes escape byte
+
+        // when / then
+        assert_eq!(extractor.prefix_len(&prefix(&buf)), None);
+    }
+
+    #[test]
+    fn should_return_some_for_log_entry_prefix_with_terminator_present() {
+        // given — a scan prefix that includes the full encoded user key
+        // plus its terminator (no varint suffix). This is what
+        // `LogEntryKey::scan_prefix` produces.
+        let extractor = LogKeyPrefixExtractor;
+        let segment = crate::segment::LogSegment::new(
+            FIRST_USER_SEGMENT_ID,
+            crate::serde::SegmentMeta::new(0, 0),
+        );
+        let scan_prefix = LogEntryKey::scan_prefix(&segment, b"orders");
+
+        // when
+        let n = extractor
+            .prefix_len(&PrefixTarget::Prefix(scan_prefix.clone()))
+            .unwrap();
+
+        // then — the entire scan_prefix is the extracted prefix
+        assert_eq!(n, scan_prefix.len());
+    }
+
+    #[test]
+    fn should_satisfy_truncation_invariant_for_log_entry_prefix() {
+        // Trait invariant: if Prefix(p) returns Some(n), every extension q
+        // of p satisfies Point(q) = Some(n) and q[..n] == p[..n]. Exercise
+        // this on a (segment, user_key) prefix.
+        let extractor = LogKeyPrefixExtractor;
+        let segment = crate::segment::LogSegment::new(3, crate::serde::SegmentMeta::new(0, 0));
+        let scan_prefix = LogEntryKey::scan_prefix(&segment, b"weights");
+
+        let n = extractor
+            .prefix_len(&PrefixTarget::Prefix(scan_prefix.clone()))
+            .unwrap();
+
+        // Any full LogEntry key with this (segment, user_key) is an
+        // extension of scan_prefix; the extractor on Point must agree on n.
+        for seq in [0u64, 1, 7, 250, 65_000] {
+            let full = LogEntryKey::new(3, Bytes::from_static(b"weights"), seq).serialize(0);
+            let point_n = extractor
+                .prefix_len(&PrefixTarget::Point(full.clone()))
+                .unwrap();
+            assert_eq!(
+                point_n, n,
+                "Point extracted {point_n} but Prefix extracted {n}"
+            );
+            assert_eq!(&full[..point_n], &scan_prefix[..n]);
+        }
+    }
+
+    #[test]
+    fn should_return_none_for_prefix_shorter_than_segmented_prefix() {
+        let extractor = LogKeyPrefixExtractor;
+        let short = [SUBSYSTEM, KEY_VERSION, 0, 0, 0, 1];
+        assert_eq!(extractor.prefix_len(&prefix(&short)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_prefix_with_wrong_subsystem() {
+        let extractor = LogKeyPrefixExtractor;
+        let bad = [0xFF, KEY_VERSION, 0, 0, 0, 1, 0x10];
+        assert_eq!(extractor.prefix_len(&prefix(&bad)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_prefix_with_wrong_version() {
+        let extractor = LogKeyPrefixExtractor;
+        let bad = [SUBSYSTEM, 0xFF, 0, 0, 0, 1, 0x10];
+        assert_eq!(extractor.prefix_len(&prefix(&bad)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_prefix_with_unknown_record_type() {
+        let extractor = LogKeyPrefixExtractor;
+        let bad = [SUBSYSTEM, KEY_VERSION, 0, 0, 0, 1, 0x99];
+        assert_eq!(extractor.prefix_len(&prefix(&bad)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_segment_meta_prefix_with_partial_suffix() {
+        // given — a scan prefix that's missing the trailing
+        // described-segment-id bytes is short of the SegmentMeta key
+        // length, so the truncation invariant fails for shorter `n`.
+        let extractor = LogKeyPrefixExtractor;
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&[SUBSYSTEM, KEY_VERSION]);
+        buf.extend_from_slice(&0u32.to_be_bytes());
+        buf.push(RecordType::SegmentMeta.tag().as_byte());
+        buf.extend_from_slice(&[0, 0]); // only 2 of the 4 suffix bytes
+
+        // when / then
+        assert_eq!(extractor.prefix_len(&prefix(&buf)), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed log key")]
+    fn should_panic_on_point_shorter_than_segmented_prefix() {
+        let extractor = LogKeyPrefixExtractor;
+        let short = [SUBSYSTEM, KEY_VERSION, 0, 0, 0, 1];
+        let _ = extractor.prefix_len(&point(&short));
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed log key")]
+    fn should_panic_on_point_with_wrong_subsystem() {
+        let extractor = LogKeyPrefixExtractor;
+        let bad = [0xFF, KEY_VERSION, 0, 0, 0, 1, 0x10];
+        let _ = extractor.prefix_len(&point(&bad));
+    }
+
+    #[test]
+    #[should_panic(expected = "unknown record-type tag")]
+    fn should_panic_on_point_with_unknown_record_type() {
+        let extractor = LogKeyPrefixExtractor;
+        let bad = [SUBSYSTEM, KEY_VERSION, 0, 0, 0, 1, 0x99];
+        let _ = extractor.prefix_len(&point(&bad));
+    }
+
+    /// End-to-end integration test that drives a real SlateDB-backed LogDb
+    /// across the bloom-filter path. Verifies that writes large enough to
+    /// populate filters in compacted SSTs can be read back after close +
+    /// reopen with no data loss, and that scans for an absent
+    /// `(segment, user_key)` return empty. Together these cover the two
+    /// failure modes a misconfigured prefix extractor would produce: false
+    /// negatives that drop live data, or filters that never fire.
+    ///
+    /// Lives in the crate rather than `tests/` so it can sit next to the
+    /// extractor it exercises.
+    #[cfg(test)]
+    mod integration_tests {
+        use bytes::Bytes;
+        use common::StorageConfig;
+        use common::storage::config::{
+            LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig,
+        };
+        use tempfile::TempDir;
+
+        use crate::config::Config;
+        use crate::log::LogDb;
+        use crate::model::Record;
+        use crate::reader::LogRead;
+
+        fn slatedb_storage_config(temp_dir: &TempDir) -> StorageConfig {
+            StorageConfig::SlateDb(SlateDbStorageConfig {
+                path: "log-data".to_string(),
+                object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
+                    path: temp_dir.path().to_string_lossy().to_string(),
+                }),
+                settings_path: None,
+                block_cache: None,
+            })
+        }
+
+        /// Writes enough entries under one `(segment, user_key)` to cross
+        /// slatedb's default `min_filter_keys = 1000` threshold so that
+        /// SSTs are emitted with filter blocks. Closes the writer, reopens
+        /// LogDb against the same path (re-running the full builder chain
+        /// including the bloom policy), and verifies every appended entry
+        /// is still readable via `scan`. A misconfigured prefix extractor
+        /// — e.g., one that hashes different bytes at build time vs query
+        /// time — would manifest here as missing entries.
+        #[tokio::test]
+        async fn filter_does_not_drop_stored_entries_across_reopen() {
+            // given
+            let temp_dir = TempDir::new().expect("tempdir");
+            let storage = slatedb_storage_config(&temp_dir);
+            let key = Bytes::from_static(b"orders");
+            // Cross min_filter_keys (1000) twice over so compacted SSTs
+            // build filters rather than falling back to the no-filter path.
+            let total: usize = 2500;
+
+            // when — append + flush + close
+            {
+                let log = LogDb::open(Config {
+                    storage: storage.clone(),
+                    ..Default::default()
+                })
+                .await
+                .expect("open LogDb");
+                // Batch the appends so the test runs quickly but the writes
+                // cross multiple memtable flushes.
+                for chunk in (0..total).collect::<Vec<_>>().chunks(100) {
+                    let records: Vec<Record> = chunk
+                        .iter()
+                        .map(|i| Record {
+                            key: key.clone(),
+                            value: Bytes::from(format!("v-{i}")),
+                        })
+                        .collect();
+                    log.try_append(records).await.expect("append");
+                }
+                log.flush().await.expect("flush");
+                log.close().await.expect("close");
+            }
+
+            // then — reopen and scan all entries back
+            let log = LogDb::open(Config {
+                storage,
+                ..Default::default()
+            })
+            .await
+            .expect("reopen LogDb");
+
+            // Stored entries: scan returns every one of them.
+            let mut iter = log.scan(key.clone(), ..).await.expect("scan");
+            let mut seen: Vec<Bytes> = Vec::with_capacity(total);
+            while let Some(entry) = iter.next().await.expect("read") {
+                seen.push(entry.value);
+            }
+            assert_eq!(
+                seen.len(),
+                total,
+                "filter must not drop stored entries; got {} of {}",
+                seen.len(),
+                total,
+            );
+            for (i, value) in seen.iter().enumerate() {
+                assert_eq!(value, &Bytes::from(format!("v-{i}")));
+            }
+
+            // Absent key: scan returns empty. Confirms the filter
+            // doesn't accidentally route reads to data under a different
+            // user key.
+            let mut iter = log
+                .scan(Bytes::from_static(b"absent"), ..)
+                .await
+                .expect("scan");
+            assert!(
+                iter.next().await.expect("read").is_none(),
+                "scan for absent user key must return empty",
+            );
+
+            log.close().await.expect("close");
+        }
+    }
+
+    /// Property tests for the three contract properties the extractor must
+    /// satisfy. Each property is documented at the module level; these
+    /// tests turn each one into an executable invariant over arbitrary
+    /// `(segment_id, user_key, sequence)` triples.
+    mod proptests {
+        use super::*;
+        use proptest::prelude::*;
+
+        /// Arbitrary user keys, including empty, single-byte, and keys
+        /// containing the encoding's special bytes (`0x00`, `0x01`) which
+        /// stress the escape-aware terminator scan.
+        fn arb_user_key() -> impl Strategy<Value = Vec<u8>> {
+            prop::collection::vec(any::<u8>(), 0..32)
+        }
+
+        proptest! {
+            /// Property 1: length cap. `prefix_len(Point(k))` must not
+            /// exceed `k.len()`. Slatedb's `BloomFilterBuilder::add_key`
+            /// asserts this; violation would panic at SST build time.
+            #[test]
+            fn point_extracted_length_never_exceeds_input_length(
+                segment_id in 1u32..1000,
+                user_key in arb_user_key(),
+                sequence in 0u64..u64::MAX,
+            ) {
+                let extractor = LogKeyPrefixExtractor;
+                let serialized = LogEntryKey::new(segment_id, Bytes::from(user_key), sequence)
+                    .serialize(0);
+                let n = extractor
+                    .prefix_len(&PrefixTarget::Point(serialized.clone()))
+                    .expect("LogEntry Point must always extract");
+                prop_assert!(
+                    n <= serialized.len(),
+                    "extracted length {} exceeds input length {}",
+                    n,
+                    serialized.len(),
+                );
+            }
+
+            /// Property 1 over `Prefix` targets: any `Some(n)` returned
+            /// must satisfy `n <= input.len()`. Slatedb's
+            /// `BloomFilter::might_match` slices `bytes[..n]` after the
+            /// extractor returns; an out-of-bounds `n` would panic.
+            #[test]
+            fn prefix_extracted_length_never_exceeds_input_length(
+                bytes in prop::collection::vec(any::<u8>(), 0..64),
+            ) {
+                let extractor = LogKeyPrefixExtractor;
+                let target = PrefixTarget::Prefix(Bytes::from(bytes.clone()));
+                if let Some(n) = extractor.prefix_len(&target) {
+                    prop_assert!(
+                        n <= bytes.len(),
+                        "extracted length {} exceeds input length {}",
+                        n,
+                        bytes.len(),
+                    );
+                }
+            }
+
+            /// Property 2: truncation invariant. For a `LogEntryKey`'s
+            /// scan prefix `p` (which always contains the user-key
+            /// terminator), every concrete LogEntry key sharing the same
+            /// `(segment, user_key)` is an extension of `p`. The
+            /// extractor must report the same length `n` for both, and
+            /// the extracted bytes must be identical.
+            #[test]
+            fn log_entry_prefix_truncation_invariant_holds(
+                segment_id in 1u32..1000,
+                user_key in arb_user_key(),
+                sequence in 0u64..u64::MAX,
+            ) {
+                let extractor = LogKeyPrefixExtractor;
+                let segment = crate::segment::LogSegment::new(
+                    segment_id,
+                    crate::serde::SegmentMeta::new(0, 0),
+                );
+                let scan_prefix = LogEntryKey::scan_prefix(&segment, &user_key);
+                let full_key = LogEntryKey::new(
+                    segment_id,
+                    Bytes::copy_from_slice(&user_key),
+                    sequence,
+                )
+                .serialize(0);
+
+                let n_prefix = extractor
+                    .prefix_len(&PrefixTarget::Prefix(scan_prefix.clone()))
+                    .expect("scan_prefix always contains the terminator");
+                let n_point = extractor
+                    .prefix_len(&PrefixTarget::Point(full_key.clone()))
+                    .expect("LogEntry Point must always extract");
+
+                prop_assert_eq!(
+                    n_prefix, n_point,
+                    "Prefix extracted {} but Point extracted {}",
+                    n_prefix, n_point,
+                );
+                prop_assert_eq!(
+                    &scan_prefix[..n_prefix],
+                    &full_key[..n_point],
+                    "extracted bytes diverge across Prefix and Point",
+                );
+            }
+
+            /// Property 3: determinism / no false negatives. Two
+            /// `Point(k)` calls with the same input must produce the
+            /// same answer; in particular, the extracted prefix used at
+            /// build time matches the one used at query time. Combined
+            /// with property 2, this means every stored key probes its
+            /// own filter hash and survives `might_match`.
+            #[test]
+            fn point_extraction_is_deterministic(
+                segment_id in 1u32..1000,
+                user_key in arb_user_key(),
+                sequence in 0u64..u64::MAX,
+            ) {
+                let extractor = LogKeyPrefixExtractor;
+                let serialized = LogEntryKey::new(
+                    segment_id,
+                    Bytes::from(user_key),
+                    sequence,
+                )
+                .serialize(0);
+                let n1 = extractor.prefix_len(&PrefixTarget::Point(serialized.clone()));
+                let n2 = extractor.prefix_len(&PrefixTarget::Point(serialized.clone()));
+                prop_assert_eq!(n1, n2);
+            }
+
+            /// All entries sharing a `(segment, user_key)` must extract
+            /// to identical bytes regardless of sequence — this is what
+            /// lets slatedb's consecutive-prefix dedup collapse them to
+            /// a single stored hash in the SST filter.
+            #[test]
+            fn same_segment_and_key_extract_identical_prefix(
+                segment_id in 1u32..1000,
+                user_key in arb_user_key(),
+                seq_a in 0u64..u64::MAX,
+                seq_b in 0u64..u64::MAX,
+            ) {
+                let extractor = LogKeyPrefixExtractor;
+                let key_a = LogEntryKey::new(
+                    segment_id,
+                    Bytes::copy_from_slice(&user_key),
+                    seq_a,
+                )
+                .serialize(0);
+                let key_b = LogEntryKey::new(
+                    segment_id,
+                    Bytes::copy_from_slice(&user_key),
+                    seq_b,
+                )
+                .serialize(0);
+                let n_a = extractor
+                    .prefix_len(&PrefixTarget::Point(key_a.clone()))
+                    .unwrap();
+                let n_b = extractor
+                    .prefix_len(&PrefixTarget::Point(key_b.clone()))
+                    .unwrap();
+                prop_assert_eq!(n_a, n_b);
+                prop_assert_eq!(&key_a[..n_a], &key_b[..n_b]);
+            }
+        }
+    }
+}

--- a/log/src/key_extractor.rs
+++ b/log/src/key_extractor.rs
@@ -70,20 +70,15 @@ const EXTRACTOR_NAME: &str = "opendata-log/v2/key-prefix";
 /// Dispatches on the record-type byte at offset 6:
 ///
 /// - `LogEntry (0x10)` — variable region is `[terminated_user_key,
-///   var_u64(relative_seq)]`. The extractor finds the first unescaped
-///   `0x00` (the terminator that closes the user key) starting at offset
-///   `SEGMENTED_PREFIX_LEN` and returns its position + 1. Removing the
-///   sequence varint from the hashed prefix lets the SST builder dedupe
-///   all entries for a given `(segment, user_key)` down to a single
-///   stored hash.
-/// - `SeqBlock (0x20)` — fixed 7-byte key, no variable suffix; the prefix
-///   *is* the whole key.
+///   var_u64(relative_seq)]`. Returns the position one past the first
+///   unescaped `0x00` (the terminator that closes the user key),
+///   excluding the sequence varint.
+/// - `SeqBlock (0x20)` — fixed 7-byte key, no variable suffix; whole key.
 /// - `SegmentMeta (0x30)` — fixed 11-byte key (segmented prefix + 4-byte
 ///   described-segment-id suffix); whole key.
 /// - `ListingEntry (0x40)` — variable suffix without a terminator. Whole
 ///   key for `Point`; `None` for `Prefix` (truncation-unsafe — any
-///   extension is a strictly longer key with a longer extracted length,
-///   violating the trait's prefix-extension invariant).
+///   extension is a longer key with a longer extracted length).
 ///
 /// Unknown or malformed inputs panic for `Point` (LogDb bug) and return
 /// `None` for `Prefix` (caller-supplied, benign).
@@ -149,11 +144,9 @@ fn prefix_len_for_point(bytes: &[u8]) -> usize {
     }
 }
 
-/// Computes the prefix length for a `Prefix` target — a caller-supplied
-/// scan prefix. Returns `None` for any case where the truncation invariant
-/// (`prefix_len(Prefix(p)) = Some(n)` ⇒ every extension `q` has
-/// `prefix_len(Point(q)) = Some(n)` and `q[..n] == p[..n]`) cannot be
-/// guaranteed.
+/// Computes the prefix length for a caller-supplied scan prefix. Returns
+/// `None` when this impl cannot guarantee the truncation invariant
+/// described in the module doc.
 fn prefix_len_for_prefix(bytes: &[u8]) -> Option<usize> {
     if !has_segmented_prefix(bytes) {
         return None;
@@ -161,22 +154,19 @@ fn prefix_len_for_prefix(bytes: &[u8]) -> Option<usize> {
 
     let tag = bytes[RECORD_TYPE_OFFSET];
     match decode_record_type(tag)? {
-        // Terminator-bounded variable region. Returning `Some(pos+1)` only
-        // when the terminator is present in `bytes` means every extension
-        // `q` of `p` has its terminator at the same position (the encoding
-        // can't move it) — invariant satisfied.
+        // Terminator at a fixed position once seen; the encoding can't
+        // move it under extension, so returning `Some(pos+1)` is
+        // truncation-safe.
         RecordType::LogEntry => terminated_bytes::find_terminator_end(bytes, SEGMENTED_PREFIX_LEN),
-        // Fixed-length keys: extracted length is constant for every valid
-        // extension. Safe to return as long as the prefix already contains
-        // the full key.
+        // Fixed-length keys: only safe to answer once `bytes` already
+        // contains the full key, otherwise extensions would extract a
+        // longer prefix than what we report here.
         RecordType::SeqBlock => Some(SEGMENTED_PREFIX_LEN),
         RecordType::SegmentMeta => {
             (bytes.len() >= SEGMENT_META_KEY_LEN).then_some(SEGMENT_META_KEY_LEN)
         }
-        // Variable suffix with no delimiter. For any candidate `n`, an
-        // extension `q` longer than `p` would extract `q.len() != n`, so
-        // returning `Some(_)` would lie about future extensions and could
-        // produce false negatives. Disable the filter for these scans.
+        // Variable suffix with no delimiter: every extension would extract
+        // a strictly longer prefix, so no `Some(_)` answer is truncation-safe.
         RecordType::ListingEntry => None,
     }
 }

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -50,7 +50,7 @@ mod compaction;
 mod config;
 mod direct;
 mod error;
-mod key_extractor;
+mod filter_prefix;
 mod listing;
 mod log;
 mod model;

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -49,6 +49,7 @@
 mod config;
 mod direct;
 mod error;
+mod key_extractor;
 mod listing;
 mod log;
 mod model;

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -17,7 +17,7 @@ use std::sync::OnceLock;
 use common::clock::{Clock, SystemClock};
 use common::coordinator::{Durability, EpochWatcher, EpochWatermarks};
 use common::storage::config::StorageConfig;
-use common::{CompactorBuilder, StorageBuilder, create_object_store};
+use common::{CompactorBuilder, StorageBuilder, StorageSemantics, create_object_store};
 use slatedb::compactor::CompactionSchedulerSupplier;
 use tokio::sync::RwLock;
 use tokio::sync::watch;
@@ -555,7 +555,11 @@ impl LogDbBuilder {
         self.config.validate_compaction()?;
         let sb = StorageBuilder::new(&self.config.storage)
             .await
-            .map_err(|e| Error::Storage(e.to_string()))?;
+            .map_err(|e| Error::Storage(e.to_string()))?
+            .with_semantics(
+                StorageSemantics::new()
+                    .with_filter_policies(crate::filter_prefix::bloom_filter_policies()),
+            );
         // Route every log record to a SlateDB segment keyed by the 6-byte
         // routing prefix `[subsystem, version, segment_id]`. No-op for the
         // in-memory backend; for slatedb-backed storage this installs the
@@ -567,17 +571,9 @@ impl LogDbBuilder {
         // doc for the contract). `whole_key_filtering=false` because the
         // extracted prefix already discriminates everything we need to
         // probe — adding per-key hashes would only inflate the filter.
-        let sb =
-            sb.map_slatedb(|db| {
-                db.with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())
-                    .with_filter_policies(vec![Arc::new(
-                        slatedb::BloomFilterPolicy::new(10)
-                            .with_prefix_extractor(
-                                crate::key_extractor::LogKeyPrefixExtractor::shared(),
-                            )
-                            .with_whole_key_filtering(false),
-                    )])
-            });
+        let sb = sb.map_slatedb(|db| {
+            db.with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())
+        });
         // Install the LogDb compaction scheduler for every SlateDB-backed log.
         let compactor_view_cell: CompactorViewCell = Arc::new(OnceLock::new());
         let sb = if let StorageConfig::SlateDb(ref slate_config) = self.config.storage {
@@ -591,7 +587,9 @@ impl LogDbBuilder {
                 });
             sb.map_slatedb(move |db| {
                 db.with_compactor_builder(
-                    CompactorBuilder::new(path, object_store).with_scheduler_supplier(supplier),
+                    CompactorBuilder::new(path, object_store)
+                        .with_scheduler_supplier(supplier)
+                        .with_filter_policies(crate::filter_prefix::bloom_filter_policies()),
                 )
             })
         } else {

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -540,17 +540,14 @@ impl LogDbBuilder {
         // Route every log record to a SlateDB segment keyed by the 6-byte
         // routing prefix `[subsystem, version, segment_id]`. No-op for the
         // in-memory backend; for slatedb-backed storage this installs the
-        // extractor on the underlying `DbBuilder` (see RFC 0024). The
-        // prefix bloom policy is independent of the segment extractor: it
-        // hashes the logical key (segment + user key, without sequence)
-        // into per-SST bloom filters so `db.scan_prefix` can skip SSTs
-        // that contain no matching (segment, user_key). `bits_per_key=10`
-        // matches slatedb's default. `whole_key_filtering=false` because
-        // for LogEntry keys the prefix subsumes any per-sequence hash
-        // (slatedb's consecutive-prefix dedup collapses N entries per
-        // user key down to one stored hash), and for the fixed-length /
-        // whole-key record types the extracted prefix already is the
-        // full key.
+        // extractor on the underlying `DbBuilder` (see RFC 0024).
+        //
+        // The bloom filter policy is an orthogonal slatedb axis: the
+        // `LogKeyPrefixExtractor` hashes only the logical `(segment,
+        // user_key)` prefix into per-SST bloom filters (see its module
+        // doc for the contract). `whole_key_filtering=false` because the
+        // extracted prefix already discriminates everything we need to
+        // probe — adding per-key hashes would only inflate the filter.
         let sb =
             sb.map_slatedb(|db| {
                 db.with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -540,10 +540,28 @@ impl LogDbBuilder {
         // Route every log record to a SlateDB segment keyed by the 6-byte
         // routing prefix `[subsystem, version, segment_id]`. No-op for the
         // in-memory backend; for slatedb-backed storage this installs the
-        // extractor on the underlying `DbBuilder` (see RFC 0024).
-        let sb = sb.map_slatedb(|db| {
-            db.with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())
-        });
+        // extractor on the underlying `DbBuilder` (see RFC 0024). The
+        // prefix bloom policy is independent of the segment extractor: it
+        // hashes the logical key (segment + user key, without sequence)
+        // into per-SST bloom filters so `db.scan_prefix` can skip SSTs
+        // that contain no matching (segment, user_key). `bits_per_key=10`
+        // matches slatedb's default. `whole_key_filtering=false` because
+        // for LogEntry keys the prefix subsumes any per-sequence hash
+        // (slatedb's consecutive-prefix dedup collapses N entries per
+        // user key down to one stored hash), and for the fixed-length /
+        // whole-key record types the extracted prefix already is the
+        // full key.
+        let sb =
+            sb.map_slatedb(|db| {
+                db.with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())
+                    .with_filter_policies(vec![Arc::new(
+                        slatedb::BloomFilterPolicy::new(10)
+                            .with_prefix_extractor(
+                                crate::key_extractor::LogKeyPrefixExtractor::shared(),
+                            )
+                            .with_whole_key_filtering(false),
+                    )])
+            });
         let storage = sb
             .build()
             .await

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -486,7 +486,8 @@ impl LogDbReader {
         let storage: Arc<dyn StorageRead> = create_storage_read(
             &config.storage,
             StorageReaderRuntime::new(),
-            StorageSemantics::new(),
+            StorageSemantics::new()
+                .with_filter_policies(crate::filter_prefix::bloom_filter_policies()),
             reader_options,
         )
         .await

--- a/log/src/serde.rs
+++ b/log/src/serde.rs
@@ -142,10 +142,14 @@ impl RecordType {
 const SEGMENT_ID_OFFSET: usize = KEY_PREFIX_LEN;
 
 /// Offset of the record-type tag byte inside a log key, after the segment id.
-const RECORD_TYPE_OFFSET: usize = SEGMENT_ID_OFFSET + 4;
+pub(crate) const RECORD_TYPE_OFFSET: usize = SEGMENT_ID_OFFSET + 4;
 
 /// Length of the v2 segmented key prefix: `[subsystem, version, seg_id(4), record_type]`.
-const SEGMENTED_PREFIX_LEN: usize = RECORD_TYPE_OFFSET + 1;
+pub(crate) const SEGMENTED_PREFIX_LEN: usize = RECORD_TYPE_OFFSET + 1;
+
+/// Length of a fully-serialized [`SegmentMetaKey`]: the 7-byte segmented prefix
+/// plus a 4-byte described-segment-id suffix.
+pub(crate) const SEGMENT_META_KEY_LEN: usize = SEGMENTED_PREFIX_LEN + 4;
 
 /// Writes the v2 segmented prefix into `buf`:
 /// `[subsystem, version, seg_id BE, record_type]`.
@@ -265,6 +269,24 @@ impl LogEntryKey {
         BytesRange::new(Bound::Included(start_key), Bound::Excluded(end_key))
     }
 
+    /// Returns the storage key prefix shared by every entry for `(segment, key)`.
+    ///
+    /// The prefix is `[sub, ver, segment_id, 0x10, terminated_key]`, ending at
+    /// the terminator byte that closes the user key. Every entry under this
+    /// `(segment, key)` differs only in the trailing `var_u64(relative_seq)`,
+    /// so a prefix scan returns the full set of entries in sequence order and
+    /// lets the caller narrow on `sequence` client-side.
+    ///
+    /// This is the prefix that `LogKeyPrefixExtractor` produces for LogEntry
+    /// keys, so a `scan_prefix` against this byte string is the form that lets
+    /// slatedb's bloom filter skip SSTs whose `(segment, key)` is absent.
+    pub fn scan_prefix(segment: &LogSegment, key: &[u8]) -> Bytes {
+        let mut buf = BytesMut::new();
+        write_segmented_prefix(&mut buf, segment.id(), RecordType::LogEntry.tag().as_byte());
+        terminated_bytes::serialize(key, &mut buf);
+        buf.freeze()
+    }
+
     /// Builds a complete scan key with segment prefix and relative sequence.
     fn build_scan_key(segment: &LogSegment, key: &[u8], seq: u64) -> Bytes {
         let relative_seq = seq.saturating_sub(segment.meta().start_seq);
@@ -299,7 +321,7 @@ impl SegmentMetaKey {
 
     /// Encodes the key to bytes for storage
     pub fn serialize(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(SEGMENTED_PREFIX_LEN + 4);
+        let mut buf = BytesMut::with_capacity(SEGMENT_META_KEY_LEN);
         write_segmented_prefix(
             &mut buf,
             SYSTEM_SEGMENT_ID,
@@ -596,6 +618,42 @@ mod tests {
         assert_eq!(serialized.len(), 10);
         // relative_seq = 5 as varint: length code 0, value 5
         assert_eq!(serialized[9], 0x05);
+    }
+
+    #[test]
+    fn should_share_scan_prefix_with_scan_range_endpoints() {
+        // given
+        let segment = LogSegment::new(7, SegmentMeta::new(1000, 0));
+        let user_key = Bytes::from("orders");
+
+        // when
+        let prefix = LogEntryKey::scan_prefix(&segment, &user_key);
+        let range = LogEntryKey::scan_range(&segment, &user_key, 1000..2000);
+
+        // then — the prefix must be the shared prefix of the range endpoints,
+        // ending at the terminator byte (the 0x00 that closes terminated_bytes).
+        let start = match range.start_bound() {
+            Bound::Included(b) => b.clone(),
+            _ => unreachable!(),
+        };
+        let end = match range.end_bound() {
+            Bound::Excluded(b) => b.clone(),
+            _ => unreachable!(),
+        };
+        assert!(
+            start.starts_with(&prefix),
+            "range start {:02x?} must start with prefix {:02x?}",
+            start.as_ref(),
+            prefix.as_ref(),
+        );
+        assert!(
+            end.starts_with(&prefix),
+            "range end {:02x?} must start with prefix {:02x?}",
+            end.as_ref(),
+            prefix.as_ref(),
+        );
+        // The prefix ends with the terminated_bytes terminator (0x00).
+        assert_eq!(prefix.last(), Some(&0x00));
     }
 
     #[test]

--- a/log/src/storage.rs
+++ b/log/src/storage.rs
@@ -71,14 +71,21 @@ pub(crate) trait LogStorageRead: StorageRead {
     /// Scans log entries for a key within a segment and sequence range.
     ///
     /// Returns an iterator that yields `LogEntry` values in sequence order.
+    ///
+    /// Issues a prefix scan over the `(segment, key)` prefix rather than a
+    /// bounded range so that backends with prefix-aware bloom filters
+    /// (slatedb's `BloomFilterPolicy` with `LogKeyPrefixExtractor`) can skip
+    /// SSTs that contain no entries for this `(segment, key)`. The seq range
+    /// is enforced client-side by [`SegmentIterator`], which early-exits
+    /// once `sequence >= seq_range.end`.
     async fn scan_entries(
         &self,
         segment: &LogSegment,
         key: &Bytes,
         seq_range: Range<u64>,
     ) -> Result<SegmentIterator> {
-        let scan_range = LogEntryKey::scan_range(segment, key, seq_range.clone());
-        let inner = self.scan_iter(scan_range).await?;
+        let prefix = LogEntryKey::scan_prefix(segment, key);
+        let inner = self.scan_prefix_iter(prefix).await?;
         Ok(SegmentIterator::new(
             inner,
             seq_range,


### PR DESCRIPTION
LogDb keys are roughly structured as `segment + log_key + sequence`. The default bloom filter from SlateDb uses the full key, but this just wastes space. Instead, we can use Slatedb's fancy new prefix bloom filters and index just `segment + log_key`. The bloom filter tells us whether a log_key may be present in the table, and the index tells us exactly which blocks may have entries.