### PR TITLE
[buffer] add consumer read-ahead

### DIFF
--- a/buffer/rfcs/0003-consumer-read-ahead.md
+++ b/buffer/rfcs/0003-consumer-read-ahead.md
@@ -8,25 +8,23 @@
 
 ## Summary
 
-Add a fetch-handle type and three methods to `buffer::Consumer` so
-high-throughput consumers can fetch and decode many data batches
-concurrently while keeping manifest mutation serialized:
+Add a fetch-handle type and three methods to `buffer::Consumer` so a consumer
+can fetch and decode many data batches **concurrently** while keeping manifest
+mutation **serialized and batched**:
 
 ```rust
 impl Consumer {
     pub async fn next_descriptors(&mut self, max: usize)
         -> Result<Vec<BatchDescriptor>>;
 
-    /// Convenience wrapper for serial callers. The high-throughput
-    /// runtime uses [`fetch_handle`] instead.
+    /// Convenience wrapper for serial callers; constructs a local
+    /// fetch handle and calls `fetch`.
     pub async fn fetch_descriptor(&mut self, descriptor: BatchDescriptor)
         -> Result<ConsumedBatch>;
 
     /// Cheap, cloneable handle to the read path. Holds an `Arc` to
     /// the object store; carries no manifest state and no mutable
-    /// cursor. The owning `Consumer` keeps `&mut`-only access to
-    /// manifest operations (`next_descriptors`, `ack`, `ack_through`,
-    /// `flush`).
+    /// cursor.
     pub fn fetch_handle(&self) -> ConsumerFetchHandle;
 
     pub async fn ack_through(&mut self, sequence: u64) -> Result<()>;
@@ -47,39 +45,31 @@ pub struct BatchDescriptor {
     pub sequence: u64,
     pub location: String,
     pub metadata: Vec<Metadata>,
-    /// Object size in bytes when known. Reserved for byte-budget
-    /// accounting in `opendata-ingest-runtime` (RFC 0002 in
-    /// `opendata-contrib`). v1 manifests do not carry size, so this
-    /// is always `None` until a future manifest format extension
-    /// fills it in. Callers that observe `None` use a pessimistic
-    /// reservation per their own configuration; see "BatchDescriptor
-    /// and Object Size" below.
-    pub object_bytes: Option<u64>,
 }
 ```
 
-`next_descriptors` reads the manifest once and returns a contiguous run
-of entries past the consumer's read-ahead cursor without performing any
-object-store fetch. `ConsumerFetchHandle::fetch` performs the object
-fetch and batch decode for a single descriptor; it is stateless and
-clone-shareable across worker tasks. `Consumer::fetch_descriptor` is a
-convenience wrapper for serial callers; under the hood it constructs a
-local handle and calls `fetch` (it takes `&mut self` only because
-it forwards lag-metric updates to the consumer's serial cursor —
-parallel callers should use the handle directly). `ack_through(seq)`
-advances the durable ack frontier through `seq` in one call,
-replacing the per-sequence loop the high-throughput runtime would
-otherwise need; durable-dequeue happens **before** any in-memory
-state advances.
+`next_descriptors` reads the manifest once and returns a contiguous run of
+entries past the consumer's read-ahead cursor, performing no object-store
+fetch. `ConsumerFetchHandle::fetch` performs the object fetch and batch decode
+for a single descriptor; it is stateless and clone-shareable across worker
+tasks, so many fetches can run in parallel. `ack_through(seq)` advances the
+durable ack frontier through `seq` in a single manifest write, replacing the
+per-sequence ack loop a batching consumer would otherwise run.
+
+Together these turn the two manifest interactions — discovering work and
+acknowledging it — into **batch** operations, and let the high-volume work —
+fetching and decoding batch objects — run **in parallel**. That is the whole
+point; see the Motivation for why this is the lever for throughput.
 
 The existing `next_batch`, `ack`, `flush`, and `close` API is preserved
-unchanged; `next_batch` becomes a thin compatibility wrapper over
-`next_descriptors(1)` + `fetch_descriptor`. Epoch fencing semantics are
-unchanged.
+unchanged. `next_batch` becomes a thin wrapper over `next_descriptors(1)` +
+`fetch_descriptor`, and — as today — can be called repeatedly to read
+successive batches before any of them are acked (the read cursor is
+independent of the durable ack frontier). Epoch fencing is unchanged.
 
-This RFC is the Buffer-side companion to opendata-contrib RFC 0002
-(generic ingest runtime), which consumes this API for parallel fetch
-and decode.
+opendata-contrib RFC 0002 (the generic ingest runtime) is **one example** of a
+pipelined client built on these primitives. The API stands on its own and is
+useful to any consumer that wants parallel fetch/decode and batched acks.
 
 ## Motivation
 
@@ -91,82 +81,71 @@ pub async fn ack(&mut self, sequence: u64) -> Result<()>;
 pub async fn flush(&mut self) -> Result<()>;
 ```
 
-`next_batch` does three things in one async call: read the manifest,
-look up the next sequence in it, and fetch the data object from object
-storage. Each call therefore performs at least one manifest read (or
-metadata cache hit) plus one object-store GET, even when the manifest
-has hundreds of contiguous entries past the cursor.
+The throughput theory is simple, and it motivates the whole RFC:
 
-For the high-throughput ingestor (opendata-contrib RFC 0002):
+- **Batch objects are large, and fetch and decode are independent.** Fetching a
+  batch from object storage is an I/O wait; decoding (length-decode +
+  decompression) is CPU work. Running them serially on one task leaves both the
+  object-store bandwidth and the machine's cores underused. The way to use both
+  is to **fetch and decode many batches in parallel**.
+- **Manifest operations are expensive and should be batched.** Reading the
+  manifest and acking are CAS-style interactions with object storage, each with
+  a high round-trip cost. Doing one per batch caps throughput at
+  `1 / manifest_RTT`. The way to remove that cap is to **amortize the expensive
+  manifest operations over many batches**: read N descriptors per manifest read,
+  ack a whole contiguous run per manifest write.
 
-- **Object fetch is the dominant async wait** for the consumer. Running
-  fetches in parallel is the obvious throughput lever, but the current
-  API does not let multiple in-flight fetches share manifest state.
-  Calling `next_batch` from N tasks would interleave manifest reads and
-  cursor advances unpredictably, and `&mut self` rules it out anyway.
-- **Manifest reads are wasted** when the consumer pulls `K` consecutive
-  sequences. Each call re-fetches the manifest object and re-iterates
-  it; the per-sequence `read(seq)` path is `O(N)` over the manifest
-  entries (`queue.rs` line 738-742).
-- **Acks loop one sequence at a time**. After a commit group covering
-  500 sequences, the runtime calls `consumer.ack(seq).await` 500 times
-  in sequence. Each call updates an in-memory cursor and trips
-  `dequeue` every 100 acks. Even on the happy path this is wasted
-  ceremony; the runtime's invariant is "advance the durable frontier
-  through `high`," not "ack each sequence individually."
-- **Decompression and decode happen on the same task as the fetch.**
-  `fetch_batch` calls `decode_batch` synchronously after the GET,
-  inside the consumer's async task. CPU-bound decompression that should
-  run on a blocking pool blocks the I/O task instead.
+So the design is: batch the expensive, low-volume operations (manifest read,
+ack) and parallelize the cheap-per-call, high-volume operations (fetch, decode).
+The shipped API blocks both:
 
-Fixing all four with one bigger refactor (e.g. an internal worker pool)
-would couple the buffer crate to a specific runtime model. The minimal
-change that unblocks the high-throughput design is to **split the read
-path into a manifest step and a fetch step**, expose the split in the
-public API, and add a bulk ack primitive. Existing consumers do not
+- `next_batch` couples a manifest read to a single object fetch, and `&mut self`
+  rules out running fetches concurrently. Per-sequence `read(seq)` is `O(N)`
+  over the manifest entries, so pulling K consecutive sequences re-reads and
+  re-scans the manifest K times.
+- `ack(seq)` advances one sequence at a time. After processing a run of 500
+  sequences a consumer calls `ack` 500 times; the consumer's real invariant is
+  "advance the durable frontier through `high`," not "ack each sequence."
+- Decode runs on the fetch task, so CPU-bound decompression blocks the I/O task.
+
+The minimal change that unblocks this is to **split the read path into a
+manifest step and a fetch step**, expose the split so fetches can run
+concurrently, and add a bulk ack primitive. Existing serial consumers do not
 have to change.
 
 ## Goals
 
-- Add a public read-ahead API that returns multiple
-  contiguous descriptors per manifest read.
-- Add a cloneable, concurrency-safe `ConsumerFetchHandle` whose
-  `fetch(&self, ...)` runs object-store GETs in parallel without
-  sharing `&mut Consumer`.
-- Add `ack_through(sequence)` so callers can advance the durable
-  ack frontier in one call, with dequeue-first ordering so the
-  in-memory cursor and the metrics counter only advance after the
-  durable manifest mutation succeeds.
-- Preserve the existing `next_batch`, `ack`, `flush`, `close` API
-  unchanged. `next_batch` becomes a thin wrapper over the new API.
-- Preserve epoch fencing exactly. Read-ahead must surface a `Fenced`
-  error the same way the serial path does.
-- Keep manifest mutation (epoch increment, dequeue) serialized through
-  one owner.
-- Document the concurrency contract for `ConsumerFetchHandle::fetch`
-  and the descriptor-handout contract on `next_descriptors` so callers
-  can rely on them without inspecting the implementation.
+- A read-ahead method that returns multiple contiguous descriptors per manifest
+  read.
+- A cloneable, concurrency-safe `ConsumerFetchHandle` whose `fetch(&self, …)`
+  runs object-store GETs in parallel without sharing `&mut Consumer`.
+- `ack_through(sequence)` that advances the durable ack frontier in one manifest
+  write, with dequeue-first ordering so the in-memory cursor and the metrics
+  counter only advance after the durable mutation succeeds.
+- Preserve the existing `next_batch`, `ack`, `flush`, `close` API unchanged.
+- Preserve epoch fencing exactly: read-ahead must surface `Fenced` the same way
+  the serial path does.
+- Keep manifest mutation (epoch increment, dequeue) serialized through one
+  owner.
+- Document the concurrency contract for `ConsumerFetchHandle::fetch` and the
+  descriptor-handout contract on `next_descriptors` so callers can rely on them
+  without reading the implementation.
 
 ## Non-Goals
 
-- A Buffer-side worker pool, parallel-fetch helper, or
-  decode/decompression scheduler. The new API hands the caller the
-  primitives; orchestration belongs in `opendata-ingest-runtime` (RFC
-  0002 in opendata-contrib).
-- Multi-consumer fanout from one manifest. Buffer keeps "one active
-  consumer per manifest" enforced by epoch fencing. Read-ahead does
-  not change that.
-- A new manifest format, or any change to the `Manifest` /
-  `ManifestEntry` / `Metadata` shapes.
+- A Buffer-side worker pool, parallel-fetch helper, or decode scheduler. The new
+  API hands the caller the primitives; orchestration belongs in client
+  implementations — for example the new ingest runtime (opendata-contrib RFC
+  0002).
+- Multi-consumer fanout from one manifest. Buffer keeps "one active consumer per
+  manifest," enforced by epoch fencing.
+- A new manifest format, or any change to `Manifest` / `ManifestEntry` /
+  `Metadata`.
 - Changing the producer side (`QueueProducer` / `Producer`).
-- Out-of-order acks. `ack_through(n)` advances monotonically; there is
-  still no API to ack a non-contiguous sequence and have the gaps
-  later acked.
-- Replay tooling (operator-directed re-read past the durable frontier).
-  Consumers already accept `last_acked_sequence` on construction; the
-  new API does not extend that.
-- A blocking-CPU decode helper inside the buffer crate. Optional raw-
-  bytes hook (Tier 2 below) is the seam, not a scheduler.
+- Out-of-order acks. `ack_through(n)` advances the frontier monotonically; there
+  is no API to ack a non-contiguous sequence and fill the gap later.
+- Replay tooling. Consumers already accept `last_acked_sequence` on
+  construction; the new API does not extend that.
 
 ## Background
 
@@ -195,39 +174,39 @@ pub struct Metadata {
 }
 ```
 
-Internals relevant to the read-ahead design:
+Internals the read-ahead design depends on:
 
-- `Consumer` holds `QueueConsumer`, an `Arc<dyn ObjectStore>`, the GC
-  task, and three private cursors: `last_acked_sequence`,
-  `last_fetched_sequence`, `ack_count` (used to amortize `dequeue`
-  every `DEQUEUE_INTERVAL = 100` acks).
-- `QueueConsumer::peek` and `QueueConsumer::read(sequence)` both read
-  the manifest object and iterate its entries. They are
-  `pub(crate)` today; `next_batch` is the only public read entry.
-- `QueueConsumer::dequeue(through_sequence)` performs a CAS write
-  against the manifest. It is the only mutating call on the read
-  side.
-- Epoch fencing: `peek` and `read` return `Error::Fenced` if the
-  manifest's epoch differs from the consumer's epoch. The new API
-  must do the same.
-- `decode_batch` is `pub(crate)`. It does length-decoding and (when
-  configured) decompression. It runs synchronously inside `next_batch`.
+- `Consumer` holds `QueueConsumer`, an `Arc<dyn ObjectStore>`, the GC task, and
+  three private cursors: `last_acked_sequence`, `last_fetched_sequence`,
+  `ack_count` (used to amortize `dequeue` every `DEQUEUE_INTERVAL = 100` acks).
+- `QueueConsumer::dequeue(through_sequence)` removes every manifest entry up to
+  and including `through_sequence` in **one CAS write** (one manifest read, one
+  write, retrying only on a conflicting concurrent write). It is the only
+  mutating call on the read side. Because it operates on the whole range at
+  once, advancing the frontier by one sequence and by ten thousand cost the same
+  single manifest write.
+- Epoch fencing: manifest reads return `Error::Fenced` if the manifest's epoch
+  differs from the consumer's. The new API must do the same.
+- `decode_batch` does length-decoding and (when configured) decompression. It
+  runs synchronously inside the fetch path today.
 
-Two properties the new API depends on:
+Two properties the new API relies on:
 
-1. **Reading the manifest does not mutate it**, so multiple readers can
-   safely call `read_manifest` concurrently. The current
-   `pub(crate)` calls `peek` and `read` do exactly that.
-2. **`dequeue` is the only manifest mutation on the read side**, so as
-   long as `dequeue` (i.e. `flush`) stays serialized through one owner,
-   parallel fetch/decode is safe.
+1. **Reading the manifest does not mutate it**, so multiple readers can read it
+   concurrently.
+2. **`dequeue` is the only manifest mutation on the read side**, so as long as
+   `dequeue` stays serialized through one owner, parallel fetch/decode is safe.
+
+Note that `next_batch` already advances a read cursor independent of acking: a
+consumer can call `next_batch` repeatedly to walk successive batches and then
+ack them later. What it cannot do today is fetch those batches concurrently or
+ack the run in one operation.
 
 ## Design
 
 ### Public API Surface
 
-Add `BatchDescriptor`, `ConsumerFetchHandle`, and four methods to
-`Consumer`:
+Add `BatchDescriptor`, `ConsumerFetchHandle`, and four methods to `Consumer`:
 
 ```rust
 /// Lightweight pointer to one manifest entry. Carries everything a
@@ -237,11 +216,6 @@ pub struct BatchDescriptor {
     pub sequence: u64,
     pub location: String,
     pub metadata: Vec<Metadata>,
-    /// Object size in bytes when known. v1 always emits `None`
-    /// because the current manifest format does not carry size.
-    /// Reserved for a future manifest extension and for the runtime's
-    /// byte-budget accounting.
-    pub object_bytes: Option<u64>,
 }
 
 /// Cheap, cloneable handle to the read path. Construction is O(1)
@@ -257,20 +231,18 @@ pub struct ConsumerFetchHandle {
 impl ConsumerFetchHandle {
     /// Fetch and decode one batch. Stateless: does not touch any
     /// `Consumer` cursor. Two concurrent calls against distinct
-    /// descriptors are fully independent; two concurrent calls
-    /// against the same descriptor are safe but waste a GET.
+    /// descriptors are fully independent; two concurrent calls against
+    /// the same descriptor are safe but waste a GET.
     pub async fn fetch(&self, descriptor: BatchDescriptor)
         -> Result<ConsumedBatch>;
 }
 
 impl Consumer {
     /// Read the manifest once and return up to `max` contiguous
-    /// descriptors past the consumer's read-ahead cursor.
-    ///
-    /// Does not perform any object-store GET. Does not mutate the
-    /// durable ack frontier. Advances an in-memory `last_handed_out`
-    /// cursor by the number of descriptors returned. See "Descriptor
-    /// Handout Contract" below for caller obligations.
+    /// descriptors past the consumer's read-ahead cursor. Performs no
+    /// object-store GET and does not mutate the durable ack frontier.
+    /// Advances an in-memory `last_handed_out` cursor by the number of
+    /// descriptors returned. See "Descriptor Handout Contract".
     ///
     /// Returns an empty `Vec` if no new entries are available;
     /// returns `Err(Error::Fenced)` if the consumer's epoch no longer
@@ -278,56 +250,45 @@ impl Consumer {
     pub async fn next_descriptors(&mut self, max: usize)
         -> Result<Vec<BatchDescriptor>>;
 
-    /// Construct a cloneable fetch handle. Cheap; returns a new
-    /// handle on each call (callers that need many handles can call
-    /// once and clone, or call repeatedly — both are O(1)).
+    /// Construct a cloneable fetch handle. Cheap; O(1) per call.
     pub fn fetch_handle(&self) -> ConsumerFetchHandle;
 
     /// Convenience wrapper for serial callers. Equivalent to
-    /// `self.fetch_handle().fetch(descriptor).await`, but also
-    /// updates the consumer's serial lag cursor (used by the
-    /// `consumer_lag_seconds` gauge under the legacy `next_batch`
-    /// path). Parallel callers should use `fetch_handle()` and
-    /// drive the gauge themselves if they want it.
+    /// `self.fetch_handle().fetch(descriptor).await`, but also updates
+    /// the consumer's serial lag cursor (see "Cursor Semantics").
     pub async fn fetch_descriptor(&mut self, descriptor: BatchDescriptor)
         -> Result<ConsumedBatch>;
 
     /// Advance the durable ack frontier through (and including)
-    /// `sequence`. Performs `dequeue(sequence)` against the manifest,
-    /// then updates in-memory state on success. If `dequeue` returns
-    /// an error (storage failure, fence), the consumer's
-    /// `last_acked_sequence` does not advance and the metrics counter
-    /// does not increment.
+    /// `sequence` with a single `dequeue` against the manifest, then
+    /// update in-memory state on success. If `dequeue` fails (storage
+    /// error, fence), `last_acked_sequence` does not advance and the
+    /// metrics counter does not increment.
     ///
-    /// Returns an error if `sequence` is less than or equal to the
-    /// current `last_acked_sequence`. The frontier is monotonic.
+    /// Rejects `sequence <= last_acked_sequence` (the frontier is
+    /// monotonic). It does **not** otherwise validate the range — see
+    /// "Descriptor Handout Contract" for the caller's obligation.
     pub async fn ack_through(&mut self, sequence: u64) -> Result<()>;
 }
 ```
 
-The existing methods stay with their current signatures.
+The existing methods keep their current signatures.
 
-#### Why a separate handle (not just `Arc<Consumer>`)?
+#### Why a separate handle (not just `Arc<Consumer>`)
 
-An obvious alternative is to put the consumer behind `Arc<Consumer>`
-and call `fetch_descriptor(&self, ...)` from worker tasks. That does
-not work in practice: every other useful method on `Consumer`
-(`next_descriptors`, `ack`, `ack_through`, `flush`, `close`) takes
-`&mut self`. Holding any of those calls open while fetch tasks run
-requires either:
+An obvious alternative is to put the consumer behind `Arc<Consumer>` and call a
+`&self` fetch method from worker tasks. That does not work in practice: every
+other useful method on `Consumer` (`next_descriptors`, `ack`, `ack_through`,
+`flush`, `close`) takes `&mut self`. Holding any of those open while fetch tasks
+run would require either an interior-mutability rewrite of every cursor, a
+second `Consumer` (impossible — one active consumer per manifest), or a separate
+handle whose only job is reading object storage.
 
-- An interior-mutability rewrite of every cursor on `Consumer`, which
-  changes the safety story across the whole API surface, or
-- A second instance of `Consumer` (which is impossible — Buffer
-  enforces one active consumer per manifest via epoch fencing), or
-- A separate handle whose only job is reading object storage.
+The handle is the cheapest option. It owns nothing manifest-related, clones via
+`Arc`, and the `&mut Consumer` on the owner side and the `&self` on the handle
+do not interact at the borrow-checker level.
 
-The handle is the cheapest option. It owns nothing manifest-related,
-clones via `Arc`, and disappears when the consumer is dropped (the
-`Arc<dyn ObjectStore>` it holds is the same one the consumer uses, so
-a stale handle has no exclusive resource).
-
-The high-throughput runtime's expected pattern is:
+A pipelined client using these APIs would look like:
 
 ```rust
 // One owner task drives the manifest:
@@ -341,24 +302,20 @@ for _ in 0..fetch_concurrency {
     tokio::spawn(async move {
         while let Some(d) = rx.recv().await {
             let batch = f.fetch(d).await?;
-            // ...send to decode stage...
+            // ...send to a decode stage...
         }
         Ok::<(), Error>(())
     });
 }
 
-// Owner task: poll, ack, flush.
+// Owner task: poll a batch of descriptors, fan them out, ack the run.
 loop {
     let descriptors = consumer.next_descriptors(K).await?;
     for d in descriptors { descriptor_tx.send(d).await?; }
-    // ...wait for completions, then:
+    // ...wait for the contiguous-completed high watermark, then:
     consumer.ack_through(high).await?;
 }
 ```
-
-The `&mut Consumer` in the owner task and the `&self` on the handle
-do not interact at the borrow-checker level: the handle holds an
-`Arc<dyn ObjectStore>`, not a borrow of the consumer.
 
 ### `next_batch` Becomes a Compatibility Wrapper
 
@@ -372,299 +329,250 @@ pub async fn next_batch(&mut self) -> Result<Option<ConsumedBatch>> {
 }
 ```
 
-`fetch_descriptor` itself is the wrapper that drives the serial lag
-cursor. Internally:
-
-```rust
-pub async fn fetch_descriptor(&mut self, descriptor: BatchDescriptor)
-    -> Result<ConsumedBatch>
-{
-    let handle = self.fetch_handle();
-    let batch  = handle.fetch(descriptor).await?;
-    if let Some(last_meta) = batch.metadata.last() {
-        let now_ms = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_millis() as i64;
-        let lag_s = (now_ms - last_meta.ingestion_time_ms) as f64 / 1000.0;
-        metrics::gauge!(m::CONSUMER_LAG_SECONDS).set(lag_s.max(0.0));
-    }
-    self.last_fetched_sequence = match self.last_fetched_sequence {
-        Some(prev) => Some(prev.max(batch.sequence)),
-        None => Some(batch.sequence),
-    };
-    Ok(batch)
-}
-```
-
-The `&mut self` is required because the lag-cursor update belongs to
-the consumer; the handle path leaves that observation to the caller.
-
-Existing callers (the timeseries consumer, the vector consumer, the
-ClickHouse alpha) get the same return type and the same per-call cost.
-The lag gauge, latency histogram, and counter increments that
-`next_batch` records today move to `fetch_descriptor` so they fire
-exactly once per fetched batch under both code paths. The
-`ConsumerConfig` struct is unchanged.
+`fetch_descriptor` is the wrapper that drives the serial lag cursor; it calls
+the handle's `fetch` and then advances `last_fetched_sequence` and updates the
+`consumer_lag_seconds` gauge. Existing serial consumers — for example the
+timeseries and vector buffer consumers, which call `next_batch` in a loop and
+`ack` — get the same return type and per-call cost and do not change.
 
 ### Concurrency Model
 
 The Consumer is split into two roles, each with its own type:
 
-- **Manifest owner** (`Consumer` with `&mut self` access):
-  `next_descriptors`, `fetch_descriptor`, `ack`, `ack_through`,
-  `flush`, `close`. These mutate the in-memory cursor or perform
-  manifest CAS writes. **One holder at a time.** Sharing `Consumer`
-  across tasks requires the caller to pick one owner task and route
-  manifest operations through it (channels, actor pattern, etc.); the
-  RFC does not provide cross-task coordination primitives.
-- **Fetcher** (`ConsumerFetchHandle` with `&self` access): `fetch`.
-  Performs an object-store GET and `decode_batch` against a
-  descriptor that is already determined. Stateless. Does not touch
+- **Manifest owner** (`Consumer`, `&mut self`): `next_descriptors`,
+  `fetch_descriptor`, `ack`, `ack_through`, `flush`, `close`. **One holder at a
+  time.** Sharing across tasks means picking one owner task and routing manifest
+  operations through it; the RFC provides no cross-task coordination primitive.
+- **Fetcher** (`ConsumerFetchHandle`, `&self`): `fetch`. Stateless, touches no
   manifest state. **Cloneable; safe to share across many tasks.**
 
-Two patterns that callers can rely on:
+Two patterns callers can rely on:
 
-1. **Owner + N fetch workers** (the high-throughput runtime):
-   one task owns `&mut Consumer` and drives the manifest. It calls
-   `next_descriptors(K)` to refill a bounded channel of descriptors;
-   N fetch workers each hold a clone of `consumer.fetch_handle()`
-   and pop descriptors off the channel. Workers send completed
-   batches back through another channel. The owner task observes
-   completions and calls `ack_through(high)` periodically. The
-   manifest owner runs in parallel with the fetch workers because
-   their state is disjoint (the handle holds no `Consumer` borrow).
-2. **Single-task serial** (legacy callers): one task calls
-   `next_batch` (or `next_descriptors(1)` + `fetch_descriptor`) and
-   `ack` in a loop. No handle needed. This is what the timeseries
-   and vector consumers do today; they do not change.
+1. **Owner + N fetch workers** (a pipelined client): one task owns `&mut
+   Consumer`, calls `next_descriptors(K)` to refill a bounded descriptor
+   channel, and N fetch workers each hold a clone of `fetch_handle()` and pop
+   descriptors off it. Workers send completed batches back; the owner observes
+   completions and calls `ack_through(high)` periodically. Owner and workers run
+   in parallel because their state is disjoint.
+2. **Single-task serial** (legacy): one task calls `next_batch` (or
+   `next_descriptors(1)` + `fetch_descriptor`) and `ack` in a loop. No handle
+   needed.
 
 Three non-obvious safety arguments:
 
-- **Re-fetching a descriptor is safe.** Two `fetch` calls against the
-  same descriptor both perform an object-store GET and return
-  identical `ConsumedBatch` values. There is no mutation. Callers
-  should not normally do this (it wastes a GET) but doing so is not a
-  correctness bug.
-- **A descriptor outliving the manifest entry is safe to fetch.** If
-  the manifest is dequeued through `descriptor.sequence` between
-  `next_descriptors` and `fetch`, the data object on object storage
-  is still there until GC runs; the GET still succeeds. If GC has
-  already deleted the object (because the grace period elapsed), the
-  GET returns a 404, which `fetch` surfaces as `Error::Storage`.
-  Callers control this gap by acking *after* fetch + process, not
-  before, which is already the consumer pattern.
-- **The handle never observes fence on its own.** Fence is detected
-  inside `next_descriptors` (the next manifest read after fencing
-  returns `Error::Fenced`). A fetch worker that holds a stale handle
-  for a fenced consumer keeps fetching successfully against object
-  storage; the manifest owner is the one that learns about the fence
-  and propagates it to workers (e.g. by closing the descriptor
-  channel). This is intentional: fetch workers do not need
-  manifest-level state to do their job. A future RFC could add a
-  `handle.is_active() -> bool` if the runtime needs an out-of-band
-  fence signal that doesn't go through the descriptor channel.
+- **Re-fetching a descriptor is safe.** Two `fetch` calls against the same
+  descriptor both GET the object and return identical `ConsumedBatch` values.
+  Wasteful, not incorrect.
+- **A descriptor outliving its manifest entry is safe to fetch.** If the
+  manifest is dequeued through `descriptor.sequence` between `next_descriptors`
+  and `fetch`, the data object is still present until GC runs, so the GET
+  succeeds. If GC has already deleted it (grace period elapsed), the GET returns
+  404, surfaced as `Error::Storage`; the caller should retry the descriptor and,
+  if it persists, treat it as a signal that acks are outrunning processing (see
+  Failure Modes). Callers avoid this by acking *after* fetch + process, which is
+  the normal pattern.
+- **The handle never observes a fence on its own.** Fence is detected inside
+  `next_descriptors` (the next manifest read after fencing returns `Fenced`). A
+  worker holding a stale handle keeps fetching successfully against object
+  storage; the manifest owner learns of the fence and propagates it (e.g. by
+  closing the descriptor channel).
 
 ### Cursor Semantics
 
-The Consumer maintains three monotonic cursors. **All three live on
-`Consumer` and are mutated only through `&mut self` methods.**
-`ConsumerFetchHandle` is stateless and never touches them.
+The Consumer maintains three monotonic cursors. **All three live on `Consumer`
+and are mutated only through `&mut self` methods.** `ConsumerFetchHandle` is
+stateless and never touches them.
 
 | Cursor | Mutator | Meaning |
 |---|---|---|
-| `last_acked_sequence` | `ack` (success), `ack_through` (after dequeue success) | Highest sequence durably dequeued from the manifest. |
-| `last_fetched_sequence` | `fetch_descriptor` (the `&mut self` wrapper) | Highest sequence whose data object the **serial wrapper path** has read. Used by the `consumer_lag_seconds` gauge. |
-| `last_handed_out_sequence` (new) | `next_descriptors` | Highest sequence the consumer has handed out as a descriptor. |
+| `last_acked_sequence` | `ack` (success), `ack_through` (after dequeue success) | Highest sequence durably dequeued. |
+| `last_fetched_sequence` | `fetch_descriptor` (the `&mut self` wrapper) | Highest sequence the **serial wrapper path** has read. Feeds `consumer_lag_seconds`. |
+| `last_handed_out_sequence` (new) | `next_descriptors` | Highest sequence handed out as a descriptor. |
 
-`last_handed_out_sequence` is what `next_descriptors` uses to find the
-next contiguous run on a manifest re-read. It is distinct from
-`last_fetched_sequence` because callers may hand out descriptors before
-the corresponding fetches resolve.
+`last_handed_out_sequence` is what `next_descriptors` uses to find the next
+contiguous run; it is distinct from `last_fetched_sequence` because a caller may
+hand out descriptors before the corresponding fetches resolve. The initial value
+of all three is the `last_acked_sequence` passed to `Consumer::new`.
 
-Initial value of all three is `last_acked_sequence` from construction
-(`None` for a fresh consumer; `Some(seq)` when the caller passed
-`last_acked_sequence: Some(seq)`).
+**`ConsumerFetchHandle::fetch` advances no cursor.** A parallel-fetch caller
+that wants a lag signal computes it itself: each `ConsumedBatch` carries
+`metadata`, and `metadata.last().ingestion_time_ms` against the current wall
+clock is the batch's age, which the caller can emit as its own gauge per fetched
+batch. (A pipelined client typically tracks finer per-stage latencies than a
+single max-sequence gauge would give.) The serial `fetch_descriptor` wrapper
+keeps maintaining `consumer_lag_seconds` for legacy callers.
 
-`next_batch` advances `last_handed_out_sequence` and
-`last_fetched_sequence` together (via the wrapped
-`next_descriptors(1)` and `fetch_descriptor` calls), preserving
-today's behavior.
+### `ack_through` — Batched, Single-Write Acking
 
-`fetch_descriptor` (the `&mut self` wrapper) advances
-`last_fetched_sequence` to `max(current, descriptor.sequence)` after
-the fetch succeeds. It does **not** mutate `last_handed_out_sequence`
-(the descriptor was already handed out) or `last_acked_sequence` (the
-caller acks separately).
-
-**`ConsumerFetchHandle::fetch` does not advance any cursor on the
-consumer.** Parallel-fetch callers that want a `consumer_lag_seconds`-
-equivalent gauge observe it themselves from `batch.metadata.last()`
-and emit their own metric, or wire the runtime's metrics layer to do
-so. The handle deliberately holds no interior-mutable max cursor:
-that would add atomic state to the hot fetch path for a metric the
-runtime already owns (the runtime's `runtime_stage_latency_seconds{stage=fetch}`
-histogram is finer-grained than a single max-sequence gauge).
-
-`ack_through(seq)` performs **dequeue first, then in-memory state
-update**. If `dequeue` returns an error (storage failure, fence), the
-consumer's `last_acked_sequence` does not advance and the metrics
-counter does not increment. Concretely:
-
-- `ack(seq)` keeps its existing per-sequence loop semantics with
-  amortized dequeue every `DEQUEUE_INTERVAL = 100` acks.
-- `ack_through(seq)` always performs one dequeue at call time, and
-  applies its in-memory updates only after dequeue succeeds. It is
-  the right primitive when the caller already batches.
-
-### Descriptor Handout Contract
-
-`next_descriptors` advances `last_handed_out_sequence` *before* the
-caller has fetched the corresponding objects. This is intentional —
-read-ahead is the whole point — but it puts a contract on the caller
-that does not exist for the serial `next_batch` API. The contract is:
-
-> **Once `next_descriptors` returns a descriptor, the caller is
-> responsible for either (a) successfully fetching and processing it,
-> or (b) accepting that it will be re-handed-out only via process
-> restart (which restarts read-ahead from the durable
-> `last_acked_sequence`, dropping any in-flight descriptors).**
-
-Specifically:
-
-- **Lost descriptors are not reissued within a process.** If a worker
-  task panics, drops a channel send, or otherwise discards a
-  descriptor without acking the corresponding sequence, the
-  consumer's `last_handed_out_sequence` has already advanced past it.
-  The next `next_descriptors` call will not return the lost
-  descriptor; it will return descriptors strictly after it.
-- **Acking a sequence that was lost is forbidden.** The caller's own
-  bookkeeping (commit-group high watermark, route completion record)
-  must not mark a lost sequence complete. If it does, `ack_through`
-  will durably ack a sequence whose data was never processed, and the
-  data is lost.
-- **Recovery is process restart.** A new `Consumer::new(config,
-  last_acked_sequence)` initializes `last_handed_out_sequence =
-  last_acked_sequence`, so `next_descriptors` re-emits everything the
-  durable frontier hasn't acked. This is the only supported path for
-  reissuing lost descriptors.
-- **Out-of-order completion is fine, gaps are not.** Workers may
-  complete fetches in any order. The runtime's ack coordinator (RFC
-  0002 in opendata-contrib) tracks contiguous completion and only
-  calls `ack_through` for the highest contiguous complete sequence.
-  A gap (one descriptor in the run is permanently lost) means the
-  ack frontier never advances past that gap until restart.
-
-The high-throughput runtime in opendata-contrib RFC 0002 enforces
-this contract by making the descriptor channel bounded and by
-treating dropped descriptors as a runtime fatal — workers that lose
-a descriptor halt the runtime and force a restart. The buffer crate
-itself does not detect lost descriptors; that is the caller's job.
-
-A future "return descriptor" API (let the caller hand a descriptor
-back so it can be reissued without restart) is *not* in scope for
-this RFC. It would require maintaining a per-descriptor "handed
-out / returned / fetched" state inside `Consumer` that does not
-exist today, and the runtime can already recover via the documented
-restart path.
-
-### BatchDescriptor and Object Size
-
-`BatchDescriptor.object_bytes: Option<u64>` is reserved for the
-runtime's byte-budget accounting (RFC 0002 in opendata-contrib).
-The current Buffer manifest format does not carry per-entry object
-size:
+`ack_through(seq)` performs **one `dequeue(seq)`**, which removes every manifest
+entry `<= seq` in a single CAS write, then updates in-memory state only if the
+dequeue succeeded:
 
 ```rust
-pub struct ManifestEntry {
-    pub sequence: u64,
-    pub location: String,
-    pub metadata: Vec<Metadata>,
+pub async fn ack_through(&mut self, sequence: u64) -> Result<()> {
+    if let Some(last) = self.last_acked_sequence
+        && sequence <= last
+    {
+        return Err(Error::Storage(format!(
+            "non-monotonic ack_through: last_acked={last}, requested={sequence}",
+        )));
+    }
+    let count_advanced = match self.last_acked_sequence {
+        None => sequence + 1,
+        Some(last) => sequence - last,
+    };
+
+    // Durable dequeue first; bubbles up Fenced/Storage without touching state.
+    self.consumer.dequeue(sequence).await?;
+
+    self.last_acked_sequence = Some(sequence);
+    self.ack_count = self.ack_count.wrapping_add(count_advanced);
+    metrics::counter!(m::ACKS).increment(count_advanced);
+    Ok(())
 }
 ```
 
-So v1 of this RFC always emits `object_bytes: None`. The field
-exists in the public type so:
+Because `dequeue` operates on the whole range in one write, `ack_through(seq)`
+is a single manifest operation no matter how far it advances the frontier — that
+is the batching win over the per-sequence `ack` loop (which still exists,
+unchanged, with its amortize-every-100 behavior for serial callers).
 
-1. The runtime can adopt the field today and use a configured
-   pessimistic reservation (`source.estimated_max_batch_bytes`) when
-   the value is `None`.
-2. A future manifest format extension (or an opt-in producer-side
-   metadata payload) can populate the field without breaking the
-   public API.
+When `ack_through` returns `Err(_)` the caller must treat the range as **not**
+durably acked and not advance its own bookkeeping. Retrying `ack_through(seq)`
+is safe: `QueueConsumer::dequeue` is idempotent, so the retry either succeeds or
+returns the same error class.
 
-Changing the manifest format to carry object size is **out of scope
-for this RFC** (declared a non-goal above) but is a natural
-follow-up after the read-ahead path is stable. Until then, the
-runtime overcounts in-flight bytes in the common case and pauses
-source pulls slightly earlier than tight accounting would; this is
-intentional slack.
+`flush` keeps its meaning for `ack`-based callers (force the amortized dequeue).
+After `ack_through`, `flush` is a no-op (the dequeue already ran).
 
-Other ways to populate `object_bytes`, considered and rejected for
-v1:
+### Descriptor Handout Contract
 
-- **HEAD before GET**: an extra network round trip on every fetch.
-  Adds ~1 RTT to fetch latency for a metric-tightening benefit.
-  Rejected; the runtime's pessimistic reservation is cheaper.
-- **Read object metadata from the GET response and attach it to a
-  later descriptor**: requires the consumer to remember per-sequence
-  sizes across calls, which is exactly the kind of state we are
-  trying to keep out of `ConsumerFetchHandle`. Rejected for v1.
-- **Use `Metadata.payload` to carry a producer-supplied size hint**:
-  the payload is opaque and producer-defined (RFC 0001); requiring
-  producers to put a size there would couple the buffer crate to
-  its consumers in a way RFC 0001 was careful to avoid. Rejected.
+`next_descriptors` advances `last_handed_out_sequence` *before* the caller has
+fetched the objects. That is intentional — read-ahead is the point — and it
+places a contract on the caller. The key facts:
 
-### Epoch Fencing
+- **`ack_through(n)` does not verify that anything below `n` was processed.** It
+  unconditionally advances the durable frontier to `n` with one dequeue, only
+  rejecting `n <= last_acked_sequence`. The API does not — and at this layer
+  cannot — detect "gaps." So a caller that does `next_descriptors(100)`,
+  processes nothing, and calls `ack_through(100)` *will* get a successful ack
+  and **silently lose** sequences 1..100. Nothing in the contract forbids it; it
+  is the caller's responsibility not to do it.
+- **The caller must track which sequences it has actually processed and only
+  ever call `ack_through` with the highest fully-processed *contiguous*
+  sequence.** Fetches and processing may complete out of order; the caller acks
+  the contiguous-complete watermark, never past a still-pending sequence.
+- **A "gap" is a caller-side notion, not a Buffer error.** If a descriptor in a
+  run is permanently lost (a worker panics, a channel send is dropped), the
+  caller must simply not advance `ack_through` past that sequence. The frontier
+  stalls there until the caller recovers.
+- **Recovery is process restart.** `Consumer::new(config, last_acked_sequence)`
+  re-initializes `last_handed_out_sequence = last_acked_sequence`, so
+  `next_descriptors` re-emits everything the durable frontier has not acked.
+  This is the only supported way to reissue a lost descriptor; within a process,
+  a handed-out descriptor is never reissued.
 
-`next_descriptors` returns `Error::Fenced` if the consumer's epoch no
-longer matches the manifest. The check happens inside
-`QueueConsumer::read_manifest` exactly as it does today for
-`peek`/`read`.
+A client meeting this contract tracks processed sequences and issues contiguous
+`ack_through` calls; treating a lost descriptor as fatal and restarting from the
+durable frontier is the simplest correct policy. The opendata-contrib RFC 0002
+runtime is one example: it bounds the descriptor channel and treats a dropped
+descriptor as a runtime-fatal that forces a restart. The Buffer crate itself
+does not detect lost descriptors.
 
-`fetch_descriptor` does **not** consult the manifest, so it does not
-itself detect fencing. Callers that want to fail fast on fence can
-either:
+### Byte-Budget Accounting and Object Size
 
-1. Keep one `next_descriptors` task running on the consumer; it will
-   hit `Fenced` on its next manifest read.
-2. Treat repeated `Storage` errors on `fetch_descriptor` (404s after
-   GC) as a fence signal in operations.
+A pipelined client typically wants to bound in-flight bytes (pause pulling when
+too much fetched-but-undecoded data is outstanding). `BatchDescriptor`
+deliberately does **not** carry an object size: the current manifest format does
+not record per-entry object size, so Buffer cannot provide a real one. A client
+bounds in-flight bytes using its own estimate (e.g. a configured
+`estimated_max_batch_bytes`), accepting that it pauses slightly earlier than
+tight accounting would.
 
-The most common case is path (1): the high-throughput runtime drives
-`next_descriptors` continuously to keep the descriptor queue full, so
-a fence surfaces within one polling interval.
+The clean way to make this exact is a future Buffer change: record object size
+in the manifest at append time and surface it on `BatchDescriptor`. That is a
+manifest-format change (a declared non-goal here) and is the recommended
+follow-up once the read-ahead path is stable; see Alternatives for the
+size-discovery options that were rejected for this RFC.
 
-### Object Fetch Path
+### Parallel Decode
 
-`ConsumerFetchHandle::fetch` performs the same work
-`Consumer::fetch_batch` does today:
+`ConsumerFetchHandle::fetch` does the GET and then `decode_batch` (length-decode
++ decompression) on the calling task. A client that wants to keep CPU-bound
+decode off the I/O task needs a way to get the raw bytes and decode them
+elsewhere (typically on a blocking pool).
 
-1. `object_store.get(&Path::from(descriptor.location.as_str())).await`
-2. `data.bytes().await`
-3. `decode_batch(data)` to produce `Vec<Bytes>` entries
-4. Construct `ConsumedBatch { entries, sequence, location, metadata }`
+The seam for that is a sibling method on the handle plus public decode helpers:
+`fetch_raw` returns the still-encoded object bytes as a `RawConsumedBatch`, and
+`decode_batch` / `CompressionType` are public so the caller decodes when and
+where it chooses:
 
-The metrics split between two sites:
+```rust
+pub use crate::model::{decode_batch, CompressionType};
 
-- **Per-fetch counters and the per-fetch latency histogram**
-  (`BATCHES_COLLECTED`, `ENTRIES_COLLECTED`, `BYTES_COLLECTED`,
-  `FETCH_DURATION_SECONDS`) move to `ConsumerFetchHandle::fetch`.
-  These fire exactly once per fetched batch under both old and new
-  APIs.
-- **The serial lag gauge** (`CONSUMER_LAG_SECONDS`) stays on the
-  `&mut self` `fetch_descriptor` wrapper. Parallel-fetch callers do
-  not advance the consumer's serial cursor and do not update this
-  gauge; they observe lag through their own runtime metrics
-  (`runtime_stage_latency_seconds{stage=fetch}` in RFC 0002).
+impl ConsumerFetchHandle {
+    /// Like `fetch`, but returns the still-encoded object bytes.
+    /// The caller invokes `decode_batch` itself (e.g. inside
+    /// `tokio::task::spawn_blocking`) to keep decode off the I/O task.
+    pub async fn fetch_raw(&self, descriptor: BatchDescriptor)
+        -> Result<RawConsumedBatch>;
+}
 
-`decode_batch` runs on the calling task. Callers that want to put it
-on a blocking pool can call `tokio::task::spawn_blocking` around the
-decode step (see "Optional: Raw Decode Hook" below).
+pub struct RawConsumedBatch {
+    pub sequence: u64,
+    pub location: String,
+    pub metadata: Vec<Metadata>,
+    pub raw_bytes: Bytes,
+}
+```
+
+```rust
+let raw = fetch_handle.fetch_raw(d).await?;
+let entries = tokio::task::spawn_blocking(move || decode_batch(raw.raw_bytes))
+    .await
+    .map_err(|e| Error::Storage(e.to_string()))??;
+let batch = ConsumedBatch { entries, sequence: raw.sequence,
+                            location: raw.location, metadata: raw.metadata };
+```
+
+This lives on the handle (not `Consumer`) because parallel-fetch callers are the
+use case; serial callers keep using `fetch_descriptor`, which decodes inline.
+Putting decode behind an in-crate `spawn_blocking` was rejected: it bakes a
+Tokio scheduling decision into Buffer, which callers on a different scheduler or
+blocking-pool size lose control over.
+
+The core read-ahead methods (`next_descriptors`, `fetch_handle`,
+`fetch_descriptor`, `ack_through`) are the required surface. The raw-decode
+helpers (`fetch_raw` / `RawConsumedBatch` / the public `decode_batch`) are an
+additive extension for clients that parallelize decode; they can ship behind a
+feature flag so consumers that do not need them do not carry the extra public
+types.
+
+### Metrics
+
+The existing buffer metrics split between the handle's fetch path (any caller
+can drive it concurrently) and the serial `fetch_descriptor` wrapper:
+
+- `buffer.batches_collected`, `buffer.bytes_collected`,
+  `buffer.entries_collected`, `buffer.fetch_duration_seconds`: incremented
+  inside `ConsumerFetchHandle::fetch`, once per fetched batch under either path.
+- `buffer.consumer_lag_seconds` (gauge): updated only by the serial
+  `fetch_descriptor` wrapper. Parallel callers that use the handle directly do
+  not advance it and observe lag through their own metrics.
+- `buffer.acks` (counter): also incremented by `ack_through`, by the number of
+  sequences the call advances over, so the rate reads "sequences acked / sec"
+  under both APIs.
+- `buffer.queue_length` (gauge): updated inside `next_descriptors` as it is
+  inside `next_batch` today.
+
+One new metric:
+
+- `buffer.descriptors_handed_out` (counter): incremented by `descriptors.len()`
+  on each `next_descriptors` call, so operators can see read-ahead activity.
+
+No metric renames; existing dashboards keep working.
 
 ### `next_descriptors` Implementation
-
-The body adds one new path to `QueueConsumer`:
 
 ```rust
 // queue.rs
@@ -687,480 +595,208 @@ impl QueueConsumer {
                 continue;
             }
             out.push(entry);
-            if out.len() >= max {
-                break;
-            }
+            if out.len() >= max { break; }
         }
         Ok(out)
     }
 }
 ```
 
-`Consumer::next_descriptors` wraps this:
-
 ```rust
 pub async fn next_descriptors(&mut self, max: usize)
     -> Result<Vec<BatchDescriptor>>
 {
-    if max == 0 {
-        return Ok(Vec::new());
-    }
-    let entries = self
-        .consumer
-        .descriptors_after(self.last_handed_out_sequence, max)
-        .await?;
+    if max == 0 { return Ok(Vec::new()); }
+    let entries = self.consumer
+        .descriptors_after(self.last_handed_out_sequence, max).await?;
     metrics::gauge!(m::QUEUE_LENGTH).set(self.consumer.len() as f64);
     if let Some(last) = entries.last() {
         self.last_handed_out_sequence = Some(last.sequence);
     }
-    Ok(entries
-        .into_iter()
-        .map(|e| BatchDescriptor {
-            sequence: e.sequence,
-            location: e.location,
-            metadata: e.metadata,
-            // Reserved field; the current manifest format does not
-            // carry per-entry object size. See "BatchDescriptor and
-            // Object Size" above.
-            object_bytes: None,
-        })
-        .collect())
+    Ok(entries.into_iter().map(|e| BatchDescriptor {
+        sequence: e.sequence, location: e.location, metadata: e.metadata,
+    }).collect())
 }
 ```
 
-This is `O(handed_out_offset_within_manifest + max)` per call, dominated
-by the manifest read latency. It is strictly better than `K` calls to
-`next_batch` for `K` contiguous entries when `K > 1`, and equivalent
-when `K = 1`.
-
-A future optimization can teach `Manifest::iter` to skip to a target
-sequence in `O(log N)` (the manifest entries are sorted by sequence).
-That is out of scope for this RFC; the linear scan is already fine for
-manifests of the sizes we run.
-
-### `ack_through` Implementation
-
-The dequeue is the durable boundary. In-memory state is updated **only
-after** dequeue succeeds, so a fence or storage error leaves
-`last_acked_sequence` and the metrics counter unchanged:
-
-```rust
-pub async fn ack_through(&mut self, sequence: u64) -> Result<()> {
-    if let Some(last) = self.last_acked_sequence
-        && sequence <= last
-    {
-        return Err(Error::Storage(format!(
-            "non-monotonic ack_through: last_acked={}, requested={}",
-            last, sequence,
-        )));
-    }
-    let count_advanced = match self.last_acked_sequence {
-        None => sequence + 1,
-        Some(last) => sequence - last,
-    };
-
-    // Durable dequeue first. Bubbles up Fenced and Storage errors
-    // without touching local state.
-    self.consumer.dequeue(sequence).await?;
-
-    // Only mutate in-memory state after dequeue succeeds.
-    self.last_acked_sequence = Some(sequence);
-    self.ack_count = self.ack_count.wrapping_add(count_advanced);
-    metrics::counter!(m::ACKS).increment(count_advanced);
-    Ok(())
-}
-```
-
-The dequeue is unconditional. `ack` keeps its amortized-every-100-acks
-behavior; the high-throughput runtime opts into immediate dequeue by
-calling `ack_through`.
-
-**Important caller contract**: when `ack_through` returns `Err(_)`, the
-caller must treat the requested range as **not** durably acked and
-must not advance any of its own bookkeeping (commit-group high
-watermark, route completion record, etc.) past the previous
-successful ack. A retry of `ack_through(sequence)` against the same
-sequence is safe; if the underlying dequeue is idempotent (which it
-is for `QueueConsumer::dequeue`) the second call either succeeds or
-returns the same error class.
-
-`Consumer::flush` keeps its meaning: if the caller used `ack` and is
-between amortization boundaries, `flush` forces the dequeue. After
-`ack_through`, `flush` is a no-op (the dequeue already ran), which
-matches what callers want.
-
-### Optional: Raw Decode Hook (Tier 2)
-
-The high-throughput runtime wants to put `decode_batch` on a blocking
-CPU pool. Two ways to expose that:
-
-**Option A (chosen):** make `decode_batch` and `CompressionType` public,
-and add a sibling `ConsumerFetchHandle::fetch_raw` that returns the
-raw object bytes plus the descriptor without decoding. The raw method
-lives on the handle (not on `Consumer`) because parallel-fetch callers
-are the use case; serial callers continue to use `fetch_descriptor`
-which already calls `decode_batch` inline.
-
-```rust
-pub use crate::model::{decode_batch, CompressionType};
-
-impl ConsumerFetchHandle {
-    /// Like `fetch`, but returns the still-encoded object bytes.
-    /// Callers invoke `decode_batch` themselves (typically inside
-    /// `tokio::task::spawn_blocking`) to keep the CPU-bound decode
-    /// off the I/O task.
-    pub async fn fetch_raw(&self, descriptor: BatchDescriptor)
-        -> Result<RawConsumedBatch>;
-}
-
-pub struct RawConsumedBatch {
-    pub sequence: u64,
-    pub location: String,
-    pub metadata: Vec<Metadata>,
-    pub raw_bytes: Bytes,
-}
-```
-
-Callers wrap the decode in `spawn_blocking`:
-
-```rust
-let raw = fetch_handle.fetch_raw(d).await?;
-let entries = tokio::task::spawn_blocking(move || decode_batch(raw.raw_bytes))
-    .await
-    .map_err(|e| Error::Storage(e.to_string()))??;
-let batch = ConsumedBatch {
-    entries,
-    sequence: raw.sequence,
-    location: raw.location,
-    metadata: raw.metadata,
-};
-```
-
-**Option B:** keep `decode_batch` private and add an explicit
-`ConsumerFetchHandle::fetch_blocking_decode` that internally spawns
-blocking. Rejected because it bakes a Tokio scheduling decision into
-the buffer crate — callers running on a different scheduler (e.g.
-async-std, smol, or Tokio with a specific blocking-pool size) lose
-control.
-
-Option A is small, additive, and gives the runtime exactly the seam it
-wants without committing the buffer crate to a scheduling model.
-
-The Tier 2 surface ships behind a feature flag in v0.x or as a separate
-release; v1 of this RFC requires only the core read-ahead +
-`fetch_handle` + `ack_through` methods.
-
-### Metrics
-
-Carry over the existing buffer metrics, splitting them between the
-handle's fetch path (which any caller can drive concurrently) and the
-serial `Consumer::fetch_descriptor` wrapper (which additionally
-maintains the consumer's lag cursor):
-
-- `buffer.batches_collected` (counter): increments inside
-  `ConsumerFetchHandle::fetch`. Each successful fetch increments by 1
-  regardless of which call path drove it (handle directly, or via the
-  `&mut self` `Consumer::fetch_descriptor` wrapper).
-- `buffer.bytes_collected`, `buffer.entries_collected`,
-  `buffer.fetch_duration_seconds`: all increment inside
-  `ConsumerFetchHandle::fetch`.
-- `buffer.consumer_lag_seconds` (gauge): increments inside the serial
-  `Consumer::fetch_descriptor` wrapper only. Parallel callers that
-  only use `ConsumerFetchHandle::fetch` do not advance this gauge —
-  the consumer's serial cursor is not the right observation point
-  under N-way concurrency, and the runtime owns its own
-  `runtime_stage_latency_seconds{stage=fetch}` histogram (RFC 0002).
-- `buffer.acks` (counter): now also incremented by `ack_through`
-  by the number of sequences the call advances over. So a counter rate
-  reads "sequences acked per second" under both APIs.
-- `buffer.queue_length` (gauge): updated inside `next_descriptors`
-  the same way it is inside `next_batch` today.
-
-Add one new metric:
-
-- `buffer.descriptors_handed_out` (counter): increments by
-  `descriptors.len()` on each `next_descriptors` call. Lets operators
-  see read-ahead activity directly.
-
-No metrics renames; existing dashboards keep working.
-
-### Compatibility
-
-API compatibility:
-
-- `next_batch`, `ack`, `flush`, `close`, `len`, `is_empty`,
-  `conflict_rate`, `Consumer::new`, `Consumer::with_object_store`,
-  `ConsumerConfig`, `ConsumedBatch`, `Metadata`: all unchanged.
-- New types: `BatchDescriptor`, `ConsumerFetchHandle`, and
-  `RawConsumedBatch` (Tier 2 only).
-- New methods: `Consumer::next_descriptors`, `Consumer::fetch_handle`,
-  `Consumer::fetch_descriptor` (which now takes `&mut self` and is a
-  wrapper over the handle), `Consumer::ack_through`, and (Tier 2)
-  `ConsumerFetchHandle::fetch_raw`.
-- New public re-exports (Tier 2): `decode_batch`, `CompressionType`.
-
-Behavioral compatibility:
-
-- `next_batch` returns the same `ConsumedBatch` for the same input
-  manifest state. The wrapper does the same work, just composed.
-- Cursor advance under `next_batch` is unchanged.
-- `ack`'s amortization behavior is unchanged.
-- `flush` semantics are unchanged.
-- Epoch fencing surfaces from `next_descriptors` exactly as it does
-  from `next_batch`.
-
-Wire/format compatibility:
-
-- No manifest format change.
-- No data batch format change.
-
-Existing consumers (`timeseries`, `vector` BufferConsumer,
-`clickhouse-ingestor`) compile against the new buffer crate without
-changes. They get no throughput benefit until they migrate to the new
-methods, which is fine — the migration is per-consumer.
+This is `O(handed_out_offset_within_manifest + max)` per call, dominated by the
+manifest read latency, and strictly better than K calls to `next_batch` for K
+contiguous entries. A future optimization could teach `Manifest::iter` to skip
+to a target sequence in `O(log N)`; out of scope here.
 
 ## Failure Modes
 
-- **Manifest read fails (storage error)**: `next_descriptors` returns
-  `Err(Error::Storage(_))`, mirroring today's `next_batch`. The
-  consumer's cursor does not advance; a retry succeeds against a
-  recovered store.
-- **Object fetch fails (`ConsumerFetchHandle::fetch`, or its
-  serial-wrapper caller `Consumer::fetch_descriptor`)**: returns
-  `Err(Error::Storage(_))`. The handle is stateless, so no cursor
-  advances; the wrapper does not advance `last_fetched_sequence`
-  either, since it only updates the cursor after a successful decode.
-  Callers may retry the same descriptor with the same handle clone.
-- **Object fetch returns 404 (GC race)**: surfaces as `Error::Storage`
-  with a "404"-shaped message. Documented in
-  `ConsumerFetchHandle::fetch`'s rustdoc (and inherited by the
-  `Consumer::fetch_descriptor` wrapper); the runbook tells operators
-  to extend `gc_grace_period` or to investigate over-aggressive ack
-  flushing if this fires in production.
-- **Caller calls `ack_through(seq)` with `seq <= last_acked_sequence`**:
-  returns `Err(Error::Storage("non-monotonic ack_through: ..."))`. The
-  caller's cursor does not advance.
-- **Caller calls `fetch` with a sequence that is no longer in the
-  manifest** (descriptor predates a recent dequeue or restart): the
-  GET still succeeds against the still-present data object until GC
-  deletes it; identical to the "descriptor outliving manifest entry"
-  case. After GC, falls back to the 404 path above. Applies equally
-  to handle and wrapper.
-- **Fence between `next_descriptors` and a later fetch**: the fetch
-  is unaffected (the handle does not consult the manifest, and the
-  wrapper delegates to the handle). The next `next_descriptors` or
-  `ack_through` returns `Error::Fenced`. The fetched batch is
-  correct but should not be acked by a fenced consumer. The caller's
-  runtime layer is responsible for not advancing ack state after a
-  fence; today's `BufferConsumerRuntime` already treats `Fenced` as
-  fatal.
+- **Manifest read fails (storage error):** `next_descriptors` returns
+  `Err(Error::Storage(_))`, mirroring `next_batch`. The cursor does not advance;
+  a retry succeeds against a recovered store.
+- **Object fetch fails (`fetch`, or its `fetch_descriptor` wrapper):** returns
+  `Err(Error::Storage(_))`. The handle is stateless, so no cursor advances; the
+  wrapper does not advance `last_fetched_sequence`. Retry the same descriptor
+  with the same handle clone.
+- **Object fetch returns 404 (GC race):** surfaces as `Error::Storage`. Retry
+  the descriptor; if it keeps 404-ing, the data object was GC'd because acks
+  outran processing — extend `gc_grace_period` or fix the over-aggressive
+  acking. Documented in `fetch`'s rustdoc.
+- **`ack_through(seq)` with `seq <= last_acked_sequence`:** returns
+  `Err(Error::Storage("non-monotonic ack_through: …"))`; the cursor does not
+  advance. (There is no "gap" rejection — see the Descriptor Handout Contract.)
+- **Fence between `next_descriptors` and a later fetch:** the fetch is
+  unaffected (the handle does not consult the manifest). The next
+  `next_descriptors` or `ack_through` returns `Error::Fenced`. The fetched batch
+  is correct but must not be acked by a fenced consumer; the client's layer is
+  responsible for not advancing ack state after a fence (today's
+  `BufferConsumerRuntime` treats `Fenced` as fatal).
 
 ## Alternatives Considered
 
-### Add a Streamed `next_batch_stream(max: usize)` Returning Decoded Batches
+### One Bigger Refactor (Internal Worker Pool)
 
-A `futures::Stream` that yields `ConsumedBatch` values would hide the
-manifest-vs-fetch split from callers. Rejected because:
+Fixing serial fetch, wasted manifest reads, and the ack loop with a single
+larger change — e.g. an internal worker pool inside the buffer crate — would
+couple Buffer to a specific runtime/concurrency model. Splitting the read path
+into manifest + fetch steps and exposing the split is the minimal change that
+unblocks parallel clients while leaving orchestration to them; existing
+consumers do not change.
 
-- It makes `decode_batch` placement implicit (inside the stream's poll
-  task), which defeats the point of giving callers a blocking-decode
-  seam.
-- It leaks the manifest-read cadence into the iteration cadence; a
-  caller that wants to pre-fetch 1000 descriptors but decode 4 at a
-  time has no clean way to express that.
-- It gives the buffer crate a scheduling responsibility (concurrent
-  fetch under the hood) that the RFC explicitly leaves to callers.
+### Add Object Size via HEAD, GET Metadata, or a Payload Hint
 
-### Keep Read Path Serial, Add Only `ack_through`
+To give `BatchDescriptor` a real object size without a manifest-format change: a
+HEAD before each GET (an extra round trip per fetch, for a metric-tightening
+benefit — rejected, estimation is cheaper); remembering sizes from prior GET
+responses (re-introduces per-sequence state into the otherwise-stateless fetch
+path — rejected); or a producer-supplied size in `Metadata.payload` (couples
+Buffer to its producers, which RFC 0001 avoided — rejected). Recording size in
+the manifest at append time is the right long-term fix and is left as a future
+follow-up.
 
-`ack_through` alone removes the per-sequence ack loop and is a clear
-win even for serial consumers. Rejected as an isolated change because
-it does not solve the dominant cost: serial object fetch. Shipping
-both at once is cheaper to review and reason about.
+### Keep the Read Path Serial, Add Only `ack_through`
 
-### Introduce a New `BufferReader` Type Separate from `Consumer`
+`ack_through` alone removes the ack loop and helps even serial consumers, but it
+does not address the dominant cost (serial object fetch). Shipping both together
+is cheaper to review and reason about.
 
-A separate read-only handle could enforce the manifest-owner-vs-fetcher
-split through types instead of `&mut self` vs `&self`. Rejected
-because:
+### A Streamed `next_batch_stream(max)` Yielding Decoded Batches
 
-- The split is already visible in the method signatures.
-- It would force every existing caller to choose a type at construction.
-- An `Arc<Consumer>` with `&self` fetch is a smaller change, behaves
-  identically, and keeps the type surface narrow.
+A `Stream` of `ConsumedBatch` would hide the manifest-vs-fetch split, but it
+makes decode placement implicit (defeating the blocking-decode seam), leaks the
+manifest-read cadence into the iteration cadence, and hands Buffer the
+concurrent-fetch scheduling responsibility this RFC deliberately leaves to
+callers.
 
-### Make `next_descriptors` Return a Borrowed Iterator
+### A Separate `BufferReader` Type
 
-`next_descriptors` could return `impl Iterator<Item = &ManifestEntry>`
-borrowing from the manifest. Rejected because the manifest object is
-loaded inside the call and the borrowed iterator would force callers
-to either copy out the descriptors anyway or hold the consumer
-mutably while iterating, which kills the parallel-fetch use case.
-Returning `Vec<BatchDescriptor>` is one allocation per read-ahead
-window and is dominated by the manifest read latency.
+Enforcing the owner-vs-fetcher split through two types rather than `&mut self`
+vs `&self` would force every existing caller to choose a type at construction;
+the handle is a smaller change with the same safety.
 
-### Make `next_descriptors` Take an Explicit `start_sequence`
+### `next_descriptors` Returning a Borrowed Iterator, or Taking `start_sequence`
 
-Callers could pass `start_sequence` to read from any point in the
-manifest. Rejected because:
+A borrowed iterator over the loaded manifest would force callers to copy out
+descriptors or hold the consumer mutably while iterating (killing parallel
+fetch). An explicit `start_sequence` leaks the internal cursor and opens
+non-monotonic read-ahead; the `last_acked_sequence` constructor argument already
+covers "resume from a point."
 
-- The cursor is internal state the buffer crate already owns; exposing
-  it leaks an invariant.
-- An explicit `start_sequence` opens the door to non-monotonic
-  read-ahead, which makes ack tracking harder to reason about.
-- The `last_acked_sequence` argument on `Consumer::new` already covers
-  the legitimate "resume from a specific sequence" case.
+### `ack_through(&self)` for Concurrent Acking
 
-### Make `ack_through` Take `&self` (Allow Concurrent Acking)
-
-Multiple sinks could `ack_through` independently if it took `&self`.
-Rejected because manifest mutation must be serialized; concurrent acks
-would race on `dequeue`. The high-throughput runtime's `AckCoordinator`
-already serializes acks at the source level (RFC 0002 in
-opendata-contrib, "Per-Source Ack Coordinator").
-
-### Push Decompression into the Object Store Layer
-
-Pre-decompress object-store responses inside `slatedb::object_store`.
-Rejected as out of scope and as the wrong layer; decompression policy
-varies per buffer signal and per workload, and should stay near the
-batch-decode boundary.
+Manifest mutation must stay serialized; concurrent acks would race on `dequeue`.
+A client that needs many ack sources serializes them at the owner (RFC 0002's
+runtime has a per-source ack coordinator that does exactly this).
 
 ## Implementation Notes
 
-- The new `descriptors_after` method on `QueueConsumer` re-uses
-  `read_manifest`. No CAS, no mutation.
-- `Consumer::last_handed_out_sequence` is a new private field
-  initialized from `last_acked_sequence` in `with_object_store`.
+- `descriptors_after` on `QueueConsumer` re-uses `read_manifest`; no CAS, no
+  mutation.
+- `last_handed_out_sequence` is a new private field initialized from
+  `last_acked_sequence`.
 - The metric move (`fetch_batch` → `fetch_descriptor`) is mechanical;
-  `next_batch` becomes a wrapper that calls `next_descriptors(1)`,
-  pops the single descriptor, and calls `fetch_descriptor`.
-- `ack_through(seq)` does not need to call `Consumer::flush`; the
-  unconditional `dequeue` it performs is the durable boundary.
-- The Tier 2 raw-decode hook should land behind a feature flag
-  (`raw-fetch`) so consumers that do not need it do not pay for the
-  added types in their public API surface.
-- Tests must cover: `next_descriptors` returning < `max` when the
-  manifest is shorter; concurrent `ConsumerFetchHandle::fetch` calls
-  from two tasks against clones of one handle (the manifest owner
-  task continues `next_descriptors` and `ack_through` while fetches
-  run); `ack_through` skipping over a contiguous range; `ack_through`
-  rejecting non-monotonic input; `ack_through` leaving in-memory state
-  untouched on `Fenced` and storage errors (dequeue-first invariant);
-  fence detection on `next_descriptors`; `next_batch` parity with the
-  wrapper.
+  `next_batch` becomes a wrapper over `next_descriptors(1)` + `fetch_descriptor`.
+- `ack_through` performs one unconditional `dequeue`; it does not call `flush`.
+- The raw-decode helpers (`fetch_raw` / `RawConsumedBatch` / the `decode_batch`
+  re-export) can sit behind a feature flag so consumers that do not need them do
+  not carry the extra public types.
+- Tests must cover: `next_descriptors` returning `< max` on a short manifest;
+  concurrent `fetch` from two clones of one handle while the owner runs
+  `next_descriptors` / `ack_through`; `ack_through` advancing over a contiguous
+  range in one dequeue; `ack_through` rejecting non-monotonic input;
+  `ack_through` leaving state untouched on `Fenced`/storage errors
+  (dequeue-first invariant); fence detection on `next_descriptors`; `next_batch`
+  parity with the wrapper.
 
 ## Migration Plan
 
-1. **Buffer crate**: implement `BatchDescriptor` (with
-   `object_bytes: Option<u64>` reserved as `None`), `ConsumerFetchHandle`,
-   `next_descriptors`, `fetch_handle`, `fetch_descriptor` (`&mut self`,
-   wrapping the handle plus the serial-cursor update), and `ack_through`
-   (with the documented dequeue-first ordering); rewrite `next_batch`
-   as a wrapper over them.
-2. **High-throughput runtime adoption** (opendata-contrib RFC 0002):
-   the runtime uses `next_descriptors` and routes object fetches
-   through clones of `Consumer::fetch_handle()`, and calls `ack_through`
-   wherever it would otherwise loop `ack`. It can start with `max = 1`
-   and a single fetch task, then raise `max` and fan the handle out to
-   N fetch workers for parallel fetch — no further buffer changes are
-   needed between those two points. Other consumers (timeseries,
-   vector) keep using `next_batch` and `ack` unchanged.
-3. **Tier 2 raw-decode hook**: not implemented in this release. It
-   lands when the runtime is ready to move `decode_batch` onto a
-   blocking pool; until then the feature flag stays off and the public
-   surface is just the core read-ahead methods above.
+1. **Buffer crate**: implement `BatchDescriptor`, `ConsumerFetchHandle`,
+   `next_descriptors`, `fetch_handle`, `fetch_descriptor` (`&mut self`, wrapping
+   the handle plus the serial-cursor update), and `ack_through` (dequeue-first);
+   rewrite `next_batch` as a wrapper.
+2. **Pipelined-client adoption** (e.g. opendata-contrib RFC 0002): use
+   `next_descriptors`, route fetches through clones of `fetch_handle()`, and
+   call `ack_through` instead of looping `ack`. A client can start with `max =
+   1` and one fetch task, then raise `max` and fan out to N fetch workers for
+   parallel fetch with no further buffer changes. Serial consumers (timeseries,
+   vector) keep `next_batch` + `ack` unchanged.
+3. **Raw-decode helpers**: land when a client is ready to move `decode_batch`
+   onto a blocking pool; until then the feature flag stays off.
 
-The buffer crate version bumps to a minor (additive API). No SemVer
-breakage.
+The buffer crate version bumps to a minor (additive API). No SemVer breakage.
 
 ## Validation Criteria
 
 ### API and Behavior
 
-- `next_descriptors(0)` returns `Ok(Vec::new())` without manifest read.
-- `next_descriptors(K)` on an empty queue returns
-  `Ok(Vec::new())`.
-- `next_descriptors(K)` on a manifest with `M < K` available entries
-  returns `M` descriptors and advances `last_handed_out_sequence`
-  through the last returned sequence.
+- `next_descriptors(0)` returns `Ok(Vec::new())` without a manifest read.
+- `next_descriptors(K)` on an empty queue returns `Ok(Vec::new())`.
+- `next_descriptors(K)` on a manifest with `M < K` available entries returns `M`
+  descriptors and advances `last_handed_out_sequence` through the last one.
 - `next_batch` after a fresh `Consumer::new` returns the same
-  `ConsumedBatch.sequence` and the same `entries` as in v0.x for the
-  same manifest state.
-- `Consumer::fetch_descriptor(d)` (the `&mut self` wrapper) and
-  `ConsumerFetchHandle::fetch(d)` against a `d` from
-  `next_descriptors` both return a `ConsumedBatch` with
-  `sequence == d.sequence`, `location == d.location`, and
-  `metadata == d.metadata`.
-- Two concurrent `ConsumerFetchHandle::fetch` calls (against clones
-  of one handle) targeting distinct descriptors complete with no
-  manifest contention; the owner task can run `next_descriptors` /
-  `ack_through` in parallel without borrow-checker conflict.
-- `ack_through(seq)` advances `last_acked_sequence` to `seq` and
-  removes manifest entries `<= seq`. `flush()` after `ack_through` is
-  a no-op.
+  `ConsumedBatch.sequence` and `entries` as before, for the same manifest state;
+  repeated `next_batch` calls walk successive batches without an intervening ack.
+- `fetch_descriptor(d)` and `ConsumerFetchHandle::fetch(d)` against a `d` from
+  `next_descriptors` both return a `ConsumedBatch` with matching `sequence`,
+  `location`, and `metadata`.
+- Two concurrent `fetch` calls (clones of one handle) against distinct
+  descriptors complete with no manifest contention while the owner runs
+  `next_descriptors` / `ack_through`.
+- `ack_through(seq)` advances `last_acked_sequence` to `seq` and removes manifest
+  entries `<= seq` in one dequeue; `flush` afterward is a no-op.
 - `ack_through(seq)` errors when `seq <= last_acked_sequence`.
 
 ### Fencing and Failure Atomicity
 
-- A fenced consumer's `next_descriptors` returns `Error::Fenced` on the
-  next call after the fence happens.
-- A fenced consumer's `ack_through(seq)` returns `Error::Fenced`
-  *and* leaves `last_acked_sequence` and `buffer.acks` unchanged. A
-  subsequent retry against an unfenced consumer succeeds.
-- A storage-error `ack_through` (object store unreachable) leaves
-  `last_acked_sequence` and `buffer.acks` unchanged. Recovery is to
-  retry once storage is reachable.
-- `ConsumerFetchHandle::fetch` against a descriptor obtained before
-  fencing succeeds (the data object is still readable until GC). The
-  handle does not detect fence on its own.
+- A fenced consumer's `next_descriptors` returns `Error::Fenced` on the next
+  call after the fence.
+- A fenced or storage-failed `ack_through(seq)` leaves `last_acked_sequence` and
+  `buffer.acks` unchanged; a retry against a healthy consumer succeeds.
+- `fetch` against a descriptor obtained before fencing succeeds (the data object
+  is readable until GC); the handle does not detect fence on its own.
 
 ### Concurrency (handle path)
 
-- `Consumer::fetch_handle()` returns a value that is `Clone + Send +
-  Sync + 'static`.
-- Two clones of a fetch handle, called concurrently from two
-  `tokio::spawn` tasks against distinct descriptors, complete with no
-  manifest contention.
-- A fetch handle clone outlives the spawned task that produced it
-  (drop-after-spawn does not invalidate the handle).
-- `ConsumerFetchHandle::fetch` does **not** mutate any cursor on the
-  parent `Consumer`. After a fetch handle call, `next_batch` /
-  `fetch_descriptor` from the owner task observe unchanged
-  `last_fetched_sequence`.
+- `fetch_handle()` returns a value that is `Clone + Send + Sync + 'static`.
+- Two handle clones fetch concurrently from two tasks with no manifest
+  contention; a clone outlives the task that produced it.
+- `fetch` mutates no `Consumer` cursor: after a handle fetch, the owner's
+  `last_fetched_sequence` is unchanged.
 
 ### Descriptor Handout Contract
 
-- After `next_descriptors` returns a descriptor with sequence `S`, a
-  subsequent `next_descriptors` call without an intervening
-  `ack_through` returns descriptors with sequence > `S` only.
-- Process restart (`Consumer::new(_, Some(durable_frontier))`)
-  re-emits descriptors strictly after `durable_frontier`, including
-  any sequences a previous process handed out but did not ack.
-
-### Compatibility
-
-- `cargo test -p buffer` is green against the new crate without
-  changes to existing tests.
-- Downstream consumers (timeseries, vector, clickhouse-ingestor) build
-  unchanged.
+- After `next_descriptors` returns sequence `S`, a subsequent call without an
+  intervening `ack_through` returns sequences `> S` only.
+- `Consumer::new(_, Some(frontier))` re-emits descriptors strictly after
+  `frontier`, including sequences a previous process handed out but never acked.
 
 ### Metrics
 
-- `buffer.batches_collected` increments exactly once per
-  `fetch_descriptor` call (and therefore once per `next_batch` under
-  the wrapper).
-- `buffer.acks` increments by the number of sequences `ack_through`
-  advances over.
-- `buffer.descriptors_handed_out` increments by `descriptors.len()` on
-  every `next_descriptors` call.
+- `buffer.batches_collected` increments once per `fetch_descriptor` call (and
+  thus once per `next_batch`).
+- `buffer.acks` increments by the number of sequences `ack_through` advances.
+- `buffer.descriptors_handed_out` increments by `descriptors.len()` per
+  `next_descriptors` call.
 
-### Tier 2 (when feature is enabled)
+### Raw-decode helpers (when the feature is enabled)
 
-- `ConsumerFetchHandle::fetch_raw(d)` returns a `RawConsumedBatch`
-  whose `decode_batch(raw_bytes)` produces an `entries` vector
-  identical to the one returned by `Consumer::fetch_descriptor(d)`.
-- `decode_batch` is callable from `tokio::task::spawn_blocking` and
-  produces the same output as the in-line decode.
-- `fetch_raw` lives only on the handle (not on `Consumer`); serial
-  callers continue to use `Consumer::fetch_descriptor`.
+- `fetch_raw(d)` returns a `RawConsumedBatch` whose `decode_batch(raw_bytes)`
+  produces an `entries` vector identical to `fetch_descriptor(d)`'s.
+- `decode_batch` is callable from `spawn_blocking` and produces the same output
+  as the inline decode.
+- `fetch_raw` lives only on the handle; serial callers use `fetch_descriptor`.

--- a/buffer/rfcs/0003-consumer-read-ahead.md
+++ b/buffer/rfcs/0003-consumer-read-ahead.md
@@ -1,0 +1,1166 @@
+# RFC 0003: Consumer Read-Ahead and `ack_through`
+
+**Status**: Accepted
+
+**Authors**:
+
+- Apurva Mehta
+
+## Summary
+
+Add a fetch-handle type and three methods to `buffer::Consumer` so
+high-throughput consumers can fetch and decode many data batches
+concurrently while keeping manifest mutation serialized:
+
+```rust
+impl Consumer {
+    pub async fn next_descriptors(&mut self, max: usize)
+        -> Result<Vec<BatchDescriptor>>;
+
+    /// Convenience wrapper for serial callers. The high-throughput
+    /// runtime uses [`fetch_handle`] instead.
+    pub async fn fetch_descriptor(&mut self, descriptor: BatchDescriptor)
+        -> Result<ConsumedBatch>;
+
+    /// Cheap, cloneable handle to the read path. Holds an `Arc` to
+    /// the object store; carries no manifest state and no mutable
+    /// cursor. The owning `Consumer` keeps `&mut`-only access to
+    /// manifest operations (`next_descriptors`, `ack`, `ack_through`,
+    /// `flush`).
+    pub fn fetch_handle(&self) -> ConsumerFetchHandle;
+
+    pub async fn ack_through(&mut self, sequence: u64) -> Result<()>;
+}
+
+#[derive(Clone)]
+pub struct ConsumerFetchHandle { /* Arc<dyn ObjectStore> + manifest_path */ }
+
+impl ConsumerFetchHandle {
+    /// Stateless fetch + decode. Takes `&self`; safe to call
+    /// concurrently from many tasks. Does not touch the consumer's
+    /// cursors.
+    pub async fn fetch(&self, descriptor: BatchDescriptor)
+        -> Result<ConsumedBatch>;
+}
+
+pub struct BatchDescriptor {
+    pub sequence: u64,
+    pub location: String,
+    pub metadata: Vec<Metadata>,
+    /// Object size in bytes when known. Reserved for byte-budget
+    /// accounting in `opendata-ingest-runtime` (RFC 0002 in
+    /// `opendata-contrib`). v1 manifests do not carry size, so this
+    /// is always `None` until a future manifest format extension
+    /// fills it in. Callers that observe `None` use a pessimistic
+    /// reservation per their own configuration; see "BatchDescriptor
+    /// and Object Size" below.
+    pub object_bytes: Option<u64>,
+}
+```
+
+`next_descriptors` reads the manifest once and returns a contiguous run
+of entries past the consumer's read-ahead cursor without performing any
+object-store fetch. `ConsumerFetchHandle::fetch` performs the object
+fetch and batch decode for a single descriptor; it is stateless and
+clone-shareable across worker tasks. `Consumer::fetch_descriptor` is a
+convenience wrapper for serial callers; under the hood it constructs a
+local handle and calls `fetch` (it takes `&mut self` only because
+it forwards lag-metric updates to the consumer's serial cursor —
+parallel callers should use the handle directly). `ack_through(seq)`
+advances the durable ack frontier through `seq` in one call,
+replacing the per-sequence loop the high-throughput runtime would
+otherwise need; durable-dequeue happens **before** any in-memory
+state advances.
+
+The existing `next_batch`, `ack`, `flush`, and `close` API is preserved
+unchanged; `next_batch` becomes a thin compatibility wrapper over
+`next_descriptors(1)` + `fetch_descriptor`. Epoch fencing semantics are
+unchanged.
+
+This RFC is the Buffer-side companion to opendata-contrib RFC 0002
+(generic ingest runtime), which consumes this API for parallel fetch
+and decode.
+
+## Motivation
+
+The shipped `Consumer` API (RFC 0001) is single-threaded and serial:
+
+```rust
+pub async fn next_batch(&mut self) -> Result<Option<ConsumedBatch>>;
+pub async fn ack(&mut self, sequence: u64) -> Result<()>;
+pub async fn flush(&mut self) -> Result<()>;
+```
+
+`next_batch` does three things in one async call: read the manifest,
+look up the next sequence in it, and fetch the data object from object
+storage. Each call therefore performs at least one manifest read (or
+metadata cache hit) plus one object-store GET, even when the manifest
+has hundreds of contiguous entries past the cursor.
+
+For the high-throughput ingestor (opendata-contrib RFC 0002):
+
+- **Object fetch is the dominant async wait** for the consumer. Running
+  fetches in parallel is the obvious throughput lever, but the current
+  API does not let multiple in-flight fetches share manifest state.
+  Calling `next_batch` from N tasks would interleave manifest reads and
+  cursor advances unpredictably, and `&mut self` rules it out anyway.
+- **Manifest reads are wasted** when the consumer pulls `K` consecutive
+  sequences. Each call re-fetches the manifest object and re-iterates
+  it; the per-sequence `read(seq)` path is `O(N)` over the manifest
+  entries (`queue.rs` line 738-742).
+- **Acks loop one sequence at a time**. After a commit group covering
+  500 sequences, the runtime calls `consumer.ack(seq).await` 500 times
+  in sequence. Each call updates an in-memory cursor and trips
+  `dequeue` every 100 acks. Even on the happy path this is wasted
+  ceremony; the runtime's invariant is "advance the durable frontier
+  through `high`," not "ack each sequence individually."
+- **Decompression and decode happen on the same task as the fetch.**
+  `fetch_batch` calls `decode_batch` synchronously after the GET,
+  inside the consumer's async task. CPU-bound decompression that should
+  run on a blocking pool blocks the I/O task instead.
+
+Fixing all four with one bigger refactor (e.g. an internal worker pool)
+would couple the buffer crate to a specific runtime model. The minimal
+change that unblocks the high-throughput design is to **split the read
+path into a manifest step and a fetch step**, expose the split in the
+public API, and add a bulk ack primitive. Existing consumers do not
+have to change.
+
+## Goals
+
+- Add a public read-ahead API that returns multiple
+  contiguous descriptors per manifest read.
+- Add a cloneable, concurrency-safe `ConsumerFetchHandle` whose
+  `fetch(&self, ...)` runs object-store GETs in parallel without
+  sharing `&mut Consumer`.
+- Add `ack_through(sequence)` so callers can advance the durable
+  ack frontier in one call, with dequeue-first ordering so the
+  in-memory cursor and the metrics counter only advance after the
+  durable manifest mutation succeeds.
+- Preserve the existing `next_batch`, `ack`, `flush`, `close` API
+  unchanged. `next_batch` becomes a thin wrapper over the new API.
+- Preserve epoch fencing exactly. Read-ahead must surface a `Fenced`
+  error the same way the serial path does.
+- Keep manifest mutation (epoch increment, dequeue) serialized through
+  one owner.
+- Document the concurrency contract for `ConsumerFetchHandle::fetch`
+  and the descriptor-handout contract on `next_descriptors` so callers
+  can rely on them without inspecting the implementation.
+
+## Non-Goals
+
+- A Buffer-side worker pool, parallel-fetch helper, or
+  decode/decompression scheduler. The new API hands the caller the
+  primitives; orchestration belongs in `opendata-ingest-runtime` (RFC
+  0002 in opendata-contrib).
+- Multi-consumer fanout from one manifest. Buffer keeps "one active
+  consumer per manifest" enforced by epoch fencing. Read-ahead does
+  not change that.
+- A new manifest format, or any change to the `Manifest` /
+  `ManifestEntry` / `Metadata` shapes.
+- Changing the producer side (`QueueProducer` / `Producer`).
+- Out-of-order acks. `ack_through(n)` advances monotonically; there is
+  still no API to ack a non-contiguous sequence and have the gaps
+  later acked.
+- Replay tooling (operator-directed re-read past the durable frontier).
+  Consumers already accept `last_acked_sequence` on construction; the
+  new API does not extend that.
+- A blocking-CPU decode helper inside the buffer crate. Optional raw-
+  bytes hook (Tier 2 below) is the seam, not a scheduler.
+
+## Background
+
+The shipped contract from RFC 0001:
+
+```rust
+impl Consumer {
+    pub async fn new(config: ConsumerConfig, last_acked_sequence: Option<u64>) -> Result<Self>;
+    pub async fn next_batch(&mut self) -> Result<Option<ConsumedBatch>>;
+    pub async fn ack(&mut self, sequence: u64) -> Result<()>;
+    pub async fn flush(&mut self) -> Result<()>;
+    pub async fn close(self) -> Result<()>;
+}
+
+pub struct ConsumedBatch {
+    pub entries: Vec<Bytes>,
+    pub sequence: u64,
+    pub location: String,
+    pub metadata: Vec<Metadata>,
+}
+
+pub struct Metadata {
+    pub start_index: u32,
+    pub ingestion_time_ms: i64,
+    pub payload: Bytes,
+}
+```
+
+Internals relevant to the read-ahead design:
+
+- `Consumer` holds `QueueConsumer`, an `Arc<dyn ObjectStore>`, the GC
+  task, and three private cursors: `last_acked_sequence`,
+  `last_fetched_sequence`, `ack_count` (used to amortize `dequeue`
+  every `DEQUEUE_INTERVAL = 100` acks).
+- `QueueConsumer::peek` and `QueueConsumer::read(sequence)` both read
+  the manifest object and iterate its entries. They are
+  `pub(crate)` today; `next_batch` is the only public read entry.
+- `QueueConsumer::dequeue(through_sequence)` performs a CAS write
+  against the manifest. It is the only mutating call on the read
+  side.
+- Epoch fencing: `peek` and `read` return `Error::Fenced` if the
+  manifest's epoch differs from the consumer's epoch. The new API
+  must do the same.
+- `decode_batch` is `pub(crate)`. It does length-decoding and (when
+  configured) decompression. It runs synchronously inside `next_batch`.
+
+Two properties the new API depends on:
+
+1. **Reading the manifest does not mutate it**, so multiple readers can
+   safely call `read_manifest` concurrently. The current
+   `pub(crate)` calls `peek` and `read` do exactly that.
+2. **`dequeue` is the only manifest mutation on the read side**, so as
+   long as `dequeue` (i.e. `flush`) stays serialized through one owner,
+   parallel fetch/decode is safe.
+
+## Design
+
+### Public API Surface
+
+Add `BatchDescriptor`, `ConsumerFetchHandle`, and four methods to
+`Consumer`:
+
+```rust
+/// Lightweight pointer to one manifest entry. Carries everything a
+/// caller needs to fetch the batch without re-reading the manifest.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BatchDescriptor {
+    pub sequence: u64,
+    pub location: String,
+    pub metadata: Vec<Metadata>,
+    /// Object size in bytes when known. v1 always emits `None`
+    /// because the current manifest format does not carry size.
+    /// Reserved for a future manifest extension and for the runtime's
+    /// byte-budget accounting.
+    pub object_bytes: Option<u64>,
+}
+
+/// Cheap, cloneable handle to the read path. Construction is O(1)
+/// (clones an `Arc<dyn ObjectStore>` and copies the manifest path
+/// string). Carries no manifest state and no mutable cursor; safe to
+/// share across many fetch worker tasks.
+#[derive(Clone)]
+pub struct ConsumerFetchHandle {
+    object_store: Arc<dyn ObjectStore>,
+    manifest_path: String,  // for tracing/labels only
+}
+
+impl ConsumerFetchHandle {
+    /// Fetch and decode one batch. Stateless: does not touch any
+    /// `Consumer` cursor. Two concurrent calls against distinct
+    /// descriptors are fully independent; two concurrent calls
+    /// against the same descriptor are safe but waste a GET.
+    pub async fn fetch(&self, descriptor: BatchDescriptor)
+        -> Result<ConsumedBatch>;
+}
+
+impl Consumer {
+    /// Read the manifest once and return up to `max` contiguous
+    /// descriptors past the consumer's read-ahead cursor.
+    ///
+    /// Does not perform any object-store GET. Does not mutate the
+    /// durable ack frontier. Advances an in-memory `last_handed_out`
+    /// cursor by the number of descriptors returned. See "Descriptor
+    /// Handout Contract" below for caller obligations.
+    ///
+    /// Returns an empty `Vec` if no new entries are available;
+    /// returns `Err(Error::Fenced)` if the consumer's epoch no longer
+    /// matches the manifest's.
+    pub async fn next_descriptors(&mut self, max: usize)
+        -> Result<Vec<BatchDescriptor>>;
+
+    /// Construct a cloneable fetch handle. Cheap; returns a new
+    /// handle on each call (callers that need many handles can call
+    /// once and clone, or call repeatedly — both are O(1)).
+    pub fn fetch_handle(&self) -> ConsumerFetchHandle;
+
+    /// Convenience wrapper for serial callers. Equivalent to
+    /// `self.fetch_handle().fetch(descriptor).await`, but also
+    /// updates the consumer's serial lag cursor (used by the
+    /// `consumer_lag_seconds` gauge under the legacy `next_batch`
+    /// path). Parallel callers should use `fetch_handle()` and
+    /// drive the gauge themselves if they want it.
+    pub async fn fetch_descriptor(&mut self, descriptor: BatchDescriptor)
+        -> Result<ConsumedBatch>;
+
+    /// Advance the durable ack frontier through (and including)
+    /// `sequence`. Performs `dequeue(sequence)` against the manifest,
+    /// then updates in-memory state on success. If `dequeue` returns
+    /// an error (storage failure, fence), the consumer's
+    /// `last_acked_sequence` does not advance and the metrics counter
+    /// does not increment.
+    ///
+    /// Returns an error if `sequence` is less than or equal to the
+    /// current `last_acked_sequence`. The frontier is monotonic.
+    pub async fn ack_through(&mut self, sequence: u64) -> Result<()>;
+}
+```
+
+The existing methods stay with their current signatures.
+
+#### Why a separate handle (not just `Arc<Consumer>`)?
+
+An obvious alternative is to put the consumer behind `Arc<Consumer>`
+and call `fetch_descriptor(&self, ...)` from worker tasks. That does
+not work in practice: every other useful method on `Consumer`
+(`next_descriptors`, `ack`, `ack_through`, `flush`, `close`) takes
+`&mut self`. Holding any of those calls open while fetch tasks run
+requires either:
+
+- An interior-mutability rewrite of every cursor on `Consumer`, which
+  changes the safety story across the whole API surface, or
+- A second instance of `Consumer` (which is impossible — Buffer
+  enforces one active consumer per manifest via epoch fencing), or
+- A separate handle whose only job is reading object storage.
+
+The handle is the cheapest option. It owns nothing manifest-related,
+clones via `Arc`, and disappears when the consumer is dropped (the
+`Arc<dyn ObjectStore>` it holds is the same one the consumer uses, so
+a stale handle has no exclusive resource).
+
+The high-throughput runtime's expected pattern is:
+
+```rust
+// One owner task drives the manifest:
+let consumer = Consumer::new(...).await?;
+let fetcher  = consumer.fetch_handle();
+
+// Spawn N fetch workers, each holding a clone:
+for _ in 0..fetch_concurrency {
+    let f = fetcher.clone();
+    let rx = descriptor_rx.clone();
+    tokio::spawn(async move {
+        while let Some(d) = rx.recv().await {
+            let batch = f.fetch(d).await?;
+            // ...send to decode stage...
+        }
+        Ok::<(), Error>(())
+    });
+}
+
+// Owner task: poll, ack, flush.
+loop {
+    let descriptors = consumer.next_descriptors(K).await?;
+    for d in descriptors { descriptor_tx.send(d).await?; }
+    // ...wait for completions, then:
+    consumer.ack_through(high).await?;
+}
+```
+
+The `&mut Consumer` in the owner task and the `&self` on the handle
+do not interact at the borrow-checker level: the handle holds an
+`Arc<dyn ObjectStore>`, not a borrow of the consumer.
+
+### `next_batch` Becomes a Compatibility Wrapper
+
+```rust
+pub async fn next_batch(&mut self) -> Result<Option<ConsumedBatch>> {
+    let mut descriptors = self.next_descriptors(1).await?;
+    match descriptors.pop() {
+        Some(d) => Ok(Some(self.fetch_descriptor(d).await?)),
+        None => Ok(None),
+    }
+}
+```
+
+`fetch_descriptor` itself is the wrapper that drives the serial lag
+cursor. Internally:
+
+```rust
+pub async fn fetch_descriptor(&mut self, descriptor: BatchDescriptor)
+    -> Result<ConsumedBatch>
+{
+    let handle = self.fetch_handle();
+    let batch  = handle.fetch(descriptor).await?;
+    if let Some(last_meta) = batch.metadata.last() {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as i64;
+        let lag_s = (now_ms - last_meta.ingestion_time_ms) as f64 / 1000.0;
+        metrics::gauge!(m::CONSUMER_LAG_SECONDS).set(lag_s.max(0.0));
+    }
+    self.last_fetched_sequence = match self.last_fetched_sequence {
+        Some(prev) => Some(prev.max(batch.sequence)),
+        None => Some(batch.sequence),
+    };
+    Ok(batch)
+}
+```
+
+The `&mut self` is required because the lag-cursor update belongs to
+the consumer; the handle path leaves that observation to the caller.
+
+Existing callers (the timeseries consumer, the vector consumer, the
+ClickHouse alpha) get the same return type and the same per-call cost.
+The lag gauge, latency histogram, and counter increments that
+`next_batch` records today move to `fetch_descriptor` so they fire
+exactly once per fetched batch under both code paths. The
+`ConsumerConfig` struct is unchanged.
+
+### Concurrency Model
+
+The Consumer is split into two roles, each with its own type:
+
+- **Manifest owner** (`Consumer` with `&mut self` access):
+  `next_descriptors`, `fetch_descriptor`, `ack`, `ack_through`,
+  `flush`, `close`. These mutate the in-memory cursor or perform
+  manifest CAS writes. **One holder at a time.** Sharing `Consumer`
+  across tasks requires the caller to pick one owner task and route
+  manifest operations through it (channels, actor pattern, etc.); the
+  RFC does not provide cross-task coordination primitives.
+- **Fetcher** (`ConsumerFetchHandle` with `&self` access): `fetch`.
+  Performs an object-store GET and `decode_batch` against a
+  descriptor that is already determined. Stateless. Does not touch
+  manifest state. **Cloneable; safe to share across many tasks.**
+
+Two patterns that callers can rely on:
+
+1. **Owner + N fetch workers** (the high-throughput runtime):
+   one task owns `&mut Consumer` and drives the manifest. It calls
+   `next_descriptors(K)` to refill a bounded channel of descriptors;
+   N fetch workers each hold a clone of `consumer.fetch_handle()`
+   and pop descriptors off the channel. Workers send completed
+   batches back through another channel. The owner task observes
+   completions and calls `ack_through(high)` periodically. The
+   manifest owner runs in parallel with the fetch workers because
+   their state is disjoint (the handle holds no `Consumer` borrow).
+2. **Single-task serial** (legacy callers): one task calls
+   `next_batch` (or `next_descriptors(1)` + `fetch_descriptor`) and
+   `ack` in a loop. No handle needed. This is what the timeseries
+   and vector consumers do today; they do not change.
+
+Three non-obvious safety arguments:
+
+- **Re-fetching a descriptor is safe.** Two `fetch` calls against the
+  same descriptor both perform an object-store GET and return
+  identical `ConsumedBatch` values. There is no mutation. Callers
+  should not normally do this (it wastes a GET) but doing so is not a
+  correctness bug.
+- **A descriptor outliving the manifest entry is safe to fetch.** If
+  the manifest is dequeued through `descriptor.sequence` between
+  `next_descriptors` and `fetch`, the data object on object storage
+  is still there until GC runs; the GET still succeeds. If GC has
+  already deleted the object (because the grace period elapsed), the
+  GET returns a 404, which `fetch` surfaces as `Error::Storage`.
+  Callers control this gap by acking *after* fetch + process, not
+  before, which is already the consumer pattern.
+- **The handle never observes fence on its own.** Fence is detected
+  inside `next_descriptors` (the next manifest read after fencing
+  returns `Error::Fenced`). A fetch worker that holds a stale handle
+  for a fenced consumer keeps fetching successfully against object
+  storage; the manifest owner is the one that learns about the fence
+  and propagates it to workers (e.g. by closing the descriptor
+  channel). This is intentional: fetch workers do not need
+  manifest-level state to do their job. A future RFC could add a
+  `handle.is_active() -> bool` if the runtime needs an out-of-band
+  fence signal that doesn't go through the descriptor channel.
+
+### Cursor Semantics
+
+The Consumer maintains three monotonic cursors. **All three live on
+`Consumer` and are mutated only through `&mut self` methods.**
+`ConsumerFetchHandle` is stateless and never touches them.
+
+| Cursor | Mutator | Meaning |
+|---|---|---|
+| `last_acked_sequence` | `ack` (success), `ack_through` (after dequeue success) | Highest sequence durably dequeued from the manifest. |
+| `last_fetched_sequence` | `fetch_descriptor` (the `&mut self` wrapper) | Highest sequence whose data object the **serial wrapper path** has read. Used by the `consumer_lag_seconds` gauge. |
+| `last_handed_out_sequence` (new) | `next_descriptors` | Highest sequence the consumer has handed out as a descriptor. |
+
+`last_handed_out_sequence` is what `next_descriptors` uses to find the
+next contiguous run on a manifest re-read. It is distinct from
+`last_fetched_sequence` because callers may hand out descriptors before
+the corresponding fetches resolve.
+
+Initial value of all three is `last_acked_sequence` from construction
+(`None` for a fresh consumer; `Some(seq)` when the caller passed
+`last_acked_sequence: Some(seq)`).
+
+`next_batch` advances `last_handed_out_sequence` and
+`last_fetched_sequence` together (via the wrapped
+`next_descriptors(1)` and `fetch_descriptor` calls), preserving
+today's behavior.
+
+`fetch_descriptor` (the `&mut self` wrapper) advances
+`last_fetched_sequence` to `max(current, descriptor.sequence)` after
+the fetch succeeds. It does **not** mutate `last_handed_out_sequence`
+(the descriptor was already handed out) or `last_acked_sequence` (the
+caller acks separately).
+
+**`ConsumerFetchHandle::fetch` does not advance any cursor on the
+consumer.** Parallel-fetch callers that want a `consumer_lag_seconds`-
+equivalent gauge observe it themselves from `batch.metadata.last()`
+and emit their own metric, or wire the runtime's metrics layer to do
+so. The handle deliberately holds no interior-mutable max cursor:
+that would add atomic state to the hot fetch path for a metric the
+runtime already owns (the runtime's `runtime_stage_latency_seconds{stage=fetch}`
+histogram is finer-grained than a single max-sequence gauge).
+
+`ack_through(seq)` performs **dequeue first, then in-memory state
+update**. If `dequeue` returns an error (storage failure, fence), the
+consumer's `last_acked_sequence` does not advance and the metrics
+counter does not increment. Concretely:
+
+- `ack(seq)` keeps its existing per-sequence loop semantics with
+  amortized dequeue every `DEQUEUE_INTERVAL = 100` acks.
+- `ack_through(seq)` always performs one dequeue at call time, and
+  applies its in-memory updates only after dequeue succeeds. It is
+  the right primitive when the caller already batches.
+
+### Descriptor Handout Contract
+
+`next_descriptors` advances `last_handed_out_sequence` *before* the
+caller has fetched the corresponding objects. This is intentional —
+read-ahead is the whole point — but it puts a contract on the caller
+that does not exist for the serial `next_batch` API. The contract is:
+
+> **Once `next_descriptors` returns a descriptor, the caller is
+> responsible for either (a) successfully fetching and processing it,
+> or (b) accepting that it will be re-handed-out only via process
+> restart (which restarts read-ahead from the durable
+> `last_acked_sequence`, dropping any in-flight descriptors).**
+
+Specifically:
+
+- **Lost descriptors are not reissued within a process.** If a worker
+  task panics, drops a channel send, or otherwise discards a
+  descriptor without acking the corresponding sequence, the
+  consumer's `last_handed_out_sequence` has already advanced past it.
+  The next `next_descriptors` call will not return the lost
+  descriptor; it will return descriptors strictly after it.
+- **Acking a sequence that was lost is forbidden.** The caller's own
+  bookkeeping (commit-group high watermark, route completion record)
+  must not mark a lost sequence complete. If it does, `ack_through`
+  will durably ack a sequence whose data was never processed, and the
+  data is lost.
+- **Recovery is process restart.** A new `Consumer::new(config,
+  last_acked_sequence)` initializes `last_handed_out_sequence =
+  last_acked_sequence`, so `next_descriptors` re-emits everything the
+  durable frontier hasn't acked. This is the only supported path for
+  reissuing lost descriptors.
+- **Out-of-order completion is fine, gaps are not.** Workers may
+  complete fetches in any order. The runtime's ack coordinator (RFC
+  0002 in opendata-contrib) tracks contiguous completion and only
+  calls `ack_through` for the highest contiguous complete sequence.
+  A gap (one descriptor in the run is permanently lost) means the
+  ack frontier never advances past that gap until restart.
+
+The high-throughput runtime in opendata-contrib RFC 0002 enforces
+this contract by making the descriptor channel bounded and by
+treating dropped descriptors as a runtime fatal — workers that lose
+a descriptor halt the runtime and force a restart. The buffer crate
+itself does not detect lost descriptors; that is the caller's job.
+
+A future "return descriptor" API (let the caller hand a descriptor
+back so it can be reissued without restart) is *not* in scope for
+this RFC. It would require maintaining a per-descriptor "handed
+out / returned / fetched" state inside `Consumer` that does not
+exist today, and the runtime can already recover via the documented
+restart path.
+
+### BatchDescriptor and Object Size
+
+`BatchDescriptor.object_bytes: Option<u64>` is reserved for the
+runtime's byte-budget accounting (RFC 0002 in opendata-contrib).
+The current Buffer manifest format does not carry per-entry object
+size:
+
+```rust
+pub struct ManifestEntry {
+    pub sequence: u64,
+    pub location: String,
+    pub metadata: Vec<Metadata>,
+}
+```
+
+So v1 of this RFC always emits `object_bytes: None`. The field
+exists in the public type so:
+
+1. The runtime can adopt the field today and use a configured
+   pessimistic reservation (`source.estimated_max_batch_bytes`) when
+   the value is `None`.
+2. A future manifest format extension (or an opt-in producer-side
+   metadata payload) can populate the field without breaking the
+   public API.
+
+Changing the manifest format to carry object size is **out of scope
+for this RFC** (declared a non-goal above) but is a natural
+follow-up after the read-ahead path is stable. Until then, the
+runtime overcounts in-flight bytes in the common case and pauses
+source pulls slightly earlier than tight accounting would; this is
+intentional slack.
+
+Other ways to populate `object_bytes`, considered and rejected for
+v1:
+
+- **HEAD before GET**: an extra network round trip on every fetch.
+  Adds ~1 RTT to fetch latency for a metric-tightening benefit.
+  Rejected; the runtime's pessimistic reservation is cheaper.
+- **Read object metadata from the GET response and attach it to a
+  later descriptor**: requires the consumer to remember per-sequence
+  sizes across calls, which is exactly the kind of state we are
+  trying to keep out of `ConsumerFetchHandle`. Rejected for v1.
+- **Use `Metadata.payload` to carry a producer-supplied size hint**:
+  the payload is opaque and producer-defined (RFC 0001); requiring
+  producers to put a size there would couple the buffer crate to
+  its consumers in a way RFC 0001 was careful to avoid. Rejected.
+
+### Epoch Fencing
+
+`next_descriptors` returns `Error::Fenced` if the consumer's epoch no
+longer matches the manifest. The check happens inside
+`QueueConsumer::read_manifest` exactly as it does today for
+`peek`/`read`.
+
+`fetch_descriptor` does **not** consult the manifest, so it does not
+itself detect fencing. Callers that want to fail fast on fence can
+either:
+
+1. Keep one `next_descriptors` task running on the consumer; it will
+   hit `Fenced` on its next manifest read.
+2. Treat repeated `Storage` errors on `fetch_descriptor` (404s after
+   GC) as a fence signal in operations.
+
+The most common case is path (1): the high-throughput runtime drives
+`next_descriptors` continuously to keep the descriptor queue full, so
+a fence surfaces within one polling interval.
+
+### Object Fetch Path
+
+`ConsumerFetchHandle::fetch` performs the same work
+`Consumer::fetch_batch` does today:
+
+1. `object_store.get(&Path::from(descriptor.location.as_str())).await`
+2. `data.bytes().await`
+3. `decode_batch(data)` to produce `Vec<Bytes>` entries
+4. Construct `ConsumedBatch { entries, sequence, location, metadata }`
+
+The metrics split between two sites:
+
+- **Per-fetch counters and the per-fetch latency histogram**
+  (`BATCHES_COLLECTED`, `ENTRIES_COLLECTED`, `BYTES_COLLECTED`,
+  `FETCH_DURATION_SECONDS`) move to `ConsumerFetchHandle::fetch`.
+  These fire exactly once per fetched batch under both old and new
+  APIs.
+- **The serial lag gauge** (`CONSUMER_LAG_SECONDS`) stays on the
+  `&mut self` `fetch_descriptor` wrapper. Parallel-fetch callers do
+  not advance the consumer's serial cursor and do not update this
+  gauge; they observe lag through their own runtime metrics
+  (`runtime_stage_latency_seconds{stage=fetch}` in RFC 0002).
+
+`decode_batch` runs on the calling task. Callers that want to put it
+on a blocking pool can call `tokio::task::spawn_blocking` around the
+decode step (see "Optional: Raw Decode Hook" below).
+
+### `next_descriptors` Implementation
+
+The body adds one new path to `QueueConsumer`:
+
+```rust
+// queue.rs
+impl QueueConsumer {
+    pub(crate) async fn descriptors_after(
+        &self,
+        after_sequence: Option<u64>,
+        max: usize,
+    ) -> Result<Vec<QueueEntry>> {
+        let (manifest, _) = self.read_manifest().await?;
+        if manifest.epoch != self.epoch.load(Ordering::Relaxed) {
+            return Err(Error::Fenced);
+        }
+        let mut out = Vec::with_capacity(max);
+        for entry in manifest.iter() {
+            let entry = entry?;
+            if let Some(after) = after_sequence
+                && entry.sequence <= after
+            {
+                continue;
+            }
+            out.push(entry);
+            if out.len() >= max {
+                break;
+            }
+        }
+        Ok(out)
+    }
+}
+```
+
+`Consumer::next_descriptors` wraps this:
+
+```rust
+pub async fn next_descriptors(&mut self, max: usize)
+    -> Result<Vec<BatchDescriptor>>
+{
+    if max == 0 {
+        return Ok(Vec::new());
+    }
+    let entries = self
+        .consumer
+        .descriptors_after(self.last_handed_out_sequence, max)
+        .await?;
+    metrics::gauge!(m::QUEUE_LENGTH).set(self.consumer.len() as f64);
+    if let Some(last) = entries.last() {
+        self.last_handed_out_sequence = Some(last.sequence);
+    }
+    Ok(entries
+        .into_iter()
+        .map(|e| BatchDescriptor {
+            sequence: e.sequence,
+            location: e.location,
+            metadata: e.metadata,
+            // Reserved field; the current manifest format does not
+            // carry per-entry object size. See "BatchDescriptor and
+            // Object Size" above.
+            object_bytes: None,
+        })
+        .collect())
+}
+```
+
+This is `O(handed_out_offset_within_manifest + max)` per call, dominated
+by the manifest read latency. It is strictly better than `K` calls to
+`next_batch` for `K` contiguous entries when `K > 1`, and equivalent
+when `K = 1`.
+
+A future optimization can teach `Manifest::iter` to skip to a target
+sequence in `O(log N)` (the manifest entries are sorted by sequence).
+That is out of scope for this RFC; the linear scan is already fine for
+manifests of the sizes we run.
+
+### `ack_through` Implementation
+
+The dequeue is the durable boundary. In-memory state is updated **only
+after** dequeue succeeds, so a fence or storage error leaves
+`last_acked_sequence` and the metrics counter unchanged:
+
+```rust
+pub async fn ack_through(&mut self, sequence: u64) -> Result<()> {
+    if let Some(last) = self.last_acked_sequence
+        && sequence <= last
+    {
+        return Err(Error::Storage(format!(
+            "non-monotonic ack_through: last_acked={}, requested={}",
+            last, sequence,
+        )));
+    }
+    let count_advanced = match self.last_acked_sequence {
+        None => sequence + 1,
+        Some(last) => sequence - last,
+    };
+
+    // Durable dequeue first. Bubbles up Fenced and Storage errors
+    // without touching local state.
+    self.consumer.dequeue(sequence).await?;
+
+    // Only mutate in-memory state after dequeue succeeds.
+    self.last_acked_sequence = Some(sequence);
+    self.ack_count = self.ack_count.wrapping_add(count_advanced);
+    metrics::counter!(m::ACKS).increment(count_advanced);
+    Ok(())
+}
+```
+
+The dequeue is unconditional. `ack` keeps its amortized-every-100-acks
+behavior; the high-throughput runtime opts into immediate dequeue by
+calling `ack_through`.
+
+**Important caller contract**: when `ack_through` returns `Err(_)`, the
+caller must treat the requested range as **not** durably acked and
+must not advance any of its own bookkeeping (commit-group high
+watermark, route completion record, etc.) past the previous
+successful ack. A retry of `ack_through(sequence)` against the same
+sequence is safe; if the underlying dequeue is idempotent (which it
+is for `QueueConsumer::dequeue`) the second call either succeeds or
+returns the same error class.
+
+`Consumer::flush` keeps its meaning: if the caller used `ack` and is
+between amortization boundaries, `flush` forces the dequeue. After
+`ack_through`, `flush` is a no-op (the dequeue already ran), which
+matches what callers want.
+
+### Optional: Raw Decode Hook (Tier 2)
+
+The high-throughput runtime wants to put `decode_batch` on a blocking
+CPU pool. Two ways to expose that:
+
+**Option A (chosen):** make `decode_batch` and `CompressionType` public,
+and add a sibling `ConsumerFetchHandle::fetch_raw` that returns the
+raw object bytes plus the descriptor without decoding. The raw method
+lives on the handle (not on `Consumer`) because parallel-fetch callers
+are the use case; serial callers continue to use `fetch_descriptor`
+which already calls `decode_batch` inline.
+
+```rust
+pub use crate::model::{decode_batch, CompressionType};
+
+impl ConsumerFetchHandle {
+    /// Like `fetch`, but returns the still-encoded object bytes.
+    /// Callers invoke `decode_batch` themselves (typically inside
+    /// `tokio::task::spawn_blocking`) to keep the CPU-bound decode
+    /// off the I/O task.
+    pub async fn fetch_raw(&self, descriptor: BatchDescriptor)
+        -> Result<RawConsumedBatch>;
+}
+
+pub struct RawConsumedBatch {
+    pub sequence: u64,
+    pub location: String,
+    pub metadata: Vec<Metadata>,
+    pub raw_bytes: Bytes,
+}
+```
+
+Callers wrap the decode in `spawn_blocking`:
+
+```rust
+let raw = fetch_handle.fetch_raw(d).await?;
+let entries = tokio::task::spawn_blocking(move || decode_batch(raw.raw_bytes))
+    .await
+    .map_err(|e| Error::Storage(e.to_string()))??;
+let batch = ConsumedBatch {
+    entries,
+    sequence: raw.sequence,
+    location: raw.location,
+    metadata: raw.metadata,
+};
+```
+
+**Option B:** keep `decode_batch` private and add an explicit
+`ConsumerFetchHandle::fetch_blocking_decode` that internally spawns
+blocking. Rejected because it bakes a Tokio scheduling decision into
+the buffer crate — callers running on a different scheduler (e.g.
+async-std, smol, or Tokio with a specific blocking-pool size) lose
+control.
+
+Option A is small, additive, and gives the runtime exactly the seam it
+wants without committing the buffer crate to a scheduling model.
+
+The Tier 2 surface ships behind a feature flag in v0.x or as a separate
+release; v1 of this RFC requires only the core read-ahead +
+`fetch_handle` + `ack_through` methods.
+
+### Metrics
+
+Carry over the existing buffer metrics, splitting them between the
+handle's fetch path (which any caller can drive concurrently) and the
+serial `Consumer::fetch_descriptor` wrapper (which additionally
+maintains the consumer's lag cursor):
+
+- `buffer.batches_collected` (counter): increments inside
+  `ConsumerFetchHandle::fetch`. Each successful fetch increments by 1
+  regardless of which call path drove it (handle directly, or via the
+  `&mut self` `Consumer::fetch_descriptor` wrapper).
+- `buffer.bytes_collected`, `buffer.entries_collected`,
+  `buffer.fetch_duration_seconds`: all increment inside
+  `ConsumerFetchHandle::fetch`.
+- `buffer.consumer_lag_seconds` (gauge): increments inside the serial
+  `Consumer::fetch_descriptor` wrapper only. Parallel callers that
+  only use `ConsumerFetchHandle::fetch` do not advance this gauge —
+  the consumer's serial cursor is not the right observation point
+  under N-way concurrency, and the runtime owns its own
+  `runtime_stage_latency_seconds{stage=fetch}` histogram (RFC 0002).
+- `buffer.acks` (counter): now also incremented by `ack_through`
+  by the number of sequences the call advances over. So a counter rate
+  reads "sequences acked per second" under both APIs.
+- `buffer.queue_length` (gauge): updated inside `next_descriptors`
+  the same way it is inside `next_batch` today.
+
+Add one new metric:
+
+- `buffer.descriptors_handed_out` (counter): increments by
+  `descriptors.len()` on each `next_descriptors` call. Lets operators
+  see read-ahead activity directly.
+
+No metrics renames; existing dashboards keep working.
+
+### Compatibility
+
+API compatibility:
+
+- `next_batch`, `ack`, `flush`, `close`, `len`, `is_empty`,
+  `conflict_rate`, `Consumer::new`, `Consumer::with_object_store`,
+  `ConsumerConfig`, `ConsumedBatch`, `Metadata`: all unchanged.
+- New types: `BatchDescriptor`, `ConsumerFetchHandle`, and
+  `RawConsumedBatch` (Tier 2 only).
+- New methods: `Consumer::next_descriptors`, `Consumer::fetch_handle`,
+  `Consumer::fetch_descriptor` (which now takes `&mut self` and is a
+  wrapper over the handle), `Consumer::ack_through`, and (Tier 2)
+  `ConsumerFetchHandle::fetch_raw`.
+- New public re-exports (Tier 2): `decode_batch`, `CompressionType`.
+
+Behavioral compatibility:
+
+- `next_batch` returns the same `ConsumedBatch` for the same input
+  manifest state. The wrapper does the same work, just composed.
+- Cursor advance under `next_batch` is unchanged.
+- `ack`'s amortization behavior is unchanged.
+- `flush` semantics are unchanged.
+- Epoch fencing surfaces from `next_descriptors` exactly as it does
+  from `next_batch`.
+
+Wire/format compatibility:
+
+- No manifest format change.
+- No data batch format change.
+
+Existing consumers (`timeseries`, `vector` BufferConsumer,
+`clickhouse-ingestor`) compile against the new buffer crate without
+changes. They get no throughput benefit until they migrate to the new
+methods, which is fine — the migration is per-consumer.
+
+## Failure Modes
+
+- **Manifest read fails (storage error)**: `next_descriptors` returns
+  `Err(Error::Storage(_))`, mirroring today's `next_batch`. The
+  consumer's cursor does not advance; a retry succeeds against a
+  recovered store.
+- **Object fetch fails (`ConsumerFetchHandle::fetch`, or its
+  serial-wrapper caller `Consumer::fetch_descriptor`)**: returns
+  `Err(Error::Storage(_))`. The handle is stateless, so no cursor
+  advances; the wrapper does not advance `last_fetched_sequence`
+  either, since it only updates the cursor after a successful decode.
+  Callers may retry the same descriptor with the same handle clone.
+- **Object fetch returns 404 (GC race)**: surfaces as `Error::Storage`
+  with a "404"-shaped message. Documented in
+  `ConsumerFetchHandle::fetch`'s rustdoc (and inherited by the
+  `Consumer::fetch_descriptor` wrapper); the runbook tells operators
+  to extend `gc_grace_period` or to investigate over-aggressive ack
+  flushing if this fires in production.
+- **Caller calls `ack_through(seq)` with `seq <= last_acked_sequence`**:
+  returns `Err(Error::Storage("non-monotonic ack_through: ..."))`. The
+  caller's cursor does not advance.
+- **Caller calls `fetch` with a sequence that is no longer in the
+  manifest** (descriptor predates a recent dequeue or restart): the
+  GET still succeeds against the still-present data object until GC
+  deletes it; identical to the "descriptor outliving manifest entry"
+  case. After GC, falls back to the 404 path above. Applies equally
+  to handle and wrapper.
+- **Fence between `next_descriptors` and a later fetch**: the fetch
+  is unaffected (the handle does not consult the manifest, and the
+  wrapper delegates to the handle). The next `next_descriptors` or
+  `ack_through` returns `Error::Fenced`. The fetched batch is
+  correct but should not be acked by a fenced consumer. The caller's
+  runtime layer is responsible for not advancing ack state after a
+  fence; today's `BufferConsumerRuntime` already treats `Fenced` as
+  fatal.
+
+## Alternatives Considered
+
+### Add a Streamed `next_batch_stream(max: usize)` Returning Decoded Batches
+
+A `futures::Stream` that yields `ConsumedBatch` values would hide the
+manifest-vs-fetch split from callers. Rejected because:
+
+- It makes `decode_batch` placement implicit (inside the stream's poll
+  task), which defeats the point of giving callers a blocking-decode
+  seam.
+- It leaks the manifest-read cadence into the iteration cadence; a
+  caller that wants to pre-fetch 1000 descriptors but decode 4 at a
+  time has no clean way to express that.
+- It gives the buffer crate a scheduling responsibility (concurrent
+  fetch under the hood) that the RFC explicitly leaves to callers.
+
+### Keep Read Path Serial, Add Only `ack_through`
+
+`ack_through` alone removes the per-sequence ack loop and is a clear
+win even for serial consumers. Rejected as an isolated change because
+it does not solve the dominant cost: serial object fetch. Shipping
+both at once is cheaper to review and reason about.
+
+### Introduce a New `BufferReader` Type Separate from `Consumer`
+
+A separate read-only handle could enforce the manifest-owner-vs-fetcher
+split through types instead of `&mut self` vs `&self`. Rejected
+because:
+
+- The split is already visible in the method signatures.
+- It would force every existing caller to choose a type at construction.
+- An `Arc<Consumer>` with `&self` fetch is a smaller change, behaves
+  identically, and keeps the type surface narrow.
+
+### Make `next_descriptors` Return a Borrowed Iterator
+
+`next_descriptors` could return `impl Iterator<Item = &ManifestEntry>`
+borrowing from the manifest. Rejected because the manifest object is
+loaded inside the call and the borrowed iterator would force callers
+to either copy out the descriptors anyway or hold the consumer
+mutably while iterating, which kills the parallel-fetch use case.
+Returning `Vec<BatchDescriptor>` is one allocation per read-ahead
+window and is dominated by the manifest read latency.
+
+### Make `next_descriptors` Take an Explicit `start_sequence`
+
+Callers could pass `start_sequence` to read from any point in the
+manifest. Rejected because:
+
+- The cursor is internal state the buffer crate already owns; exposing
+  it leaks an invariant.
+- An explicit `start_sequence` opens the door to non-monotonic
+  read-ahead, which makes ack tracking harder to reason about.
+- The `last_acked_sequence` argument on `Consumer::new` already covers
+  the legitimate "resume from a specific sequence" case.
+
+### Make `ack_through` Take `&self` (Allow Concurrent Acking)
+
+Multiple sinks could `ack_through` independently if it took `&self`.
+Rejected because manifest mutation must be serialized; concurrent acks
+would race on `dequeue`. The high-throughput runtime's `AckCoordinator`
+already serializes acks at the source level (RFC 0002 in
+opendata-contrib, "Per-Source Ack Coordinator").
+
+### Push Decompression into the Object Store Layer
+
+Pre-decompress object-store responses inside `slatedb::object_store`.
+Rejected as out of scope and as the wrong layer; decompression policy
+varies per buffer signal and per workload, and should stay near the
+batch-decode boundary.
+
+## Implementation Notes
+
+- The new `descriptors_after` method on `QueueConsumer` re-uses
+  `read_manifest`. No CAS, no mutation.
+- `Consumer::last_handed_out_sequence` is a new private field
+  initialized from `last_acked_sequence` in `with_object_store`.
+- The metric move (`fetch_batch` → `fetch_descriptor`) is mechanical;
+  `next_batch` becomes a wrapper that calls `next_descriptors(1)`,
+  pops the single descriptor, and calls `fetch_descriptor`.
+- `ack_through(seq)` does not need to call `Consumer::flush`; the
+  unconditional `dequeue` it performs is the durable boundary.
+- The Tier 2 raw-decode hook should land behind a feature flag
+  (`raw-fetch`) so consumers that do not need it do not pay for the
+  added types in their public API surface.
+- Tests must cover: `next_descriptors` returning < `max` when the
+  manifest is shorter; concurrent `ConsumerFetchHandle::fetch` calls
+  from two tasks against clones of one handle (the manifest owner
+  task continues `next_descriptors` and `ack_through` while fetches
+  run); `ack_through` skipping over a contiguous range; `ack_through`
+  rejecting non-monotonic input; `ack_through` leaving in-memory state
+  untouched on `Fenced` and storage errors (dequeue-first invariant);
+  fence detection on `next_descriptors`; `next_batch` parity with the
+  wrapper.
+
+## Migration Plan
+
+1. **Buffer crate**: implement `BatchDescriptor` (with
+   `object_bytes: Option<u64>` reserved as `None`), `ConsumerFetchHandle`,
+   `next_descriptors`, `fetch_handle`, `fetch_descriptor` (`&mut self`,
+   wrapping the handle plus the serial-cursor update), and `ack_through`
+   (with the documented dequeue-first ordering); rewrite `next_batch`
+   as a wrapper over them.
+2. **High-throughput runtime adoption** (opendata-contrib RFC 0002):
+   the runtime uses `next_descriptors` and routes object fetches
+   through clones of `Consumer::fetch_handle()`, and calls `ack_through`
+   wherever it would otherwise loop `ack`. It can start with `max = 1`
+   and a single fetch task, then raise `max` and fan the handle out to
+   N fetch workers for parallel fetch — no further buffer changes are
+   needed between those two points. Other consumers (timeseries,
+   vector) keep using `next_batch` and `ack` unchanged.
+3. **Tier 2 raw-decode hook**: not implemented in this release. It
+   lands when the runtime is ready to move `decode_batch` onto a
+   blocking pool; until then the feature flag stays off and the public
+   surface is just the core read-ahead methods above.
+
+The buffer crate version bumps to a minor (additive API). No SemVer
+breakage.
+
+## Validation Criteria
+
+### API and Behavior
+
+- `next_descriptors(0)` returns `Ok(Vec::new())` without manifest read.
+- `next_descriptors(K)` on an empty queue returns
+  `Ok(Vec::new())`.
+- `next_descriptors(K)` on a manifest with `M < K` available entries
+  returns `M` descriptors and advances `last_handed_out_sequence`
+  through the last returned sequence.
+- `next_batch` after a fresh `Consumer::new` returns the same
+  `ConsumedBatch.sequence` and the same `entries` as in v0.x for the
+  same manifest state.
+- `Consumer::fetch_descriptor(d)` (the `&mut self` wrapper) and
+  `ConsumerFetchHandle::fetch(d)` against a `d` from
+  `next_descriptors` both return a `ConsumedBatch` with
+  `sequence == d.sequence`, `location == d.location`, and
+  `metadata == d.metadata`.
+- Two concurrent `ConsumerFetchHandle::fetch` calls (against clones
+  of one handle) targeting distinct descriptors complete with no
+  manifest contention; the owner task can run `next_descriptors` /
+  `ack_through` in parallel without borrow-checker conflict.
+- `ack_through(seq)` advances `last_acked_sequence` to `seq` and
+  removes manifest entries `<= seq`. `flush()` after `ack_through` is
+  a no-op.
+- `ack_through(seq)` errors when `seq <= last_acked_sequence`.
+
+### Fencing and Failure Atomicity
+
+- A fenced consumer's `next_descriptors` returns `Error::Fenced` on the
+  next call after the fence happens.
+- A fenced consumer's `ack_through(seq)` returns `Error::Fenced`
+  *and* leaves `last_acked_sequence` and `buffer.acks` unchanged. A
+  subsequent retry against an unfenced consumer succeeds.
+- A storage-error `ack_through` (object store unreachable) leaves
+  `last_acked_sequence` and `buffer.acks` unchanged. Recovery is to
+  retry once storage is reachable.
+- `ConsumerFetchHandle::fetch` against a descriptor obtained before
+  fencing succeeds (the data object is still readable until GC). The
+  handle does not detect fence on its own.
+
+### Concurrency (handle path)
+
+- `Consumer::fetch_handle()` returns a value that is `Clone + Send +
+  Sync + 'static`.
+- Two clones of a fetch handle, called concurrently from two
+  `tokio::spawn` tasks against distinct descriptors, complete with no
+  manifest contention.
+- A fetch handle clone outlives the spawned task that produced it
+  (drop-after-spawn does not invalidate the handle).
+- `ConsumerFetchHandle::fetch` does **not** mutate any cursor on the
+  parent `Consumer`. After a fetch handle call, `next_batch` /
+  `fetch_descriptor` from the owner task observe unchanged
+  `last_fetched_sequence`.
+
+### Descriptor Handout Contract
+
+- After `next_descriptors` returns a descriptor with sequence `S`, a
+  subsequent `next_descriptors` call without an intervening
+  `ack_through` returns descriptors with sequence > `S` only.
+- Process restart (`Consumer::new(_, Some(durable_frontier))`)
+  re-emits descriptors strictly after `durable_frontier`, including
+  any sequences a previous process handed out but did not ack.
+
+### Compatibility
+
+- `cargo test -p buffer` is green against the new crate without
+  changes to existing tests.
+- Downstream consumers (timeseries, vector, clickhouse-ingestor) build
+  unchanged.
+
+### Metrics
+
+- `buffer.batches_collected` increments exactly once per
+  `fetch_descriptor` call (and therefore once per `next_batch` under
+  the wrapper).
+- `buffer.acks` increments by the number of sequences `ack_through`
+  advances over.
+- `buffer.descriptors_handed_out` increments by `descriptors.len()` on
+  every `next_descriptors` call.
+
+### Tier 2 (when feature is enabled)
+
+- `ConsumerFetchHandle::fetch_raw(d)` returns a `RawConsumedBatch`
+  whose `decode_batch(raw_bytes)` produces an `entries` vector
+  identical to the one returned by `Consumer::fetch_descriptor(d)`.
+- `decode_batch` is callable from `tokio::task::spawn_blocking` and
+  produces the same output as the in-line decode.
+- `fetch_raw` lives only on the handle (not on `Consumer`); serial
+  callers continue to use `Consumer::fetch_descriptor`.

--- a/buffer/src/consumer.rs
+++ b/buffer/src/consumer.rs
@@ -41,13 +41,6 @@ pub struct BatchDescriptor {
     pub location: String,
     /// Per-range metadata items attached to this batch by producers.
     pub metadata: Vec<Metadata>,
-    /// Object size in bytes when known. Reserved for the runtime's
-    /// byte-budget accounting (see `opendata-contrib` RFC 0002). The
-    /// current Buffer manifest format does not carry per-entry object
-    /// size, so v1 always emits `None`. A future manifest extension
-    /// may populate this; runtime callers handle `None` with a
-    /// pessimistic reservation.
-    pub object_bytes: Option<u64>,
 }
 
 /// Cloneable, concurrency-safe handle for fetching data batches from
@@ -231,9 +224,6 @@ impl Consumer {
             sequence: entry.sequence,
             location: entry.location,
             metadata: entry.metadata,
-            // Reserved field; v1 manifests do not carry per-entry
-            // object size.
-            object_bytes: None,
         };
         // fetch_descriptor advances last_fetched_sequence on success
         // and updates the consumer_lag_seconds gauge. We then advance
@@ -285,9 +275,6 @@ impl Consumer {
                 sequence: e.sequence,
                 location: e.location,
                 metadata: e.metadata,
-                // Reserved field; the current manifest format does not
-                // carry per-entry object size. See RFC 0003.
-                object_bytes: None,
             })
             .collect())
     }
@@ -907,8 +894,6 @@ mod tests {
         assert_eq!(v[0].sequence, 0);
         assert_eq!(v[1].sequence, 1);
         assert_eq!(v[2].sequence, 2);
-        // object_bytes is reserved (always None in v1).
-        assert!(v.iter().all(|d| d.object_bytes.is_none()));
 
         // Cursor advanced; next call returns sequences 3 and 4 only.
         let v2 = collector.next_descriptors(10).await.unwrap();

--- a/buffer/src/consumer.rs
+++ b/buffer/src/consumer.rs
@@ -187,30 +187,26 @@ impl Consumer {
 
     /// Read the next data batch from object storage.
     ///
-    /// Compatibility shim for pre-RFC-0003 callers. Behavior is
-    /// preserved: peeks the next manifest entry past the last
-    /// handed-out / fetched sequence, fetches the corresponding
-    /// object, and returns it. Returns `None` if no matching entry is
-    /// available.
+    /// Serial fetch of the next batch: peeks the next manifest entry
+    /// past the last handed-out / fetched sequence, fetches the
+    /// corresponding object, and returns it. Returns `None` if no
+    /// entry is available. May be called repeatedly to walk successive
+    /// batches; the read cursor is independent of the ack frontier.
     ///
     /// **Cancellation-safe and fetch-failure-safe.** The cursor
     /// (`last_handed_out_sequence`) advances **only after** a
     /// successful fetch. If the fetch fails, or if the future is
-    /// dropped mid-fetch (cancellation), the cursor is unchanged and
-    /// a subsequent `next_batch` re-fetches the same entry. This
-    /// preserves the legacy "fetch failure does not advance the
-    /// cursor" semantics that pre-RFC-0003 callers rely on.
+    /// dropped mid-fetch, the cursor is unchanged and a subsequent
+    /// `next_batch` re-fetches the same entry.
     ///
-    /// The implementation is a manual peek-fetch-advance flow rather
-    /// than a wrapper over [`Consumer::next_descriptors`] +
-    /// [`Consumer::fetch_descriptor`]: `next_descriptors` advances
-    /// the cursor at handout time per the
-    /// "Descriptor Handout Contract" (lost descriptors are not
-    /// reissued in-process), which is correct for the new-API
-    /// caller but is exactly the legacy regression this method must
-    /// avoid. Inlining keeps the cursor-advance after the
-    /// `fetch_descriptor` await, making cancellation safety a
-    /// structural invariant rather than a `Drop`-guard liability.
+    /// This is written as an inline peek-fetch-advance rather than a
+    /// wrapper over [`Consumer::next_descriptors`] +
+    /// [`Consumer::fetch_descriptor`] because `next_descriptors`
+    /// advances the cursor at handout time (a handed-out descriptor is
+    /// not reissued within a process; see the Descriptor Handout
+    /// Contract). Inlining keeps the cursor advance after the fetch
+    /// `await`, so a failed or dropped fetch leaves the cursor
+    /// untouched — the behavior `next_batch` callers expect.
     pub async fn next_batch(&mut self) -> Result<Option<ConsumedBatch>> {
         let entries = self
             .consumer
@@ -869,7 +865,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_next_descriptors_max_zero_returns_empty_without_manifest_read() {
+    async fn should_next_descriptors_max_zero_return_empty_without_manifest_read() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
         enqueue_n(&store, &producer, 3).await;
@@ -884,7 +880,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_next_descriptors_returns_contiguous_run_when_available() {
+    async fn should_next_descriptors_return_contiguous_run_when_available() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
         enqueue_n(&store, &producer, 5).await;
@@ -907,7 +903,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_next_descriptors_returns_fewer_than_max_on_short_manifest() {
+    async fn should_next_descriptors_return_fewer_than_max_on_short_manifest() {
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
         enqueue_n(&store, &producer, 2).await;
@@ -1002,79 +998,80 @@ mod tests {
 
     #[tokio::test]
     async fn should_next_batch_not_advance_cursor_when_future_is_dropped() {
-        // Cancellation safety: a `next_batch` future dropped before it
-        // completes must not have advanced last_handed_out_sequence.
-        // The next next_batch must return the same entry.
-        //
-        // The structural property this verifies: last_handed_out_sequence
-        // is mutated *after* the fetch_descriptor await returns Ok.
-        // If the future is dropped before that line, the cursor is
-        // unchanged. (Earlier versions of next_batch advanced the
-        // cursor inside next_descriptors(1) before the fetch — that
-        // version was cancellation-unsafe even though the Err path
-        // rolled back.)
+        // Cancellation safety: constructing a `next_batch` future and
+        // dropping it before it completes must leave
+        // last_handed_out_sequence untouched, so the entry is not
+        // skipped. The structural property: last_handed_out_sequence is
+        // mutated *after* the fetch_descriptor await returns Ok, so a
+        // future dropped before that line leaves the cursor unchanged.
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
         let entries = test_entries();
         write_batch(&store, "batches/cancel-a", &entries).await;
-        write_batch(&store, "batches/cancel-b", &entries).await;
         producer
             .enqueue("batches/cancel-a".to_string(), vec![])
-            .await
-            .unwrap();
-        producer
-            .enqueue("batches/cancel-b".to_string(), vec![])
             .await
             .unwrap();
 
         assert_eq!(collector.last_handed_out_sequence, None);
 
         // Construct the future and drop it without ever polling it.
-        // This is the cleanest test of "the body never runs" and
-        // exercises the no-side-effects-before-fetch invariant.
         {
             let fut = collector.next_batch();
             drop(fut);
         }
         assert_eq!(
             collector.last_handed_out_sequence, None,
-            "dropped (unpolled) next_batch future must not advance the cursor"
+            "dropped next_batch future must not advance the cursor"
         );
 
-        // Race a real next_batch against an immediate timeout. If the
-        // timeout wins, the future was cancelled mid-flight (after
-        // some polls) and the cursor must still not have advanced.
-        // If the future wins, the cursor advanced exactly to the
-        // returned batch's sequence.
-        let r = tokio::time::timeout(std::time::Duration::ZERO, collector.next_batch()).await;
-        match r {
-            Ok(Ok(Some(b))) => {
-                assert_eq!(b.sequence, 0);
-                assert_eq!(b.location, "batches/cancel-a");
-                assert_eq!(collector.last_handed_out_sequence, Some(0));
-            }
-            Ok(Ok(None)) => panic!("expected a batch"),
-            Ok(Err(e)) => panic!("unexpected error: {e:?}"),
-            Err(_elapsed) => {
-                // Cancellation path: cursor unchanged.
-                assert_eq!(collector.last_handed_out_sequence, None);
-            }
-        }
-
-        // Functional retry: regardless of which branch above executed,
-        // a normal next_batch now returns the next un-fetched entry.
-        // If we cancelled, that's A (sequence 0). If we succeeded,
-        // that's B (sequence 1).
-        let next = collector.next_batch().await.unwrap().unwrap();
-        assert!(
-            next.sequence == 0 || next.sequence == 1,
-            "after cancellation or success, next_batch must return one of the two enqueued entries"
-        );
+        // The entry was not consumed: a real next_batch still returns it.
+        let b = collector.next_batch().await.unwrap().unwrap();
+        assert_eq!(b.sequence, 0);
+        assert_eq!(b.location, "batches/cancel-a");
+        assert_eq!(collector.last_handed_out_sequence, Some(0));
     }
 
     #[tokio::test]
-    async fn should_fetch_handle_be_clone_send_sync_static() {
-        // Compile-time check: handle is Clone + Send + Sync + 'static.
+    async fn should_next_batch_advance_cursor_on_successful_fetch() {
+        // The success branch (the deterministic counterpart to the
+        // dropped-future test): a completed next_batch advances
+        // last_handed_out_sequence to the fetched sequence, and
+        // successive calls walk forward one entry at a time.
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        let entries = test_entries();
+        write_batch(&store, "batches/ok-a", &entries).await;
+        write_batch(&store, "batches/ok-b", &entries).await;
+        producer
+            .enqueue("batches/ok-a".to_string(), vec![])
+            .await
+            .unwrap();
+        producer
+            .enqueue("batches/ok-b".to_string(), vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(collector.last_handed_out_sequence, None);
+
+        let a = collector.next_batch().await.unwrap().unwrap();
+        assert_eq!(a.sequence, 0);
+        assert_eq!(collector.last_handed_out_sequence, Some(0));
+
+        let b = collector.next_batch().await.unwrap().unwrap();
+        assert_eq!(b.sequence, 1);
+        assert_eq!(collector.last_handed_out_sequence, Some(1));
+    }
+
+    #[tokio::test]
+    async fn should_fetch_handle_clones_fetch_concurrently_without_blocking_owner() {
+        // The fetch handle is the parallel-fetch seam: it must be
+        // Clone + Send + Sync + 'static (compile-time assertion below),
+        // two clones must fetch from separate spawned tasks
+        // concurrently, and the owning Consumer must keep &mut access
+        // throughout (the handle holds an Arc, not a borrow) so it can
+        // still drive the manifest — checked by the ack_through at the
+        // end.
         fn assert_send_sync_static<T: Send + Sync + 'static>() {}
         assert_send_sync_static::<ConsumerFetchHandle>();
 

--- a/buffer/src/consumer.rs
+++ b/buffer/src/consumer.rs
@@ -27,6 +27,95 @@ pub struct ConsumedBatch {
     pub metadata: Vec<Metadata>,
 }
 
+/// Lightweight pointer to one manifest entry. Carries everything a
+/// caller needs to fetch the corresponding data batch from object
+/// storage without re-reading the manifest.
+///
+/// Returned by [`Consumer::next_descriptors`]. See RFC 0003.
+#[derive(Debug, Clone, PartialEq)]
+pub struct BatchDescriptor {
+    /// The queue sequence number of this batch.
+    pub sequence: u64,
+    /// The object storage path of the data batch.
+    pub location: String,
+    /// Per-range metadata items attached to this batch by producers.
+    pub metadata: Vec<Metadata>,
+    /// Object size in bytes when known. Reserved for the runtime's
+    /// byte-budget accounting (see `opendata-contrib` RFC 0002). The
+    /// current Buffer manifest format does not carry per-entry object
+    /// size, so v1 always emits `None`. A future manifest extension
+    /// may populate this; runtime callers handle `None` with a
+    /// pessimistic reservation.
+    pub object_bytes: Option<u64>,
+}
+
+/// Cloneable, concurrency-safe handle for fetching data batches from
+/// object storage given a [`BatchDescriptor`].
+///
+/// The handle holds an `Arc<dyn ObjectStore>` and the manifest path
+/// (used as a metric label only). It carries no manifest cursor and
+/// no mutable state, so it is safe to clone into many fetch worker
+/// tasks while the owning [`Consumer`] keeps `&mut`-only access to
+/// manifest operations (`next_descriptors`, `ack`, `ack_through`,
+/// `flush`).
+///
+/// See RFC 0003 ("Concurrency Model") for the full contract.
+#[derive(Clone)]
+pub struct ConsumerFetchHandle {
+    object_store: Arc<dyn ObjectStore>,
+    manifest_path: String,
+}
+
+impl std::fmt::Debug for ConsumerFetchHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConsumerFetchHandle")
+            .field("manifest_path", &self.manifest_path)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ConsumerFetchHandle {
+    /// Fetch and decode the batch identified by `descriptor`. Stateless
+    /// — does not consult or mutate manifest state. Safe to call
+    /// concurrently from multiple tasks (against the same handle clone
+    /// or distinct clones); two calls against the same descriptor
+    /// produce identical [`ConsumedBatch`] values.
+    ///
+    /// The handle does not detect epoch fencing on its own; a fenced
+    /// consumer's [`Consumer::next_descriptors`] is what surfaces
+    /// `Error::Fenced`. Fetches against descriptors handed out before
+    /// fencing succeed against object storage as long as the data
+    /// object is still present (i.e. before GC runs).
+    pub async fn fetch(&self, descriptor: BatchDescriptor) -> Result<ConsumedBatch> {
+        let _ = &self.manifest_path; // reserved for future per-source label
+        let start = Instant::now();
+        let path = Path::from(descriptor.location.as_str());
+        let data = self
+            .object_store
+            .get(&path)
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?
+            .bytes()
+            .await
+            .map_err(|e| Error::Storage(e.to_string()))?;
+
+        let data_len = data.len() as u64;
+        let entries = decode_batch(data)?;
+
+        metrics::counter!(m::BATCHES_COLLECTED).increment(1);
+        metrics::counter!(m::ENTRIES_COLLECTED).increment(entries.len() as u64);
+        metrics::counter!(m::BYTES_COLLECTED).increment(data_len);
+        metrics::histogram!(m::FETCH_DURATION_SECONDS).record(start.elapsed().as_secs_f64());
+
+        Ok(ConsumedBatch {
+            entries,
+            sequence: descriptor.sequence,
+            location: descriptor.location,
+            metadata: descriptor.metadata,
+        })
+    }
+}
+
 /// Reads batches of ingested entries from object storage via a queue consumer.
 ///
 /// The consumer iterates over entries in the queue manifest in ingestion order,
@@ -36,11 +125,18 @@ pub struct ConsumedBatch {
 pub struct Consumer {
     consumer: QueueConsumer,
     object_store: Arc<dyn ObjectStore>,
+    manifest_path: String,
     gc_shutdown: CancellationToken,
     gc_handle: tokio::task::JoinHandle<()>,
     ack_count: u64,
     last_acked_sequence: Option<u64>,
     last_fetched_sequence: Option<u64>,
+    /// Read-ahead cursor: highest sequence handed out by
+    /// [`Consumer::next_descriptors`]. Distinct from
+    /// `last_fetched_sequence` because callers may receive
+    /// descriptors before the corresponding fetch resolves.
+    /// Initialized from `last_acked_sequence` on construction.
+    last_handed_out_sequence: Option<u64>,
 }
 
 impl Consumer {
@@ -62,8 +158,9 @@ impl Consumer {
         last_acked_sequence: Option<u64>,
     ) -> Result<Self> {
         crate::metric_names::describe_consumer_metrics();
+        let manifest_path = config.manifest_path.clone();
         let consumer =
-            QueueConsumer::with_object_store(config.manifest_path.clone(), object_store.clone());
+            QueueConsumer::with_object_store(manifest_path.clone(), object_store.clone());
 
         // Fence previous consumers and position the cursor before spawning GC.
         consumer.initialize().await?;
@@ -84,75 +181,114 @@ impl Consumer {
         Ok(Self {
             consumer,
             object_store,
+            manifest_path,
             ack_count: 0,
             last_acked_sequence,
             gc_shutdown,
             gc_handle,
             last_fetched_sequence: last_acked_sequence,
+            last_handed_out_sequence: last_acked_sequence,
         })
     }
 
     /// Read the next data batch from object storage.
     ///
-    /// If no batch has been fetched yet, peeks the earliest entry in the queue.
-    /// Otherwise, reads the entry with sequence `last_fetched_sequence + 1`.
-    /// Returns `None` if no matching entry is available.
+    /// Compatibility wrapper over [`Consumer::next_descriptors`] +
+    /// [`Consumer::fetch_descriptor`]. Behavior is preserved from
+    /// pre-RFC-0003: peeks the next manifest entry past the last
+    /// handed-out / fetched sequence, fetches the corresponding object,
+    /// and returns it. Returns `None` if no matching entry is
+    /// available.
     pub async fn next_batch(&mut self) -> Result<Option<ConsumedBatch>> {
-        let queue_entry = match self.last_fetched_sequence {
-            None => self.consumer.peek().await?,
-            Some(seq) => self.consumer.read(seq.wrapping_add(1)).await?,
-        };
-        metrics::gauge!(m::QUEUE_LENGTH).set(self.consumer.len() as f64);
-        match queue_entry {
-            Some(entry) => {
-                let sequence = entry.sequence;
-                let batch = self.fetch_batch(entry).await?;
-                self.last_fetched_sequence = Some(sequence);
-                if let Some(ref b) = batch
-                    && let Some(last_meta) = b.metadata.last()
-                {
-                    let now_ms = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap_or_default()
-                        .as_millis() as i64;
-                    let lag_s = (now_ms - last_meta.ingestion_time_ms) as f64 / 1000.0;
-                    metrics::gauge!(m::CONSUMER_LAG_SECONDS).set(lag_s.max(0.0));
-                }
-                Ok(batch)
-            }
+        let mut descriptors = self.next_descriptors(1).await?;
+        match descriptors.pop() {
+            Some(d) => Ok(Some(self.fetch_descriptor(d).await?)),
             None => Ok(None),
         }
     }
 
-    async fn fetch_batch(
-        &self,
-        queue_entry: crate::queue::QueueEntry,
-    ) -> Result<Option<ConsumedBatch>> {
-        let start = Instant::now();
-        let path = Path::from(queue_entry.location.as_str());
-        let data = self
-            .object_store
-            .get(&path)
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))?
-            .bytes()
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))?;
+    /// Read the manifest once and return up to `max` contiguous
+    /// [`BatchDescriptor`]s past the consumer's read-ahead cursor.
+    ///
+    /// Does not perform any object-store GET. Does not mutate the
+    /// durable ack frontier. Advances the in-memory read-ahead cursor
+    /// (`last_handed_out_sequence`) by the number of descriptors
+    /// returned.
+    ///
+    /// Returns an empty `Vec` if no new entries are available;
+    /// returns `Err(Error::Fenced)` if the consumer's epoch no longer
+    /// matches the manifest's.
+    ///
+    /// **Caller contract**: once a descriptor is returned, the caller
+    /// is responsible for either fetching and processing it or
+    /// accepting that it will be re-handed-out only via process
+    /// restart (`Consumer::new` with a `last_acked_sequence` argument).
+    /// Lost descriptors are not reissued within a process. See RFC
+    /// 0003 "Descriptor Handout Contract" for the full rules.
+    pub async fn next_descriptors(&mut self, max: usize) -> Result<Vec<BatchDescriptor>> {
+        if max == 0 {
+            return Ok(Vec::new());
+        }
+        let entries = self
+            .consumer
+            .descriptors_after(self.last_handed_out_sequence, max)
+            .await?;
+        metrics::gauge!(m::QUEUE_LENGTH).set(self.consumer.len() as f64);
+        if let Some(last) = entries.last() {
+            self.last_handed_out_sequence = Some(last.sequence);
+        }
+        let count = entries.len() as u64;
+        if count > 0 {
+            metrics::counter!(m::DESCRIPTORS_HANDED_OUT).increment(count);
+        }
+        Ok(entries
+            .into_iter()
+            .map(|e| BatchDescriptor {
+                sequence: e.sequence,
+                location: e.location,
+                metadata: e.metadata,
+                // Reserved field; the current manifest format does not
+                // carry per-entry object size. See RFC 0003.
+                object_bytes: None,
+            })
+            .collect())
+    }
 
-        let data_len = data.len() as u64;
-        let entries = decode_batch(data)?;
+    /// Construct a cloneable fetch handle. O(1); each call returns a
+    /// fresh handle, and the handle itself implements `Clone` for
+    /// further duplication into worker tasks.
+    pub fn fetch_handle(&self) -> ConsumerFetchHandle {
+        ConsumerFetchHandle {
+            object_store: self.object_store.clone(),
+            manifest_path: self.manifest_path.clone(),
+        }
+    }
 
-        metrics::counter!(m::BATCHES_COLLECTED).increment(1);
-        metrics::counter!(m::ENTRIES_COLLECTED).increment(entries.len() as u64);
-        metrics::counter!(m::BYTES_COLLECTED).increment(data_len);
-        metrics::histogram!(m::FETCH_DURATION_SECONDS).record(start.elapsed().as_secs_f64());
-
-        Ok(Some(ConsumedBatch {
-            entries,
-            sequence: queue_entry.sequence,
-            location: queue_entry.location,
-            metadata: queue_entry.metadata,
-        }))
+    /// Fetch and decode a single batch via the consumer's serial
+    /// wrapper. Equivalent to `self.fetch_handle().fetch(descriptor)`,
+    /// but additionally maintains the consumer's serial lag cursor
+    /// (`last_fetched_sequence` + the `consumer_lag_seconds` gauge)
+    /// used by the legacy `next_batch` path.
+    ///
+    /// Parallel-fetch callers should use [`Consumer::fetch_handle`]
+    /// directly; the runtime owns its own per-stage latency
+    /// histograms (RFC 0002).
+    pub async fn fetch_descriptor(&mut self, descriptor: BatchDescriptor) -> Result<ConsumedBatch> {
+        let handle = self.fetch_handle();
+        let batch = handle.fetch(descriptor).await?;
+        self.last_fetched_sequence = match self.last_fetched_sequence {
+            Some(prev) => Some(prev.max(batch.sequence)),
+            None => Some(batch.sequence),
+        };
+        if let Some(last_meta) = batch.metadata.last() {
+            let now_ms = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_millis() as i64;
+            let lag_s = (now_ms - last_meta.ingestion_time_ms) as f64 / 1000.0;
+            metrics::gauge!(m::CONSUMER_LAG_SECONDS).set(lag_s.max(0.0));
+        }
+        Ok(batch)
     }
 
     /// Acknowledge that the batch with the given sequence number has been processed.
@@ -177,6 +313,40 @@ impl Consumer {
         if self.ack_count.is_multiple_of(DEQUEUE_INTERVAL) {
             self.consumer.dequeue(sequence).await?;
         }
+        Ok(())
+    }
+
+    /// Advance the durable ack frontier through (and including)
+    /// `sequence`. Performs `dequeue(sequence)` against the manifest
+    /// **first**, then updates in-memory state on success.
+    ///
+    /// On error (storage, fence), `last_acked_sequence` and the
+    /// `buffer.acks` counter remain at their pre-call values. A retry
+    /// against the same sequence is safe.
+    ///
+    /// Errors if `sequence <= last_acked_sequence` (the frontier is
+    /// monotonic).
+    pub async fn ack_through(&mut self, sequence: u64) -> Result<()> {
+        if let Some(last) = self.last_acked_sequence
+            && sequence <= last
+        {
+            return Err(Error::Storage(format!(
+                "non-monotonic ack_through: last_acked={last}, requested={sequence}"
+            )));
+        }
+        let count_advanced = match self.last_acked_sequence {
+            None => sequence + 1,
+            Some(last) => sequence - last,
+        };
+
+        // Durable dequeue first. Bubbles up Fenced and Storage errors
+        // without touching local state.
+        self.consumer.dequeue(sequence).await?;
+
+        // Only mutate in-memory state after dequeue succeeds.
+        self.last_acked_sequence = Some(sequence);
+        self.ack_count = self.ack_count.wrapping_add(count_advanced);
+        metrics::counter!(m::ACKS).increment(count_advanced);
         Ok(())
     }
 
@@ -651,5 +821,239 @@ mod tests {
         let batch = collector.next_batch().await.unwrap().unwrap();
         assert_eq!(batch.location, "batches/second");
         assert_eq!(batch.sequence, 1);
+    }
+
+    // ========================================================================
+    // RFC 0003 read-ahead API tests.
+    // ========================================================================
+
+    async fn enqueue_n(
+        store: &Arc<dyn ObjectStore>,
+        producer: &QueueProducer,
+        n: usize,
+    ) -> Vec<String> {
+        let entries = test_entries();
+        let mut locations = Vec::with_capacity(n);
+        for i in 0..n {
+            let loc = format!("batches/seq-{i:06}");
+            write_batch(store, &loc, &entries).await;
+            producer.enqueue(loc.clone(), vec![]).await.unwrap();
+            locations.push(loc);
+        }
+        locations
+    }
+
+    #[tokio::test]
+    async fn should_next_descriptors_max_zero_returns_empty_without_manifest_read() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        enqueue_n(&store, &producer, 3).await;
+
+        // max=0 returns empty and does not advance the cursor.
+        let v = collector.next_descriptors(0).await.unwrap();
+        assert!(v.is_empty());
+
+        // Subsequent next_descriptors still sees all three.
+        let v = collector.next_descriptors(10).await.unwrap();
+        assert_eq!(v.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn should_next_descriptors_returns_contiguous_run_when_available() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        enqueue_n(&store, &producer, 5).await;
+
+        let v = collector.next_descriptors(3).await.unwrap();
+        assert_eq!(v.len(), 3);
+        assert_eq!(v[0].sequence, 0);
+        assert_eq!(v[1].sequence, 1);
+        assert_eq!(v[2].sequence, 2);
+        // object_bytes is reserved (always None in v1).
+        assert!(v.iter().all(|d| d.object_bytes.is_none()));
+
+        // Cursor advanced; next call returns sequences 3 and 4 only.
+        let v2 = collector.next_descriptors(10).await.unwrap();
+        assert_eq!(v2.len(), 2);
+        assert_eq!(v2[0].sequence, 3);
+        assert_eq!(v2[1].sequence, 4);
+
+        // Empty when nothing new.
+        let v3 = collector.next_descriptors(10).await.unwrap();
+        assert!(v3.is_empty());
+    }
+
+    #[tokio::test]
+    async fn should_next_descriptors_returns_fewer_than_max_on_short_manifest() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        enqueue_n(&store, &producer, 2).await;
+
+        let v = collector.next_descriptors(10).await.unwrap();
+        assert_eq!(v.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn should_fetch_handle_return_same_consumed_batch_as_fetch_descriptor() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        enqueue_n(&store, &producer, 2).await;
+
+        let descriptors = collector.next_descriptors(2).await.unwrap();
+        let handle = collector.fetch_handle();
+        let from_handle = handle.fetch(descriptors[0].clone()).await.unwrap();
+        let from_wrapper = collector
+            .fetch_descriptor(descriptors[1].clone())
+            .await
+            .unwrap();
+
+        assert_eq!(from_handle.sequence, descriptors[0].sequence);
+        assert_eq!(from_handle.location, descriptors[0].location);
+        assert_eq!(from_handle.entries.len(), 2);
+        assert_eq!(from_wrapper.sequence, descriptors[1].sequence);
+        assert_eq!(from_wrapper.location, descriptors[1].location);
+        assert_eq!(from_wrapper.entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn should_fetch_handle_be_clone_send_sync_static() {
+        // Compile-time check: handle is Clone + Send + Sync + 'static.
+        fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+        assert_send_sync_static::<ConsumerFetchHandle>();
+
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        enqueue_n(&store, &producer, 4).await;
+        let descriptors = collector.next_descriptors(4).await.unwrap();
+
+        // Two clones of the same handle, run from spawned tasks.
+        let handle = collector.fetch_handle();
+        let h1 = handle.clone();
+        let h2 = handle.clone();
+        let d0 = descriptors[0].clone();
+        let d1 = descriptors[1].clone();
+        let t1 = tokio::spawn(async move { h1.fetch(d0).await.unwrap() });
+        let t2 = tokio::spawn(async move { h2.fetch(d1).await.unwrap() });
+        let r1 = t1.await.unwrap();
+        let r2 = t2.await.unwrap();
+        assert_eq!(r1.sequence, 0);
+        assert_eq!(r2.sequence, 1);
+
+        // Owner can still drive next_descriptors and ack_through after
+        // the spawned tasks completed (no &mut conflict because the
+        // handle holds an Arc, not a borrow).
+        collector.ack_through(1).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn should_ack_through_advance_frontier_in_one_call() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        enqueue_n(&store, &producer, 5).await;
+
+        let _v = collector.next_descriptors(5).await.unwrap();
+
+        // Advance through sequence 3 in one call.
+        collector.ack_through(3).await.unwrap();
+        // Manifest has 1 entry remaining (sequence 4).
+        assert_eq!(collector.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn should_ack_through_reject_non_monotonic_input() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        enqueue_n(&store, &producer, 5).await;
+        collector.next_descriptors(5).await.unwrap();
+
+        collector.ack_through(2).await.unwrap();
+        let err = collector.ack_through(2).await.unwrap_err();
+        match err {
+            Error::Storage(msg) => assert!(msg.contains("non-monotonic ack_through")),
+            other => panic!("expected Error::Storage, got {other:?}"),
+        }
+        // The bookkeeping did not advance.
+        assert_eq!(collector.last_acked_sequence, Some(2));
+    }
+
+    #[tokio::test]
+    async fn should_ack_through_leave_state_unchanged_on_fence() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector1) =
+            make_collector(&store, test_collector_config(), None).await;
+        enqueue_n(&store, &producer, 5).await;
+        collector1.next_descriptors(5).await.unwrap();
+        collector1.ack_through(0).await.unwrap();
+        assert_eq!(collector1.last_acked_sequence, Some(0));
+
+        // Fence collector1 by spinning up a second consumer.
+        let (_, _collector2) = make_collector(&store, test_collector_config(), None).await;
+
+        // ack_through against the fenced consumer must error and leave
+        // last_acked_sequence at 0.
+        let err = collector1.ack_through(2).await.unwrap_err();
+        assert!(matches!(err, Error::Fenced));
+        assert_eq!(collector1.last_acked_sequence, Some(0));
+    }
+
+    #[tokio::test]
+    async fn should_next_descriptors_surface_fence() {
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector1) =
+            make_collector(&store, test_collector_config(), None).await;
+        enqueue_n(&store, &producer, 3).await;
+
+        let (_, _collector2) = make_collector(&store, test_collector_config(), None).await;
+
+        let result = collector1.next_descriptors(10).await;
+        assert!(matches!(result, Err(Error::Fenced)));
+    }
+
+    #[tokio::test]
+    async fn should_next_batch_be_equivalent_to_descriptor_plus_fetch() {
+        // Equivalence: next_batch == next_descriptors(1) + fetch_descriptor.
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        let entries = test_entries();
+        let location = "batches/equiv";
+        write_batch(&store, location, &entries).await;
+        producer
+            .enqueue(location.to_string(), vec![])
+            .await
+            .unwrap();
+
+        let via_wrapper = collector.next_batch().await.unwrap().unwrap();
+        assert_eq!(via_wrapper.sequence, 0);
+        assert_eq!(via_wrapper.location, location);
+        assert_eq!(via_wrapper.entries.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn should_descriptor_handout_contract_not_reissue_lost_descriptors() {
+        // Per RFC 0003: once next_descriptors returns a descriptor,
+        // it is not handed out again within the same process.
+        // Recovery is restart from the durable ack frontier.
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        enqueue_n(&store, &producer, 3).await;
+
+        // Hand out 2 descriptors; "lose" them (drop without acking).
+        let lost = collector.next_descriptors(2).await.unwrap();
+        assert_eq!(lost.len(), 2);
+        drop(lost);
+
+        // The same consumer's next_descriptors moves on past them.
+        let next = collector.next_descriptors(10).await.unwrap();
+        assert_eq!(next.len(), 1);
+        assert_eq!(next[0].sequence, 2);
+
+        // Recovery: a fresh consumer initialized from the last durable
+        // ack (None here, since nothing was acked) re-emits the
+        // unacked range from the start.
+        collector.close().await.unwrap();
+        let (_, mut recovered) = make_collector(&store, test_collector_config(), None).await;
+        let again = recovered.next_descriptors(10).await.unwrap();
+        assert_eq!(again.len(), 3);
+        assert_eq!(again[0].sequence, 0);
     }
 }

--- a/buffer/src/consumer.rs
+++ b/buffer/src/consumer.rs
@@ -16,6 +16,7 @@ use crate::queue::{Metadata, QueueConsumer};
 const DEQUEUE_INTERVAL: u64 = 100;
 
 /// A batch of entries read from object storage by the [`Consumer`].
+#[derive(Debug)]
 pub struct ConsumedBatch {
     /// The deserialized opaque byte entries from the data batch.
     pub entries: Vec<Bytes>,
@@ -199,11 +200,36 @@ impl Consumer {
     /// handed-out / fetched sequence, fetches the corresponding object,
     /// and returns it. Returns `None` if no matching entry is
     /// available.
+    ///
+    /// **Fetch failure preserves legacy semantics.** Pre-RFC-0003
+    /// `next_batch` advanced its cursor only after a successful fetch;
+    /// callers expect that a transient `Storage` error from `next_batch`
+    /// can be retried and the same batch is re-attempted. The
+    /// new-API path (`next_descriptors` + `fetch_descriptor`) does not
+    /// roll back: lost descriptors are not reissued in-process per the
+    /// descriptor-handout contract. To preserve the legacy semantics
+    /// for `next_batch` callers, this wrapper rolls back
+    /// `last_handed_out_sequence` to its pre-call value when the
+    /// downstream fetch fails. The wrapper has exclusive `&mut self`
+    /// access, so the rollback is safe — no other path could observe
+    /// the descriptor between the handout and the fetch failure.
     pub async fn next_batch(&mut self) -> Result<Option<ConsumedBatch>> {
+        let saved_handed_out = self.last_handed_out_sequence;
         let mut descriptors = self.next_descriptors(1).await?;
-        match descriptors.pop() {
-            Some(d) => Ok(Some(self.fetch_descriptor(d).await?)),
-            None => Ok(None),
+        let Some(descriptor) = descriptors.pop() else {
+            return Ok(None);
+        };
+        match self.fetch_descriptor(descriptor).await {
+            Ok(batch) => Ok(Some(batch)),
+            Err(e) => {
+                // Roll back so the next call to next_batch re-issues
+                // the same descriptor (legacy "fetch failure does not
+                // advance the cursor" semantics). The descriptor was
+                // never visible to a caller because next_batch owns it
+                // for the duration of this method.
+                self.last_handed_out_sequence = saved_handed_out;
+                Err(e)
+            }
         }
     }
 
@@ -895,24 +921,86 @@ mod tests {
 
     #[tokio::test]
     async fn should_fetch_handle_return_same_consumed_batch_as_fetch_descriptor() {
+        // Fetch the *same* descriptor through both paths and compare:
+        // sequence, location, metadata, entries must all match.
         let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
         let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
-        enqueue_n(&store, &producer, 2).await;
-
-        let descriptors = collector.next_descriptors(2).await.unwrap();
-        let handle = collector.fetch_handle();
-        let from_handle = handle.fetch(descriptors[0].clone()).await.unwrap();
-        let from_wrapper = collector
-            .fetch_descriptor(descriptors[1].clone())
+        let entries = test_entries();
+        let location = "batches/handle-vs-wrapper";
+        write_batch(&store, location, &entries).await;
+        let metadata = vec![Metadata {
+            start_index: 0,
+            ingestion_time_ms: 1_700_000_000_000,
+            payload: Bytes::from(r#"{"k":"v"}"#),
+        }];
+        producer
+            .enqueue(location.to_string(), metadata.clone())
             .await
             .unwrap();
 
-        assert_eq!(from_handle.sequence, descriptors[0].sequence);
-        assert_eq!(from_handle.location, descriptors[0].location);
+        let descriptors = collector.next_descriptors(1).await.unwrap();
+        assert_eq!(descriptors.len(), 1);
+        let d = descriptors[0].clone();
+
+        let from_handle = collector.fetch_handle().fetch(d.clone()).await.unwrap();
+        let from_wrapper = collector.fetch_descriptor(d).await.unwrap();
+
+        assert_eq!(from_handle.sequence, from_wrapper.sequence);
+        assert_eq!(from_handle.location, from_wrapper.location);
+        assert_eq!(from_handle.metadata, from_wrapper.metadata);
+        assert_eq!(from_handle.entries, from_wrapper.entries);
+        // And both must match what the producer actually wrote.
+        assert_eq!(from_handle.location, location);
         assert_eq!(from_handle.entries.len(), 2);
-        assert_eq!(from_wrapper.sequence, descriptors[1].sequence);
-        assert_eq!(from_wrapper.location, descriptors[1].location);
-        assert_eq!(from_wrapper.entries.len(), 2);
+        assert_eq!(from_handle.metadata, metadata);
+    }
+
+    #[tokio::test]
+    async fn should_next_batch_not_advance_cursor_on_fetch_failure() {
+        // Pre-RFC-0003 contract: next_batch advances its cursor only
+        // after a successful fetch. The wrapper must roll back the
+        // private last_handed_out_sequence on fetch error so a retry
+        // re-issues the same batch.
+        use slatedb::object_store::path::Path;
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        let entries = test_entries();
+        let location_a = "batches/a-fails-then-succeeds";
+        let location_b = "batches/b";
+        write_batch(&store, location_a, &entries).await;
+        write_batch(&store, location_b, &entries).await;
+        producer
+            .enqueue(location_a.to_string(), vec![])
+            .await
+            .unwrap();
+        producer
+            .enqueue(location_b.to_string(), vec![])
+            .await
+            .unwrap();
+
+        // Delete A's data object so the fetch will fail.
+        store.delete(&Path::from(location_a)).await.unwrap();
+
+        // First next_batch fails on the fetch.
+        let r = collector.next_batch().await;
+        assert!(
+            matches!(r, Err(Error::Storage(_))),
+            "expected Storage error, got {r:?}"
+        );
+
+        // Re-write A so the next fetch succeeds.
+        write_batch(&store, location_a, &entries).await;
+
+        // Second next_batch must return A — cursor did not advance past
+        // it on the previous failure.
+        let b = collector.next_batch().await.unwrap().unwrap();
+        assert_eq!(b.sequence, 0);
+        assert_eq!(b.location, location_a);
+        // Acknowledge A and confirm forward progress to B.
+        collector.ack(b.sequence).await.unwrap();
+        let b2 = collector.next_batch().await.unwrap().unwrap();
+        assert_eq!(b2.sequence, 1);
+        assert_eq!(b2.location, location_b);
     }
 
     #[tokio::test]

--- a/buffer/src/consumer.rs
+++ b/buffer/src/consumer.rs
@@ -194,43 +194,55 @@ impl Consumer {
 
     /// Read the next data batch from object storage.
     ///
-    /// Compatibility wrapper over [`Consumer::next_descriptors`] +
-    /// [`Consumer::fetch_descriptor`]. Behavior is preserved from
-    /// pre-RFC-0003: peeks the next manifest entry past the last
-    /// handed-out / fetched sequence, fetches the corresponding object,
-    /// and returns it. Returns `None` if no matching entry is
+    /// Compatibility shim for pre-RFC-0003 callers. Behavior is
+    /// preserved: peeks the next manifest entry past the last
+    /// handed-out / fetched sequence, fetches the corresponding
+    /// object, and returns it. Returns `None` if no matching entry is
     /// available.
     ///
-    /// **Fetch failure preserves legacy semantics.** Pre-RFC-0003
-    /// `next_batch` advanced its cursor only after a successful fetch;
-    /// callers expect that a transient `Storage` error from `next_batch`
-    /// can be retried and the same batch is re-attempted. The
-    /// new-API path (`next_descriptors` + `fetch_descriptor`) does not
-    /// roll back: lost descriptors are not reissued in-process per the
-    /// descriptor-handout contract. To preserve the legacy semantics
-    /// for `next_batch` callers, this wrapper rolls back
-    /// `last_handed_out_sequence` to its pre-call value when the
-    /// downstream fetch fails. The wrapper has exclusive `&mut self`
-    /// access, so the rollback is safe — no other path could observe
-    /// the descriptor between the handout and the fetch failure.
+    /// **Cancellation-safe and fetch-failure-safe.** The cursor
+    /// (`last_handed_out_sequence`) advances **only after** a
+    /// successful fetch. If the fetch fails, or if the future is
+    /// dropped mid-fetch (cancellation), the cursor is unchanged and
+    /// a subsequent `next_batch` re-fetches the same entry. This
+    /// preserves the legacy "fetch failure does not advance the
+    /// cursor" semantics that pre-RFC-0003 callers rely on.
+    ///
+    /// The implementation is a manual peek-fetch-advance flow rather
+    /// than a wrapper over [`Consumer::next_descriptors`] +
+    /// [`Consumer::fetch_descriptor`]: `next_descriptors` advances
+    /// the cursor at handout time per the
+    /// "Descriptor Handout Contract" (lost descriptors are not
+    /// reissued in-process), which is correct for the new-API
+    /// caller but is exactly the legacy regression this method must
+    /// avoid. Inlining keeps the cursor-advance after the
+    /// `fetch_descriptor` await, making cancellation safety a
+    /// structural invariant rather than a `Drop`-guard liability.
     pub async fn next_batch(&mut self) -> Result<Option<ConsumedBatch>> {
-        let saved_handed_out = self.last_handed_out_sequence;
-        let mut descriptors = self.next_descriptors(1).await?;
-        let Some(descriptor) = descriptors.pop() else {
+        let entries = self
+            .consumer
+            .descriptors_after(self.last_handed_out_sequence, 1)
+            .await?;
+        metrics::gauge!(m::QUEUE_LENGTH).set(self.consumer.len() as f64);
+        let Some(entry) = entries.into_iter().next() else {
             return Ok(None);
         };
-        match self.fetch_descriptor(descriptor).await {
-            Ok(batch) => Ok(Some(batch)),
-            Err(e) => {
-                // Roll back so the next call to next_batch re-issues
-                // the same descriptor (legacy "fetch failure does not
-                // advance the cursor" semantics). The descriptor was
-                // never visible to a caller because next_batch owns it
-                // for the duration of this method.
-                self.last_handed_out_sequence = saved_handed_out;
-                Err(e)
-            }
-        }
+        let descriptor = BatchDescriptor {
+            sequence: entry.sequence,
+            location: entry.location,
+            metadata: entry.metadata,
+            // Reserved field; v1 manifests do not carry per-entry
+            // object size.
+            object_bytes: None,
+        };
+        // fetch_descriptor advances last_fetched_sequence on success
+        // and updates the consumer_lag_seconds gauge. We then advance
+        // last_handed_out_sequence ourselves — only on success. If
+        // the fetch errors or the future is cancelled, neither cursor
+        // moves and the next next_batch re-issues the same entry.
+        let batch = self.fetch_descriptor(descriptor).await?;
+        self.last_handed_out_sequence = Some(batch.sequence);
+        Ok(Some(batch))
     }
 
     /// Read the manifest once and return up to `max` contiguous
@@ -1001,6 +1013,78 @@ mod tests {
         let b2 = collector.next_batch().await.unwrap().unwrap();
         assert_eq!(b2.sequence, 1);
         assert_eq!(b2.location, location_b);
+    }
+
+    #[tokio::test]
+    async fn should_next_batch_not_advance_cursor_when_future_is_dropped() {
+        // Cancellation safety: a `next_batch` future dropped before it
+        // completes must not have advanced last_handed_out_sequence.
+        // The next next_batch must return the same entry.
+        //
+        // The structural property this verifies: last_handed_out_sequence
+        // is mutated *after* the fetch_descriptor await returns Ok.
+        // If the future is dropped before that line, the cursor is
+        // unchanged. (Earlier versions of next_batch advanced the
+        // cursor inside next_descriptors(1) before the fetch — that
+        // version was cancellation-unsafe even though the Err path
+        // rolled back.)
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let (producer, mut collector) = make_collector(&store, test_collector_config(), None).await;
+        let entries = test_entries();
+        write_batch(&store, "batches/cancel-a", &entries).await;
+        write_batch(&store, "batches/cancel-b", &entries).await;
+        producer
+            .enqueue("batches/cancel-a".to_string(), vec![])
+            .await
+            .unwrap();
+        producer
+            .enqueue("batches/cancel-b".to_string(), vec![])
+            .await
+            .unwrap();
+
+        assert_eq!(collector.last_handed_out_sequence, None);
+
+        // Construct the future and drop it without ever polling it.
+        // This is the cleanest test of "the body never runs" and
+        // exercises the no-side-effects-before-fetch invariant.
+        {
+            let fut = collector.next_batch();
+            drop(fut);
+        }
+        assert_eq!(
+            collector.last_handed_out_sequence, None,
+            "dropped (unpolled) next_batch future must not advance the cursor"
+        );
+
+        // Race a real next_batch against an immediate timeout. If the
+        // timeout wins, the future was cancelled mid-flight (after
+        // some polls) and the cursor must still not have advanced.
+        // If the future wins, the cursor advanced exactly to the
+        // returned batch's sequence.
+        let r = tokio::time::timeout(std::time::Duration::ZERO, collector.next_batch()).await;
+        match r {
+            Ok(Ok(Some(b))) => {
+                assert_eq!(b.sequence, 0);
+                assert_eq!(b.location, "batches/cancel-a");
+                assert_eq!(collector.last_handed_out_sequence, Some(0));
+            }
+            Ok(Ok(None)) => panic!("expected a batch"),
+            Ok(Err(e)) => panic!("unexpected error: {e:?}"),
+            Err(_elapsed) => {
+                // Cancellation path: cursor unchanged.
+                assert_eq!(collector.last_handed_out_sequence, None);
+            }
+        }
+
+        // Functional retry: regardless of which branch above executed,
+        // a normal next_batch now returns the next un-fetched entry.
+        // If we cancelled, that's A (sequence 0). If we succeeded,
+        // that's B (sequence 1).
+        let next = collector.next_batch().await.unwrap().unwrap();
+        assert!(
+            next.sequence == 0 || next.sequence == 1,
+            "after cancellation or success, next_batch must return one of the two enqueued entries"
+        );
     }
 
     #[tokio::test]

--- a/buffer/src/lib.rs
+++ b/buffer/src/lib.rs
@@ -9,7 +9,7 @@ mod queue;
 mod util;
 
 pub use config::{ConsumerConfig, ProducerConfig};
-pub use consumer::{ConsumedBatch, Consumer};
+pub use consumer::{BatchDescriptor, ConsumedBatch, Consumer, ConsumerFetchHandle};
 pub use error::{Error, Result};
 pub use model::CompressionType;
 pub use producer::{DurabilityWatcher, Producer, WriteHandle};

--- a/buffer/src/metric_names.rs
+++ b/buffer/src/metric_names.rs
@@ -49,6 +49,11 @@ pub(crate) const FETCH_DURATION_SECONDS: &str = "buffer.fetch_duration_seconds";
 pub(crate) const MANIFEST_WRITES: &str = "buffer.manifest_writes";
 pub(crate) const MANIFEST_CONFLICTS: &str = "buffer.manifest_conflicts";
 
+/// Increments by `descriptors.len()` on every successful
+/// `Consumer::next_descriptors` call. Lets operators see read-ahead
+/// activity directly. Added in RFC 0003.
+pub(crate) const DESCRIPTORS_HANDED_OUT: &str = "buffer.descriptors_handed_out";
+
 pub(crate) fn describe_buffer_metrics() {
     metrics::describe_counter!(BATCHES_FLUSHED, "Batches written to object store");
     metrics::describe_counter!(ENTRIES_FLUSHED, "Entries across all flushed batches");
@@ -84,4 +89,8 @@ pub(crate) fn describe_consumer_metrics() {
     );
     metrics::describe_counter!(MANIFEST_WRITES, "Consumer manifest write attempts");
     metrics::describe_counter!(MANIFEST_CONFLICTS, "Consumer manifest CAS conflicts");
+    metrics::describe_counter!(
+        DESCRIPTORS_HANDED_OUT,
+        "Manifest entries returned by Consumer::next_descriptors"
+    );
 }

--- a/buffer/src/queue.rs
+++ b/buffer/src/queue.rs
@@ -720,6 +720,11 @@ impl QueueConsumer {
 
     /// Return the first entry in the queue without dequeueing it.
     /// Returns `Fenced` if the consumer's epoch does not match the manifest's epoch.
+    ///
+    /// Superseded by [`QueueConsumer::descriptors_after`] for the
+    /// `Consumer::next_batch` path; retained for tests and future
+    /// callers that need a single-entry peek.
+    #[allow(dead_code)]
     pub(crate) async fn peek(&self) -> Result<Option<QueueEntry>> {
         let (manifest, _) = self.read_manifest().await?;
         if manifest.epoch != self.epoch.load(Ordering::Relaxed) {
@@ -728,8 +733,48 @@ impl QueueConsumer {
         manifest.iter().next().transpose()
     }
 
+    /// Return up to `max` contiguous queue entries with sequence strictly
+    /// greater than `after_sequence` (or all entries when `after_sequence`
+    /// is `None`), in manifest order.
+    ///
+    /// Reads the manifest once. Does not mutate it. Returns `Fenced` if
+    /// the consumer's epoch does not match the manifest's epoch. This is
+    /// the read-ahead primitive `Consumer::next_descriptors` builds on
+    /// (RFC 0003).
+    pub(crate) async fn descriptors_after(
+        &self,
+        after_sequence: Option<u64>,
+        max: usize,
+    ) -> Result<Vec<QueueEntry>> {
+        if max == 0 {
+            return Ok(Vec::new());
+        }
+        let (manifest, _) = self.read_manifest().await?;
+        if manifest.epoch != self.epoch.load(Ordering::Relaxed) {
+            return Err(Error::Fenced);
+        }
+        let mut out = Vec::with_capacity(max);
+        for entry in manifest.iter() {
+            let entry = entry?;
+            if let Some(after) = after_sequence
+                && entry.sequence <= after
+            {
+                continue;
+            }
+            out.push(entry);
+            if out.len() >= max {
+                break;
+            }
+        }
+        Ok(out)
+    }
+
     /// Return the entry with the given sequence number, or None if not found.
     /// Returns `Fenced` if the consumer's epoch does not match the manifest's epoch.
+    ///
+    /// Superseded by [`QueueConsumer::descriptors_after`] for bulk
+    /// reads; retained for legacy single-sequence lookups.
+    #[allow(dead_code)]
     pub(crate) async fn read(&self, sequence: u64) -> Result<Option<QueueEntry>> {
         let (manifest, _) = self.read_manifest().await?;
         if manifest.epoch != self.epoch.load(Ordering::Relaxed) {


### PR DESCRIPTION
## Summary

Adds parallel-IO + batched-ack primitives to `buffer::Consumer` so a consumer can
fetch and decode many batches concurrently while keeping manifest mutation
serialized and batched. This is the buffer-side foundation for high-throughput
pipelined consumers; the existing serial `next_batch` / `ack` API is preserved
unchanged.

## What's included 
- New public API (additive; documented in `buffer/rfcs/0003-consumer-read-ahead.md`):
  - `BatchDescriptor` — a lightweight, fetch-without-re-reading pointer to a manifest entry.
  - `ConsumerFetchHandle` (`Clone + Send + Sync + 'static`) — stateless `fetch(&self, …)`, cloneable into N fetch workers.
  - `Consumer::next_descriptors(max)` — one manifest read → a contiguous run of descriptors.
  - `Consumer::fetch_handle()` / `fetch_descriptor()` — the handle, and the serial `&mut self` wrapper that the existing `next_batch` is implemented upon.
  - `Consumer::ack_through(seq)` — advance the durable frontier in a single dequeue CAS (dequeue-first; storage/fence errors leave state untouched).
- `next_batch` becomes a wrapper over `next_descriptors(1)` + `fetch_descriptor`; cancellation- and fetch-failure-safe (cursor advances only after a successful fetch).
- New `buffer.descriptors_handed_out` counter; no metric renames.
- RFC 0003 doc.

## Compatibility

Additive — `opendata-buffer` 0.2.0 → **0.3.0** (minor). `next_batch`'s signature is
unchanged; in-workspace consumers (`timeseries`, `vector`) build without changes.

## Testing

Several unit tests added to the consumer to test the new behavior + compatibility with the old behavior. this implementation was tested with a pipelined clickhouse consumer in opendata-contrib (with a separate PR and RFC) for both correctness and performance. It can sustain 1Gbps throughput on a single ingestor node with 4 core CPU and 8GB of ram. Even then the main bottleneck is clickhouse. 

<img width="1820" height="1040" alt="image" src="https://github.com/user-attachments/assets/e2c32787-a51e-41bc-955c-6582258ef19d" />

## Reviewer notes

The RFC is intended to be the main review artifacts. The public interfaces and implementation pseudo code is included in the RFC. 

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
