### PR TITLE
Add l0_only compaction option

### DIFF
--- a/log/rfcs/0005-compaction-and-retention.md
+++ b/log/rfcs/0005-compaction-and-retention.md
@@ -224,6 +224,11 @@ struct LogCompactionOptions {
     /// Maximum number of L0 SSTs to roll into one fresh SR per
     /// active-segment compaction.
     pub max_l0_per_compaction: usize,
+
+    /// When set, skip the sealed-segment final consolidation and keep
+    /// only L0 relief (see [Sealed segment](#sealed-segment)). Trades higher read
+    /// amplification for lower write amplification. Default: `false`.
+    pub l0_only: bool,
 }
 ```
 
@@ -367,6 +372,13 @@ for (prefix, tree) in sealed_trees(manifest) {
 
 Because no new writes land in a sealed segment, this runs once in the
 success case; if it fails or is preempted, the scheduler re-proposes it.
+
+With `l0_only` set, this final consolidation is suppressed: sealed
+segments keep whatever SRs they accumulated and are scanned as multiple
+SRs, trading higher read amplification for one fewer rewrite per record.
+L0 relief still runs on sealed segments (an L0 count pinned at
+`l0_max_ssts` would otherwise permanently fail the commit gate for any
+memtable touching the segment), so L0 stays bounded under either setting.
 
 #### Orphaned (expired) segment
 
@@ -589,3 +601,4 @@ compactor rather than keeping them with the writer.
 |------------|-------------|
 | 2026-05-20 | Initial draft. SegmentMeta-as-source-of-truth protocol: writer deletes SegmentMeta on expiry, compactor garbage-collects orphaned SlateDB segments. |
 | 2026-05-22 | Implementation: rename `l0_high_water` → `min_l0_per_compaction`; drop `live_set_refresh_interval` (deferred to standalone-compactor RFC); restate live-set propagation as a shape-dependent concern (in-process notification for embedded, storage polling for future standalone). |
+| 2026-05-29 | Add `l0_only` option: suppress sealed-segment final consolidation, keeping only L0 relief, to trade read amplification for lower write amplification. |

--- a/log/src/compaction.rs
+++ b/log/src/compaction.rs
@@ -278,7 +278,26 @@ pub(crate) fn propose_compactions(
                 }
             }
             _ => {
-                if bounds.is_some()
+                // Sealed-segment policy. With `l0_only` we skip the one-shot
+                // consolidation (L0+SRs → single SR) and only relieve L0
+                // pressure; otherwise we consolidate.
+                //
+                // L0 relief MUST run on sealed segments even under l0_only: a
+                // segment sealed with its L0 count at `l0_max_ssts` would
+                // permanently fail the L0 commit gate for any memtable that
+                // touches it (e.g. a batch crossing the seal boundary), and
+                // the active-segment branch can't drain it.
+                if options.l0_only {
+                    if segment.l0_ids.len() >= options.min_l0_per_compaction
+                        && let Some(spec) = build_active_l0_spec(
+                            segment,
+                            &mut next_sr,
+                            options.max_l0_per_compaction,
+                        )
+                    {
+                        out.push(spec);
+                    }
+                } else if bounds.is_some()
                     && !is_single_sr_steady(segment)
                     && let Some(spec) = build_consolidation_spec(segment, &mut next_sr)
                 {
@@ -720,5 +739,46 @@ mod tests {
         // Sealed id 3 was steady — must not be in the output.
         assert!(!kinds.iter().any(|(p, _)| p == &prefix_for(3)));
         assert_eq!(kinds.len(), 4);
+    }
+
+    #[test]
+    fn l0_only_skips_sealed_consolidation_but_keeps_everything_else() {
+        // Layout:
+        //   id 0: system, L0=2  → still consolidates (system path unaffected)
+        //   id 1: orphan (outside bounds) → still drained
+        //   id 2: sealed, not steady (1 L0 + 2 SRs) → would normally consolidate; SKIPPED
+        //   id 3: sealed, steady (0 L0 + 1 SR) → no work either way
+        //   id 4: active, L0 at threshold → still L0-compacts
+        let segments = vec![
+            snapshot(0, 2, &[]),
+            snapshot(1, 0, &[7]),
+            snapshot(2, 1, &[8, 9]),
+            snapshot(3, 0, &[5]),
+            snapshot(4, 4, &[]),
+        ];
+        let opts = LogCompactionOptions {
+            l0_only: true,
+            ..default_options()
+        };
+        let specs = propose_compactions(
+            &segments,
+            bounds(2, 4),
+            &ActiveCompactionsView::default(),
+            &opts,
+        );
+
+        let kinds: Vec<_> = specs
+            .iter()
+            .map(|s| (s.segment().clone(), s.is_drain()))
+            .collect();
+        // System consolidates (unaffected by l0_only).
+        assert!(kinds.contains(&(prefix_for(0), false)));
+        // Orphan drained (unaffected by l0_only).
+        assert!(kinds.contains(&(prefix_for(1), true)));
+        // Sealed non-steady id 2 is suppressed — this is the l0_only effect.
+        assert!(!kinds.iter().any(|(p, _)| p == &prefix_for(2)));
+        // Active L0 compaction proceeds.
+        assert!(kinds.contains(&(prefix_for(4), false)));
+        assert_eq!(kinds.len(), 3);
     }
 }

--- a/log/src/config.rs
+++ b/log/src/config.rs
@@ -247,6 +247,21 @@ pub struct LogCompactionOptions {
     /// Defaults to 8.
     #[serde(default = "default_max_l0_per_compaction")]
     pub max_l0_per_compaction: usize,
+
+    /// When set, skip the one-shot final consolidation that merges a sealed
+    /// segment's L0s and sorted runs into a single SR, saving one rewrite per
+    /// record at the cost of leaving sealed segments as multiple SRs. L0
+    /// relief still runs, so L0 counts stay bounded; the system segment
+    /// (id 0) and orphan drains are unaffected.
+    ///
+    /// The log is append-only, so unlike general SlateDB use there are no
+    /// updates or deletes to reconcile across L0s and SRs — the merge buys no
+    /// correctness, only read-side key locality within each SST. When writes
+    /// target a small subset of logs (low key cardinality), a single relief
+    /// pass already yields good per-SST locality, so consolidation adds
+    /// little and `l0_only` is a clear win.
+    #[serde(default)]
+    pub l0_only: bool,
 }
 
 fn default_min_l0_per_compaction() -> usize {
@@ -262,6 +277,7 @@ impl Default for LogCompactionOptions {
         Self {
             min_l0_per_compaction: default_min_l0_per_compaction(),
             max_l0_per_compaction: default_max_l0_per_compaction(),
+            l0_only: false,
         }
     }
 }
@@ -459,6 +475,7 @@ mod tests {
             compaction: LogCompactionOptions {
                 min_l0_per_compaction: 10,
                 max_l0_per_compaction: 5,
+                ..LogCompactionOptions::default()
             },
             ..Config::default()
         };
@@ -480,6 +497,7 @@ mod tests {
             compaction: LogCompactionOptions {
                 min_l0_per_compaction: 4,
                 max_l0_per_compaction: 4,
+                ..LogCompactionOptions::default()
             },
             ..Config::default()
         };

--- a/log/tests/retention_config.rs
+++ b/log/tests/retention_config.rs
@@ -70,6 +70,7 @@ async fn open_rejects_min_l0_above_max_l0() {
         compaction: LogCompactionOptions {
             min_l0_per_compaction: 10,
             max_l0_per_compaction: 5,
+            ..LogCompactionOptions::default()
         },
         ..Config::default()
     };


### PR DESCRIPTION
For the log, it's useful to be able to limit write amplification from compaction. When the number of keys is relatively low, even l0 provide can provide pretty good key-block locality. In this patch, I've added an `l0_only` option to the log's compaction config which limits the scope of compaction to just one round. This saves the final compaction that is triggered once a segment is sealed. Based on my testing, this final compaction kills throughput, so this is a nice knob when you are really trying to push the write side.