### PR TITLE
fix(timeseries): sort points before Gorilla encode to avoid overflow panic

### DIFF
--- a/timeseries/src/serde/timeseries.rs
+++ b/timeseries/src/serde/timeseries.rs
@@ -180,12 +180,17 @@ impl TimeSeriesValue {
             return Ok(Bytes::new());
         }
 
+        // Gorilla delta encoding requires monotonically non-decreasing timestamps,
+        // so sort defensively to avoid a subtract-with-overflow panic on out-of-order input.
+        let mut points: Vec<&Sample> = self.points.iter().collect();
+        points.sort_by_key(|p| p.timestamp_ms);
+
         // Use Gorilla compression
         let w = BufferedWriter::new();
-        let start_time = self.points[0].timestamp_ms as u64;
+        let start_time = points[0].timestamp_ms as u64;
         let mut encoder = StdEncoder::new(start_time, w);
 
-        for point in &self.points {
+        for point in &points {
             let dp = DataPoint::new(point.timestamp_ms as u64, point.value);
             encoder.encode(dp);
         }
@@ -316,6 +321,41 @@ mod tests {
 
         // then
         assert_eq!(decoded, value);
+    }
+
+    #[test]
+    fn should_encode_when_points_are_out_of_order() {
+        // given
+        let value = TimeSeriesValue {
+            points: vec![
+                Sample {
+                    timestamp_ms: 2000,
+                    value: 20.0,
+                },
+                Sample {
+                    timestamp_ms: 1000,
+                    value: 10.0,
+                },
+                Sample {
+                    timestamp_ms: 3000,
+                    value: 30.0,
+                },
+            ],
+        };
+
+        // when
+        let encoded = value.encode().unwrap();
+        let decoded = TimeSeriesValue::decode(encoded.as_ref()).unwrap();
+
+        // then
+        assert_eq!(
+            decoded
+                .points
+                .iter()
+                .map(|p| p.timestamp_ms)
+                .collect::<Vec<_>>(),
+            vec![1000, 2000, 3000]
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #432.

`TimeSeriesValue::encode()` fed `self.points` straight into the Gorilla `StdEncoder`, whose `write_next_timestamp` does an unsigned `time - self.time` subtraction. Any series whose samples are not in non-decreasing timestamp order triggered `attempt to subtract with overflow` and killed the tokio worker.

This sorts the points by timestamp inside `encode()` before encoding, which also makes the `start_time = points[0]` assumption correct for unordered input. The merge path already produces sorted output, so this only changes behavior for out-of-order batches.

Test plan:
- Added `should_encode_when_points_are_out_of_order`, which panicked with the exact `subtract with overflow` before the fix and passes after.
- `cargo test -p opendata-timeseries`, `cargo clippy -p opendata-timeseries --all-targets -- -D warnings`, and `cargo fmt --all` are clean.