### PR TITLE
Logdb: optimize compactor view tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2527,6 +2527,7 @@ dependencies = [
 name = "opendata-log"
 version = "0.2.2"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "axum",
  "base64 0.22.1",

--- a/log/Cargo.toml
+++ b/log/Cargo.toml
@@ -23,6 +23,7 @@ default = []
 http-server = ["dep:axum", "dep:tower", "dep:clap", "dep:prometheus-client", "dep:metrics-exporter-prometheus", "dep:tikv-jemallocator"]
 
 [dependencies]
+arc-swap = "1"
 async-trait.workspace = true
 bytes.workspace = true
 common.workspace = true

--- a/log/src/compaction.rs
+++ b/log/src/compaction.rs
@@ -5,23 +5,22 @@
 //! orphaned and proposes compactions or drains accordingly. See
 //! [`propose_compactions`] for the per-state behaviour.
 //!
-//! The scheduler doesn't read storage. It subscribes to a compactor-facing
-//! view (via a [`std::sync::OnceLock`] installed after the writer is created)
-//! and derives the live user-segment range from the two segment-id watermarks
-//! published there. Because retention only deletes from the low end of the
-//! log (RFC 0005), the live set is always a contiguous id range, so two
-//! integers fully describe it.
+//! The scheduler doesn't read storage. It reads a compactor-facing view (a
+//! shared [`ArcSwap`] the writer publishes into) and derives the live
+//! user-segment range from the two segment-id watermarks published there.
+//! Because retention only deletes from the low end of the log (RFC 0005), the
+//! live set is always a contiguous id range, so two integers fully describe it.
 
 use std::collections::HashSet;
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
+use arc_swap::ArcSwap;
 use bytes::Bytes;
 use slatedb::compactor::{
     CompactionScheduler, CompactionSchedulerSupplier, CompactionSpec, CompactorStateView, SourceId,
 };
 use slatedb::config::CompactorOptions;
 use slatedb::manifest::Segment;
-use tokio::sync::watch;
 use ulid::Ulid;
 
 use crate::config::LogCompactionOptions;
@@ -40,10 +39,11 @@ pub(crate) struct CompactorView {
     pub last_deleted_segment_id: Option<SegmentId>,
 }
 
-/// Cell shared between the builder and the supplier; the writer's
-/// `CompactorView` receiver is installed here once the writer exists. While
-/// empty the scheduler treats the live set as uninitialized.
-pub(crate) type CompactorViewCell = Arc<OnceLock<watch::Receiver<CompactorView>>>;
+/// Cell shared between the builder, the compaction supplier, and the writer.
+/// The writer publishes the latest `CompactorView` here on each segment
+/// change; the scheduler reads the most recent value. Initialised to an empty
+/// live set (`None`/`None`), which `compute_bounds` treats as uninitialized.
+pub(crate) type CompactorViewCell = Arc<ArcSwap<CompactorView>>;
 
 /// L0 SST count at or above which the system segment is consolidated.
 const SYSTEM_SEGMENT_L0_THRESHOLD: usize = 2;
@@ -82,7 +82,7 @@ impl CompactionSchedulerSupplier for LogCompactionSchedulerSupplier {
 }
 
 /// LogDb's `CompactionScheduler` impl. Reads the writer's live-set watermarks
-/// from a shared `OnceLock`-gated watch receiver; never touches storage.
+/// from a shared `ArcSwap` cell; never touches storage.
 pub(crate) struct LogCompactionScheduler {
     cell: CompactorViewCell,
     options: LogCompactionOptions,
@@ -90,10 +90,8 @@ pub(crate) struct LogCompactionScheduler {
 
 impl CompactionScheduler for LogCompactionScheduler {
     fn propose(&self, state: &CompactorStateView) -> Vec<CompactionSpec> {
-        let bounds = self.cell.get().and_then(|rx| {
-            let view = rx.borrow();
-            compute_bounds(view.last_segment_id, view.last_deleted_segment_id)
-        });
+        let view = self.cell.load();
+        let bounds = compute_bounds(view.last_segment_id, view.last_deleted_segment_id);
         let active = collect_active_compactions(state);
         let segments: Vec<SegmentSnapshot> = state
             .manifest()

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -5,14 +5,13 @@
 //! ([`try_append`](LogDb::try_append), [`append_timeout`](LogDb::append_timeout))
 //! and read operations ([`scan`], [`count`]) via the [`LogRead`] trait.
 
-use std::collections::VecDeque;
 use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::time::Duration;
 
+use arc_swap::ArcSwap;
 use async_trait::async_trait;
 use bytes::Bytes;
-use std::sync::OnceLock;
 
 use common::clock::{Clock, SystemClock};
 use common::coordinator::{Durability, EpochWatcher, EpochWatermarks};
@@ -111,7 +110,6 @@ pub struct LogDb {
     epoch_watcher: EpochWatcher,
     durable_sequence_rx: watch::Receiver<Sequence>,
     read_subscriber_task: JoinHandle<()>,
-    compactor_view_task: Option<JoinHandle<()>>,
     read_visibility: ReadVisibility,
 }
 
@@ -342,9 +340,6 @@ impl LogDb {
         drop(self.handle);
         let _ = self.writer_task.await;
         self.read_subscriber_task.abort();
-        if let Some(task) = self.compactor_view_task {
-            task.abort();
-        }
         self.storage
             .close()
             .await
@@ -402,9 +397,10 @@ impl LogDb {
     }
 
     /// Shared construction logic used by `LogDb::new` and `LogDbBuilder::build`.
-    /// When `compactor_view_cell` is `Some`, a durable-gated compactor view
-    /// receiver is installed there so the embedded compaction scheduler can
-    /// track the live set.
+    /// When `compactor_view_cell` is `Some`, it is seeded with the recovered
+    /// live set here and handed to the writer, which publishes later updates
+    /// (segment creates at written latency, deletes once durable). The embedded
+    /// compaction scheduler reads the cell.
     async fn from_storage(
         storage: Arc<dyn common::Storage>,
         direct: Option<Arc<crate::direct::LogDirect>>,
@@ -425,11 +421,23 @@ impl LogDb {
         let segment_cache = SegmentCache::open(snapshot.as_ref(), segment_config).await?;
         let listing_cache = ListingCache::new();
 
+        let initial_segment_id = segment_cache.latest().map(|s| s.id());
+        let initial_deleted_segment_id = segment_cache.initial_deleted_segment_id();
+        // Seed the compactor view with recovered state so the scheduler sees
+        // the live set immediately; the writer owns all further updates.
+        if let Some(cell) = compactor_view_cell.as_ref() {
+            cell.store(Arc::new(CompactorView {
+                last_segment_id: initial_segment_id,
+                last_deleted_segment_id: initial_deleted_segment_id,
+            }));
+        }
+
         let writer_config = LogWriterConfig {
             retention: retention_config.retention.map(|retention| RetentionPolicy {
                 retention,
                 check_interval: retention_config.check_interval,
             }),
+            compactor_view: compactor_view_cell,
             ..LogWriterConfig::default()
         };
         let (writer, mut handle) = LogWriter::new(
@@ -444,25 +452,7 @@ impl LogDb {
         .map_err(Error::Storage)?;
 
         let written_rx = handle.written_rx();
-        let initial_segment_id = segment_cache.latest().map(|s| s.id());
-        let initial_deleted_segment_id = segment_cache.initial_deleted_segment_id();
         let initial_next_sequence = written_rx.borrow().next_sequence;
-        let compactor_view_task = if let Some(cell) = compactor_view_cell.as_ref() {
-            let (compactor_rx, task) = spawn_compactor_view_publisher(
-                written_rx.clone(),
-                &storage,
-                initial_segment_id,
-                initial_deleted_segment_id,
-            );
-            // Err from `set` would mean the cell was already initialised — that
-            // never happens on our paths, so log it loudly rather than swallow.
-            if cell.set(compactor_rx).is_err() {
-                tracing::warn!("compactor view cell was already initialised");
-            }
-            Some(task)
-        } else {
-            None
-        };
         let writer_task = handle.spawn(writer);
 
         let read_view = Arc::new(RwLock::new(LogReadView::new(
@@ -490,7 +480,6 @@ impl LogDb {
             epoch_watcher,
             durable_sequence_rx,
             read_subscriber_task,
-            compactor_view_task,
             read_visibility,
         })
     }
@@ -582,7 +571,11 @@ impl LogDbBuilder {
             db.with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())
         });
         // Install the LogDb compaction scheduler for every SlateDB-backed log.
-        let compactor_view_cell: CompactorViewCell = Arc::new(OnceLock::new());
+        let compactor_view_cell: CompactorViewCell =
+            Arc::new(ArcSwap::from_pointee(CompactorView {
+                last_segment_id: None,
+                last_deleted_segment_id: None,
+            }));
         let sb = if let StorageConfig::SlateDb(ref slate_config) = self.config.storage {
             let path = slate_config.path.clone();
             let object_store = create_object_store(&slate_config.object_store)
@@ -626,79 +619,6 @@ impl LogDbBuilder {
             cell_for_writer,
         )
         .await
-    }
-}
-
-fn spawn_compactor_view_publisher(
-    mut written_rx: watch::Receiver<WrittenView>,
-    storage: &Arc<dyn common::Storage>,
-    initial_segment_id: Option<SegmentId>,
-    initial_deleted_segment_id: Option<SegmentId>,
-) -> (watch::Receiver<CompactorView>, JoinHandle<()>) {
-    let (compactor_tx, compactor_rx) = watch::channel(CompactorView {
-        last_segment_id: initial_segment_id,
-        last_deleted_segment_id: initial_deleted_segment_id,
-    });
-    let mut durable_rx = storage.subscribe_durable();
-
-    let task = tokio::spawn(async move {
-        let mut pending_deletes: VecDeque<(u64, Option<SegmentId>)> = VecDeque::new();
-        let mut last_durable_seq = *durable_rx.borrow();
-
-        loop {
-            tokio::select! {
-                result = written_rx.changed() => {
-                    if result.is_err() {
-                        break;
-                    }
-                    let view = written_rx.borrow_and_update().clone();
-                    pending_deletes.push_back((view.seqnum, view.last_deleted_segment_id));
-                    compactor_tx.send_modify(|state| {
-                        state.last_segment_id = view.last_segment_id;
-                    });
-                    drain_compactor_deletes(
-                        &mut pending_deletes,
-                        last_durable_seq,
-                        &compactor_tx,
-                    );
-                }
-                result = durable_rx.changed() => {
-                    if result.is_err() {
-                        break;
-                    }
-                    last_durable_seq = *durable_rx.borrow_and_update();
-                    drain_compactor_deletes(
-                        &mut pending_deletes,
-                        last_durable_seq,
-                        &compactor_tx,
-                    );
-                }
-            }
-        }
-    });
-
-    (compactor_rx, task)
-}
-
-fn drain_compactor_deletes(
-    pending_deletes: &mut VecDeque<(u64, Option<SegmentId>)>,
-    durable_seq: u64,
-    compactor_tx: &watch::Sender<CompactorView>,
-) {
-    let mut latest_durable_delete = None;
-    while pending_deletes
-        .front()
-        .is_some_and(|(seqnum, _)| *seqnum <= durable_seq)
-    {
-        latest_durable_delete = pending_deletes
-            .pop_front()
-            .map(|(_, deleted_id)| deleted_id);
-    }
-
-    if let Some(last_deleted_segment_id) = latest_durable_delete {
-        compactor_tx.send_modify(|state| {
-            state.last_deleted_segment_id = last_deleted_segment_id;
-        });
     }
 }
 
@@ -885,10 +805,8 @@ fn spawn_subscriber(
 
 #[cfg(test)]
 mod tests {
-    use common::Storage;
     use common::StorageBuilder;
     use common::StorageConfig;
-    use common::storage::in_memory::InMemoryStorage;
 
     use super::*;
     use crate::config::Config;
@@ -899,94 +817,6 @@ mod tests {
             storage: StorageConfig::InMemory,
             ..Default::default()
         }
-    }
-
-    async fn make_written_view(
-        storage: &Arc<dyn common::Storage>,
-        seqnum: u64,
-        last_segment_id: Option<SegmentId>,
-        last_deleted_segment_id: Option<SegmentId>,
-    ) -> WrittenView {
-        WrittenView {
-            epoch: seqnum,
-            snapshot: storage.snapshot().await.unwrap(),
-            seqnum,
-            next_sequence: 0,
-            last_segment_id,
-            last_deleted_segment_id,
-        }
-    }
-
-    #[tokio::test]
-    async fn compactor_view_should_publish_new_segments_at_written_latency() {
-        let storage = Arc::new(InMemoryStorage::new().with_deferred_durability());
-        let storage_dyn = storage.clone() as Arc<dyn common::Storage>;
-        let initial_view = make_written_view(&storage_dyn, 0, None, None).await;
-        let (written_tx, written_rx) = watch::channel(initial_view);
-        let (mut compactor_rx, task) =
-            spawn_compactor_view_publisher(written_rx, &storage_dyn, None, None);
-
-        let write_result = storage
-            .apply(vec![common::storage::RecordOp::Delete(Bytes::from_static(
-                b"segment-meta-1",
-            ))])
-            .await
-            .unwrap();
-        written_tx.send_replace(
-            make_written_view(&storage_dyn, write_result.seqnum, Some(3), None).await,
-        );
-
-        tokio::time::timeout(Duration::from_secs(1), compactor_rx.changed())
-            .await
-            .expect("timed out waiting for compactor view")
-            .expect("compactor view channel closed");
-        let view = *compactor_rx.borrow_and_update();
-        assert_eq!(view.last_segment_id, Some(3));
-        assert_eq!(view.last_deleted_segment_id, None);
-
-        task.abort();
-    }
-
-    #[tokio::test]
-    async fn compactor_view_should_delay_deleted_segments_until_durable() {
-        let storage = Arc::new(InMemoryStorage::new().with_deferred_durability());
-        let storage_dyn = storage.clone() as Arc<dyn common::Storage>;
-        let initial_view = make_written_view(&storage_dyn, 0, Some(2), None).await;
-        let (written_tx, written_rx) = watch::channel(initial_view);
-        let (mut compactor_rx, task) =
-            spawn_compactor_view_publisher(written_rx, &storage_dyn, Some(2), None);
-
-        let write_result = storage
-            .apply(vec![common::storage::RecordOp::Delete(Bytes::from_static(
-                b"segment-meta-1",
-            ))])
-            .await
-            .unwrap();
-        written_tx.send_replace(
-            make_written_view(&storage_dyn, write_result.seqnum, Some(2), Some(1)).await,
-        );
-
-        tokio::time::timeout(Duration::from_secs(1), compactor_rx.changed())
-            .await
-            .expect("timed out waiting for written compactor update")
-            .expect("compactor view channel closed");
-        let view = *compactor_rx.borrow_and_update();
-        assert_eq!(view.last_segment_id, Some(2));
-        assert_eq!(
-            view.last_deleted_segment_id, None,
-            "delete should remain hidden until durable",
-        );
-
-        storage.flush_to(write_result.seqnum);
-
-        tokio::time::timeout(Duration::from_secs(1), compactor_rx.changed())
-            .await
-            .expect("timed out waiting for durable compactor update")
-            .expect("compactor view channel closed");
-        let view = *compactor_rx.borrow_and_update();
-        assert_eq!(view.last_deleted_segment_id, Some(1));
-
-        task.abort();
     }
 
     #[tokio::test]

--- a/log/src/writer.rs
+++ b/log/src/writer.rs
@@ -14,6 +14,7 @@
 //!   memtable (visible to snapshot reads, but not yet on disk).
 //! - **Durable** — after `storage.flush()`, once SlateDB has synced to disk.
 
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -26,6 +27,7 @@ use common::{PutRecordOp, SequenceAllocator, WriteOptions};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::JoinHandle;
 
+use crate::compaction::{CompactorView, CompactorViewCell};
 use crate::error::AppendError;
 use crate::listing::ListingCache;
 use crate::model::{AppendOutput, Record as UserRecord, SegmentId, Sequence};
@@ -90,6 +92,9 @@ pub(crate) struct LogWriterConfig {
     /// retention check that deletes `SegmentMeta` records for expired sealed
     /// segments. `None` disables the check entirely.
     pub retention: Option<RetentionPolicy>,
+    /// Shared cell the writer publishes the compactor-facing live-set view
+    /// into. `None` disables compactor publication (no embedded compaction).
+    pub compactor_view: Option<CompactorViewCell>,
 }
 
 impl Default for LogWriterConfig {
@@ -97,6 +102,7 @@ impl Default for LogWriterConfig {
         Self {
             queue_capacity: 10_000,
             retention: None,
+            compactor_view: None,
         }
     }
 }
@@ -123,6 +129,20 @@ pub(crate) struct LogWriter {
     last_deleted_segment_id: Option<SegmentId>,
     clock: Arc<dyn Clock>,
     retention: Option<RetentionPolicy>,
+    /// Shared cell publishing the compactor-facing live-set view. `None` when
+    /// embedded compaction is disabled.
+    compactor_view: Option<CompactorViewCell>,
+    /// Segment deletions awaiting durability, as `(write seqnum, resulting
+    /// last_deleted_segment_id)`. `run`'s durable branch drains an entry once
+    /// its seqnum is durable and publishes its id, so the compactor never sees
+    /// a deletion before its `SegmentMeta` delete is durable. Always empty when
+    /// `compactor_view` is `None`; entries left queued at shutdown are dropped
+    /// (re-seeded from durable state on the next open).
+    ///
+    /// The id is captured per entry, not read from `self` at drain time: a
+    /// later, not-yet-durable delete may already have advanced
+    /// `last_deleted_segment_id`, and publishing that would expose it early.
+    pending_deletes: VecDeque<(u64, Option<SegmentId>)>,
 }
 
 impl LogWriter {
@@ -167,6 +187,8 @@ impl LogWriter {
             last_deleted_segment_id,
             clock,
             retention: config.retention,
+            compactor_view: config.compactor_view,
+            pending_deletes: VecDeque::new(),
         };
 
         let handle = LogWriteHandle {
@@ -186,7 +208,14 @@ impl LogWriter {
             .retention
             .as_ref()
             .map(|p| tokio::time::interval(p.check_interval));
+        let mut durable_rx = self.storage.subscribe_durable();
+        let mut durable_closed = false;
         loop {
+            // Listen for durability only while deletes await their gate;
+            // otherwise the branch parks and plain appends never wake the
+            // writer here. Stop once the channel closes, so a closed
+            // `durable_rx` can't busy-spin the branch on `Err`.
+            let awaiting_durable = !self.pending_deletes.is_empty() && !durable_closed;
             tokio::select! {
                 cmd = rx.recv() => {
                     let Some(cmd) = cmd else { break };
@@ -199,6 +228,23 @@ impl LogWriter {
                     }
                 } => {
                     self.tick_retention().await;
+                }
+                result = async {
+                    if awaiting_durable {
+                        durable_rx.changed().await
+                    } else {
+                        std::future::pending().await
+                    }
+                } => {
+                    // A closed durable channel means storage is shutting down;
+                    // stop draining but keep serving until the command channel
+                    // closes.
+                    if result.is_err() {
+                        durable_closed = true;
+                    } else {
+                        let durable_seq = *durable_rx.borrow_and_update();
+                        self.drain_compactor_deletes(durable_seq);
+                    }
                 }
             }
         }
@@ -346,6 +392,17 @@ impl LogWriter {
         {
             self.last_deleted_segment_id = Some(segment_id);
         }
+        // Queue for the compactor; `run`'s durable branch releases it once
+        // `write_result.seqnum` is durable. No drain here: `durable_rx` is
+        // long-lived and consumed only in that branch, so a durable advance
+        // that lands now (some storages flush synchronously inside `apply`) is
+        // retained as an unseen `watch` version. Since the seqnum exceeds the
+        // current durable watermark, the branch's next `changed()` fires either
+        // immediately or after the flush that makes it durable.
+        if self.compactor_view.is_some() {
+            self.pending_deletes
+                .push_back((write_result.seqnum, self.last_deleted_segment_id));
+        }
         self.broadcast(write_result.seqnum).await
     }
 
@@ -365,8 +422,52 @@ impl LogWriter {
             && assignment.is_new
         {
             self.last_segment_id = Some(assignment.segment.id());
+            self.publish_compactor_segment();
         }
         self.broadcast(write_result.seqnum).await
+    }
+
+    /// Publishes `last_segment_id` to the compactor view when a new segment is
+    /// created, so plain appends do no compactor work. No-op when compaction is
+    /// disabled. `rcu` keeps the read-modify-write atomic so the other field is
+    /// preserved (the writer task is the only runtime mutator, but cheap).
+    fn publish_compactor_segment(&self) {
+        let Some(cell) = self.compactor_view.as_ref() else {
+            return;
+        };
+        cell.rcu(|current| CompactorView {
+            last_segment_id: self.last_segment_id,
+            ..**current
+        });
+    }
+
+    /// Releases queued segment deletions to the compactor view once their write
+    /// is durable. Pops every pending delete with `seqnum <= durable_seq` and
+    /// publishes the highest resulting `last_deleted_segment_id`. No-op when
+    /// compaction is disabled or nothing is newly durable.
+    fn drain_compactor_deletes(&mut self, durable_seq: u64) {
+        let Some(cell) = self.compactor_view.as_ref() else {
+            return;
+        };
+        let mut latest_durable_delete = None;
+        while self
+            .pending_deletes
+            .front()
+            .is_some_and(|(seqnum, _)| *seqnum <= durable_seq)
+        {
+            latest_durable_delete = self
+                .pending_deletes
+                .pop_front()
+                .map(|(_, deleted_id)| deleted_id);
+        }
+        if let Some(last_deleted_segment_id) = latest_durable_delete {
+            // `rcu` keeps the read-modify-write atomic; see
+            // `publish_compactor_segment` for why.
+            cell.rcu(|current| CompactorView {
+                last_deleted_segment_id,
+                ..**current
+            });
+        }
     }
 
     /// Writes ops to storage. Returns the resulting `WriteResult`.
@@ -981,6 +1082,148 @@ mod tests {
         // then: watermark is the max of the two, not the most recent
         let view = written_rx.borrow_and_update().clone();
         assert_eq!(view.last_deleted_segment_id, Some(2));
+    }
+
+    // ---- Compactor-view publication tests ----
+
+    use arc_swap::ArcSwap;
+
+    fn empty_compactor_view() -> CompactorViewCell {
+        Arc::new(ArcSwap::from_pointee(CompactorView {
+            last_segment_id: None,
+            last_deleted_segment_id: None,
+        }))
+    }
+
+    async fn wait_for_deleted(cell: &CompactorViewCell, expected: Option<SegmentId>) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if cell.load().last_deleted_segment_id == expected {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(2)).await;
+            }
+        })
+        .await
+        .expect("compactor view did not reflect durable delete in time");
+    }
+
+    #[tokio::test]
+    async fn compactor_view_should_publish_new_segment_at_written_latency() {
+        let cell = empty_compactor_view();
+        let config = LogWriterConfig {
+            compactor_view: Some(cell.clone()),
+            ..LogWriterConfig::default()
+        };
+        let (writer, mut handle, _storage) = create_writer_with_config(config).await;
+        let _task = handle.spawn(writer);
+
+        // The first append creates segment 1; its id is published immediately,
+        // without waiting for durability.
+        handle.try_append(make_write(&["k1"], 1000)).await.unwrap();
+
+        let view = **cell.load();
+        assert_eq!(view.last_segment_id, Some(1));
+        assert_eq!(view.last_deleted_segment_id, None);
+    }
+
+    #[tokio::test]
+    async fn compactor_view_should_delay_deleted_segment_until_durable() {
+        let storage: Arc<dyn common::Storage> =
+            Arc::new(InMemoryStorage::new().with_deferred_durability());
+        let cell = empty_compactor_view();
+        let config = LogWriterConfig {
+            compactor_view: Some(cell.clone()),
+            ..LogWriterConfig::default()
+        };
+        let (writer, mut handle, _storage) = create_writer_with_storage(storage, config).await;
+        let _task = handle.spawn(writer);
+
+        // Create two user segments (ids 1 and 2).
+        handle.try_append(make_write(&["k1"], 1000)).await.unwrap();
+        handle.force_seal(2000).await.unwrap();
+        assert_eq!(cell.load().last_segment_id, Some(2));
+
+        // Delete segment 1. Its write isn't durable yet (deferred durability),
+        // so the deletion stays hidden from the compactor view.
+        handle.delete_segment_meta(1).await.unwrap();
+        assert_eq!(
+            cell.load().last_deleted_segment_id,
+            None,
+            "delete should remain hidden until durable",
+        );
+
+        // Flushing makes the delete durable; the writer's durable branch then
+        // releases it to the compactor view.
+        handle.flush().await.unwrap();
+        wait_for_deleted(&cell, Some(1)).await;
+    }
+
+    #[tokio::test]
+    async fn compactor_view_should_release_delete_without_explicit_flush_when_durability_is_synchronous()
+     {
+        // Default InMemoryStorage marks writes durable synchronously inside
+        // `apply`, so a delete is durable the instant it is written. The writer
+        // must still release it to the compactor view — the durable branch
+        // reacts to the unseen `watch` version left by that synchronous durable
+        // advance, with no explicit flush. This pins the immediate-drain path
+        // that the deferred-durability test above does not exercise.
+        let cell = empty_compactor_view();
+        let config = LogWriterConfig {
+            compactor_view: Some(cell.clone()),
+            ..LogWriterConfig::default()
+        };
+        let (writer, mut handle, _storage) = create_writer_with_config(config).await;
+        let _task = handle.spawn(writer);
+
+        handle.try_append(make_write(&["k1"], 1000)).await.unwrap();
+        handle.force_seal(2000).await.unwrap();
+        handle.delete_segment_meta(1).await.unwrap();
+
+        wait_for_deleted(&cell, Some(1)).await;
+    }
+
+    #[tokio::test]
+    async fn compactor_view_should_gate_each_delete_on_its_own_durability() {
+        // Two deletes queued together must be released independently as their
+        // individual writes become durable: making only the first delete's
+        // write durable must advance the view to the first id, NOT the second,
+        // even though `self.last_deleted_segment_id` already reflects the
+        // second. This is the per-entry durability gate in `pending_deletes`.
+        let storage = Arc::new(InMemoryStorage::new().with_deferred_durability());
+        let cell = empty_compactor_view();
+        let config = LogWriterConfig {
+            compactor_view: Some(cell.clone()),
+            ..LogWriterConfig::default()
+        };
+        let (writer, mut handle, _storage) =
+            create_writer_with_storage(storage.clone() as Arc<dyn common::Storage>, config).await;
+        let mut written_rx = handle.written_rx();
+        let _task = handle.spawn(writer);
+
+        // Three user segments (ids 1, 2, 3) so segments 1 and 2 can be deleted.
+        handle.try_append(make_write(&["k1"], 1000)).await.unwrap();
+        handle.force_seal(2000).await.unwrap();
+        handle.force_seal(3000).await.unwrap();
+
+        // Delete segment 1, then segment 2, capturing each write's seqnum.
+        handle.delete_segment_meta(1).await.unwrap();
+        let delete_1_seq = written_rx.borrow_and_update().seqnum;
+        handle.delete_segment_meta(2).await.unwrap();
+        let delete_2_seq = written_rx.borrow_and_update().seqnum;
+        assert!(delete_2_seq > delete_1_seq);
+
+        // Nothing durable yet: both deletes stay hidden.
+        assert_eq!(cell.load().last_deleted_segment_id, None);
+
+        // Make ONLY delete 1 durable. The view must advance to Some(1); delete
+        // 2's SegmentMeta write is not durable, so it must remain hidden.
+        storage.flush_to(delete_1_seq);
+        wait_for_deleted(&cell, Some(1)).await;
+
+        // Now make delete 2 durable too.
+        storage.flush_to(delete_2_seq);
+        wait_for_deleted(&cell, Some(2)).await;
     }
 
     #[storage_test]


### PR DESCRIPTION
We were using a roundabout path to keep the compactor's view of segments fresh. We used a separate task to forward written views published by the writer for the reader to the compactor. This forwarding task gets woken up on every write even though segment events are extremely rare. This patch moves this logic into the writer and changes the compactor to hold an ArcSwap instead of a watch since it really only care about the current value. Based on my testing, this provides a 10-20% speedup when running with small batches.