### PR TITLE
add the deletions bitmap for fts

### DIFF
--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -27,6 +27,7 @@ use crate::serde::key::{
     SeqBlockKey,
 };
 use crate::serde::posting_list::{PostingListValue, PostingUpdate};
+use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_id::{LEAF_LEVEL, ROOT_VECTOR_ID, VectorId};
 use crate::storage::VectorDbStorageReadExt;
 use crate::storage::merge_operator::VectorDbMergeOperator;
@@ -122,6 +123,9 @@ pub(crate) struct LastAppliedSnapshot {
     pub(crate) centroid_index: Arc<LeveledCentroidIndex<'static>>,
     pub(crate) centroid_cache: Arc<AllCentroidsCache>,
     pub(crate) centroid_count: usize,
+    /// FTS deletions bitmap loaded from storage after the last flush, used by
+    /// the BM25 query path to hide deleted/replaced docs without a per-query read.
+    pub(crate) fts_deletions: Arc<VectorBitmap>,
 }
 
 /// Vector database for storing and querying embedding vectors.
@@ -250,11 +254,13 @@ impl VectorDb {
             config.distance_metric,
         )
         .await?;
+        let fts_deletions = Arc::new(snapshot.get_deletions().await?);
         let last_applied_snapshot = Arc::new(Mutex::new(LastAppliedSnapshot {
             snapshot: snapshot.clone(),
             centroid_cache: Arc::new(loaded_tree.centroid_cache.cache()),
             centroid_index: loaded_tree.query_centroid_index,
             centroid_count: loaded_tree.num_leaf_centroids,
+            fts_deletions,
         }));
 
         let _ = id_allocator.freeze();
@@ -890,16 +896,20 @@ impl VectorDb {
 
     /// Create a QueryEngine from the current snapshot for executing queries.
     pub(crate) fn query_engine(&self) -> QueryEngine {
-        let (snapshot, centroid_index) = {
+        let (snapshot, centroid_index, deletions) = {
             let guard = self.last_applied_snapshot.lock().expect("lock poisoned");
-            (guard.snapshot.clone(), guard.centroid_index.clone())
+            (
+                guard.snapshot.clone(),
+                guard.centroid_index.clone(),
+                guard.fts_deletions.clone(),
+            )
         };
         let options = QueryEngineOptions {
             dimensions: self.config.dimensions,
             distance_metric: self.config.distance_metric,
             query_pruning_factor: self.config.query_pruning_factor,
         };
-        QueryEngine::new(options, centroid_index, snapshot)
+        QueryEngine::new(options, centroid_index, snapshot, deletions)
     }
 
     /// Search using brute-force centroid lookup (for diagnostics).
@@ -912,16 +922,25 @@ impl VectorDb {
     }
 
     pub async fn snapshot(&self) -> Box<dyn VectorDbRead> {
-        let (snapshot, centroid_index) = {
+        let (snapshot, centroid_index, deletions) = {
             let guard = self.last_applied_snapshot.lock().expect("lock poisoned");
-            (guard.snapshot.clone(), guard.centroid_index.clone())
+            (
+                guard.snapshot.clone(),
+                guard.centroid_index.clone(),
+                guard.fts_deletions.clone(),
+            )
         };
         let options = QueryEngineOptions {
             dimensions: self.config.dimensions,
             distance_metric: self.config.distance_metric,
             query_pruning_factor: self.config.query_pruning_factor,
         };
-        Box::new(VectorDbReader::new(options, centroid_index, snapshot)) as Box<dyn VectorDbRead>
+        Box::new(VectorDbReader::new(
+            options,
+            centroid_index,
+            snapshot,
+            deletions,
+        )) as Box<dyn VectorDbRead>
     }
 }
 

--- a/vector/src/query_engine.rs
+++ b/vector/src/query_engine.rs
@@ -10,6 +10,7 @@ use crate::serde::field_stats::FieldStatsValue;
 use crate::serde::key::{FieldStatsKey, TermPostingsKey, TermStatsKey};
 use crate::serde::term_postings::{PostingEntry, TermPostingsValue};
 use crate::serde::term_stats::TermStatsValue;
+use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_data::VectorDataValue;
 use crate::serde::vector_id::VectorId;
 use crate::storage::VectorDbStorageReadExt;
@@ -45,6 +46,10 @@ pub(crate) struct QueryEngine {
     options: QueryEngineOptions,
     centroid_index: Arc<LeveledCentroidIndex<'static>>,
     storage: Arc<dyn StorageRead>,
+    /// FTS deletions bitmap published by the flusher, used by the BM25 query
+    /// path to hide deleted/replaced docs without a per-query storage read.
+    #[allow(dead_code)]
+    deletions: Arc<VectorBitmap>,
 }
 
 impl QueryEngine {
@@ -52,11 +57,13 @@ impl QueryEngine {
         options: QueryEngineOptions,
         centroid_index: Arc<LeveledCentroidIndex<'static>>,
         storage: Arc<dyn StorageRead>,
+        deletions: Arc<VectorBitmap>,
     ) -> Self {
         Self {
             options,
             centroid_index,
             storage,
+            deletions,
         }
     }
 
@@ -363,6 +370,17 @@ impl QueryEngine {
                 continue;
             }
 
+            // The in-memory FTS deletions bitmap is the authority for delete
+            // resolution on this path. `doc_id` is the raw internal id from
+            // the posting, which is the same id space the bitmap indexes
+            // (data vectors are level 0, so the raw u64 equals
+            // `VectorId::data_vector_id(doc_id).id()`). Skip deleted/replaced
+            // docs before paying the scoring cost; this — not the forward
+            // index — hides deleted documents.
+            if self.deletions.contains(doc_id) {
+                continue;
+            }
+
             // Single BM25 evaluation per document.
             let score = bm25::score(&hits, avgdl);
 
@@ -374,37 +392,36 @@ impl QueryEngine {
                 continue;
             }
 
-            // TODO(rfc-0006 milestone 1): once the FTS deletions bitmap is
-            // available, defer this lookup until after the loop and consult
-            // the bitmap inline here instead. With the bitmap we only need
-            // the forward index for the K survivors, not for every scored
-            // candidate.
-            let id = VectorId::data_vector_id(doc_id);
-            let Some(vector_data) = self.storage.get_vector_data(id, dimensions).await? else {
-                continue;
-            };
-
             // The bound check above already guaranteed this entry beats the
             // current worst when the heap is full, so just evict and push.
+            // We defer the forward-index `get_vector_data` lookup until after
+            // the loop so it runs only for the K survivors rather than every
+            // scored candidate.
             if top_k.len() == query.limit {
                 top_k.pop();
             }
-            top_k.push(WorstFirst {
-                score,
-                doc_id,
-                vector_data,
+            top_k.push(WorstFirst { score, doc_id });
+        }
+
+        // Fetch the forward-index `VectorData` for only the K survivors. The
+        // deletions bitmap above already resolved deletes, so the get None
+        // branch is a defensive fallback (e.g. a concurrent compaction) rather
+        // than the primary delete mechanism.
+        let mut results: Vec<SearchResult> = Vec::with_capacity(top_k.len());
+        for candidate in top_k.into_iter() {
+            let vector_id = VectorId::data_vector_id(candidate.doc_id);
+            let Some(vector_data) = self.storage.get_vector_data(vector_id, dimensions).await?
+            else {
+                continue;
+            };
+            results.push(SearchResult {
+                score: candidate.score,
+                vector: Self::vector_data_to_vector(&vector_data),
             });
         }
 
-        // Drain top-K and order results: descending score, ties broken by
-        // ascending doc id (matches the existing ANN ordering convention).
-        let mut results: Vec<SearchResult> = top_k
-            .into_iter()
-            .map(|e| SearchResult {
-                score: e.score,
-                vector: Self::vector_data_to_vector(&e.vector_data),
-            })
-            .collect();
+        // Order results: descending score, ties broken by ascending doc id
+        // (matches the existing ANN ordering convention).
         results.sort_by(|a, b| {
             b.score
                 .partial_cmp(&a.score)
@@ -893,10 +910,13 @@ fn window_for(doc_id: u64) -> (u64, u64) {
 
 /// Top-K candidate ordered so `BinaryHeap::peek()` returns the worst
 /// (lowest-score, highest-doc-id) entry — the one to evict next.
+///
+/// Only the score and `doc_id` are carried through the scoring loop; the
+/// forward-index `VectorData` is fetched lazily for the K survivors after the
+/// loop completes (see `search_bm25`).
 struct WorstFirst {
     score: f32,
     doc_id: u64,
-    vector_data: VectorDataValue,
 }
 
 impl PartialEq for WorstFirst {

--- a/vector/src/reader.rs
+++ b/vector/src/reader.rs
@@ -10,6 +10,7 @@ use crate::db::VectorDbRead;
 use crate::error::{Error, Result};
 use crate::model::{Query, ReaderConfig, SearchOptions, SearchResult};
 use crate::query_engine::{QueryEngine, QueryEngineOptions};
+use crate::serde::vector_bitmap::VectorBitmap;
 use crate::storage::VectorDbStorageReadExt;
 use crate::storage::merge_operator::VectorDbMergeOperator;
 use crate::write::indexer::tree::centroids::{
@@ -33,6 +34,9 @@ pub struct VectorDbReader {
     options: QueryEngineOptions,
     centroid_index: Arc<LeveledCentroidIndex<'static>>,
     storage: Arc<dyn StorageRead>,
+    /// FTS deletions bitmap loaded at open time. The reader only supports
+    /// static dbs, so this is loaded once and shared with each QueryEngine.
+    deletions: Arc<VectorBitmap>,
 }
 
 impl VectorDbReader {
@@ -79,18 +83,22 @@ impl VectorDbReader {
             query_pruning_factor: config.query_pruning_factor,
         };
 
-        Ok(Self::new(options, centroid_index, storage))
+        let deletions = Arc::new(storage.get_deletions().await?);
+
+        Ok(Self::new(options, centroid_index, storage, deletions))
     }
 
     pub(crate) fn new(
         options: QueryEngineOptions,
         centroid_index: Arc<LeveledCentroidIndex<'static>>,
         storage: Arc<dyn StorageRead>,
+        deletions: Arc<VectorBitmap>,
     ) -> Self {
         Self {
             options,
             centroid_index,
             storage,
+            deletions,
         }
     }
 
@@ -111,6 +119,7 @@ impl VectorDbReader {
             self.options.clone(),
             self.centroid_index.clone(),
             self.storage.clone(),
+            self.deletions.clone(),
         )
     }
 }

--- a/vector/src/serde/deletions.rs
+++ b/vector/src/serde/deletions.rs
@@ -1,0 +1,160 @@
+//! `Deletions` value encoding/decoding for FTS (RFC-0006).
+//!
+//! A singleton record whose value is a [`VectorBitmap`] (RoaringTreemap) of the
+//! internal vector ids that have been deleted or replaced. Deletes are applied
+//! via merge operands that UNION their bitmaps into the running set, so writes
+//! never require a read-modify-write.
+//!
+//! ## Value Layout
+//!
+//! ```text
+//! ┌─────────────────────────────────────────────┐
+//! │  vector_ids: RoaringTreemap serialization    │
+//! └─────────────────────────────────────────────┘
+//! ```
+//!
+//! ## Merge Semantics
+//!
+//! Each merge operand contributes a bitmap of deleted ids. The merge operator
+//! unions all operand bitmaps plus any existing value into a single bitmap.
+
+use bytes::Bytes;
+
+use super::EncodingError;
+use super::vector_bitmap::VectorBitmap;
+
+/// Singleton set of deleted/replaced internal vector ids.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub(crate) struct DeletionsValue(pub(crate) VectorBitmap);
+
+impl DeletionsValue {
+    pub(crate) fn new(bitmap: VectorBitmap) -> Self {
+        Self(bitmap)
+    }
+
+    pub(crate) fn encode_to_bytes(&self) -> Result<Bytes, EncodingError> {
+        self.0.encode_to_bytes()
+    }
+
+    pub(crate) fn decode_from_bytes(buf: &[u8]) -> Result<Self, EncodingError> {
+        Ok(Self(VectorBitmap::decode_from_bytes(buf)?))
+    }
+}
+
+/// Union existing + all operands into a single deletions bitmap.
+///
+/// Starts from the existing value (or empty) and unions every operand. A decode
+/// failure panics rather than being skipped: dropping a deletions operand would
+/// resurrect an already-deleted vector on the query path, so we fail loudly and
+/// preserve the data instead.
+pub(crate) fn merge_batch_deletions(existing: Option<Bytes>, operands: &[Bytes]) -> Bytes {
+    let mut merged = VectorBitmap::new();
+    if let Some(b) = existing {
+        let v = DeletionsValue::decode_from_bytes(&b)
+            .expect("Failed to decode existing DeletionsValue");
+        merged.union_with(&v.0);
+    }
+    for op in operands {
+        let v =
+            DeletionsValue::decode_from_bytes(op).expect("Failed to decode operand DeletionsValue");
+        merged.union_with(&v.0);
+    }
+    DeletionsValue::new(merged)
+        .encode_to_bytes()
+        .expect("Failed to serialize merged DeletionsValue")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_round_trip_deletions_value() {
+        // given
+        let mut bitmap = VectorBitmap::new();
+        bitmap.insert(1);
+        bitmap.insert(100);
+        bitmap.insert(u64::MAX);
+        let value = DeletionsValue::new(bitmap);
+
+        // when
+        let encoded = value.encode_to_bytes().unwrap();
+        let decoded = DeletionsValue::decode_from_bytes(&encoded).unwrap();
+
+        // then
+        assert_eq!(decoded, value);
+        assert!(decoded.0.contains(1));
+        assert!(decoded.0.contains(100));
+        assert!(decoded.0.contains(u64::MAX));
+    }
+
+    #[test]
+    fn should_union_existing_and_operands() {
+        // given - existing {1, 2}, operands {2, 3} (overlap) and {10, 11} (disjoint)
+        let existing = DeletionsValue::new(VectorBitmap::from_treemap({
+            let mut t = roaring::RoaringTreemap::new();
+            t.insert(1);
+            t.insert(2);
+            t
+        }))
+        .encode_to_bytes()
+        .unwrap();
+        let op0 = DeletionsValue::new(VectorBitmap::from_treemap({
+            let mut t = roaring::RoaringTreemap::new();
+            t.insert(2);
+            t.insert(3);
+            t
+        }))
+        .encode_to_bytes()
+        .unwrap();
+        let op1 = DeletionsValue::new(VectorBitmap::from_treemap({
+            let mut t = roaring::RoaringTreemap::new();
+            t.insert(10);
+            t.insert(11);
+            t
+        }))
+        .encode_to_bytes()
+        .unwrap();
+
+        // when
+        let merged = merge_batch_deletions(Some(existing), &[op0, op1]);
+        let decoded = DeletionsValue::decode_from_bytes(&merged).unwrap();
+
+        // then
+        assert_eq!(decoded.0.len(), 5);
+        for id in [1, 2, 3, 10, 11] {
+            assert!(decoded.0.contains(id), "missing {}", id);
+        }
+    }
+
+    #[test]
+    fn should_union_operands_only() {
+        // given - no existing value; operands overlap on 3
+        let op0 = DeletionsValue::new(VectorBitmap::from_treemap({
+            let mut t = roaring::RoaringTreemap::new();
+            t.insert(3);
+            t.insert(4);
+            t
+        }))
+        .encode_to_bytes()
+        .unwrap();
+        let op1 = DeletionsValue::new(VectorBitmap::from_treemap({
+            let mut t = roaring::RoaringTreemap::new();
+            t.insert(3);
+            t.insert(7);
+            t
+        }))
+        .encode_to_bytes()
+        .unwrap();
+
+        // when
+        let merged = merge_batch_deletions(None, &[op0, op1]);
+        let decoded = DeletionsValue::decode_from_bytes(&merged).unwrap();
+
+        // then
+        assert_eq!(decoded.0.len(), 3);
+        for id in [3, 4, 7] {
+            assert!(decoded.0.contains(id), "missing {}", id);
+        }
+    }
+}

--- a/vector/src/serde/key.rs
+++ b/vector/src/serde/key.rs
@@ -80,6 +80,44 @@ impl Default for CentroidsKey {
     }
 }
 
+/// Deletions key - singleton record storing the FTS deletions bitmap.
+///
+/// Key layout: `[subsystem | version | tag]` (3 bytes)
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeletionsKey;
+
+impl RecordKey for DeletionsKey {
+    const RECORD_TYPE: RecordType = RecordType::Deletions;
+}
+
+impl DeletionsKey {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn encode(&self) -> Bytes {
+        let mut buf = BytesMut::with_capacity(3);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
+        buf.freeze()
+    }
+
+    pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
+        if buf.len() < PREFIX_AND_TAG_LEN {
+            return Err(EncodingError {
+                message: "Buffer too short for DeletionsKey".to_string(),
+            });
+        }
+        validate_key_prefix::<Self>(buf)?;
+        Ok(DeletionsKey)
+    }
+}
+
+impl Default for DeletionsKey {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// PostingList key - maps centroid ID to vector IDs.
 ///
 /// Key layout: `[subsystem | version | tag | centroid_id:u64-BE]` (11 bytes)
@@ -789,6 +827,20 @@ mod tests {
         // when
         let encoded = key.encode();
         let decoded = CentroidsKey::decode(&encoded).unwrap();
+
+        // then
+        assert_eq!(decoded, key);
+        assert_eq!(encoded.len(), 3);
+    }
+
+    #[test]
+    fn should_round_trip_deletions_key() {
+        // given
+        let key = DeletionsKey::new();
+
+        // when
+        let encoded = key.encode();
+        let decoded = DeletionsKey::decode(&encoded).unwrap();
 
         // then
         assert_eq!(decoded, key);

--- a/vector/src/serde/mod.rs
+++ b/vector/src/serde/mod.rs
@@ -6,6 +6,7 @@ pub mod centroid_info;
 pub mod centroid_stats;
 pub mod centroids;
 pub mod collection_meta;
+pub(crate) mod deletions;
 pub(crate) mod field_stats;
 pub mod id_dictionary;
 pub mod key;
@@ -58,6 +59,8 @@ pub enum RecordType {
     CentroidStats = 0x09,
     Centroids = 0x0A,
     CentroidInfo = 0x0B,
+    /// FTS deletions bitmap — singleton RoaringTreemap of deleted vector ids.
+    Deletions = 0x0C,
     /// FTS term postings or term stats (discriminated by trailing key byte).
     FtsTerm = 0x0D,
     /// FTS per-vector field length stats.
@@ -86,6 +89,7 @@ impl RecordType {
             0x09 => Ok(RecordType::CentroidStats),
             0x0A => Ok(RecordType::Centroids),
             0x0B => Ok(RecordType::CentroidInfo),
+            0x0C => Ok(RecordType::Deletions),
             0x0D => Ok(RecordType::FtsTerm),
             0x0E => Ok(RecordType::FtsVectorFieldStats),
             0x0F => Ok(RecordType::FtsFieldStats),
@@ -771,6 +775,7 @@ mod tests {
             RecordType::CentroidStats,
             RecordType::Centroids,
             RecordType::CentroidInfo,
+            RecordType::Deletions,
             RecordType::FtsTerm,
             RecordType::FtsVectorFieldStats,
             RecordType::FtsFieldStats,

--- a/vector/src/storage/merge_operator.rs
+++ b/vector/src/storage/merge_operator.rs
@@ -4,6 +4,7 @@
 //! record type encoded in the key.
 
 use crate::serde::centroid_stats::CentroidStatsValue;
+use crate::serde::deletions::merge_batch_deletions;
 use crate::serde::field_stats::merge_batch_field_stats;
 use crate::serde::key::{TERM_POSTINGS_DISCRIMINATOR, TERM_STATS_DISCRIMINATOR};
 use crate::serde::metadata_index::MetadataIndexValue;
@@ -43,6 +44,7 @@ impl common::storage::MergeOperator for VectorDbMergeOperator {
                 merge_batch_posting_list(existing_value, operands, self.dimensions)
             }
             RecordType::CentroidStats => merge_batch_centroid_stats(existing_value, operands),
+            RecordType::Deletions => merge_batch_deletions(existing_value, operands),
             RecordType::FtsTerm => match key.last().copied() {
                 Some(TERM_POSTINGS_DISCRIMINATOR) => {
                     merge_batch_term_postings(existing_value, operands)
@@ -120,9 +122,13 @@ fn merge_batch_centroid_stats(existing: Option<Bytes>, operands: &[Bytes]) -> By
 mod tests {
     use super::*;
     use crate::serde::FieldValue;
-    use crate::serde::key::{CentroidStatsKey, IdDictionaryKey, MetadataIndexKey, PostingListKey};
+    use crate::serde::deletions::DeletionsValue;
+    use crate::serde::key::{
+        CentroidStatsKey, DeletionsKey, IdDictionaryKey, MetadataIndexKey, PostingListKey,
+    };
     use crate::serde::metadata_index::MetadataIndexValue;
     use crate::serde::posting_list::{PostingListValue, PostingUpdate};
+    use crate::serde::vector_bitmap::VectorBitmap;
     use crate::serde::vector_id::VectorId;
     use common::storage::MergeOperator;
     use roaring::RoaringTreemap;
@@ -344,6 +350,35 @@ mod tests {
         // then
         let decoded = CentroidStatsValue::decode_from_bytes(&merged).unwrap();
         assert_eq!(decoded.num_vectors, 12);
+    }
+
+    #[test]
+    fn should_route_deletions_to_bitmap_union_merge() {
+        // given
+        let operator = VectorDbMergeOperator::new(3);
+        let key = DeletionsKey::new().encode();
+
+        let mut existing_bitmap = VectorBitmap::new();
+        existing_bitmap.insert(1);
+        existing_bitmap.insert(2);
+        let existing_value = DeletionsValue::new(existing_bitmap)
+            .encode_to_bytes()
+            .unwrap();
+
+        let mut new_bitmap = VectorBitmap::new();
+        new_bitmap.insert(2);
+        new_bitmap.insert(3);
+        let new_value = DeletionsValue::new(new_bitmap).encode_to_bytes().unwrap();
+
+        // when
+        let merged = operator.merge_batch(&key, Some(existing_value), &[new_value]);
+
+        // then - union of {1,2} and {2,3} is {1,2,3}
+        let decoded = DeletionsValue::decode_from_bytes(&merged).unwrap();
+        assert_eq!(decoded.0.len(), 3);
+        for id in [1, 2, 3] {
+            assert!(decoded.0.contains(id), "missing {}", id);
+        }
     }
 
     #[test]

--- a/vector/src/storage/mod.rs
+++ b/vector/src/storage/mod.rs
@@ -5,13 +5,15 @@ use crate::error::{Error, Result};
 use crate::serde::centroid_info::CentroidInfoValue;
 use crate::serde::centroid_stats::CentroidStatsValue;
 use crate::serde::centroids::CentroidsValue;
+use crate::serde::deletions::DeletionsValue;
 use crate::serde::id_dictionary::IdDictionaryValue;
 use crate::serde::key::{
-    CentroidInfoKey, CentroidStatsKey, CentroidsKey, IdDictionaryKey, MetadataIndexKey,
-    PostingListKey, VectorDataKey, VectorIndexDataKey,
+    CentroidInfoKey, CentroidStatsKey, CentroidsKey, DeletionsKey, IdDictionaryKey,
+    MetadataIndexKey, PostingListKey, VectorDataKey, VectorIndexDataKey,
 };
 use crate::serde::metadata_index::MetadataIndexValue;
 use crate::serde::posting_list::PostingListValue;
+use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_data::VectorDataValue;
 use crate::serde::vector_id::{ROOT_VECTOR_ID, VectorId};
 use crate::serde::vector_index_data::VectorIndexDataValue;
@@ -244,6 +246,24 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
                 Ok(value)
             }
             None => Ok(MetadataIndexValue::new()),
+        }
+    }
+
+    /// Load the singleton FTS deletions bitmap.
+    ///
+    /// Returns a bitmap of internal vector IDs that have been deleted or
+    /// replaced. Returns an empty bitmap if the record does not exist yet.
+    async fn get_deletions(&self) -> Result<VectorBitmap> {
+        let key = DeletionsKey::new().encode();
+        let record = self.get(key).await?;
+        match record {
+            Some(record) => {
+                let value = DeletionsValue::decode_from_bytes(&record.value).map_err(|e| {
+                    Error::Encoding(format!("failed to decode DeletionsValue: {e}"))
+                })?;
+                Ok(value.0)
+            }
+            None => Ok(VectorBitmap::new()),
         }
     }
 }

--- a/vector/src/write/flusher.rs
+++ b/vector/src/write/flusher.rs
@@ -1,4 +1,5 @@
 use crate::db::LastAppliedSnapshot;
+use crate::storage::VectorDbStorageReadExt;
 use crate::write::delta::{VectorDbDeltaView, VectorDbOpDelta};
 use crate::write::indexer::tree::centroids::{
     CachedCentroidReader, CentroidCache, LeveledCentroidIndex, StoredCentroidReader,
@@ -113,6 +114,7 @@ impl VectorDbFlusher {
 
         let snapshot = self.storage.snapshot().await.map_err(|e| e.to_string())?;
         self.validate(snapshot.clone()).await;
+        let fts_deletions = Arc::new(snapshot.get_deletions().await.map_err(|e| e.to_string())?);
         let stored_reader = StoredCentroidReader::new(
             self.opts.dimensions as usize,
             snapshot.clone(),
@@ -132,6 +134,7 @@ impl VectorDbFlusher {
             centroid_cache: index_outputs.centroid_cache,
             centroid_index: Arc::new(query_centroid_index),
             centroid_count: index_outputs.leaf_centroids,
+            fts_deletions,
         };
         self.last_snapshot = snapshot.clone();
         self.last_snapshot_epoch = snapshot_epoch;
@@ -297,6 +300,7 @@ mod tests {
                 centroid_cache: cache,
                 centroid_index: query_centroid_index,
                 centroid_count: 1,
+                fts_deletions: Arc::new(crate::serde::vector_bitmap::VectorBitmap::new()),
             })),
         )
     }

--- a/vector/src/write/indexer/tree/merge.rs
+++ b/vector/src/write/indexer/tree/merge.rs
@@ -303,7 +303,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let merge = MergeCentroids::new(&opts, level, &snapshot, 1);
         let (reassignments, merge_count) = merge.execute(&h.state, &mut delta).await.unwrap();
         h.apply_delta(delta).await;
@@ -374,7 +374,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let merge = MergeCentroids::new(&opts, level, &snapshot, 1);
         let (reassignments, merge_count) = merge.execute(&h.state, &mut delta).await.unwrap();
 
@@ -413,7 +413,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let merge = MergeCentroids::new(&opts, level, &snapshot, 1);
         let (reassignments, merge_count) = merge.execute(&h.state, &mut delta).await.unwrap();
 
@@ -431,7 +431,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let (reassignments, merge_count) = MergeCentroids::new(&opts, level, &snapshot, 1)
             .execute(&h.state, &mut delta)
             .await
@@ -503,7 +503,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let (reassignments, merge_count) = MergeCentroids::new(&opts, level, &snapshot, 1)
             .execute(&h.state, &mut delta)
             .await
@@ -530,7 +530,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let (reassignments, merge_count) = MergeCentroids::new(&opts, level, &snapshot, 1)
             .execute(&h.state, &mut delta)
             .await

--- a/vector/src/write/indexer/tree/mod.rs
+++ b/vector/src/write/indexer/tree/mod.rs
@@ -59,11 +59,12 @@ pub(crate) struct IndexerOpts {
     pub(crate) indexed_fields: HashSet<String>,
     /// Names of fields declared with `FieldType::Text` (RFC-0006).
     ///
-    /// Currently informational: the Indexer drives FTS updates from each
-    /// `VectorWrite.text_attribute_summaries`, which is pre-populated by the
-    /// write path. Carrying the set here lets future milestones (e.g. delete
-    /// handling) discover text fields without re-reading `CollectionMeta`.
-    #[allow(dead_code)]
+    /// The Indexer drives FTS updates from each
+    /// `VectorWrite.text_attribute_summaries` (pre-populated by the write
+    /// path); this set lets it discover, without re-reading `CollectionMeta`,
+    /// whether the collection uses FTS at all. When empty, the `FtsIndexDelta`
+    /// freezes to a no-op so non-FTS collections don't pay the deletions
+    /// bitmap's storage overhead.
     pub(crate) text_fields: HashSet<String>,
 }
 
@@ -159,7 +160,11 @@ impl Indexer {
         );
         let update_start = Instant::now();
         let mut stats = IndexerStats::default();
-        let mut delta = VectorIndexDelta::new(&self.state);
+        // Gate FTS index emission on whether the collection actually declares
+        // text fields; without them the delta freezes to a no-op (see
+        // `FtsIndexDelta::freeze`), sparing non-FTS collections the deletions
+        // bitmap's storage overhead.
+        let mut delta = VectorIndexDelta::new(&self.state, !self.opts.text_fields.is_empty());
 
         let batch = WriteVectors::new(&self.opts, &snapshot, snapshot_epoch, ops);
         let batch_start = Instant::now();

--- a/vector/src/write/indexer/tree/root.rs
+++ b/vector/src/write/indexer/tree/root.rs
@@ -146,7 +146,7 @@ mod tests {
         let original_root_count = h.state.root_centroid_count();
 
         // when
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         SplitRoot::new(&opts, &snapshot, 1)
             .execute(&mut delta, &h.state)
             .await
@@ -174,7 +174,7 @@ mod tests {
         .await;
         let opts = create_opts(4);
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
 
         // when:
         SplitRoot::new(&opts, &snapshot, 1)

--- a/vector/src/write/indexer/tree/split.rs
+++ b/vector/src/write/indexer/tree/split.rs
@@ -753,7 +753,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let split = SplitCentroids::new(&opts, level, &snapshot, 1);
         let result = split.execute(&h.state, &mut delta).await.unwrap();
         assert_eq!(result.splits.len(), 1);
@@ -838,7 +838,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let split = SplitCentroids::new(&opts, level, &snapshot, 1);
         let result = split.execute(&h.state, &mut delta).await.unwrap();
         assert_eq!(result.splits.len(), 1);
@@ -911,7 +911,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let split = SplitCentroids::new(&opts, level, &snapshot, 1);
         let result = split.execute(&h.state, &mut delta).await.unwrap();
 
@@ -938,7 +938,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let split = SplitCentroids::new_with_max_splits_and_clustering(
             &opts,
             level,
@@ -993,7 +993,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let split = SplitCentroids::new_with_max_splits_and_clustering(
             &opts,
             level,
@@ -1049,7 +1049,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let split = SplitCentroids::new(&opts, level, &snapshot, 1);
         let result = split.execute(&h.state, &mut delta).await.unwrap();
         assert_eq!(result.splits.len(), 1);
@@ -1102,7 +1102,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let split = SplitCentroids::new_with_max_splits_and_clustering(
             &opts,
             level,
@@ -1168,7 +1168,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let split = SplitCentroids::new_with_max_splits_and_clustering(
             &opts,
             level,

--- a/vector/src/write/indexer/tree/state.rs
+++ b/vector/src/write/indexer/tree/state.rs
@@ -5,15 +5,17 @@ use crate::serde::centroid_info::CentroidInfoValue;
 use crate::serde::centroid_stats::CentroidStatsValue;
 use crate::serde::centroids::CentroidsValue;
 use crate::serde::collection_meta::DistanceMetric;
+use crate::serde::deletions::DeletionsValue;
 use crate::serde::field_stats::FieldStatsValue;
 use crate::serde::key::{
-    CentroidInfoKey, CentroidStatsKey, CentroidsKey, FieldStatsKey, PostingListKey,
+    CentroidInfoKey, CentroidStatsKey, CentroidsKey, DeletionsKey, FieldStatsKey, PostingListKey,
     TermPostingsKey, TermStatsKey, VectorDataKey,
 };
 use crate::serde::metadata_index::MetadataIndexValue;
 use crate::serde::posting_list::{PostingListValue, PostingUpdate};
 use crate::serde::term_postings::{PostingEntry, TermPostingsValue};
 use crate::serde::term_stats::TermStatsValue;
+use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_data::{Field, VectorDataValue};
 use crate::serde::vector_id::{ROOT_VECTOR_ID, VectorId};
 use crate::serde::vector_index_data::VectorIndexDataValue;
@@ -610,11 +612,26 @@ pub(crate) struct FtsIndexDelta {
     term_doc_freq_delta: HashMap<(String, String), i64>,
     /// field -> (doc-count delta, total-length delta).
     field_stats_delta: HashMap<String, (i64, i64)>,
+    /// Internal vector ids deleted or replaced in this batch. On freeze these
+    /// are merged into the singleton `Deletions` bitmap so the BM25 query path
+    /// can hide them without retracting postings/term-stats.
+    deleted_vector_ids: VectorBitmap,
+    /// Whether the collection declares any `FieldType::Text` field. Supplied at
+    /// construction from `IndexerOpts.text_fields`. When false, [`freeze`] emits
+    /// nothing: a collection with no text fields has no postings to hide, so
+    /// writing the deletions bitmap (the only record a non-FTS batch would
+    /// produce) is pure storage overhead.
+    ///
+    /// [`freeze`]: FtsIndexDelta::freeze
+    has_text_fields: bool,
 }
 
 impl FtsIndexDelta {
-    fn new() -> Self {
-        Self::default()
+    fn new(has_text_fields: bool) -> Self {
+        Self {
+            has_text_fields,
+            ..Default::default()
+        }
     }
 
     /// Append every `(field, term)` posting from a single document.
@@ -653,11 +670,26 @@ impl FtsIndexDelta {
         }
     }
 
+    /// Record an internal vector id as deleted or replaced. On freeze the
+    /// accumulated set is merged into the singleton `Deletions` bitmap.
+    pub(crate) fn add_deleted_vector_id(&mut self, vector_id: VectorId) {
+        self.deleted_vector_ids.insert(vector_id.id());
+    }
+
     fn freeze(self, output_ops: &mut Vec<RecordOp>) {
+        // No text fields means no postings to hide on the query path, so there
+        // is nothing worth recording — not even the deletions bitmap. Skip all
+        // FTS emission to avoid imposing storage overhead on non-FTS users.
+        if !self.has_text_fields {
+            return;
+        }
+
         let FtsIndexDelta {
             term_postings,
             term_doc_freq_delta,
             field_stats_delta,
+            deleted_vector_ids,
+            has_text_fields: _,
         } = self;
 
         for ((field, term), entries) in term_postings {
@@ -685,6 +717,14 @@ impl FtsIndexDelta {
             let value = FieldStatsValue::new(count_delta, total_delta, 0).encode_to_bytes();
             output_ops.push(RecordOp::Merge(Record::new(key, value).into()));
         }
+
+        if !deleted_vector_ids.is_empty() {
+            let key = DeletionsKey::new().encode();
+            let value = DeletionsValue::new(deleted_vector_ids)
+                .encode_to_bytes()
+                .expect("Failed to serialize DeletionsValue");
+            output_ops.push(RecordOp::Merge(Record::new(key, value).into()));
+        }
     }
 }
 
@@ -696,11 +736,14 @@ pub(crate) struct VectorIndexDelta {
 }
 
 impl VectorIndexDelta {
-    pub(crate) fn new(state: &VectorIndexState) -> Self {
+    /// `has_text_fields` records whether the collection declares any
+    /// `FieldType::Text` field; when false the FTS sub-delta freezes to a no-op
+    /// (see [`FtsIndexDelta::freeze`]).
+    pub(crate) fn new(state: &VectorIndexState, has_text_fields: bool) -> Self {
         Self {
             forward_index: ForwardIndexDelta::new(state),
             search_index: SearchIndexDelta::new(state),
-            fts_index: FtsIndexDelta::new(),
+            fts_index: FtsIndexDelta::new(has_text_fields),
         }
     }
 
@@ -956,6 +999,34 @@ mod tests {
 
     const DIMS: usize = 2;
     const EPOCH: u64 = 1;
+
+    #[test]
+    fn should_emit_no_fts_ops_when_collection_has_no_text_fields() {
+        // given - a delta for a collection with no text fields, plus a delete
+        let mut delta = FtsIndexDelta::new(false);
+        delta.add_deleted_vector_id(VectorId::data_vector_id(7));
+
+        // when
+        let mut ops = Vec::new();
+        delta.freeze(&mut ops);
+
+        // then - freeze is a no-op: no deletions bitmap (or any FTS record)
+        assert!(ops.is_empty());
+    }
+
+    #[test]
+    fn should_emit_deletions_when_collection_has_text_fields() {
+        // given - the same delete, but the collection declares text fields
+        let mut delta = FtsIndexDelta::new(true);
+        delta.add_deleted_vector_id(VectorId::data_vector_id(7));
+
+        // when
+        let mut ops = Vec::new();
+        delta.freeze(&mut ops);
+
+        // then - the deletions bitmap merge is emitted
+        assert_eq!(ops.len(), 1);
+    }
 
     async fn setup() -> (Arc<dyn Storage>, VectorIndexState) {
         setup_with_prefill(0, 1).await
@@ -1877,7 +1948,7 @@ mod tests {
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
         let delta_id = VectorId::data_vector_id(99);
-        let mut delta = VectorIndexDelta::new(&state);
+        let mut delta = VectorIndexDelta::new(&state, false);
         delta
             .forward_index
             .dictionary_updates
@@ -1901,7 +1972,7 @@ mod tests {
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
-        let delta = VectorIndexDelta::new(&state);
+        let delta = VectorIndexDelta::new(&state, false);
         let snapshot: Arc<dyn StorageRead> = storage.snapshot().await.unwrap();
         let view = vector_index_view(&delta, &state, &snapshot);
 
@@ -1919,7 +1990,7 @@ mod tests {
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
-        let mut delta = VectorIndexDelta::new(&state);
+        let mut delta = VectorIndexDelta::new(&state, false);
         delta.forward_index.delete_vector(vector_id);
         let snapshot: Arc<dyn StorageRead> = storage.snapshot().await.unwrap();
         let view = vector_index_view(&delta, &state, &snapshot);
@@ -1938,7 +2009,7 @@ mod tests {
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
-        let mut delta = VectorIndexDelta::new(&state);
+        let mut delta = VectorIndexDelta::new(&state, false);
         delta
             .forward_index
             .vector_updates
@@ -1963,7 +2034,7 @@ mod tests {
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
-        let delta = VectorIndexDelta::new(&state);
+        let delta = VectorIndexDelta::new(&state, false);
         let snapshot: Arc<dyn StorageRead> = storage.snapshot().await.unwrap();
         let view = vector_index_view(&delta, &state, &snapshot);
 
@@ -1984,7 +2055,7 @@ mod tests {
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
-        let mut delta = VectorIndexDelta::new(&state);
+        let mut delta = VectorIndexDelta::new(&state, false);
         delta.forward_index.delete_vector(vector_id);
         let snapshot: Arc<dyn StorageRead> = storage.snapshot().await.unwrap();
         let view = vector_index_view(&delta, &state, &snapshot);
@@ -2003,7 +2074,7 @@ mod tests {
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
-        let mut delta = VectorIndexDelta::new(&state);
+        let mut delta = VectorIndexDelta::new(&state, false);
         delta.forward_index.update_vector_index_data(
             vector_id,
             vec![leaf_centroid(2), leaf_centroid(3)],
@@ -2029,7 +2100,7 @@ mod tests {
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
-        let delta = VectorIndexDelta::new(&state);
+        let delta = VectorIndexDelta::new(&state, false);
         let snapshot: Arc<dyn StorageRead> = storage.snapshot().await.unwrap();
         let view = vector_index_view(&delta, &state, &snapshot);
 
@@ -2052,7 +2123,7 @@ mod tests {
         state
             .centroid_counts
             .insert(level.level(), HashMap::from([(existing, 5), (deleted, 2)]));
-        let mut delta = VectorIndexDelta::new(&state);
+        let mut delta = VectorIndexDelta::new(&state, false);
         delta
             .search_index
             .centroid_count_deltas
@@ -2074,7 +2145,7 @@ mod tests {
         let (storage, state) = setup().await;
         let vector_id = VectorId::data_vector_id(42);
         let centroid_id = leaf_centroid(7);
-        let mut delta = VectorIndexDelta::new(&state);
+        let mut delta = VectorIndexDelta::new(&state, false);
         delta
             .search_index
             .current_posting

--- a/vector/src/write/indexer/tree/test_utils.rs
+++ b/vector/src/write/indexer/tree/test_utils.rs
@@ -162,7 +162,7 @@ impl IndexerOpTestHarnessBuilder {
             centroid_cache,
         );
 
-        let mut delta = VectorIndexDelta::new(&state);
+        let mut delta = VectorIndexDelta::new(&state, false);
 
         let mut centroid_ids: Vec<_> = self.vectors.keys().copied().collect();
         centroid_ids.sort();
@@ -302,7 +302,7 @@ impl IndexerOpTestHarness {
             assert_attributes_conform_to_schema(&self.vector_schema, &write.attributes);
         }
         let snapshot = self.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&self.state);
+        let mut delta = VectorIndexDelta::new(&self.state, false);
         let ops = vec![VectorDbOp::Write(writes)];
         let wv = WriteVectors::new(opts, &snapshot, SNAPSHOT_EPOCH, ops);
         wv.execute(&self.state, &mut delta).await.unwrap();
@@ -311,7 +311,7 @@ impl IndexerOpTestHarness {
 
     pub async fn delete_and_apply(&mut self, opts: &Arc<IndexerOpts>, ids: Vec<String>) -> usize {
         let snapshot = self.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&self.state);
+        let mut delta = VectorIndexDelta::new(&self.state, false);
         let ops = vec![VectorDbOp::Delete(ids)];
         let wv = WriteVectors::new(opts, &snapshot, SNAPSHOT_EPOCH, ops);
         let (_inserts, _updates, deletes) = wv.execute(&self.state, &mut delta).await.unwrap();

--- a/vector/src/write/indexer/tree/validator.rs
+++ b/vector/src/write/indexer/tree/validator.rs
@@ -856,6 +856,7 @@ mod tests {
             centroid_cache: query_cache,
             centroid_index: Arc::new(centroid_index),
             centroid_count: 0,
+            fts_deletions: Arc::new(crate::serde::vector_bitmap::VectorBitmap::new()),
         }
     }
 

--- a/vector/src/write/indexer/tree/vector.rs
+++ b/vector/src/write/indexer/tree/vector.rs
@@ -198,6 +198,9 @@ impl WriteVectors {
                     ))
                 })?;
             delta.forward_index.delete_vector(old_vector_id);
+            // RFC-0006: hide the replaced internal id on the FTS query path via
+            // the Deletions bitmap (postings/term-stats are left in place).
+            delta.fts_index.add_deleted_vector_id(old_vector_id);
             for old_centroid in old_vector_index_data.postings {
                 delta
                     .search_index
@@ -247,6 +250,9 @@ impl WriteVectors {
             delta
                 .forward_index
                 .delete_external_id_and_vector(external_id, vector_id);
+            // RFC-0006: hide the deleted internal id on the FTS query path via
+            // the Deletions bitmap (postings/term-stats are left in place).
+            delta.fts_index.add_deleted_vector_id(vector_id);
             for old_centroid in old_vector_index_data.postings {
                 delta
                     .search_index
@@ -834,7 +840,7 @@ mod tests {
         let id_b = h.storage.lookup_internal_id("b").await.unwrap().unwrap();
         let id_c = h.storage.lookup_internal_id("c").await.unwrap().unwrap();
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let depth = TreeDepth::of(h.state.centroids_meta().depth);
         let level = TreeLevel::leaf(depth);
         let old_centroid = centroid_id(CENTROID_ID_NUM);
@@ -896,7 +902,7 @@ mod tests {
 
         // when
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let rv = ReassignVectors::new(&opts, &snapshot, 1, reassignments, level);
         rv.execute(&h.state, &mut delta).await.unwrap();
         let ops = delta.freeze(1, &mut h.state);
@@ -918,7 +924,7 @@ mod tests {
             .await;
         let id_a = h.storage.lookup_internal_id("a").await.unwrap().unwrap();
         let snapshot = h.snapshot().await;
-        let mut delta = VectorIndexDelta::new(&h.state);
+        let mut delta = VectorIndexDelta::new(&h.state, false);
         let depth = TreeDepth::of(h.state.centroids_meta().depth);
         let level = TreeLevel::leaf(depth);
         let old_centroid = centroid_id(CENTROID_ID_NUM);

--- a/vector/tests/text_search.rs
+++ b/vector/tests/text_search.rs
@@ -161,6 +161,123 @@ async fn should_return_text_field_by_default_in_bm25_results() {
 }
 
 #[tokio::test]
+async fn should_exclude_deleted_documents_from_bm25_results() {
+    // given - several docs where a subset contain "quick"
+    let db = VectorDb::open(make_db_config()).await.unwrap();
+    db.write(vec![
+        doc("d1", "quick brown fox jumps over the lazy dog"),
+        doc("d2", "a quick rabbit hops across the green meadow"),
+        doc("d3", "the quick otter slides down the muddy bank"),
+        doc("d4", "slow turtle naps under a warm rock all day"),
+        doc("d5", "calm river flows gently past the old mill"),
+    ])
+    .await
+    .unwrap();
+    db.flush().await.unwrap();
+
+    // sanity - "quick" matches the three quick docs and excludes the rest
+    let results = db
+        .search(&Query::bm25("body", "quick").with_limit(10))
+        .await
+        .unwrap();
+    let ids: Vec<&str> = results.iter().map(|r| r.vector.id.as_str()).collect();
+    assert!(ids.contains(&"d1"), "expected d1 present, got {:?}", ids);
+    assert!(ids.contains(&"d2"), "expected d2 present, got {:?}", ids);
+    assert!(ids.contains(&"d3"), "expected d3 present, got {:?}", ids);
+    assert!(!ids.contains(&"d4"), "expected d4 absent, got {:?}", ids);
+    assert!(!ids.contains(&"d5"), "expected d5 absent, got {:?}", ids);
+
+    // when - delete one of the matching docs and flush
+    db.delete(vec!["d2"]).await.unwrap();
+    db.flush().await.unwrap();
+
+    let results = db
+        .search(&Query::bm25("body", "quick").with_limit(10))
+        .await
+        .unwrap();
+    let ids: Vec<&str> = results.iter().map(|r| r.vector.id.as_str()).collect();
+
+    // then - the deleted doc is gone, the other matching docs remain
+    assert!(
+        !ids.contains(&"d2"),
+        "expected deleted d2 to be absent from results, got {:?}",
+        ids
+    );
+    assert!(
+        ids.contains(&"d1"),
+        "expected d1 to still be present, got {:?}",
+        ids
+    );
+    assert!(
+        ids.contains(&"d3"),
+        "expected d3 to still be present, got {:?}",
+        ids
+    );
+
+    // and - scores remain non-increasing (sensible ranking)
+    for window in results.windows(2) {
+        assert!(
+            window[0].score >= window[1].score,
+            "expected non-increasing BM25 scores, got {} then {}",
+            window[0].score,
+            window[1].score,
+        );
+    }
+}
+
+#[tokio::test]
+async fn should_reflect_upsert_in_bm25_results() {
+    // given - a doc whose body contains "quick"
+    let db = VectorDb::open(make_db_config()).await.unwrap();
+    db.write(vec![doc("d1", "quick brown fox jumps high")])
+        .await
+        .unwrap();
+    db.flush().await.unwrap();
+
+    let results = db
+        .search(&Query::bm25("body", "quick").with_limit(10))
+        .await
+        .unwrap();
+    let ids: Vec<&str> = results.iter().map(|r| r.vector.id.as_str()).collect();
+    assert!(
+        ids.contains(&"d1"),
+        "expected d1 present before upsert, got {:?}",
+        ids
+    );
+
+    // when - upsert d1 with a body that does NOT contain "quick"
+    db.write(vec![doc("d1", "sleepy badger digs a deep burrow")])
+        .await
+        .unwrap();
+    db.flush().await.unwrap();
+
+    // then - d1 is absent from "quick" results (old internal id hidden by the
+    // deletions bitmap, new internal id has no "quick" posting)
+    let results = db
+        .search(&Query::bm25("body", "quick").with_limit(10))
+        .await
+        .unwrap();
+    let ids: Vec<&str> = results.iter().map(|r| r.vector.id.as_str()).collect();
+    assert!(
+        !ids.contains(&"d1"),
+        "expected upserted d1 to be absent from 'quick' results, got {:?}",
+        ids
+    );
+
+    // and - a query for a term in the new body returns d1
+    let results = db
+        .search(&Query::bm25("body", "badger").with_limit(10))
+        .await
+        .unwrap();
+    let ids: Vec<&str> = results.iter().map(|r| r.vector.id.as_str()).collect();
+    assert!(
+        ids.contains(&"d1"),
+        "expected d1 to match a term from its new body, got {:?}",
+        ids
+    );
+}
+
+#[tokio::test]
 async fn should_respect_field_projection_for_bm25_results() {
     // given
     let db = VectorDb::open(make_db_config()).await.unwrap();


### PR DESCRIPTION
## Summary

- adds storage format for deletions bitmap
- write to the deletions bitmap when indexing
- use the deletions bitmap to filter candidates when scoring

## Test Plan

unit + e2e tests

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
