### PR TITLE
Logdb: hooks for telemetry/logging in the C api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2559,6 +2559,8 @@ version = "0.3.0"
 dependencies = [
  "bytes",
  "cbindgen",
+ "metrics",
+ "metrics-exporter-prometheus",
  "opendata-common",
  "opendata-log",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2563,6 +2563,7 @@ dependencies = [
  "opendata-log",
  "tempfile",
  "tokio",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/log/c/Cargo.toml
+++ b/log/c/Cargo.toml
@@ -15,6 +15,7 @@ log = { path = "..", package = "opendata-log" }
 common = { workspace = true }
 tokio = { workspace = true }
 bytes = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/log/c/Cargo.toml
+++ b/log/c/Cargo.toml
@@ -16,6 +16,8 @@ common = { workspace = true }
 tokio = { workspace = true }
 bytes = { workspace = true }
 tracing-subscriber = { workspace = true }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/log/c/include/opendata_log.h
+++ b/log/c/include/opendata_log.h
@@ -298,4 +298,36 @@ struct opendata_log_result_t opendata_log_reader_list_segments(const struct open
                                                                struct opendata_log_segment_t **out_segments,
                                                                uintptr_t *out_count);
 
+/**
+ * Installs a global `metrics-rs` Prometheus recorder that captures SlateDB
+ * metrics emitted from any `LogDb` or `LogDbReader` opened in this process.
+ *
+ * **Idempotent and lock-free.** Safe to call any number of times from any
+ * thread; only the first call actually installs the recorder, subsequent
+ * calls observe the cached result. Safe to call before or after
+ * `opendata_log_open` / `opendata_log_reader_open`.
+ *
+ * Returns `OPENDATA_LOG_ERROR_INTERNAL` if a different `metrics-rs` recorder
+ * is already installed in the process (e.g. by another embedded Rust
+ * component). In that case `opendata_log_render_metrics` will return an
+ * empty buffer.
+ */
+struct opendata_log_result_t opendata_log_init_telemetry(void);
+
+/**
+ * Renders the current SlateDB metrics in Prometheus text-exposition format.
+ *
+ * On success, allocates a heap buffer and writes its address and length to
+ * `*out_data` / `*out_len`. The caller owns the buffer and must release it
+ * with `opendata_log_bytes_free`.
+ *
+ * Lazily initializes the recorder on first call if `opendata_log_init_telemetry`
+ * was not invoked explicitly. If a foreign `metrics-rs` recorder occupies
+ * the global slot, returns success with `*out_data = NULL` and `*out_len = 0`
+ * (an empty buffer is not an error).
+ *
+ * `out_data` and `out_len` must be non-null. The function never blocks.
+ */
+struct opendata_log_result_t opendata_log_render_metrics(uint8_t **out_data, uintptr_t *out_len);
+
 #endif  /* OPENDATA_LOG_H */

--- a/log/c/include/opendata_log.h
+++ b/log/c/include/opendata_log.h
@@ -237,6 +237,24 @@ struct opendata_log_result_t opendata_log_key_iterator_next(struct opendata_log_
 
 struct opendata_log_result_t opendata_log_key_iterator_close(struct opendata_log_key_iterator_t *iterator);
 
+/**
+ * Installs a global `tracing` subscriber that writes to stderr.
+ *
+ * `filter` is an `EnvFilter` directive string (same syntax as `RUST_LOG`),
+ * e.g. `"info"`, `"slatedb=debug"`, or `"slatedb=debug,opendata_log=info"`.
+ * Pass `NULL` to fall back to the `RUST_LOG` environment variable, or
+ * `"info"` if `RUST_LOG` is unset.
+ *
+ * Must be called at most once per process, before `opendata_log_open`. The
+ * underlying `tracing` global default can only be set once; if a subscriber
+ * is already installed (e.g. by another Rust component embedded in the same
+ * host), this returns `OPENDATA_LOG_ERROR_INTERNAL`.
+ *
+ * Hosts that already manage their own `tracing` subscriber should not call
+ * this function.
+ */
+struct opendata_log_result_t opendata_log_enable_logging(const char *filter);
+
 void opendata_log_result_free(struct opendata_log_result_t result);
 
 void opendata_log_bytes_free(uint8_t *data, uintptr_t len);

--- a/log/c/src/lib.rs
+++ b/log/c/src/lib.rs
@@ -15,6 +15,7 @@ pub mod ffi;
 
 mod db;
 mod iterator;
+mod logging;
 mod memory;
 mod object_store;
 mod reader;
@@ -25,6 +26,7 @@ pub use ffi::*;
 // Re-export all extern "C" functions so they appear in the cdylib.
 pub use db::*;
 pub use iterator::*;
+pub use logging::*;
 pub use memory::*;
 pub use object_store::*;
 pub use reader::*;

--- a/log/c/src/lib.rs
+++ b/log/c/src/lib.rs
@@ -19,6 +19,7 @@ mod logging;
 mod memory;
 mod object_store;
 mod reader;
+mod telemetry;
 
 // Re-export all public FFI types for cbindgen discovery.
 pub use ffi::*;
@@ -30,3 +31,4 @@ pub use logging::*;
 pub use memory::*;
 pub use object_store::*;
 pub use reader::*;
+pub use telemetry::*;

--- a/log/c/src/logging.rs
+++ b/log/c/src/logging.rs
@@ -1,0 +1,58 @@
+use std::ffi::c_char;
+
+use tracing_subscriber::EnvFilter;
+
+use crate::ffi::*;
+
+/// Installs a global `tracing` subscriber that writes to stderr.
+///
+/// `filter` is an `EnvFilter` directive string (same syntax as `RUST_LOG`),
+/// e.g. `"info"`, `"slatedb=debug"`, or `"slatedb=debug,opendata_log=info"`.
+/// Pass `NULL` to fall back to the `RUST_LOG` environment variable, or
+/// `"info"` if `RUST_LOG` is unset.
+///
+/// Must be called at most once per process, before `opendata_log_open`. The
+/// underlying `tracing` global default can only be set once; if a subscriber
+/// is already installed (e.g. by another Rust component embedded in the same
+/// host), this returns `OPENDATA_LOG_ERROR_INTERNAL`.
+///
+/// Hosts that already manage their own `tracing` subscriber should not call
+/// this function.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn opendata_log_enable_logging(
+    filter: *const c_char,
+) -> opendata_log_result_t {
+    let directive = if filter.is_null() {
+        None
+    } else {
+        match cstr_to_string(filter, "filter") {
+            Ok(s) => Some(s),
+            Err(e) => return e,
+        }
+    };
+
+    let env_filter = match directive {
+        Some(s) => match EnvFilter::try_new(&s) {
+            Ok(f) => f,
+            Err(e) => {
+                return error_result(
+                    opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+                    &format!("invalid filter directive {s:?}: {e}"),
+                );
+            }
+        },
+        None => EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+    };
+
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_writer(std::io::stderr)
+        .try_init()
+        .map(|()| success_result())
+        .unwrap_or_else(|e| {
+            error_result(
+                opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INTERNAL,
+                &format!("failed to install tracing subscriber: {e}"),
+            )
+        })
+}

--- a/log/c/src/telemetry.rs
+++ b/log/c/src/telemetry.rs
@@ -1,0 +1,77 @@
+use std::sync::OnceLock;
+
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+
+use crate::ffi::*;
+
+/// Lazily-initialized global `PrometheusHandle`. The inner `Result` distinguishes
+/// "we own the global metrics recorder" (`Ok`) from "someone else installed a
+/// recorder before us so our handle would render nothing useful" (`Err`).
+static HANDLE: OnceLock<Result<PrometheusHandle, ()>> = OnceLock::new();
+
+fn handle() -> &'static Result<PrometheusHandle, ()> {
+    HANDLE.get_or_init(|| {
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let h = recorder.handle();
+        match metrics::set_global_recorder(recorder) {
+            Ok(()) => Ok(h),
+            Err(_) => Err(()),
+        }
+    })
+}
+
+/// Installs a global `metrics-rs` Prometheus recorder that captures SlateDB
+/// metrics emitted from any `LogDb` or `LogDbReader` opened in this process.
+///
+/// **Idempotent and lock-free.** Safe to call any number of times from any
+/// thread; only the first call actually installs the recorder, subsequent
+/// calls observe the cached result. Safe to call before or after
+/// `opendata_log_open` / `opendata_log_reader_open`.
+///
+/// Returns `OPENDATA_LOG_ERROR_INTERNAL` if a different `metrics-rs` recorder
+/// is already installed in the process (e.g. by another embedded Rust
+/// component). In that case `opendata_log_render_metrics` will return an
+/// empty buffer.
+#[unsafe(no_mangle)]
+pub extern "C" fn opendata_log_init_telemetry() -> opendata_log_result_t {
+    match handle() {
+        Ok(_) => success_result(),
+        Err(()) => error_result(
+            opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INTERNAL,
+            "another metrics-rs recorder is already installed in this process",
+        ),
+    }
+}
+
+/// Renders the current SlateDB metrics in Prometheus text-exposition format.
+///
+/// On success, allocates a heap buffer and writes its address and length to
+/// `*out_data` / `*out_len`. The caller owns the buffer and must release it
+/// with `opendata_log_bytes_free`.
+///
+/// Lazily initializes the recorder on first call if `opendata_log_init_telemetry`
+/// was not invoked explicitly. If a foreign `metrics-rs` recorder occupies
+/// the global slot, returns success with `*out_data = NULL` and `*out_len = 0`
+/// (an empty buffer is not an error).
+///
+/// `out_data` and `out_len` must be non-null. The function never blocks.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn opendata_log_render_metrics(
+    out_data: *mut *mut u8,
+    out_len: *mut usize,
+) -> opendata_log_result_t {
+    if out_data.is_null() || out_len.is_null() {
+        return error_result(
+            opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+            "out_data and out_len must not be null",
+        );
+    }
+
+    let (ptr, len) = match handle() {
+        Ok(h) => alloc_bytes(h.render().as_bytes()),
+        Err(()) => (std::ptr::null_mut(), 0),
+    };
+    *out_data = ptr;
+    *out_len = len;
+    success_result()
+}

--- a/log/c/tests/integration_test.rs
+++ b/log/c/tests/integration_test.rs
@@ -944,3 +944,78 @@ fn subscribe_rejects_null_out_pointer() {
     );
     assert_ok(unsafe { opendata_log_close(log) });
 }
+
+// ---- telemetry tests ----
+
+#[test]
+fn telemetry_captures_slatedb_metrics() {
+    // Install the recorder before opening the log so slatedb's metric
+    // describes land in our PrometheusRecorder. Idempotent across tests —
+    // the OnceLock makes repeat calls cheap and any order tolerable.
+    assert_ok(opendata_log_init_telemetry());
+
+    let dir = tempfile::tempdir().unwrap();
+    let os_path = CString::new(dir.path().to_str().unwrap()).unwrap();
+    let db_path = CString::new("telemetry-test").unwrap();
+
+    let mut store: *mut opendata_log_object_store_t = ptr::null_mut();
+    assert_ok(unsafe { opendata_log_object_store_local(os_path.as_ptr(), &mut store) });
+
+    let config = opendata_log_config_t {
+        storage_type: OPENDATA_LOG_STORAGE_SLATEDB,
+        slatedb_path: db_path.as_ptr(),
+        object_store: store,
+        settings_path: ptr::null(),
+        seal_interval_ms: -1,
+        read_visibility: OPENDATA_LOG_READ_VISIBILITY_MEMORY,
+    };
+    let mut log: *mut opendata_log_t = ptr::null_mut();
+    assert_ok(unsafe { opendata_log_open(&config, &mut log) });
+
+    unsafe { append_records(log, b"telemetry-key", 4) };
+    assert_ok(unsafe { opendata_log_flush(log) });
+
+    let mut data: *mut u8 = ptr::null_mut();
+    let mut len: usize = 0;
+    assert_ok(unsafe { opendata_log_render_metrics(&mut data, &mut len) });
+    assert!(!data.is_null());
+    assert!(len > 0, "rendered metrics buffer must not be empty");
+
+    let text = unsafe { std::slice::from_raw_parts(data, len) };
+    let text = std::str::from_utf8(text).expect("metrics text is utf-8");
+    assert!(
+        text.contains("slatedb_db_"),
+        "expected slatedb_db_* metric in rendered output, got:\n{text}"
+    );
+
+    unsafe { opendata_log_bytes_free(data, len) };
+
+    // Render again to exercise the steady-state path and confirm the first
+    // release didn't poison the global state.
+    let mut data2: *mut u8 = ptr::null_mut();
+    let mut len2: usize = 0;
+    assert_ok(unsafe { opendata_log_render_metrics(&mut data2, &mut len2) });
+    assert!(!data2.is_null());
+    assert!(len2 > 0);
+    unsafe { opendata_log_bytes_free(data2, len2) };
+
+    // Repeat init must be a successful no-op.
+    assert_ok(opendata_log_init_telemetry());
+
+    assert_ok(unsafe { opendata_log_close(log) });
+    assert_ok(unsafe { opendata_log_object_store_close(store) });
+}
+
+#[test]
+fn render_metrics_rejects_null_out_params() {
+    let mut data: *mut u8 = ptr::null_mut();
+    let mut len: usize = 0;
+    assert_error(
+        unsafe { opendata_log_render_metrics(ptr::null_mut(), &mut len) },
+        opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+    );
+    assert_error(
+        unsafe { opendata_log_render_metrics(&mut data, ptr::null_mut()) },
+        opendata_log_error_kind_t::OPENDATA_LOG_ERROR_INVALID_INPUT,
+    );
+}


### PR DESCRIPTION
Adds logging/telemetry hooks for observability when running anything based off the C API.