### PR TITLE
Log: durable subscribe API

### DIFF
--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -104,9 +104,13 @@ impl SlateDbStorage {
                 let mut slate_rx = slate_rx;
                 while slate_rx.changed().await.is_ok() {
                     let durable_seq = slate_rx.borrow_and_update().durable_seq;
-                    if tx.send(durable_seq).is_err() {
-                        break;
-                    }
+                    // Use send_replace rather than send: SlateDB may publish
+                    // a DbStatus change during `open` (e.g. manifest write)
+                    // before any consumer has subscribed, and `send` would
+                    // return Err on zero receivers — killing the bridge
+                    // permanently. send_replace doesn't care about receiver
+                    // count, so late subscribers still get future updates.
+                    tx.send_replace(durable_seq);
                 }
             }
         });

--- a/log/c/cbindgen.toml
+++ b/log/c/cbindgen.toml
@@ -14,6 +14,8 @@ include = [
     "opendata_log_iterator_t",
     "opendata_log_key_iterator_t",
     "opendata_log_object_store_t",
+    "opendata_log_subscription_t",
+    "opendata_log_durable_callback_t",
     "opendata_log_config_t",
     "opendata_log_reader_config_t",
     "opendata_log_seq_bound_t",

--- a/log/c/include/opendata_log.h
+++ b/log/c/include/opendata_log.h
@@ -186,8 +186,10 @@ struct opendata_log_result_t opendata_log_durable_sequence(const struct opendata
  *
  * `user_data` is passed back verbatim to each callback invocation. The
  * caller is responsible for ensuring it remains valid (and safe for
- * concurrent access from worker threads) until the subscription is freed
- * via `opendata_log_unsubscribe_durable`.
+ * concurrent access from worker threads) for the entire lifetime of the
+ * subscription, **including any in-flight callback that may still be
+ * running after `opendata_log_unsubscribe_durable` returns** (see that
+ * function's contract).
  */
 struct opendata_log_result_t opendata_log_subscribe_durable(const struct opendata_log_t *log,
                                                             void (*callback)(uint64_t durable_sequence,
@@ -198,10 +200,23 @@ struct opendata_log_result_t opendata_log_subscribe_durable(const struct opendat
 /**
  * Cancels a durable-sequence subscription and frees the handle.
  *
- * Best-effort: an in-flight callback may complete after this returns. After
- * this call, no further callbacks for this subscription will be scheduled.
- * Safe to call after `opendata_log_close` (the abort is a no-op once the
- * runtime has been torn down).
+ * **Best-effort with respect to in-flight callbacks.** This call signals the
+ * spawned task to stop and returns immediately. If a callback is currently
+ * executing on a worker thread, it will run to completion *after* this
+ * function returns. A new callback for this subscription will not be
+ * scheduled.
+ *
+ * **Caller obligation:** `user_data` must remain valid until every
+ * in-flight invocation of the callback has finished. The C API does not
+ * synchronize with worker threads on unsubscribe; freeing `user_data`
+ * immediately after this call returns is a use-after-free if a callback is
+ * mid-execution. A safe pattern is to keep `user_data` alive as long as
+ * any subscription that references it, e.g. by tying it to the lifetime of
+ * the `opendata_log_t` (close the log first, then free `user_data` once no
+ * pending callback work could possibly remain).
+ *
+ * Safe to call after `opendata_log_close` (the spawned task will already
+ * have exited because its watch channel closed when the log dropped).
  */
 struct opendata_log_result_t opendata_log_unsubscribe_durable(struct opendata_log_subscription_t *subscription);
 

--- a/log/c/include/opendata_log.h
+++ b/log/c/include/opendata_log.h
@@ -39,6 +39,16 @@ typedef struct opendata_log_object_store_t opendata_log_object_store_t;
 
 typedef struct opendata_log_reader_t opendata_log_reader_t;
 
+/**
+ * Opaque handle representing a registered durable-sequence subscription.
+ *
+ * Created by `opendata_log_subscribe_durable` and destroyed by
+ * `opendata_log_unsubscribe_durable`. Must be freed explicitly even if the
+ * log has been closed; closing the log aborts the task but does not free
+ * this handle.
+ */
+typedef struct opendata_log_subscription_t opendata_log_subscription_t;
+
 typedef struct opendata_log_t opendata_log_t;
 
 typedef struct opendata_log_result_t {
@@ -94,6 +104,19 @@ typedef struct opendata_log_reader_config_t {
   int64_t refresh_interval_ms;
 } opendata_log_reader_config_t;
 
+/**
+ * Callback invoked when the durable-sequence watermark advances.
+ *
+ * The first invocation carries the current value at subscription time; each
+ * subsequent invocation carries the latest observed value (intermediate
+ * values may be coalesced).
+ *
+ * The callback is invoked on a tokio worker thread, not the caller's thread.
+ * It must not call other `opendata_log_*` functions on the same log handle
+ * (this would deadlock the runtime).
+ */
+typedef void (*opendata_log_durable_callback_t)(uint64_t durable_sequence, void *user_data);
+
 struct opendata_log_result_t opendata_log_open(const struct opendata_log_config_t *config,
                                                struct opendata_log_t **out_log);
 
@@ -138,6 +161,49 @@ struct opendata_log_result_t opendata_log_list_segments(const struct opendata_lo
                                                         const struct opendata_log_seq_range_t *seq_range,
                                                         struct opendata_log_segment_t **out_segments,
                                                         uintptr_t *out_count);
+
+/**
+ * Reads the current durable-sequence watermark.
+ *
+ * `*out_sequence` is set to N such that all records with `sequence < N` are
+ * durably persisted. Initial value is 0; advances as the underlying storage
+ * confirms durability (no explicit flush required, though `opendata_log_flush`
+ * does force it).
+ */
+struct opendata_log_result_t opendata_log_durable_sequence(const struct opendata_log_t *log,
+                                                           uint64_t *out_sequence);
+
+/**
+ * Subscribes to durable-sequence watermark changes.
+ *
+ * `callback` is invoked once on registration with the current watermark, then
+ * on each subsequent advancement. The callback runs on a tokio worker thread
+ * (not the caller's thread) and **must not call other `opendata_log_*`
+ * functions on the same log handle** — doing so will deadlock the runtime.
+ *
+ * Intermediate values may be coalesced; the callback always receives the
+ * latest observed value.
+ *
+ * `user_data` is passed back verbatim to each callback invocation. The
+ * caller is responsible for ensuring it remains valid (and safe for
+ * concurrent access from worker threads) until the subscription is freed
+ * via `opendata_log_unsubscribe_durable`.
+ */
+struct opendata_log_result_t opendata_log_subscribe_durable(const struct opendata_log_t *log,
+                                                            void (*callback)(uint64_t durable_sequence,
+                                                                             void *user_data),
+                                                            void *user_data,
+                                                            struct opendata_log_subscription_t **out_subscription);
+
+/**
+ * Cancels a durable-sequence subscription and frees the handle.
+ *
+ * Best-effort: an in-flight callback may complete after this returns. After
+ * this call, no further callbacks for this subscription will be scheduled.
+ * Safe to call after `opendata_log_close` (the abort is a no-op once the
+ * runtime has been torn down).
+ */
+struct opendata_log_result_t opendata_log_unsubscribe_durable(struct opendata_log_subscription_t *subscription);
 
 struct opendata_log_result_t opendata_log_iterator_next(struct opendata_log_iterator_t *iterator,
                                                         bool *out_present,

--- a/log/c/src/db.rs
+++ b/log/c/src/db.rs
@@ -366,8 +366,10 @@ pub unsafe extern "C" fn opendata_log_durable_sequence(
 ///
 /// `user_data` is passed back verbatim to each callback invocation. The
 /// caller is responsible for ensuring it remains valid (and safe for
-/// concurrent access from worker threads) until the subscription is freed
-/// via `opendata_log_unsubscribe_durable`.
+/// concurrent access from worker threads) for the entire lifetime of the
+/// subscription, **including any in-flight callback that may still be
+/// running after `opendata_log_unsubscribe_durable` returns** (see that
+/// function's contract).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn opendata_log_subscribe_durable(
     log: *const opendata_log_t,
@@ -410,10 +412,23 @@ pub unsafe extern "C" fn opendata_log_subscribe_durable(
 
 /// Cancels a durable-sequence subscription and frees the handle.
 ///
-/// Best-effort: an in-flight callback may complete after this returns. After
-/// this call, no further callbacks for this subscription will be scheduled.
-/// Safe to call after `opendata_log_close` (the abort is a no-op once the
-/// runtime has been torn down).
+/// **Best-effort with respect to in-flight callbacks.** This call signals the
+/// spawned task to stop and returns immediately. If a callback is currently
+/// executing on a worker thread, it will run to completion *after* this
+/// function returns. A new callback for this subscription will not be
+/// scheduled.
+///
+/// **Caller obligation:** `user_data` must remain valid until every
+/// in-flight invocation of the callback has finished. The C API does not
+/// synchronize with worker threads on unsubscribe; freeing `user_data`
+/// immediately after this call returns is a use-after-free if a callback is
+/// mid-execution. A safe pattern is to keep `user_data` alive as long as
+/// any subscription that references it, e.g. by tying it to the lifetime of
+/// the `opendata_log_t` (close the log first, then free `user_data` once no
+/// pending callback work could possibly remain).
+///
+/// Safe to call after `opendata_log_close` (the spawned task will already
+/// have exited because its watch channel closed when the log dropped).
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn opendata_log_unsubscribe_durable(
     subscription: *mut opendata_log_subscription_t,
@@ -424,7 +439,8 @@ pub unsafe extern "C" fn opendata_log_unsubscribe_durable(
             "subscription must not be null",
         );
     }
-    let sub = Box::from_raw(subscription);
-    sub.abort_handle.abort();
+    // Reboxing transfers ownership back. The handle's Drop impl aborts the
+    // spawned task as it goes out of scope.
+    let _ = Box::from_raw(subscription);
     success_result()
 }

--- a/log/c/src/db.rs
+++ b/log/c/src/db.rs
@@ -1,3 +1,4 @@
+use std::ffi::c_void;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -326,4 +327,104 @@ unsafe fn build_records(
         });
     }
     Ok(records)
+}
+
+/// Reads the current durable-sequence watermark.
+///
+/// `*out_sequence` is set to N such that all records with `sequence < N` are
+/// durably persisted. Initial value is 0; advances as the underlying storage
+/// confirms durability (no explicit flush required, though `opendata_log_flush`
+/// does force it).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn opendata_log_durable_sequence(
+    log: *const opendata_log_t,
+    out_sequence: *mut u64,
+) -> opendata_log_result_t {
+    if let Err(e) = require_handle(log, "log") {
+        return e;
+    }
+    if out_sequence.is_null() {
+        return error_result(
+            opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+            "out_sequence must not be null",
+        );
+    }
+    let handle = &*log;
+    *out_sequence = handle.log.durable_sequence();
+    success_result()
+}
+
+/// Subscribes to durable-sequence watermark changes.
+///
+/// `callback` is invoked once on registration with the current watermark, then
+/// on each subsequent advancement. The callback runs on a tokio worker thread
+/// (not the caller's thread) and **must not call other `opendata_log_*`
+/// functions on the same log handle** — doing so will deadlock the runtime.
+///
+/// Intermediate values may be coalesced; the callback always receives the
+/// latest observed value.
+///
+/// `user_data` is passed back verbatim to each callback invocation. The
+/// caller is responsible for ensuring it remains valid (and safe for
+/// concurrent access from worker threads) until the subscription is freed
+/// via `opendata_log_unsubscribe_durable`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn opendata_log_subscribe_durable(
+    log: *const opendata_log_t,
+    callback: Option<extern "C" fn(durable_sequence: u64, user_data: *mut c_void)>,
+    user_data: *mut c_void,
+    out_subscription: *mut *mut opendata_log_subscription_t,
+) -> opendata_log_result_t {
+    if let Err(e) = require_handle(log, "log") {
+        return e;
+    }
+    if let Err(e) = require_out_ptr(out_subscription, "out_subscription") {
+        return e;
+    }
+    let Some(callback) = callback else {
+        return error_result(
+            opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+            "callback must not be null",
+        );
+    };
+
+    let handle = &*log;
+    let mut rx = handle.log.subscribe_durable();
+    let ud = CallbackUserData::new(user_data);
+
+    let task = handle.runtime.spawn(async move {
+        // Initial fire with the current value to bootstrap the subscriber.
+        ud.invoke(callback, *rx.borrow_and_update());
+
+        while rx.changed().await.is_ok() {
+            ud.invoke(callback, *rx.borrow_and_update());
+        }
+    });
+
+    let subscription = Box::new(opendata_log_subscription_t {
+        abort_handle: task.abort_handle(),
+    });
+    *out_subscription = Box::into_raw(subscription);
+    success_result()
+}
+
+/// Cancels a durable-sequence subscription and frees the handle.
+///
+/// Best-effort: an in-flight callback may complete after this returns. After
+/// this call, no further callbacks for this subscription will be scheduled.
+/// Safe to call after `opendata_log_close` (the abort is a no-op once the
+/// runtime has been torn down).
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn opendata_log_unsubscribe_durable(
+    subscription: *mut opendata_log_subscription_t,
+) -> opendata_log_result_t {
+    if subscription.is_null() {
+        return error_result(
+            opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+            "subscription must not be null",
+        );
+    }
+    let sub = Box::from_raw(subscription);
+    sub.abort_handle.abort();
+    success_result()
 }

--- a/log/c/src/ffi.rs
+++ b/log/c/src/ffi.rs
@@ -1,7 +1,9 @@
-use std::ffi::{CStr, CString, c_char};
+use std::ffi::{CStr, CString, c_char, c_void};
 use std::ops::{Bound, RangeBounds};
 use std::sync::Arc;
 use std::time::Duration;
+
+use tokio::task::AbortHandle;
 
 use common::storage::config::{ObjectStoreConfig, SlateDbStorageConfig, StorageConfig};
 use log::{Config, ReadVisibility, ReaderConfig, SegmentConfig};
@@ -30,6 +32,54 @@ pub struct opendata_log_key_iterator_t {
 pub struct opendata_log_object_store_t {
     pub(crate) config: ObjectStoreConfig,
 }
+
+/// Opaque handle representing a registered durable-sequence subscription.
+///
+/// Created by `opendata_log_subscribe_durable` and destroyed by
+/// `opendata_log_unsubscribe_durable`. Must be freed explicitly even if the
+/// log has been closed; closing the log aborts the task but does not free
+/// this handle.
+pub struct opendata_log_subscription_t {
+    pub(crate) abort_handle: AbortHandle,
+}
+
+/// Callback invoked when the durable-sequence watermark advances.
+///
+/// The first invocation carries the current value at subscription time; each
+/// subsequent invocation carries the latest observed value (intermediate
+/// values may be coalesced).
+///
+/// The callback is invoked on a tokio worker thread, not the caller's thread.
+/// It must not call other `opendata_log_*` functions on the same log handle
+/// (this would deadlock the runtime).
+pub type opendata_log_durable_callback_t =
+    extern "C" fn(durable_sequence: u64, user_data: *mut c_void);
+
+/// Wrapper that lets us send a raw pointer across the .await boundary in the
+/// spawned subscription task. Safety is the C caller's responsibility: they
+/// must ensure `user_data` is valid for the lifetime of the subscription and
+/// safe to access from worker threads.
+pub(crate) struct CallbackUserData(*mut c_void);
+
+impl CallbackUserData {
+    pub(crate) fn new(ptr: *mut c_void) -> Self {
+        Self(ptr)
+    }
+
+    /// Invokes the callback with the wrapped `user_data` pointer. Goes through
+    /// a method so the surrounding async block captures the whole
+    /// [`CallbackUserData`] (which is `Send`) rather than projecting the inner
+    /// `*mut c_void` field (which would not be `Send`).
+    pub(crate) fn invoke(&self, cb: opendata_log_durable_callback_t, sequence: u64) {
+        cb(sequence, self.0);
+    }
+}
+
+// SAFETY: the C caller owns `user_data` and is contractually required to
+// keep it valid for the subscription lifetime. We never deref the pointer
+// in Rust — we only pass it back to the C callback verbatim.
+unsafe impl Send for CallbackUserData {}
+unsafe impl Sync for CallbackUserData {}
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/log/c/src/ffi.rs
+++ b/log/c/src/ffi.rs
@@ -43,6 +43,17 @@ pub struct opendata_log_subscription_t {
     pub(crate) abort_handle: AbortHandle,
 }
 
+impl Drop for opendata_log_subscription_t {
+    /// Defense-in-depth: if the handle is ever dropped without going through
+    /// `opendata_log_unsubscribe_durable` (e.g. a future code path that
+    /// reboxes-then-drops, or a panic in unsubscribe before `abort()` runs),
+    /// stop the spawned task here so it can't keep dereferencing `user_data`.
+    /// Idempotent against a prior explicit `abort()`.
+    fn drop(&mut self) {
+        self.abort_handle.abort();
+    }
+}
+
 /// Callback invoked when the durable-sequence watermark advances.
 ///
 /// The first invocation carries the current value at subscription time; each

--- a/log/c/tests/integration_test.rs
+++ b/log/c/tests/integration_test.rs
@@ -767,3 +767,180 @@ fn open_with_local_slatedb() {
     assert_ok(unsafe { opendata_log_close(log) });
     assert_ok(unsafe { opendata_log_object_store_close(store) });
 }
+
+// ---- durable_sequence / subscription tests ----
+
+use std::ffi::c_void;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+/// Shared state used by `record_callback`: collects every value seen.
+struct CallbackSink {
+    values: Mutex<Vec<u64>>,
+}
+
+extern "C" fn record_callback(durable_sequence: u64, user_data: *mut c_void) {
+    // SAFETY: tests pass a leaked Arc<CallbackSink> as user_data and keep
+    // the original Arc alive for the duration of the subscription.
+    let sink: &CallbackSink = unsafe { &*(user_data as *const CallbackSink) };
+    sink.values.lock().unwrap().push(durable_sequence);
+}
+
+#[test]
+fn durable_sequence_initial_value_is_zero() {
+    let log = open_in_memory_log();
+    let mut seq: u64 = u64::MAX;
+    assert_ok(unsafe { opendata_log_durable_sequence(log, &mut seq) });
+    assert_eq!(seq, 0);
+    assert_ok(unsafe { opendata_log_close(log) });
+}
+
+#[test]
+fn durable_sequence_rejects_null_log() {
+    let mut seq: u64 = 0;
+    assert_error(
+        unsafe { opendata_log_durable_sequence(ptr::null(), &mut seq) },
+        opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+    );
+}
+
+#[test]
+fn durable_sequence_rejects_null_out_pointer() {
+    let log = open_in_memory_log();
+    assert_error(
+        unsafe { opendata_log_durable_sequence(log, ptr::null_mut()) },
+        opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+    );
+    assert_ok(unsafe { opendata_log_close(log) });
+}
+
+#[test]
+fn durable_sequence_advances_after_append_on_immediately_durable_storage() {
+    // Default InMemoryStorage marks writes immediately durable.
+    let log = open_in_memory_log();
+    unsafe { append_records(log, b"orders", 3) };
+
+    // Poll the snapshot until it advances; bounded by test runner timeout.
+    let mut seq: u64 = 0;
+    for _ in 0..200 {
+        assert_ok(unsafe { opendata_log_durable_sequence(log, &mut seq) });
+        if seq >= 3 {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    assert!(seq >= 3, "durable_sequence did not advance: {seq}");
+
+    assert_ok(unsafe { opendata_log_close(log) });
+}
+
+#[test]
+fn subscribe_durable_fires_initial_value_on_registration() {
+    let log = open_in_memory_log();
+    let sink = Arc::new(CallbackSink {
+        values: Mutex::new(Vec::new()),
+    });
+    let ud = Arc::as_ptr(&sink) as *mut c_void;
+
+    let mut sub: *mut opendata_log_subscription_t = ptr::null_mut();
+    assert_ok(unsafe { opendata_log_subscribe_durable(log, Some(record_callback), ud, &mut sub) });
+    assert!(!sub.is_null());
+
+    // Wait for the initial fire.
+    for _ in 0..200 {
+        if !sink.values.lock().unwrap().is_empty() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    let observed = sink.values.lock().unwrap().clone();
+    assert!(
+        !observed.is_empty(),
+        "callback should have fired at least once on subscription"
+    );
+    assert_eq!(observed[0], 0, "initial fire should carry current value 0");
+
+    assert_ok(unsafe { opendata_log_unsubscribe_durable(sub) });
+    assert_ok(unsafe { opendata_log_close(log) });
+    drop(sink);
+}
+
+#[test]
+fn subscribe_durable_fires_on_advance() {
+    let log = open_in_memory_log();
+    let sink = Arc::new(CallbackSink {
+        values: Mutex::new(Vec::new()),
+    });
+    let ud = Arc::as_ptr(&sink) as *mut c_void;
+
+    let mut sub: *mut opendata_log_subscription_t = ptr::null_mut();
+    assert_ok(unsafe { opendata_log_subscribe_durable(log, Some(record_callback), ud, &mut sub) });
+
+    // Wait for the initial fire so we have a baseline.
+    for _ in 0..200 {
+        if !sink.values.lock().unwrap().is_empty() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    let initial_count = sink.values.lock().unwrap().len();
+
+    // Append should drive durable_sequence forward (InMemoryStorage is
+    // immediately durable by default).
+    unsafe { append_records(log, b"orders", 5) };
+
+    // Wait for a subsequent fire reflecting the advance.
+    for _ in 0..200 {
+        let v = sink.values.lock().unwrap();
+        if v.len() > initial_count && *v.last().unwrap() >= 5 {
+            break;
+        }
+        drop(v);
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+    let observed = sink.values.lock().unwrap().clone();
+    assert!(
+        observed.last().copied().unwrap_or(0) >= 5,
+        "callback should observe durable_sequence >= 5, got: {observed:?}"
+    );
+
+    assert_ok(unsafe { opendata_log_unsubscribe_durable(sub) });
+    assert_ok(unsafe { opendata_log_close(log) });
+    drop(sink);
+}
+
+#[test]
+fn unsubscribe_rejects_null() {
+    assert_error(
+        unsafe { opendata_log_unsubscribe_durable(ptr::null_mut()) },
+        opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+    );
+}
+
+#[test]
+fn subscribe_rejects_null_callback() {
+    let log = open_in_memory_log();
+    let mut sub: *mut opendata_log_subscription_t = ptr::null_mut();
+    assert_error(
+        unsafe { opendata_log_subscribe_durable(log, None, ptr::null_mut(), &mut sub) },
+        opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+    );
+    assert_ok(unsafe { opendata_log_close(log) });
+}
+
+#[test]
+fn subscribe_rejects_null_out_pointer() {
+    let log = open_in_memory_log();
+    assert_error(
+        unsafe {
+            opendata_log_subscribe_durable(
+                log,
+                Some(record_callback),
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+        },
+        opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+    );
+    assert_ok(unsafe { opendata_log_close(log) });
+}

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -766,10 +766,18 @@ async fn try_advance_durable(
             .await;
         }
         watermarks.update_durable(advanced.epoch);
-        // send_if_modified is monotonic by construction since broadcasts
-        // increase next_sequence and drains pop in order, but we use
-        // send_replace for simplicity — watch coalesces duplicates.
-        durable_sequence_tx.send_replace(advanced.next_sequence);
+        // Only notify on actual advance: `send_replace` always wakes
+        // receivers regardless of value, which would surface phantom
+        // "advance" events to subscribers (e.g. the initial drain
+        // republishing the bootstrap value).
+        durable_sequence_tx.send_if_modified(|current| {
+            if advanced.next_sequence > *current {
+                *current = advanced.next_sequence;
+                true
+            } else {
+                false
+            }
+        });
     }
 }
 

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -109,6 +109,7 @@ pub struct LogDb {
     clock: Arc<dyn Clock>,
     read_view: Arc<RwLock<LogReadView>>,
     epoch_watcher: EpochWatcher,
+    durable_sequence_rx: watch::Receiver<Sequence>,
     read_subscriber_task: JoinHandle<()>,
     compactor_view_task: Option<JoinHandle<()>>,
     read_visibility: ReadVisibility,
@@ -294,6 +295,28 @@ impl LogDb {
         Ok(())
     }
 
+    /// Returns the exclusive upper bound of global sequences durably persisted.
+    ///
+    /// A returned value of `N` means every record with sequence `seq < N` is
+    /// durable. The initial value is the next sequence that would be assigned
+    /// at construction; it advances as the underlying storage confirms
+    /// durability — without requiring an explicit [`flush`](Self::flush).
+    ///
+    /// Pairs with [`subscribe_durable`](Self::subscribe_durable) for change
+    /// notifications.
+    pub fn durable_sequence(&self) -> Sequence {
+        *self.durable_sequence_rx.borrow()
+    }
+
+    /// Subscribes to the durable-sequence watermark.
+    ///
+    /// The returned receiver updates whenever the durable-sequence watermark
+    /// advances. See [`durable_sequence`](Self::durable_sequence) for the
+    /// semantics of the value.
+    pub fn subscribe_durable(&self) -> watch::Receiver<Sequence> {
+        self.durable_sequence_rx.clone()
+    }
+
     /// Waits for read-side visibility to reach the current requirement.
     async fn sync_reads(&self) -> Result<()> {
         let (target, durability) = match self.read_visibility {
@@ -423,6 +446,7 @@ impl LogDb {
         let written_rx = handle.written_rx();
         let initial_segment_id = segment_cache.latest().map(|s| s.id());
         let initial_deleted_segment_id = segment_cache.initial_deleted_segment_id();
+        let initial_next_sequence = written_rx.borrow().next_sequence;
         let compactor_view_task = if let Some(cell) = compactor_view_cell.as_ref() {
             let (compactor_rx, task) = spawn_compactor_view_publisher(
                 written_rx.clone(),
@@ -447,22 +471,15 @@ impl LogDb {
             segment_cache,
         )));
 
-        let (epoch_watcher, read_subscriber_task) = if read_visibility.is_remote() {
-            spawn_durable_subscriber(
-                written_rx,
-                Arc::clone(&read_view),
-                &storage,
-                initial_segment_id,
-                initial_deleted_segment_id,
-            )
-        } else {
-            spawn_written_subscriber(
-                written_rx,
-                Arc::clone(&read_view),
-                initial_segment_id,
-                initial_deleted_segment_id,
-            )
-        };
+        let (epoch_watcher, durable_sequence_rx, read_subscriber_task) = spawn_subscriber(
+            written_rx,
+            &storage,
+            Arc::clone(&read_view),
+            read_visibility,
+            initial_segment_id,
+            initial_deleted_segment_id,
+            initial_next_sequence,
+        );
 
         Ok(Self {
             handle,
@@ -471,6 +488,7 @@ impl LogDb {
             clock,
             read_view,
             epoch_watcher,
+            durable_sequence_rx,
             read_subscriber_task,
             compactor_view_task,
             read_visibility,
@@ -684,119 +702,109 @@ fn drain_compactor_deletes(
     }
 }
 
-/// Tries to advance the tracker and, on success, applies the new snapshot
-/// to the shared read view and reconciles the local segment cache against
-/// the writer's published watermarks.
-///
-/// Two independent reconciliations happen on a tick:
-///
-/// - **Adds.** When `last_segment_id` advanced, scan storage for the new
-///   segments and append them.
-/// - **Drops.** When `last_deleted_segment_id` advanced, drop every
-///   locally-cached segment with id `<= new value`. Sound because retention
-///   only deletes from the low end of the log (RFC 0005).
-async fn try_advance_read_view(
-    tracker: &mut ViewTracker,
+/// Applies a written view directly to the read view (used in Memory mode where
+/// reads see writes as soon as they're broadcast — no durability gate).
+async fn advance_read_view_to(
     read_view: &RwLock<LogReadView>,
-    watermarks: &EpochWatermarks,
     known_segment_id: &mut Option<SegmentId>,
     known_deleted_segment_id: &mut Option<SegmentId>,
-    durability: Durability,
-    through_seq: u64,
+    snapshot: Arc<dyn common::storage::StorageSnapshot>,
+    new_segment_id: Option<SegmentId>,
+    new_deleted_segment_id: Option<SegmentId>,
 ) {
-    if let Some(advanced) = tracker.advance(through_seq) {
-        let mut rv = read_view.write().await;
-        rv.update_snapshot(advanced.snapshot as Arc<dyn common::StorageRead>);
+    let mut rv = read_view.write().await;
+    rv.update_snapshot(snapshot as Arc<dyn common::StorageRead>);
 
-        // Refresh segments from the snapshot when the writer reports a new segment.
-        if advanced.last_segment_id != *known_segment_id {
-            match rv.refresh_segments(*known_segment_id).await {
-                Ok(()) => {
-                    *known_segment_id = advanced.last_segment_id;
-                }
-                Err(e) => {
-                    tracing::warn!("failed to refresh segments: {e}");
-                }
+    if new_segment_id != *known_segment_id {
+        match rv.refresh_segments(*known_segment_id).await {
+            Ok(()) => {
+                *known_segment_id = new_segment_id;
+            }
+            Err(e) => {
+                tracing::warn!("failed to refresh segments: {e}");
             }
         }
+    }
 
-        // Drop segments that have been deleted off the low end since our
-        // last observation.
-        if advanced.last_deleted_segment_id > *known_deleted_segment_id {
-            if let Some(through_id) = advanced.last_deleted_segment_id {
-                rv.drop_segments_through(through_id);
-            }
-            *known_deleted_segment_id = advanced.last_deleted_segment_id;
+    if new_deleted_segment_id > *known_deleted_segment_id {
+        if let Some(through_id) = new_deleted_segment_id {
+            rv.drop_segments_through(through_id);
         }
-
-        match durability {
-            Durability::Written => watermarks.update_written(advanced.epoch),
-            Durability::Durable | Durability::Applied => watermarks.update_durable(advanced.epoch),
-        }
+        *known_deleted_segment_id = new_deleted_segment_id;
     }
 }
 
-fn spawn_written_subscriber(
-    mut written_rx: watch::Receiver<WrittenView>,
-    read_view: Arc<RwLock<LogReadView>>,
-    initial_segment_id: Option<SegmentId>,
-    initial_deleted_segment_id: Option<SegmentId>,
-) -> (EpochWatcher, JoinHandle<()>) {
-    let (watermarks, watcher) = EpochWatermarks::new();
-    let mut tracker = ViewTracker::new();
-    let mut known_segment_id = initial_segment_id;
-    let mut known_deleted_segment_id = initial_deleted_segment_id;
-    let task = tokio::spawn(async move {
-        while written_rx.changed().await.is_ok() {
-            let view = written_rx.borrow_and_update().clone();
-            let seqnum = view.seqnum;
-            tracker.push(ViewEntry {
-                seqnum,
-                epoch: view.epoch,
-                snapshot: view.snapshot,
-                last_segment_id: view.last_segment_id,
-                last_deleted_segment_id: view.last_deleted_segment_id,
-            });
-
-            try_advance_read_view(
-                &mut tracker,
-                &read_view,
-                &watermarks,
-                &mut known_segment_id,
-                &mut known_deleted_segment_id,
-                Durability::Written,
-                seqnum,
+/// Drains the tracker up to `durable_seq` and, on advance, atomically updates:
+///
+/// - `durable_sequence_tx` — the published global-sequence watermark
+/// - `watermarks.durable` — the durable epoch
+/// - When `advance_read_view` is true: the shared read view (Remote mode)
+///
+/// All updates happen under the same drain so that subscribers observing
+/// `durable_sequence` advance can rely on the read view having advanced too.
+#[allow(clippy::too_many_arguments)]
+async fn try_advance_durable(
+    tracker: &mut ViewTracker,
+    read_view: &RwLock<LogReadView>,
+    watermarks: &EpochWatermarks,
+    durable_sequence_tx: &watch::Sender<Sequence>,
+    known_segment_id: &mut Option<SegmentId>,
+    known_deleted_segment_id: &mut Option<SegmentId>,
+    advance_read_view: bool,
+    durable_seq: u64,
+) {
+    if let Some(advanced) = tracker.advance(durable_seq) {
+        if advance_read_view {
+            advance_read_view_to(
+                read_view,
+                known_segment_id,
+                known_deleted_segment_id,
+                advanced.snapshot,
+                advanced.last_segment_id,
+                advanced.last_deleted_segment_id,
             )
             .await;
         }
-    });
-    (watcher, task)
+        watermarks.update_durable(advanced.epoch);
+        // send_if_modified is monotonic by construction since broadcasts
+        // increase next_sequence and drains pop in order, but we use
+        // send_replace for simplicity — watch coalesces duplicates.
+        durable_sequence_tx.send_replace(advanced.next_sequence);
+    }
 }
 
-/// Spawns subscriber tasks for `ReadVisibility::Remote` mode.
+/// Spawns the read-view subscriber.
 ///
-/// A single task watches both the WrittenView channel and the durable
-/// sequence watermark. When a new WrittenView arrives, it's pushed into
-/// the ViewTracker and the "written" watermark is advanced. When
-/// the durable_seq advances, the tracker is drained and the LogReadView
-/// and "durable" watermark are updated.
-fn spawn_durable_subscriber(
+/// A single task watches both the writer's `WrittenView` channel and the
+/// underlying storage's durable seqnum watermark. The behaviour differs by
+/// read visibility:
+///
+/// - **Memory mode** — read view advances on every `WrittenView` change.
+///   `durable_sequence` advances when storage durability catches up.
+/// - **Remote mode** — read view advances only when storage durability covers
+///   the corresponding write; `durable_sequence` advances at the same moment.
+///
+/// In both modes, `durable_sequence` and (in Remote) the read view are
+/// updated together inside [`try_advance_durable`], so observers cannot see
+/// `durable_sequence` move past a write while the read view still lags.
+fn spawn_subscriber(
     mut written_rx: watch::Receiver<WrittenView>,
-    read_view: Arc<RwLock<LogReadView>>,
     storage: &Arc<dyn common::Storage>,
+    read_view: Arc<RwLock<LogReadView>>,
+    read_visibility: ReadVisibility,
     initial_segment_id: Option<SegmentId>,
     initial_deleted_segment_id: Option<SegmentId>,
-) -> (EpochWatcher, JoinHandle<()>) {
+    initial_next_sequence: Sequence,
+) -> (EpochWatcher, watch::Receiver<Sequence>, JoinHandle<()>) {
     let (watermarks, watcher) = EpochWatermarks::new();
+    let (durable_sequence_tx, durable_sequence_rx) = watch::channel(initial_next_sequence);
     let mut durable_rx = storage.subscribe_durable();
     let mut tracker = ViewTracker::new();
     let mut known_segment_id = initial_segment_id;
     let mut known_deleted_segment_id = initial_deleted_segment_id;
+    let advance_rv_on_durable = read_visibility.is_remote();
 
     let task = tokio::spawn(async move {
-        // Track the latest known durable_seq so we can re-check after new
-        // writes arrive (the durable notification may arrive before the
-        // WrittenView is pushed).
         let mut last_durable_seq: u64 = *durable_rx.borrow();
 
         loop {
@@ -809,17 +817,37 @@ fn spawn_durable_subscriber(
                     tracker.push(ViewEntry {
                         seqnum: view.seqnum,
                         epoch: view.epoch,
-                        snapshot: view.snapshot,
+                        snapshot: view.snapshot.clone(),
+                        next_sequence: view.next_sequence,
                         last_segment_id: view.last_segment_id,
                         last_deleted_segment_id: view.last_deleted_segment_id,
                     });
                     watermarks.update_written(view.epoch);
 
-                    // Re-check: the durable watermark may already cover this entry
-                    try_advance_read_view(
-                        &mut tracker, &read_view, &watermarks,
-                        &mut known_segment_id, &mut known_deleted_segment_id,
-                        Durability::Durable, last_durable_seq,
+                    if !advance_rv_on_durable {
+                        // Memory mode: read view sees writes immediately.
+                        advance_read_view_to(
+                            &read_view,
+                            &mut known_segment_id,
+                            &mut known_deleted_segment_id,
+                            view.snapshot,
+                            view.last_segment_id,
+                            view.last_deleted_segment_id,
+                        )
+                        .await;
+                    }
+
+                    // Try drain in case durability already covers this seqnum
+                    // (e.g. InMemoryStorage default, or SlateDB already flushed).
+                    try_advance_durable(
+                        &mut tracker,
+                        &read_view,
+                        &watermarks,
+                        &durable_sequence_tx,
+                        &mut known_segment_id,
+                        &mut known_deleted_segment_id,
+                        advance_rv_on_durable,
+                        last_durable_seq,
                     )
                     .await;
                 }
@@ -828,10 +856,15 @@ fn spawn_durable_subscriber(
                         break;
                     }
                     last_durable_seq = *durable_rx.borrow_and_update();
-                    try_advance_read_view(
-                        &mut tracker, &read_view, &watermarks,
-                        &mut known_segment_id, &mut known_deleted_segment_id,
-                        Durability::Durable, last_durable_seq,
+                    try_advance_durable(
+                        &mut tracker,
+                        &read_view,
+                        &watermarks,
+                        &durable_sequence_tx,
+                        &mut known_segment_id,
+                        &mut known_deleted_segment_id,
+                        advance_rv_on_durable,
+                        last_durable_seq,
                     )
                     .await;
                 }
@@ -839,7 +872,7 @@ fn spawn_durable_subscriber(
         }
     });
 
-    (watcher, task)
+    (watcher, durable_sequence_rx, task)
 }
 
 #[cfg(test)]
@@ -870,6 +903,7 @@ mod tests {
             epoch: seqnum,
             snapshot: storage.snapshot().await.unwrap(),
             seqnum,
+            next_sequence: 0,
             last_segment_id,
             last_deleted_segment_id,
         }
@@ -2766,5 +2800,178 @@ mod tests {
         // should contribute (covered_to from count_in_range is below the
         // range start, so scan_lo gets pulled to seg_lo).
         assert_eq!(log.count(Bytes::from("k"), 7..).await.unwrap(), 3);
+    }
+
+    // ---- durable_sequence tests ----
+
+    #[tokio::test]
+    async fn durable_sequence_starts_at_zero_on_fresh_log() {
+        let log = LogDb::open(test_config()).await.unwrap();
+        assert_eq!(log.durable_sequence(), 0);
+    }
+
+    #[tokio::test]
+    async fn durable_sequence_advances_on_immediately_durable_storage() {
+        // Default InMemoryStorage marks writes durable immediately. The
+        // subscriber should pick that up without an explicit flush.
+        let log = LogDb::open(test_config()).await.unwrap();
+        let mut rx = log.subscribe_durable();
+
+        log.try_append(vec![
+            Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v0"),
+            },
+            Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v1"),
+            },
+        ])
+        .await
+        .unwrap();
+
+        // Wait for subscriber to publish past the append.
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while *rx.borrow_and_update() < 2 {
+                rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("durable_sequence should advance to >= 2 after immediately-durable append");
+
+        assert!(log.durable_sequence() >= 2);
+    }
+
+    #[tokio::test]
+    async fn durable_sequence_does_not_advance_until_storage_flushes() {
+        // With deferred durability, the storage's durable watermark stays
+        // behind until flush_to/flush is called.
+        let storage =
+            Arc::new(common::storage::in_memory::InMemoryStorage::new().with_deferred_durability());
+        let log = LogDb::new(Arc::clone(&storage) as Arc<dyn common::Storage>)
+            .await
+            .unwrap();
+        let initial = log.durable_sequence();
+
+        log.try_append(vec![Record {
+            key: Bytes::from("k"),
+            value: Bytes::from("v0"),
+        }])
+        .await
+        .unwrap();
+
+        // Give the subscriber a moment to drain anything it could.
+        tokio::task::yield_now().await;
+        assert_eq!(
+            log.durable_sequence(),
+            initial,
+            "durable_sequence must not advance without storage durability"
+        );
+
+        common::Storage::flush(storage.as_ref()).await.unwrap();
+
+        // Subscriber observes durable_rx advance and publishes.
+        let mut rx = log.subscribe_durable();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while *rx.borrow_and_update() < 1 {
+                rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("durable_sequence should advance after storage flush");
+        assert!(log.durable_sequence() >= 1);
+    }
+
+    #[tokio::test]
+    async fn durable_sequence_advances_on_explicit_flush() {
+        let storage =
+            Arc::new(common::storage::in_memory::InMemoryStorage::new().with_deferred_durability());
+        let log = LogDb::new(Arc::clone(&storage) as Arc<dyn common::Storage>)
+            .await
+            .unwrap();
+
+        log.try_append(vec![
+            Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v0"),
+            },
+            Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v1"),
+            },
+        ])
+        .await
+        .unwrap();
+
+        log.flush().await.unwrap();
+
+        let mut rx = log.subscribe_durable();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while *rx.borrow_and_update() < 2 {
+                rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .expect("durable_sequence should advance to >= 2 after LogDb::flush()");
+    }
+
+    #[tokio::test]
+    async fn durable_sequence_advance_implies_scan_visibility_in_remote_mode() {
+        // The unified subscriber updates the read view and durable_sequence
+        // under the same drain. When durable_sequence advances past N, a
+        // scan must see the records with seq < N immediately.
+        let storage =
+            Arc::new(common::storage::in_memory::InMemoryStorage::new().with_deferred_durability());
+        let log = LogDb::new_durable(Arc::clone(&storage) as Arc<dyn common::Storage>)
+            .await
+            .unwrap();
+
+        log.try_append(vec![Record {
+            key: Bytes::from("k"),
+            value: Bytes::from("v0"),
+        }])
+        .await
+        .unwrap();
+
+        // Not yet durable — scan should be empty.
+        let mut iter = log.scan(Bytes::from("k"), ..).await.unwrap();
+        assert!(iter.next().await.unwrap().is_none());
+
+        common::Storage::flush(storage.as_ref()).await.unwrap();
+
+        // Wait for durable_sequence to advance.
+        let mut rx = log.subscribe_durable();
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while *rx.borrow_and_update() < 1 {
+                rx.changed().await.unwrap();
+            }
+        })
+        .await
+        .unwrap();
+
+        // Now scan must see the record (no extra sleeps/yields needed).
+        let mut iter = log.scan(Bytes::from("k"), ..).await.unwrap();
+        let entry = iter.next().await.unwrap().unwrap();
+        assert_eq!(entry.value, Bytes::from("v0"));
+    }
+
+    #[tokio::test]
+    async fn subscribe_durable_notifies_on_advance() {
+        let log = LogDb::open(test_config()).await.unwrap();
+        let mut rx = log.subscribe_durable();
+        assert_eq!(*rx.borrow_and_update(), 0);
+
+        log.try_append(vec![Record {
+            key: Bytes::from("k"),
+            value: Bytes::from("v"),
+        }])
+        .await
+        .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), rx.changed())
+            .await
+            .expect("subscribe_durable should fire on advance")
+            .unwrap();
+        assert!(*rx.borrow() >= 1);
     }
 }

--- a/log/src/view_tracker.rs
+++ b/log/src/view_tracker.rs
@@ -8,7 +8,7 @@
 use std::collections::VecDeque;
 use std::sync::Arc;
 
-use crate::model::SegmentId;
+use crate::model::{SegmentId, Sequence};
 use common::storage::StorageSnapshot;
 
 /// A write-aligned read view entry.
@@ -16,6 +16,8 @@ pub(crate) struct ViewEntry {
     pub seqnum: u64,
     pub epoch: u64,
     pub snapshot: Arc<dyn StorageSnapshot>,
+    /// Exclusive upper bound of global sequences allocated as of this entry.
+    pub next_sequence: Sequence,
     pub last_segment_id: Option<SegmentId>,
     pub last_deleted_segment_id: Option<SegmentId>,
 }
@@ -80,6 +82,7 @@ mod tests {
             seqnum: 1,
             epoch: 10,
             snapshot: snap.clone(),
+            next_sequence: 0,
             last_segment_id: Some(7),
             last_deleted_segment_id: None,
         });
@@ -100,6 +103,7 @@ mod tests {
             seqnum: 5,
             epoch: 1,
             snapshot: snap,
+            next_sequence: 0,
             last_segment_id: Some(9),
             last_deleted_segment_id: None,
         });
@@ -118,6 +122,7 @@ mod tests {
             seqnum: 1,
             epoch: 1,
             snapshot: make_snapshot().await,
+            next_sequence: 0,
             last_segment_id: Some(0),
             last_deleted_segment_id: None,
         });
@@ -125,6 +130,7 @@ mod tests {
             seqnum: 3,
             epoch: 2,
             snapshot: make_snapshot().await,
+            next_sequence: 0,
             last_segment_id: Some(1),
             last_deleted_segment_id: None,
         });
@@ -132,6 +138,7 @@ mod tests {
             seqnum: 5,
             epoch: 3,
             snapshot: make_snapshot().await,
+            next_sequence: 0,
             last_segment_id: Some(2),
             last_deleted_segment_id: None,
         });

--- a/log/src/writer.rs
+++ b/log/src/writer.rs
@@ -28,7 +28,7 @@ use tokio::task::JoinHandle;
 
 use crate::error::AppendError;
 use crate::listing::ListingCache;
-use crate::model::{AppendOutput, Record as UserRecord, SegmentId};
+use crate::model::{AppendOutput, Record as UserRecord, SegmentId, Sequence};
 use crate::segment::{LogSegment, SegmentAssignment, SegmentCache};
 use crate::serde::{LogEntryKey, SegmentMetaKey};
 
@@ -43,6 +43,9 @@ pub(crate) struct WrittenView {
     pub snapshot: Arc<dyn common::storage::StorageSnapshot>,
     /// Storage engine sequence number for this write.
     pub seqnum: u64,
+    /// Exclusive upper bound of global sequences allocated as of this write.
+    /// Equals `SequenceAllocator::peek_next_sequence()` at broadcast time.
+    pub next_sequence: Sequence,
     /// Id of the largest user segment created so far. `None` before the first
     /// segment is created.
     pub last_segment_id: Option<SegmentId>,
@@ -137,10 +140,15 @@ impl LogWriter {
         let initial_snapshot = storage.snapshot().await.map_err(|e| e.to_string())?;
         let last_segment_id = segment_cache.latest().map(|s| s.id());
         let last_deleted_segment_id = segment_cache.initial_deleted_segment_id();
+        // Anything persisted before construction is already covered by the
+        // storage's initial durable watermark, so `peek_next_sequence` is the
+        // exclusive upper bound of already-durable global sequences.
+        let initial_next_sequence = sequence_allocator.peek_next_sequence();
         let initial_view = WrittenView {
             epoch: 0,
             snapshot: initial_snapshot,
             seqnum: 0,
+            next_sequence: initial_next_sequence,
             last_segment_id,
             last_deleted_segment_id,
         };
@@ -382,6 +390,7 @@ impl LogWriter {
             epoch: self.epoch,
             snapshot,
             seqnum,
+            next_sequence: self.sequence_allocator.peek_next_sequence(),
             last_segment_id: self.last_segment_id,
             last_deleted_segment_id: self.last_deleted_segment_id,
         });

--- a/log/tests/durable_sequence.rs
+++ b/log/tests/durable_sequence.rs
@@ -1,0 +1,196 @@
+//! Integration tests for the `LogDb::durable_sequence` API.
+//!
+//! These tests exercise the public Rust surface only (no `pub(crate)` access)
+//! to verify that the durable-sequence watermark advances as the underlying
+//! storage confirms durability.
+
+use std::time::Duration;
+
+use bytes::Bytes;
+use common::StorageConfig;
+use common::storage::config::{LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig};
+use log::{Config, LogDb, LogRead, ReadVisibility, Record};
+use tempfile::TempDir;
+
+fn slatedb_config(dir: &TempDir, read_visibility: ReadVisibility) -> Config {
+    Config {
+        storage: StorageConfig::SlateDb(SlateDbStorageConfig {
+            path: "log-data".to_string(),
+            object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
+                path: dir.path().to_string_lossy().to_string(),
+            }),
+            settings_path: None,
+            block_cache: None,
+        }),
+        read_visibility,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn durable_sequence_advances_with_in_memory_storage() {
+    let log = LogDb::open(Config {
+        storage: StorageConfig::InMemory,
+        ..Default::default()
+    })
+    .await
+    .expect("open log");
+
+    assert_eq!(log.durable_sequence(), 0);
+
+    let append = log
+        .try_append(vec![
+            Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v0"),
+            },
+            Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v1"),
+            },
+            Record {
+                key: Bytes::from("k"),
+                value: Bytes::from("v2"),
+            },
+        ])
+        .await
+        .expect("try_append");
+    let end_seq = append.start_sequence + 3;
+
+    let mut rx = log.subscribe_durable();
+    tokio::time::timeout(Duration::from_secs(5), async {
+        while *rx.borrow_and_update() < end_seq {
+            rx.changed().await.expect("subscribe_durable channel");
+        }
+    })
+    .await
+    .expect("durable_sequence should advance past the append");
+
+    assert!(log.durable_sequence() >= end_seq);
+    log.close().await.expect("close");
+}
+
+#[tokio::test]
+async fn durable_sequence_advances_with_slatedb_storage_after_flush() {
+    let dir = TempDir::new().expect("temp dir");
+    let log = LogDb::open(slatedb_config(&dir, ReadVisibility::Memory))
+        .await
+        .expect("open log");
+
+    let append = log
+        .try_append(vec![Record {
+            key: Bytes::from("k"),
+            value: Bytes::from("v0"),
+        }])
+        .await
+        .expect("try_append");
+    let end_seq = append.start_sequence + 1;
+
+    // Force a flush so the underlying durability watermark moves.
+    log.flush().await.expect("flush");
+
+    let mut rx = log.subscribe_durable();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while *rx.borrow_and_update() < end_seq {
+            rx.changed().await.expect("subscribe_durable channel");
+        }
+    })
+    .await
+    .expect("durable_sequence should advance past the flushed append");
+
+    assert!(log.durable_sequence() >= end_seq);
+    log.close().await.expect("close");
+}
+
+/// In Remote mode, once `durable_sequence` advances past `N`, a subsequent
+/// `scan` is required to return every record with `sequence < N` — the
+/// invariant the unified subscriber's drain is designed to enforce.
+#[tokio::test]
+async fn durable_sequence_advance_implies_scan_visibility_in_remote_mode_with_slatedb() {
+    let dir = TempDir::new().expect("temp dir");
+    let log = LogDb::open(slatedb_config(&dir, ReadVisibility::Remote))
+        .await
+        .expect("open log");
+
+    let key = Bytes::from("orders");
+    let records: Vec<Record> = (0..5u8)
+        .map(|i| Record {
+            key: key.clone(),
+            value: Bytes::from(vec![i]),
+        })
+        .collect();
+    let append = log.try_append(records).await.expect("try_append");
+    let end_seq = append.start_sequence + 5;
+
+    // Before durability, scan must not see the writes.
+    let mut iter = log.scan(key.clone(), ..).await.expect("scan");
+    assert!(
+        iter.next().await.expect("next").is_none(),
+        "Remote mode scan must not see non-durable writes"
+    );
+
+    log.flush().await.expect("flush");
+
+    // Wait for durable_sequence to cover the batch.
+    let mut rx = log.subscribe_durable();
+    tokio::time::timeout(Duration::from_secs(10), async {
+        while *rx.borrow_and_update() < end_seq {
+            rx.changed().await.expect("subscribe_durable channel");
+        }
+    })
+    .await
+    .expect("durable_sequence should cover the batch after flush");
+
+    // Now scan must see everything — no extra yields or sleeps.
+    let mut iter = log.scan(key, ..).await.expect("scan");
+    let mut seen = Vec::new();
+    while let Some(entry) = iter.next().await.expect("next") {
+        seen.push(entry.value);
+    }
+    assert_eq!(seen.len(), 5, "scan should see all 5 records");
+    for (i, v) in seen.iter().enumerate() {
+        assert_eq!(v.as_ref(), &[i as u8]);
+    }
+
+    log.close().await.expect("close");
+}
+
+/// `durable_sequence` is strictly monotonic across multiple flushed batches.
+#[tokio::test]
+async fn durable_sequence_is_monotonic_across_batches_with_slatedb() {
+    let dir = TempDir::new().expect("temp dir");
+    let log = LogDb::open(slatedb_config(&dir, ReadVisibility::Memory))
+        .await
+        .expect("open log");
+
+    let key = Bytes::from("events");
+    let mut prev: u64 = 0;
+    for batch in 0..5 {
+        let records: Vec<Record> = (0..3)
+            .map(|i| Record {
+                key: key.clone(),
+                value: Bytes::from(format!("b{batch}-{i}")),
+            })
+            .collect();
+        log.try_append(records).await.expect("try_append");
+        log.flush().await.expect("flush");
+
+        let mut rx = log.subscribe_durable();
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while *rx.borrow_and_update() <= prev {
+                rx.changed().await.expect("subscribe_durable channel");
+            }
+        })
+        .await
+        .expect("durable_sequence should advance after each flushed batch");
+
+        let now = log.durable_sequence();
+        assert!(
+            now > prev,
+            "durable_sequence regressed: now={now} prev={prev}"
+        );
+        prev = now;
+    }
+
+    log.close().await.expect("close");
+}


### PR DESCRIPTION
The durability of writes is exposed in LogDb API only through explicit flush() calls. The downside of flush() in a running application is that it clears the write pipeline, which takes time to rebuild. It would be better to let users track the progress of the durable sequence number. This can be used to implement kafka-like callbacks for each write as it becomes durable, which is what the openmessaging benchmark expects from write APIs today.