### PR TITLE
[vector] query engine: filter via PreparedFilter

### DIFF
--- a/vector/src/query_engine/filter.rs
+++ b/vector/src/query_engine/filter.rs
@@ -1,3 +1,300 @@
 //! Prepared query filter (`PreparedFilter`).
 //!
-//! Populated in a later refactor step; see `query-engine-refactor.md`.
+//! Lowers a [`Filter`] AST into precomputed metadata bitmaps so the query
+//! drivers can answer per-document membership with a cheap
+//! [`PreparedFilter::matches`] check. Negations are kept as exclusion bitmaps
+//! rather than complemented positive sets, so building a filter never has to
+//! enumerate the entire corpus universe.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use common::storage::StorageRead;
+use roaring::RoaringTreemap;
+
+use crate::error::Result;
+use crate::model::{AttributeValue, Filter};
+use crate::serde::FieldValue;
+use crate::storage::VectorDbStorageReadExt;
+
+/// Executable form of a query [`Filter`].
+///
+/// A document matches when it is present in `positive` (or `positive` is
+/// `None`, meaning "no positive constraint") and absent from every bitmap in
+/// `negative`. Equivalently, the matching set is `positive ∩ ¬(⋃ negative)`.
+pub(crate) struct PreparedFilter {
+    /// Documents allowed by the positive (union/intersection) part of the
+    /// filter. `None` imposes no positive constraint (matches all ids).
+    positive: Option<RoaringTreemap>,
+    /// Documents excluded by negations. A document matches only if it is
+    /// absent from every bitmap here.
+    negative: Vec<RoaringTreemap>,
+}
+
+/// A subtree collapsed to a single concrete bitmap while combining `Or`
+/// branches. `Pos(s)` matches ids in `s`; `Neg(s)` matches ids *not* in `s`.
+enum Single {
+    Pos(RoaringTreemap),
+    Neg(RoaringTreemap),
+}
+
+impl PreparedFilter {
+    /// Build a prepared filter from an optional filter expression. `None`
+    /// matches every document.
+    pub(crate) async fn build(expr: Option<&Filter>, storage: &dyn StorageRead) -> Result<Self> {
+        match expr {
+            None => Ok(Self::match_all()),
+            Some(filter) => Self::build_expr(filter, storage).await,
+        }
+    }
+
+    /// Returns `true` if `doc_id` satisfies the filter.
+    pub(crate) fn matches(&self, doc_id: u64) -> bool {
+        if let Some(positive) = &self.positive
+            && !positive.contains(doc_id)
+        {
+            return false;
+        }
+        self.negative
+            .iter()
+            .all(|excluded| !excluded.contains(doc_id))
+    }
+
+    /// No positive constraint and no exclusions: matches everything.
+    fn match_all() -> Self {
+        Self {
+            positive: None,
+            negative: Vec::new(),
+        }
+    }
+
+    /// Empty positive set: matches nothing.
+    fn match_none() -> Self {
+        Self {
+            positive: Some(RoaringTreemap::new()),
+            negative: Vec::new(),
+        }
+    }
+
+    fn build_expr<'a>(
+        filter: &'a Filter,
+        storage: &'a dyn StorageRead,
+    ) -> Pin<Box<dyn Future<Output = Result<Self>> + Send + 'a>> {
+        Box::pin(async move {
+            match filter {
+                Filter::Eq(field, value) => Ok(Self {
+                    positive: Some(load_eq(field, value, storage).await?),
+                    negative: Vec::new(),
+                }),
+                Filter::In(field, values) => {
+                    let mut set = RoaringTreemap::new();
+                    for value in values {
+                        set |= &load_eq(field, value, storage).await?;
+                    }
+                    Ok(Self {
+                        positive: Some(set),
+                        negative: Vec::new(),
+                    })
+                }
+                Filter::Neq(field, value) => Ok(Self {
+                    positive: None,
+                    negative: vec![load_eq(field, value, storage).await?],
+                }),
+                Filter::And(filters) => {
+                    let mut acc = Self::match_all();
+                    for child in filters {
+                        acc = acc.and(Self::build_expr(child, storage).await?);
+                    }
+                    Ok(acc)
+                }
+                Filter::Or(filters) => {
+                    let mut iter = filters.iter();
+                    let Some(first) = iter.next() else {
+                        // An empty `Or` matches nothing.
+                        return Ok(Self::match_none());
+                    };
+                    let mut acc = Self::build_expr(first, storage).await?;
+                    for child in iter {
+                        acc = acc.or(Self::build_expr(child, storage).await?);
+                    }
+                    Ok(acc)
+                }
+            }
+        })
+    }
+
+    /// Intersect two prepared filters (`self AND other`).
+    ///
+    /// `(P1 ∩ ¬N1) ∩ (P2 ∩ ¬N2) = (P1 ∩ P2) ∩ ¬(N1 ∪ N2)`, so positives
+    /// intersect and negatives concatenate.
+    fn and(self, other: Self) -> Self {
+        let Self {
+            positive: p1,
+            mut negative,
+        } = self;
+        let Self {
+            positive: p2,
+            negative: n2,
+        } = other;
+        let positive = match (p1, p2) {
+            (Some(mut a), Some(b)) => {
+                a &= &b;
+                Some(a)
+            }
+            (Some(a), None) | (None, Some(a)) => Some(a),
+            (None, None) => None,
+        };
+        negative.extend(n2);
+        Self { positive, negative }
+    }
+
+    /// Union two prepared filters (`self OR other`).
+    ///
+    /// Each side is first collapsed to a single concrete bitmap so the union
+    /// can be computed with set operations alone — no corpus universe needed.
+    fn or(self, other: Self) -> Self {
+        match (self.into_single(), other.into_single()) {
+            (Single::Pos(mut a), Single::Pos(b)) => {
+                a |= &b;
+                Self {
+                    positive: Some(a),
+                    negative: Vec::new(),
+                }
+            }
+            // a ∨ ¬t = ¬(t − a)
+            (Single::Pos(a), Single::Neg(mut t)) | (Single::Neg(mut t), Single::Pos(a)) => {
+                t -= &a;
+                Self {
+                    positive: None,
+                    negative: vec![t],
+                }
+            }
+            // ¬a ∨ ¬b = ¬(a ∩ b)
+            (Single::Neg(mut a), Single::Neg(b)) => {
+                a &= &b;
+                Self {
+                    positive: None,
+                    negative: vec![a],
+                }
+            }
+        }
+    }
+
+    /// Collapse to a single concrete bitmap by folding the negatives into the
+    /// positive: `Some(p)` → `Pos(p − ⋃neg)`, `None` → `Neg(⋃neg)`.
+    fn into_single(self) -> Single {
+        let mut excluded = RoaringTreemap::new();
+        for bitmap in &self.negative {
+            excluded |= bitmap;
+        }
+        match self.positive {
+            Some(mut positive) => {
+                positive -= &excluded;
+                Single::Pos(positive)
+            }
+            None => Single::Neg(excluded),
+        }
+    }
+}
+
+/// Load the metadata-index bitmap for a single `field = value` pair.
+async fn load_eq(
+    field: &str,
+    value: &AttributeValue,
+    storage: &dyn StorageRead,
+) -> Result<RoaringTreemap> {
+    let field_value: FieldValue = value.clone().into();
+    let bitmap = storage.get_metadata_index(field, field_value).await?;
+    Ok(bitmap.effective_vector_ids())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A positive leaf (`Eq`/`In`-like): matches exactly `ids`.
+    fn pos(ids: &[u64]) -> PreparedFilter {
+        PreparedFilter {
+            positive: Some(ids.iter().copied().collect()),
+            negative: Vec::new(),
+        }
+    }
+
+    /// A negated leaf (`Neq`-like): matches everything except `ids`.
+    fn neg(ids: &[u64]) -> PreparedFilter {
+        PreparedFilter {
+            positive: None,
+            negative: vec![ids.iter().copied().collect()],
+        }
+    }
+
+    /// Collect which ids in `0..=universe` the filter matches.
+    fn matching(filter: &PreparedFilter, universe: u64) -> Vec<u64> {
+        (0..=universe).filter(|&id| filter.matches(id)).collect()
+    }
+
+    #[test]
+    fn should_match_all_when_no_filter() {
+        let filter = PreparedFilter::match_all();
+        assert_eq!(matching(&filter, 4), vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn should_match_nothing_for_empty_positive() {
+        let filter = PreparedFilter::match_none();
+        assert!(matching(&filter, 4).is_empty());
+    }
+
+    #[test]
+    fn should_intersect_positives_on_and() {
+        // {1,2,3} AND {2,3,4} -> {2,3}
+        let filter = pos(&[1, 2, 3]).and(pos(&[2, 3, 4]));
+        assert_eq!(matching(&filter, 5), vec![2, 3]);
+    }
+
+    #[test]
+    fn should_exclude_on_and_with_neg() {
+        // {1,2,3} AND NOT {2} -> {1,3}
+        let filter = pos(&[1, 2, 3]).and(neg(&[2]));
+        assert_eq!(matching(&filter, 5), vec![1, 3]);
+    }
+
+    #[test]
+    fn should_union_positives_on_or() {
+        // {1,2} OR {3,4} -> {1,2,3,4}
+        let filter = pos(&[1, 2]).or(pos(&[3, 4]));
+        assert_eq!(matching(&filter, 5), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn should_handle_neg_under_or() {
+        // {1} OR NOT {1,2} == NOT {2}: everything except 2.
+        let filter = pos(&[1]).or(neg(&[1, 2]));
+        assert_eq!(matching(&filter, 4), vec![0, 1, 3, 4]);
+    }
+
+    #[test]
+    fn should_match_all_when_pos_covers_neg_under_or() {
+        // {1,2} OR NOT {2} == everything (id 2 is rescued by the positive).
+        let filter = pos(&[1, 2]).or(neg(&[2]));
+        assert_eq!(matching(&filter, 4), vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn should_intersect_negs_under_or() {
+        // NOT {1} OR NOT {2} == NOT ({1} ∩ {2}) == NOT {} == everything.
+        let filter = neg(&[1]).or(neg(&[2]));
+        assert_eq!(matching(&filter, 4), vec![0, 1, 2, 3, 4]);
+
+        // NOT {1,2} OR NOT {2,3} == NOT {2}: only id 2 is excluded.
+        let filter = neg(&[1, 2]).or(neg(&[2, 3]));
+        assert_eq!(matching(&filter, 4), vec![0, 1, 3, 4]);
+    }
+
+    #[test]
+    fn should_handle_nested_and_or() {
+        // ({1,2,3} AND NOT {3}) OR {5} -> {1,2,5}
+        let filter = pos(&[1, 2, 3]).and(neg(&[3])).or(pos(&[5]));
+        assert_eq!(matching(&filter, 6), vec![1, 2, 5]);
+    }
+}

--- a/vector/src/query_engine/mod.rs
+++ b/vector/src/query_engine/mod.rs
@@ -9,9 +9,8 @@ use crate::error::{Error, Result};
 use crate::math::bm25 as bm25_math;
 use crate::math::distance;
 use crate::metric_names::{QUERY_SEARCH_DURATION_SECONDS, QUERY_VECTORS_SCORED_TOTAL};
-use crate::model::{
-    Bm25Query, FieldSelection, Filter, Query, ScoreBy, SearchOptions, SearchResult,
-};
+use crate::model::{Bm25Query, FieldSelection, Query, ScoreBy, SearchOptions, SearchResult};
+use crate::query_engine::filter::PreparedFilter;
 use crate::serde::collection_meta::DistanceMetric;
 use crate::serde::field_stats::FieldStatsValue;
 use crate::serde::key::{FieldStatsKey, TermPostingsKey, TermStatsKey};
@@ -26,7 +25,6 @@ use crate::write::indexer::tree::centroids::{LeveledCentroidIndex, search_centro
 use crate::write::indexer::tree::posting_list::{Posting, PostingList};
 use crate::{Attribute, Vector};
 use common::storage::StorageRead;
-use roaring::RoaringTreemap;
 use std::cmp::{Ordering, Reverse};
 use std::collections::{BinaryHeap, HashSet};
 use std::sync::Arc;
@@ -166,8 +164,10 @@ impl QueryEngine {
         }
 
         // Apply metadata filter
-        if let Some(filter) = &query.filter {
-            Self::apply_filter(&mut sorted_lists, filter, self.storage.as_ref()).await?;
+        let prepared_filter =
+            PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
+        for list in sorted_lists.iter_mut() {
+            list.retain(|candidate| prepared_filter.matches(candidate.internal_id.id()));
         }
 
         let mut results = self.resolve_top_k(sorted_lists, query.limit).await?;
@@ -249,8 +249,10 @@ impl QueryEngine {
         }
 
         // 6. Apply metadata filter (if provided)
-        if let Some(filter) = &query.filter {
-            Self::apply_filter(&mut sorted_lists, filter, self.storage.as_ref()).await?;
+        let prepared_filter =
+            PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
+        for list in sorted_lists.iter_mut() {
+            list.retain(|candidate| prepared_filter.matches(candidate.internal_id.id()));
         }
 
         // 7. K-way merge and resolve top-k forward index lookups
@@ -307,19 +309,11 @@ impl QueryEngine {
             }
         }
 
-        // Filter window: re-evaluate the filter bitmap over a chunk of doc
-        // ids at a time so we never materialise the full corpus universe.
-        // `low` is inclusive; as the loop walks lower we recompute the window
-        // containing the current doc id in one step (no sliding).
-        let mut filter_window: Option<FilterWindow> = match &query.filter {
-            None => None,
-            Some(filter) => {
-                let top = head_heap.peek().expect("streams non-empty").doc_id;
-                let (low, high) = window_for(top);
-                let bitmap = self.recompute_filter_window(filter, low, high).await?;
-                Some(FilterWindow { low, high, bitmap })
-            }
-        };
+        // Prepared metadata filter. `matches` answers per-doc membership
+        // without materialising the full corpus universe, so the BM25 loop can
+        // check each candidate as it is scored.
+        let prepared_filter =
+            PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
 
         // Min-heap (via `WorstFirst` ordering) tracking the K worst candidates
         // accepted so far. `peek()` is the candidate to evict.
@@ -356,24 +350,9 @@ impl QueryEngine {
                 }
             }
 
-            // Refresh the chunked filter window if we've walked past it.
-            // The windows are aligned to multiples of `FILTER_WINDOW_SIZE`,
-            // so the window containing `doc_id` is reachable in one step.
-            if let Some(filter) = query.filter.as_ref()
-                && let Some(window) = filter_window.as_mut()
-                && doc_id < window.low
-            {
-                let (low, high) = window_for(doc_id);
-                window.bitmap = self.recompute_filter_window(filter, low, high).await?;
-                window.low = low;
-                window.high = high;
-            }
-
             // Apply the metadata filter BEFORE scoring so excluded docs
             // don't pay the BM25 cost.
-            if let Some(window) = filter_window.as_ref()
-                && !window.bitmap.contains(doc_id)
-            {
+            if !prepared_filter.matches(doc_id) {
                 continue;
             }
 
@@ -468,25 +447,6 @@ impl QueryEngine {
             streams.push(PostingStream::new(entries, bm25_math::idf(n_docs, n_t)));
         }
         Ok(streams)
-    }
-
-    /// Evaluate the query filter for a single `[low, high]` doc-id window.
-    ///
-    /// The universe used for `Filter::Neq` complement is the full inclusive
-    /// `[low, high]` range — `RoaringTreemap::insert_range` materialises this
-    /// in O(window_size / 2^16) bitmap containers, which is much cheaper than
-    /// scanning every posting stream just to collect doc ids. Doc ids outside
-    /// the streams never reach the membership check, so widening the
-    /// universe is safe.
-    async fn recompute_filter_window(
-        &self,
-        filter: &Filter,
-        low: u64,
-        high: u64,
-    ) -> Result<RoaringTreemap> {
-        let mut universe = RoaringTreemap::new();
-        universe.insert_range(low..=high);
-        Self::evaluate_filter(filter, &universe, self.storage.as_ref()).await
     }
 
     async fn load_field_stats(&self, field: &str) -> Result<FieldStatsValue> {
@@ -718,91 +678,6 @@ impl QueryEngine {
             }
         }
     }
-
-    /// Apply a metadata filter to scored candidate lists.
-    ///
-    /// Collects all candidate IDs into a bitmap, evaluates the filter against
-    /// the inverted index, then retains only candidates that pass the filter.
-    async fn apply_filter(
-        sorted_lists: &mut [Vec<ScoredCandidate>],
-        filter: &Filter,
-        storage: &dyn StorageRead,
-    ) -> Result<()> {
-        // Collect all candidate internal IDs
-        let mut candidates = RoaringTreemap::new();
-        for list in sorted_lists.iter() {
-            for candidate in list {
-                candidates.insert(candidate.internal_id.id());
-            }
-        }
-
-        // Evaluate filter to get allowed IDs
-        let allowed = Self::evaluate_filter(filter, &candidates, storage).await?;
-
-        // Filter each list
-        for list in sorted_lists.iter_mut() {
-            list.retain(|c| allowed.contains(c.internal_id.id()));
-        }
-
-        Ok(())
-    }
-
-    /// Recursively evaluate a filter against the metadata inverted index.
-    ///
-    /// Returns a bitmap of vector IDs that match the filter.
-    /// For Neq, the `candidates` bitmap is used as the universe for complement.
-    fn evaluate_filter<'a>(
-        filter: &'a Filter,
-        candidates: &'a RoaringTreemap,
-        storage: &'a dyn StorageRead,
-    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<RoaringTreemap>> + Send + 'a>>
-    {
-        Box::pin(async move {
-            match filter {
-                Filter::Eq(field, value) => {
-                    let field_value: crate::serde::FieldValue = value.clone().into();
-                    let bitmap = storage.get_metadata_index(field, field_value).await?;
-                    Ok(bitmap.effective_vector_ids())
-                }
-                Filter::Neq(field, value) => {
-                    let field_value: crate::serde::FieldValue = value.clone().into();
-                    let bitmap = storage.get_metadata_index(field, field_value).await?;
-                    let mut result = candidates.clone();
-                    result -= &bitmap.effective_vector_ids();
-                    Ok(result)
-                }
-                Filter::In(field, values) => {
-                    let mut result = RoaringTreemap::new();
-                    for value in values {
-                        let field_value: crate::serde::FieldValue = value.clone().into();
-                        let bitmap = storage.get_metadata_index(field, field_value).await?;
-                        result |= &bitmap.effective_vector_ids();
-                    }
-                    Ok(result)
-                }
-                Filter::And(filters) => {
-                    if filters.is_empty() {
-                        return Ok(candidates.clone());
-                    }
-                    let mut result =
-                        Self::evaluate_filter(&filters[0], candidates, storage).await?;
-                    for f in &filters[1..] {
-                        let sub = Self::evaluate_filter(f, candidates, storage).await?;
-                        result &= &sub;
-                    }
-                    Ok(result)
-                }
-                Filter::Or(filters) => {
-                    let mut result = RoaringTreemap::new();
-                    for f in filters {
-                        let sub = Self::evaluate_filter(f, candidates, storage).await?;
-                        result |= &sub;
-                    }
-                    Ok(result)
-                }
-            }
-        })
-    }
 }
 
 struct ScoredCandidate {
@@ -889,30 +764,6 @@ impl PartialOrd for StreamHead {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
-}
-
-/// Width of the doc-id window used to materialise the metadata-filter
-/// allow-list. Tuned so the universe roughly matches a SlateDB scan unit.
-const FILTER_WINDOW_SIZE: u64 = 10_000;
-
-/// Cached filter allow-list for an inclusive `[low, high]` doc-id window.
-struct FilterWindow {
-    /// Inclusive lower bound (zero when the window covers down to id 0).
-    low: u64,
-    /// Inclusive upper bound — the highest `doc_id` covered by `bitmap`.
-    high: u64,
-    /// Allow-list emitted by `evaluate_filter` for the doc ids in
-    /// `[low, high]`.
-    bitmap: RoaringTreemap,
-}
-
-/// Returns the `[low, high]` filter window containing `doc_id`. Windows are
-/// aligned to multiples of [`FILTER_WINDOW_SIZE`], so the loop can jump to
-/// the window covering any current doc id in one step.
-fn window_for(doc_id: u64) -> (u64, u64) {
-    let low = doc_id - (doc_id % FILTER_WINDOW_SIZE);
-    let high = low.saturating_add(FILTER_WINDOW_SIZE - 1);
-    (low, high)
 }
 
 /// Top-K candidate ordered so `BinaryHeap::peek()` returns the worst


### PR DESCRIPTION
## Summary

Changes filters to use `PreparedFilter` that evaluates each document against prepared bitmaps

## What does this PR do?

Introduces PreparedFilter in query_engine/filter.rs: it lowers the Filter AST into precomputed bitmaps and answers per-document membership with a cheap matches(doc_id) check. This keeps the filter logic simpler, and (for now) we have to load the full filters anyway.

Replace both filtering paths with PreparedFilter::matches:
- ANN (search_ann, search_exact_nprobe): retain scored candidates that match, dropping the apply_filter/evaluate_filter candidate-bitmap machinery.
- BM25 (search_bm25): drop the 10K-wide filter-window logic and check matches(doc_id) before scoring.

## Test Plan

- unit tests for `PreparedFilter`

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
