### PR TITLE
[vector] query engine: split bm25/ann search into chain of operators

### DIFF
--- a/vector/src/query_engine/ann.rs
+++ b/vector/src/query_engine/ann.rs
@@ -1,3 +1,568 @@
-//! ANN query driver (`AnnQueryDriver` / `AnnExhaustiveQueryDriver`).
+//! ANN source operators (`ANNOperator` / `ExhaustiveNNOperator`).
 //!
-//! Populated in a later refactor step; see `query-engine-refactor.md`.
+//! Both score a query vector against the candidates in a set of probed
+//! centroids and emit ranked [`ScoredVectorId`]s — the leaf of the vector
+//! search chain (`{ANNOperator | ExhaustiveNNOperator} -> LookupOperator ->
+//! ProjectOperator`). They differ only in how they pick which centroids to
+//! probe:
+//!
+//! - [`ANNOperator`] routes the query through the centroid index and probes the
+//!   `nprobe` nearest centroids (the default approximate path).
+//! - [`ExhaustiveNNOperator`] scores every centroid and keeps the `nprobe`
+//!   nearest (brute-force centroid selection, used by `search_exact_nprobe`).
+//!
+//! Forward-index lookups and field projection are deferred to the downstream
+//! operators. Deleted/replaced vectors are already removed from the centroid
+//! posting lists at write time, so — unlike the FTS path — no deletions bitmap
+//! is consulted here.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use common::storage::StorageRead;
+use tracing::debug;
+
+use crate::error::{Error, Result};
+use crate::math::distance::{self, VectorDistance};
+use crate::metric_names::QUERY_VECTORS_SCORED_TOTAL;
+use crate::query_engine::collectors::{Collector, TopK};
+use crate::query_engine::filter::PreparedFilter;
+use crate::query_engine::operator::Operator;
+use crate::query_engine::types::{Score, ScoredVectorId};
+use crate::serde::collection_meta::DistanceMetric;
+use crate::serde::vector_id::VectorId;
+use crate::storage::VectorDbStorageReadExt;
+use crate::write::indexer::tree::centroids::{LeveledCentroidIndex, search_centroids};
+use crate::write::indexer::tree::posting_list::{Posting, PostingList};
+
+use super::QueryEngineOptions;
+
+/// How a source picks which centroids to probe.
+#[derive(Clone, Copy)]
+enum Probe {
+    /// Probe the `nprobe` nearest centroids via the centroid index.
+    Nearest,
+    /// Score every centroid, then keep the `nprobe` nearest.
+    Exhaustive,
+}
+
+/// Shared state and scoring core for the two ANN source operators.
+///
+/// Owns everything needed to score one query independently of the rest of the
+/// engine so the enclosing future stays `Send + 'static`.
+struct AnnSource {
+    storage: Arc<dyn StorageRead>,
+    centroid_index: Arc<LeveledCentroidIndex<'static>>,
+    options: QueryEngineOptions,
+    /// The raw (un-normalized) query vector; normalized per-metric in `run`.
+    query_vector: Vec<f32>,
+    filter: PreparedFilter,
+    nprobe: usize,
+    limit: usize,
+}
+
+impl AnnSource {
+    /// Validate + normalize the query, probe centroids, score their posting
+    /// lists, and collect the ranked survivors.
+    async fn execute(&self, probe: Probe) -> Result<Vec<ScoredVectorId<VectorDistance>>> {
+        // 1. Validate query dimensions.
+        if self.query_vector.len() != self.options.dimensions as usize {
+            return Err(Error::InvalidInput(format!(
+                "Query dimension mismatch: expected {}, got {}",
+                self.options.dimensions,
+                self.query_vector.len()
+            )));
+        }
+
+        // 2. Normalize the query vector if the metric requires it.
+        let mut query = self.query_vector.clone();
+        self.options.distance_metric.normalize_if_needed(&mut query);
+
+        // 3. Pick (and dynamically prune) the centroids to probe.
+        let centroid_ids = select_centroids(
+            self.centroid_index.as_ref(),
+            &self.options,
+            &query,
+            self.nprobe,
+            probe,
+        )
+        .await?;
+        if centroid_ids.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // 4. Load the posting lists and score every candidate vector.
+        let scored = load_and_score(&self.storage, &self.options, &centroid_ids, &query).await?;
+
+        // 5. Apply the metadata filter and dedup candidates that appear in more
+        //    than one probed centroid (boundary replication), keeping each id's
+        //    best (most similar) distance.
+        let mut best: HashMap<VectorId, VectorDistance> = HashMap::new();
+        for (id, dist) in scored {
+            if !self.filter.matches(id.id()) {
+                continue;
+            }
+            best.entry(id)
+                .and_modify(|existing| {
+                    if dist < *existing {
+                        *existing = dist;
+                    }
+                })
+                .or_insert(dist);
+        }
+
+        // 6. Stream the deduped candidates into the shared top-k collector.
+        //    `VectorDistance` is the `Score` type, so it carries the
+        //    most-similar-first ordering directly — `TopK` ranks correctly with
+        //    no score transform.
+        let mut collector: TopK<VectorDistance> = TopK::new(self.limit);
+        for (&id, &dist) in &best {
+            collector.collect(ScoredVectorId {
+                val: id,
+                score: dist,
+            });
+        }
+        Ok(collector.finish())
+    }
+}
+
+/// Approximate nearest-neighbour source: probes the `nprobe` nearest centroids.
+pub(crate) struct ANNOperator(AnnSource);
+
+impl ANNOperator {
+    pub(crate) fn new(
+        storage: Arc<dyn StorageRead>,
+        centroid_index: Arc<LeveledCentroidIndex<'static>>,
+        options: QueryEngineOptions,
+        query_vector: Vec<f32>,
+        filter: PreparedFilter,
+        nprobe: usize,
+        limit: usize,
+    ) -> Self {
+        Self(AnnSource {
+            storage,
+            centroid_index,
+            options,
+            query_vector,
+            filter,
+            nprobe,
+            limit,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Operator<Vec<ScoredVectorId<VectorDistance>>> for ANNOperator {
+    async fn execute(&self) -> Result<Vec<ScoredVectorId<VectorDistance>>> {
+        self.0.execute(Probe::Nearest).await
+    }
+}
+
+/// Exhaustive nearest-neighbour source: scores every centroid, then keeps the
+/// `nprobe` nearest before scoring their posting lists.
+pub(crate) struct ExhaustiveNNOperator(AnnSource);
+
+impl ExhaustiveNNOperator {
+    pub(crate) fn new(
+        storage: Arc<dyn StorageRead>,
+        centroid_index: Arc<LeveledCentroidIndex<'static>>,
+        options: QueryEngineOptions,
+        query_vector: Vec<f32>,
+        filter: PreparedFilter,
+        nprobe: usize,
+        limit: usize,
+    ) -> Self {
+        Self(AnnSource {
+            storage,
+            centroid_index,
+            options,
+            query_vector,
+            filter,
+            nprobe,
+            limit,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Operator<Vec<ScoredVectorId<VectorDistance>>> for ExhaustiveNNOperator {
+    async fn execute(&self) -> Result<Vec<ScoredVectorId<VectorDistance>>> {
+        self.0.execute(Probe::Exhaustive).await
+    }
+}
+
+/// Select and dynamically prune the centroids to probe for one query.
+async fn select_centroids(
+    centroid_index: &LeveledCentroidIndex<'static>,
+    options: &QueryEngineOptions,
+    query: &[f32],
+    nprobe: usize,
+    probe: Probe,
+) -> Result<Vec<VectorId>> {
+    let candidates = match probe {
+        Probe::Nearest => search_centroids(centroid_index, query, nprobe).await?,
+        Probe::Exhaustive => {
+            // Score every centroid (closest first), then keep `nprobe`.
+            let mut all = search_centroids(centroid_index, query, usize::MAX).await?;
+            all.truncate(nprobe);
+            all
+        }
+    };
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+    Ok(prune_centroids(options, &candidates, query))
+}
+
+/// Apply query-aware dynamic pruning
+/// (SPANN §3.2: https://arxiv.org/pdf/2111.08566).
+///
+/// Given candidate centroids (already sorted closest-first), computes the raw
+/// distance from the query to each and keeps only those satisfying
+/// `dist(q, c) <= (1 + epsilon) * dist(q, closest)`. With pruning disabled
+/// (`None`), returns every candidate's id unchanged.
+fn prune_centroids(
+    options: &QueryEngineOptions,
+    centroid_ids: &[Posting],
+    query: &[f32],
+) -> Vec<VectorId> {
+    let epsilon = match options.query_pruning_factor {
+        Some(e) => e,
+        None => return centroid_ids.iter().map(|posting| posting.id()).collect(),
+    };
+
+    let metric = options.distance_metric;
+
+    // Compute raw distance (lower = closer) from query to each centroid.
+    let mut scored: Vec<(VectorId, f32)> = centroid_ids
+        .iter()
+        .map(|posting| {
+            (
+                posting.id(),
+                distance::raw_distance(query, posting.vector(), metric),
+            )
+        })
+        .collect();
+    scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    if scored.is_empty() {
+        return Vec::new();
+    }
+
+    let closest_dist = scored[0].1;
+    // Skip pruning when closest distance is non-positive (can happen with
+    // DotProduct metric) since the multiplicative threshold is meaningless.
+    if closest_dist < 0.0 {
+        return scored.into_iter().map(|(id, _)| id).collect();
+    }
+
+    let threshold = match metric {
+        // raw_distance uses squared L2, so preserve epsilon semantics in
+        // Euclidean space by squaring the multiplicative factor.
+        DistanceMetric::L2 | DistanceMetric::Cosine => (1.0 + epsilon).powi(2) * closest_dist,
+        DistanceMetric::DotProduct => (1.0 + epsilon) * closest_dist,
+    };
+    scored
+        .into_iter()
+        .take_while(|&(_, d)| d <= threshold)
+        .map(|(id, _)| id)
+        .collect()
+}
+
+/// Spawn a task per centroid to load its posting list and score every
+/// candidate against the query, returning all `(id, distance)` pairs across the
+/// probed centroids (with duplicates — dedup is the caller's job).
+async fn load_and_score(
+    storage: &Arc<dyn StorageRead>,
+    options: &QueryEngineOptions,
+    centroid_ids: &[VectorId],
+    query: &[f32],
+) -> Result<Vec<(VectorId, VectorDistance)>> {
+    let dimensions = options.dimensions as usize;
+    let metric = options.distance_metric;
+
+    let t = Instant::now();
+    let mut handles = Vec::with_capacity(centroid_ids.len());
+    for &cid in centroid_ids {
+        let snap = storage.clone();
+        let query = query.to_vec();
+        handles.push(tokio::spawn(async move {
+            let posting_list =
+                PostingList::from_value(snap.get_posting_list(cid, dimensions).await?, false);
+            let scored: Vec<(VectorId, VectorDistance)> = posting_list
+                .iter()
+                .map(|posting| {
+                    (
+                        posting.id(),
+                        distance::compute_distance(&query, posting.vector(), metric),
+                    )
+                })
+                .collect();
+            Ok::<_, Error>(scored)
+        }));
+    }
+
+    let results = futures::future::join_all(handles).await;
+    debug!(
+        op = "search/load_and_score/load",
+        elapsed_ms = t.elapsed().as_millis() as u64
+    );
+
+    let mut all = Vec::new();
+    let mut total_scored: u64 = 0;
+    for result in results {
+        let scored = result.map_err(|e| Error::Internal(format!("task join error: {}", e)))??;
+        total_scored += scored.len() as u64;
+        all.extend(scored);
+    }
+    metrics::counter!(QUERY_VECTORS_SCORED_TOTAL).increment(total_scored);
+
+    Ok(all)
+}
+
+/// `VectorDistance` already orders most-similar-first and exposes the raw
+/// distance via its inherent `score()`, so it is the ANN path's [`Score`] type
+/// directly — no wrapper or order inversion needed.
+impl Score for VectorDistance {
+    fn score(&self) -> f32 {
+        // Inherent `VectorDistance::score()`; the private field is not visible
+        // from this module.
+        VectorDistance::score(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::VectorDb;
+    use crate::model::{Config, Filter, MetadataFieldSpec, Vector};
+    use crate::serde::FieldType;
+    use crate::storage::VectorDbStorageReadExt;
+    use common::StorageConfig;
+
+    fn data_id(id: u64) -> VectorId {
+        VectorId::data_vector_id(id)
+    }
+
+    fn options(metric: DistanceMetric, pruning: Option<f32>) -> QueryEngineOptions {
+        QueryEngineOptions {
+            dimensions: 3,
+            distance_metric: metric,
+            query_pruning_factor: pruning,
+        }
+    }
+
+    // --- prune_centroids ---
+
+    #[test]
+    fn should_prune_centroids_beyond_epsilon_threshold() {
+        // given - centroids at L2 distances 1.0, 1.4, 2.0, 5.0 from query [0,0,0];
+        // epsilon = 0.5 => threshold = 1.5^2 * 1.0 = 2.25 (squared L2 space).
+        let opts = options(DistanceMetric::L2, Some(0.5));
+        let query = [0.0, 0.0, 0.0];
+        let centroids = vec![
+            Posting::from_vec(data_id(1), vec![1.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(2), vec![1.4, 0.0, 0.0]),
+            Posting::from_vec(data_id(3), vec![2.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(4), vec![5.0, 0.0, 0.0]),
+        ];
+
+        // when
+        let pruned = prune_centroids(&opts, &centroids, &query);
+
+        // then - only the two within threshold survive (squared dists 1.0, 1.96)
+        assert_eq!(pruned, vec![data_id(1), data_id(2)]);
+    }
+
+    #[test]
+    fn should_skip_pruning_when_epsilon_is_none() {
+        // given - no pruning configured
+        let opts = options(DistanceMetric::L2, None);
+        let query = [0.0, 0.0, 0.0];
+        let centroids = vec![
+            Posting::from_vec(data_id(1), vec![1.0, 0.0, 0.0]),
+            Posting::from_vec(data_id(2), vec![100.0, 0.0, 0.0]),
+        ];
+
+        // when
+        let result = prune_centroids(&opts, &centroids, &query);
+
+        // then - all centroids returned regardless of distance
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn should_prune_centroids_returns_sorted_by_distance() {
+        // given - large epsilon keeps all; centroids passed in non-distance order
+        let opts = options(DistanceMetric::L2, Some(10.0));
+        let query = [0.0, 0.0, 0.0];
+        let centroids = vec![
+            Posting::from_vec(data_id(1), vec![5.0, 0.0, 0.0]), // far
+            Posting::from_vec(data_id(3), vec![3.0, 0.0, 0.0]), // medium
+            Posting::from_vec(data_id(2), vec![1.0, 0.0, 0.0]), // close
+        ];
+
+        // when
+        let result = prune_centroids(&opts, &centroids, &query);
+
+        // then - sorted by ascending distance
+        assert_eq!(result, vec![data_id(2), data_id(3), data_id(1)]);
+    }
+
+    // --- ANNOperator / ExhaustiveNNOperator ---
+
+    fn ann_config() -> Config {
+        Config {
+            storage: StorageConfig::InMemory,
+            dimensions: 3,
+            distance_metric: DistanceMetric::L2,
+            metadata_fields: vec![MetadataFieldSpec::new("category", FieldType::String, true)],
+            ..Default::default()
+        }
+    }
+
+    fn doc(id: &str, values: Vec<f32>, category: &str) -> Vector {
+        Vector::builder(id, values)
+            .attribute("category", category)
+            .build()
+    }
+
+    async fn seeded_db() -> VectorDb {
+        let db = VectorDb::open(ann_config()).await.unwrap();
+        db.write(vec![
+            doc("close", vec![0.1, 0.0, 0.0], "a"),
+            doc("medium", vec![1.0, 0.0, 0.0], "b"),
+            doc("far", vec![5.0, 0.0, 0.0], "a"),
+        ])
+        .await
+        .unwrap();
+        db.flush().await.unwrap();
+        db
+    }
+
+    async fn prepared_filter(db: &VectorDb, filter: Option<&Filter>) -> PreparedFilter {
+        PreparedFilter::build(filter, db.query_engine().storage.as_ref())
+            .await
+            .unwrap()
+    }
+
+    /// Resolve scored internal ids back to external doc ids (rank order kept).
+    async fn external_ids(db: &VectorDb, scored: &[ScoredVectorId<VectorDistance>]) -> Vec<String> {
+        let engine = db.query_engine();
+        let dims = engine.options.dimensions as usize;
+        let mut ids = Vec::with_capacity(scored.len());
+        for entry in scored {
+            let vector_data = engine
+                .storage
+                .get_vector_data(entry.val, dims)
+                .await
+                .unwrap()
+                .unwrap();
+            ids.push(vector_data.external_id().to_string());
+        }
+        ids
+    }
+
+    fn ann_op(
+        db: &VectorDb,
+        query: Vec<f32>,
+        filter: PreparedFilter,
+        nprobe: usize,
+        limit: usize,
+    ) -> ANNOperator {
+        let engine = db.query_engine();
+        ANNOperator::new(
+            engine.storage.clone(),
+            engine.centroid_index.clone(),
+            engine.options.clone(),
+            query,
+            filter,
+            nprobe,
+            limit,
+        )
+    }
+
+    fn exhaustive_op(
+        db: &VectorDb,
+        query: Vec<f32>,
+        filter: PreparedFilter,
+        nprobe: usize,
+        limit: usize,
+    ) -> ExhaustiveNNOperator {
+        let engine = db.query_engine();
+        ExhaustiveNNOperator::new(
+            engine.storage.clone(),
+            engine.centroid_index.clone(),
+            engine.options.clone(),
+            query,
+            filter,
+            nprobe,
+            limit,
+        )
+    }
+
+    #[tokio::test]
+    async fn should_rank_candidates_by_distance() {
+        let db = seeded_db().await;
+        let filter = prepared_filter(&db, None).await;
+
+        let results = ann_op(&db, vec![0.0, 0.0, 0.0], filter, 100, 10)
+            .execute()
+            .await
+            .unwrap();
+
+        // nearest-first ordering
+        assert_eq!(
+            external_ids(&db, &results).await,
+            vec!["close", "medium", "far"]
+        );
+        // public score is the raw L2 distance: non-decreasing as rank descends
+        for window in results.windows(2) {
+            assert!(window[0].score <= window[1].score);
+        }
+    }
+
+    #[tokio::test]
+    async fn should_respect_limit() {
+        let db = seeded_db().await;
+        let filter = prepared_filter(&db, None).await;
+
+        let results = ann_op(&db, vec![0.0, 0.0, 0.0], filter, 100, 1)
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(external_ids(&db, &results).await, vec!["close"]);
+    }
+
+    #[tokio::test]
+    async fn should_apply_metadata_filter() {
+        let db = seeded_db().await;
+        let filter = prepared_filter(&db, Some(&Filter::eq("category", "a"))).await;
+
+        let results = ann_op(&db, vec![0.0, 0.0, 0.0], filter, 100, 10)
+            .execute()
+            .await
+            .unwrap();
+
+        // only category-"a" docs survive, still nearest-first
+        assert_eq!(external_ids(&db, &results).await, vec!["close", "far"]);
+    }
+
+    #[tokio::test]
+    async fn should_rank_candidates_by_distance_exhaustively() {
+        let db = seeded_db().await;
+        let filter = prepared_filter(&db, None).await;
+
+        let results = exhaustive_op(&db, vec![0.0, 0.0, 0.0], filter, 100, 10)
+            .execute()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            external_ids(&db, &results).await,
+            vec!["close", "medium", "far"]
+        );
+    }
+}

--- a/vector/src/query_engine/bm25.rs
+++ b/vector/src/query_engine/bm25.rs
@@ -18,7 +18,7 @@ use crate::model::Bm25Query;
 use crate::query_engine::collectors::{Collector, TopK};
 use crate::query_engine::filter::PreparedFilter;
 use crate::query_engine::operator::Operator;
-use crate::query_engine::types::ScoredVectorId;
+use crate::query_engine::types::{Score, ScoredVectorId};
 use crate::serde::field_stats::FieldStatsValue;
 use crate::serde::key::{FieldStatsKey, TermPostingsKey, TermStatsKey};
 use crate::serde::term_postings::{PostingEntry, TermPostingsValue};
@@ -26,6 +26,42 @@ use crate::serde::term_stats::TermStatsValue;
 use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_id::VectorId;
 use crate::text;
+
+/// A BM25 relevance score, where a higher raw value is more relevant.
+///
+/// Wraps the raw score so it participates in the generic [`Score`] ordering,
+/// which ranks better scores *first* (`Ordering::Less`). BM25 is "higher is
+/// better", so the natural `f32` order is inverted here; `score` still returns
+/// the raw value for the public `SearchResult.score`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct BM25Score(pub(crate) f32);
+
+impl Score for BM25Score {
+    fn score(&self) -> f32 {
+        self.0
+    }
+}
+
+impl PartialEq for BM25Score {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for BM25Score {}
+
+impl PartialOrd for BM25Score {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BM25Score {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Higher relevance ranks first, so invert the natural f32 order.
+        other.0.total_cmp(&self.0)
+    }
+}
 
 /// Scores a BM25 query: walks the union of the query terms' posting lists and
 /// produces the ranked `ScoredVectorId`s.
@@ -109,9 +145,9 @@ impl BM25Operator {
 }
 
 #[async_trait::async_trait]
-impl Operator<Vec<ScoredVectorId>> for BM25Operator {
-    async fn execute(&self) -> Result<Vec<ScoredVectorId>> {
-        let mut collector = TopK::new(self.limit);
+impl Operator<Vec<ScoredVectorId<BM25Score>>> for BM25Operator {
+    async fn execute(&self) -> Result<Vec<ScoredVectorId<BM25Score>>> {
+        let mut collector: TopK<BM25Score> = TopK::new(self.limit);
 
         let terms = dedupe_query_terms(&self.query.query);
         if terms.is_empty() {
@@ -185,7 +221,10 @@ impl Operator<Vec<ScoredVectorId>> for BM25Operator {
             }
 
             let score = bm25::score(&hits, avgdl);
-            collector.collect(ScoredVectorId { val: id, score });
+            collector.collect(ScoredVectorId {
+                val: id,
+                score: BM25Score(score),
+            });
         }
 
         Ok(collector.finish())
@@ -312,7 +351,7 @@ mod tests {
         query: &str,
         filter: Option<&Filter>,
         limit: usize,
-    ) -> Vec<ScoredVectorId> {
+    ) -> Vec<ScoredVectorId<BM25Score>> {
         let engine = db.query_engine();
         let filter = PreparedFilter::build(filter, engine.storage.as_ref())
             .await
@@ -333,7 +372,7 @@ mod tests {
     }
 
     /// Resolve scored internal ids back to external doc ids (rank order kept).
-    async fn external_ids(db: &VectorDb, scored: &[ScoredVectorId]) -> Vec<String> {
+    async fn external_ids(db: &VectorDb, scored: &[ScoredVectorId<BM25Score>]) -> Vec<String> {
         let engine = db.query_engine();
         let dims = engine.options.dimensions as usize;
         let mut ids = Vec::with_capacity(scored.len());
@@ -364,7 +403,7 @@ mod tests {
 
         // then - only docs containing "fox", with the denser match ranked first
         assert_eq!(external_ids(&db, &results).await, vec!["d2", "d1"]);
-        assert!(results[0].score >= results[1].score);
+        assert!(results[0].score.score() >= results[1].score.score());
     }
 
     #[tokio::test]

--- a/vector/src/query_engine/bm25.rs
+++ b/vector/src/query_engine/bm25.rs
@@ -1,3 +1,433 @@
-//! BM25 query driver (`Bm25QueryDriver` / `TermScorer`).
+//! BM25 query operator (RFC-0006 Milestone 0).
 //!
-//! Populated in a later refactor step; see `query-engine-refactor.md`.
+//! Iterates the union of per-term posting lists document by document in
+//! descending id order, accumulates each document's BM25 score in a single
+//! pass, and collects the ranked survivors into a [`TopK`]. Metadata filtering
+//! and FTS delete resolution happen before scoring so excluded documents pay no
+//! scoring cost. Forward-index lookups are deferred to the lookup operator.
+
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashSet};
+use std::sync::Arc;
+
+use common::storage::StorageRead;
+
+use crate::error::Result;
+use crate::math::bm25;
+use crate::model::Bm25Query;
+use crate::query_engine::collectors::{Collector, TopK};
+use crate::query_engine::filter::PreparedFilter;
+use crate::query_engine::operator::Operator;
+use crate::query_engine::types::ScoredVectorId;
+use crate::serde::field_stats::FieldStatsValue;
+use crate::serde::key::{FieldStatsKey, TermPostingsKey, TermStatsKey};
+use crate::serde::term_postings::{PostingEntry, TermPostingsValue};
+use crate::serde::term_stats::TermStatsValue;
+use crate::serde::vector_bitmap::VectorBitmap;
+use crate::serde::vector_id::VectorId;
+use crate::text;
+
+/// Scores a BM25 query: walks the union of the query terms' posting lists and
+/// produces the ranked `ScoredVectorId`s.
+pub(crate) struct BM25Operator {
+    storage: Arc<dyn StorageRead>,
+    query: Bm25Query,
+    filter: PreparedFilter,
+    /// In-memory FTS deletions bitmap; the authority for delete resolution on
+    /// the BM25 path.
+    deletions: Arc<VectorBitmap>,
+    limit: usize,
+}
+
+impl BM25Operator {
+    pub(crate) fn new(
+        storage: Arc<dyn StorageRead>,
+        query: Bm25Query,
+        filter: PreparedFilter,
+        deletions: Arc<VectorBitmap>,
+        limit: usize,
+    ) -> Self {
+        Self {
+            storage,
+            query,
+            filter,
+            deletions,
+            limit,
+        }
+    }
+
+    /// Load postings + term stats for each query term and wrap them as
+    /// [`TermScorer`]s carrying precomputed IDF. Terms with no documents are
+    /// omitted.
+    async fn open_term_scorers(
+        &self,
+        field: &str,
+        terms: &[String],
+        n_docs: u64,
+    ) -> Result<Vec<TermScorer>> {
+        let mut scorers = Vec::with_capacity(terms.len());
+        for term in terms {
+            let postings = self.load_term_postings(field, term).await?;
+            let stats = self.load_term_stats(field, term).await?;
+            let n_t = stats.freq.max(0) as u64;
+            if n_t == 0 {
+                continue;
+            }
+            // Block iteration order is already descending by doc id.
+            let entries: Vec<PostingEntry> = postings.iter_entries().copied().collect();
+            if entries.is_empty() {
+                continue;
+            }
+            scorers.push(TermScorer::new(entries, bm25::idf(n_docs, n_t)));
+        }
+        Ok(scorers)
+    }
+
+    async fn load_field_stats(&self, field: &str) -> Result<FieldStatsValue> {
+        let key = FieldStatsKey::new(field).encode();
+        match self.storage.get(key).await? {
+            Some(record) => Ok(FieldStatsValue::decode_from_bytes(&record.value)?),
+            None => Ok(FieldStatsValue::default()),
+        }
+    }
+
+    async fn load_term_stats(&self, field: &str, term: &str) -> Result<TermStatsValue> {
+        let key = TermStatsKey::new(field, term).encode();
+        match self.storage.get(key).await? {
+            Some(record) => Ok(TermStatsValue::decode_from_bytes(&record.value)?),
+            None => Ok(TermStatsValue::default()),
+        }
+    }
+
+    async fn load_term_postings(&self, field: &str, term: &str) -> Result<TermPostingsValue> {
+        let key = TermPostingsKey::new(field, term).encode();
+        match self.storage.get(key).await? {
+            Some(record) => Ok(TermPostingsValue::decode_from_bytes(&record.value)?),
+            None => Ok(TermPostingsValue::default()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Operator<Vec<ScoredVectorId>> for BM25Operator {
+    async fn execute(&self) -> Result<Vec<ScoredVectorId>> {
+        let mut collector = TopK::new(self.limit);
+
+        let terms = dedupe_query_terms(&self.query.query);
+        if terms.is_empty() {
+            return Ok(collector.finish());
+        }
+
+        // Per-field corpus stats are required to compute IDF / avgdl.
+        let field_stats = self.load_field_stats(&self.query.field).await?;
+        let n_docs = field_stats.count.max(0) as u64;
+        if n_docs == 0 || field_stats.total_length <= 0 {
+            return Ok(collector.finish());
+        }
+        let avgdl = field_stats.total_length as f32 / n_docs as f32;
+
+        // One scorer per query term, each carrying the term's precomputed IDF.
+        let mut scorers = self
+            .open_term_scorers(&self.query.field, &terms, n_docs)
+            .await?;
+        if scorers.is_empty() {
+            return Ok(collector.finish());
+        }
+
+        // Max-heap of (current head id, scorer index) so all scorers sharing the
+        // next-highest id can be drained together.
+        let mut head_heap: BinaryHeap<ScorerHead> = BinaryHeap::with_capacity(scorers.len());
+        for (idx, scorer) in scorers.iter().enumerate() {
+            if let Some(id) = scorer.peek_doc_id() {
+                head_heap.push(ScorerHead {
+                    id,
+                    scorer_idx: idx,
+                });
+            }
+        }
+
+        // Reused per-doc buffer so we don't allocate a fresh Vec each iteration.
+        let mut hits: Vec<bm25::Bm25TermEntry> = Vec::with_capacity(scorers.len());
+
+        while let Some(&ScorerHead { id, .. }) = head_heap.peek() {
+            // Drain every scorer sharing this id into the per-doc buffer.
+            hits.clear();
+            while let Some(head) = head_heap.peek().copied() {
+                if head.id != id {
+                    break;
+                }
+                head_heap.pop();
+                let scorer = &mut scorers[head.scorer_idx];
+                let hit = scorer
+                    .pop()
+                    .expect("scorer head was on heap but pop returned None");
+                hits.push(hit);
+                if let Some(next) = scorer.peek_doc_id() {
+                    head_heap.push(ScorerHead {
+                        id: next,
+                        scorer_idx: head.scorer_idx,
+                    });
+                }
+            }
+
+            // Apply the metadata filter BEFORE scoring so excluded docs don't
+            // pay the BM25 cost.
+            if !self.filter.matches(id.id()) {
+                continue;
+            }
+
+            // `id.id()` is the raw internal id from the posting, the same id
+            // space the deletions bitmap indexes (data vectors are level 0).
+            // Skip deleted/replaced docs before scoring; this — not the forward
+            // index — hides deleted documents.
+            if self.deletions.contains(id.id()) {
+                continue;
+            }
+
+            let score = bm25::score(&hits, avgdl);
+            collector.collect(ScoredVectorId { val: id, score });
+        }
+
+        Ok(collector.finish())
+    }
+}
+
+/// A term's postings paired with the term's precomputed IDF.
+///
+/// Yields entries in descending `doc_id` order — the same order the underlying
+/// `TermPostingsValue` blocks are stored in (RFC-0006).
+struct TermScorer {
+    /// All entries in descending `doc_id` order.
+    entries: Vec<PostingEntry>,
+    /// Index of the next entry to yield (`pop`).
+    cursor: usize,
+    /// IDF for this scorer's term in the current corpus.
+    idf: f32,
+}
+
+impl TermScorer {
+    fn new(entries: Vec<PostingEntry>, idf: f32) -> Self {
+        Self {
+            entries,
+            cursor: 0,
+            idf,
+        }
+    }
+
+    fn peek_doc_id(&self) -> Option<VectorId> {
+        self.entries.get(self.cursor).map(|entry| entry.id)
+    }
+
+    /// Consume the current head and return its BM25 term hit (the posting's
+    /// freq/norm paired with this scorer's IDF).
+    fn pop(&mut self) -> Option<bm25::Bm25TermEntry> {
+        let entry = self.entries.get(self.cursor)?;
+        let hit = bm25::Bm25TermEntry {
+            freq: entry.freq,
+            norm: entry.norm,
+            idf: self.idf,
+        };
+        self.cursor += 1;
+        Some(hit)
+    }
+}
+
+/// Heap entry referring to the current head of a [`TermScorer`] by index.
+///
+/// Ordered by `doc_id` descending so the max-heap returns the
+/// next-highest-id head across all scorers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ScorerHead {
+    id: VectorId,
+    scorer_idx: usize,
+}
+
+impl Ord for ScorerHead {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.id
+            .cmp(&other.id)
+            .then_with(|| other.scorer_idx.cmp(&self.scorer_idx))
+    }
+}
+
+impl PartialOrd for ScorerHead {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// Tokenize a BM25 query string and drop duplicate terms while preserving
+/// first-seen order.
+fn dedupe_query_terms(query: &str) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut unique = Vec::new();
+    for term in text::tokenize(query) {
+        if seen.insert(term.clone()) {
+            unique.push(term);
+        }
+    }
+    unique
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::VectorDb;
+    use crate::model::{Config, Filter, MetadataFieldSpec, Vector};
+    use crate::serde::FieldType;
+    use crate::serde::collection_meta::DistanceMetric;
+    use crate::storage::VectorDbStorageReadExt;
+    use common::StorageConfig;
+
+    fn text_config() -> Config {
+        Config {
+            storage: StorageConfig::InMemory,
+            dimensions: 3,
+            distance_metric: DistanceMetric::L2,
+            metadata_fields: vec![
+                MetadataFieldSpec::new("body", FieldType::Text, false),
+                MetadataFieldSpec::new("category", FieldType::String, true),
+            ],
+            ..Default::default()
+        }
+    }
+
+    fn doc(id: &str, body: &str, category: &str) -> Vector {
+        Vector::builder(id, vec![0.0; 3])
+            .attribute("body", body)
+            .attribute("category", category)
+            .build()
+    }
+
+    async fn seeded_db(docs: Vec<Vector>) -> VectorDb {
+        let db = VectorDb::open(text_config()).await.unwrap();
+        db.write(docs).await.unwrap();
+        db.flush().await.unwrap();
+        db
+    }
+
+    /// Build a `BM25Operator` from the db's storage snapshot and run it.
+    async fn run(
+        db: &VectorDb,
+        query: &str,
+        filter: Option<&Filter>,
+        limit: usize,
+    ) -> Vec<ScoredVectorId> {
+        let engine = db.query_engine();
+        let filter = PreparedFilter::build(filter, engine.storage.as_ref())
+            .await
+            .unwrap();
+        BM25Operator::new(
+            engine.storage.clone(),
+            Bm25Query {
+                field: "body".to_string(),
+                query: query.to_string(),
+            },
+            filter,
+            engine.deletions.clone(),
+            limit,
+        )
+        .execute()
+        .await
+        .unwrap()
+    }
+
+    /// Resolve scored internal ids back to external doc ids (rank order kept).
+    async fn external_ids(db: &VectorDb, scored: &[ScoredVectorId]) -> Vec<String> {
+        let engine = db.query_engine();
+        let dims = engine.options.dimensions as usize;
+        let mut ids = Vec::with_capacity(scored.len());
+        for entry in scored {
+            let vector_data = engine
+                .storage
+                .get_vector_data(entry.val, dims)
+                .await
+                .unwrap()
+                .unwrap();
+            ids.push(vector_data.external_id().to_string());
+        }
+        ids
+    }
+
+    #[tokio::test]
+    async fn should_rank_documents_by_bm25() {
+        // given
+        let db = seeded_db(vec![
+            doc("d1", "quick brown fox", "a"),
+            doc("d2", "fox fox", "a"),
+            doc("d3", "slow green turtle", "b"),
+        ])
+        .await;
+
+        // when
+        let results = run(&db, "fox", None, 10).await;
+
+        // then - only docs containing "fox", with the denser match ranked first
+        assert_eq!(external_ids(&db, &results).await, vec!["d2", "d1"]);
+        assert!(results[0].score >= results[1].score);
+    }
+
+    #[tokio::test]
+    async fn should_respect_limit() {
+        let db = seeded_db(vec![
+            doc("d1", "quick brown fox", "a"),
+            doc("d2", "fox fox", "a"),
+            doc("d3", "another fox here", "a"),
+        ])
+        .await;
+
+        let results = run(&db, "fox", None, 1).await;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(external_ids(&db, &results).await, vec!["d2"]);
+    }
+
+    #[tokio::test]
+    async fn should_exclude_deleted_documents() {
+        let db = seeded_db(vec![
+            doc("d1", "quick brown fox", "a"),
+            doc("d2", "fox fox", "a"),
+        ])
+        .await;
+
+        // sanity - both match before the delete
+        let before = external_ids(&db, &run(&db, "fox", None, 10).await).await;
+        assert_eq!(before, vec!["d2", "d1"]);
+
+        // when - delete the top doc and re-snapshot
+        db.delete(vec!["d2"]).await.unwrap();
+        db.flush().await.unwrap();
+
+        // then - the deleted doc is gone, the other remains
+        let after = external_ids(&db, &run(&db, "fox", None, 10).await).await;
+        assert_eq!(after, vec!["d1"]);
+    }
+
+    #[tokio::test]
+    async fn should_apply_metadata_filter() {
+        let db = seeded_db(vec![
+            doc("d1", "quick fox", "a"),
+            doc("d2", "fox fox", "b"),
+            doc("d3", "lazy fox", "a"),
+        ])
+        .await;
+
+        // when - restrict to category = "a"
+        let filter = Filter::eq("category", "a");
+        let results = run(&db, "fox", Some(&filter), 10).await;
+        let mut ids = external_ids(&db, &results).await;
+        ids.sort();
+
+        // then - only category-a docs survive scoring
+        assert_eq!(ids, vec!["d1", "d3"]);
+    }
+
+    #[tokio::test]
+    async fn should_return_empty_when_no_term_matches() {
+        let db = seeded_db(vec![doc("d1", "quick brown fox", "a")]).await;
+
+        let results = run(&db, "zebra", None, 10).await;
+
+        assert!(results.is_empty());
+    }
+}

--- a/vector/src/query_engine/collectors.rs
+++ b/vector/src/query_engine/collectors.rs
@@ -1,3 +1,215 @@
-//! Collector trait and `TopK` implementation.
-//!
-//! Populated in a later refactor step; see `query-engine-refactor.md`.
+//! `Collector` trait and the `TopK` streaming top-k collector.
+
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+
+use crate::query_engine::types::ScoredVectorId;
+use crate::serde::vector_id::VectorId;
+
+/// Consumes scored documents and produces the final ranked document set.
+pub(crate) trait Collector {
+    /// Offer one scored document to the collector.
+    fn collect(&mut self, scored: ScoredVectorId);
+
+    /// The minimum score a new document must beat to enter the result set, or
+    /// `None` while any score is still competitive (the collector is not full).
+    ///
+    /// Drivers can use this to prune work. The scalar BM25 driver does not yet,
+    /// but BlockMaxScore will, so it is part of the trait contract today.
+    #[allow(dead_code)]
+    fn min_competitive_score(&self) -> Option<f32>;
+
+    /// Consume the collector and return the ranked documents, best first.
+    fn finish(self) -> Vec<ScoredVectorId>;
+}
+
+/// Streaming top-k collector.
+///
+/// Keeps at most `limit` documents in a min-heap ordered so the worst
+/// (lowest-score, then highest-doc-id) candidate sits at the top and is evicted
+/// first. [`finish`](Collector::finish) returns them sorted by descending
+/// score, ties broken by ascending doc id.
+pub(crate) struct TopK {
+    limit: usize,
+    heap: BinaryHeap<WorstFirst>,
+}
+
+impl TopK {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            heap: BinaryHeap::with_capacity(limit),
+        }
+    }
+}
+
+impl Collector for TopK {
+    fn collect(&mut self, document: ScoredVectorId) {
+        if self.limit == 0 {
+            return;
+        }
+        let ScoredVectorId { val: id, score } = document;
+
+        // When the heap is full, only admit candidates that beat the current
+        // worst entry; otherwise just push.
+        if self.heap.len() == self.limit {
+            if let Some(worst) = self.heap.peek()
+                && !is_better(score, id, worst.score, worst.id)
+            {
+                return;
+            }
+            self.heap.pop();
+        }
+        self.heap.push(WorstFirst { score, id });
+    }
+
+    fn min_competitive_score(&self) -> Option<f32> {
+        if self.heap.len() == self.limit {
+            self.heap.peek().map(|worst| worst.score)
+        } else {
+            None
+        }
+    }
+
+    fn finish(self) -> Vec<ScoredVectorId> {
+        let mut docs: Vec<ScoredVectorId> = self
+            .heap
+            .into_iter()
+            .map(|entry| ScoredVectorId {
+                val: entry.id,
+                score: entry.score,
+            })
+            .collect();
+        // Descending score, ties broken by ascending doc id.
+        docs.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(Ordering::Equal)
+                .then_with(|| a.val.cmp(&b.val))
+        });
+        docs
+    }
+}
+
+/// Top-K heap entry ordered so `BinaryHeap::peek()` returns the worst
+/// (lowest-score, highest-doc-id) entry — the next to evict.
+struct WorstFirst {
+    score: f32,
+    id: VectorId,
+}
+
+impl PartialEq for WorstFirst {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for WorstFirst {}
+
+impl PartialOrd for WorstFirst {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for WorstFirst {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // BinaryHeap is a max-heap; we want the worst candidate at the top, so a
+        // candidate that is *worse* must compare *greater*. Worse means lower
+        // score, or — on a score tie — higher doc id (final results are sorted
+        // by ascending doc id on ties).
+        other
+            .score
+            .total_cmp(&self.score)
+            .then_with(|| self.id.cmp(&other.id))
+    }
+}
+
+/// Returns `true` when `(new_score, new_doc_id)` would rank ahead of
+/// `(other_score, other_doc_id)`: descending score, ties broken by ascending
+/// doc id.
+fn is_better(new_score: f32, new_id: VectorId, other_score: f32, other_id: VectorId) -> bool {
+    match new_score.partial_cmp(&other_score) {
+        Some(Ordering::Greater) => true,
+        Some(Ordering::Less) => false,
+        Some(Ordering::Equal) | None => new_id < other_id,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn doc(id: u64, score: f32) -> ScoredVectorId {
+        ScoredVectorId {
+            val: VectorId::from_raw(id),
+            score,
+        }
+    }
+
+    fn collect_all(collector: &mut TopK, docs: Vec<ScoredVectorId>) {
+        for d in docs {
+            collector.collect(d);
+        }
+    }
+
+    /// Final ordering is by descending score, with ties broken by ascending id.
+    fn ranked(collector: TopK) -> Vec<(u64, f32)> {
+        collector
+            .finish()
+            .into_iter()
+            .map(|d| (d.val.id(), d.score))
+            .collect()
+    }
+
+    #[test]
+    fn should_keep_only_top_k_by_score() {
+        let mut top = TopK::new(2);
+        collect_all(
+            &mut top,
+            vec![doc(1, 1.0), doc(2, 5.0), doc(3, 3.0), doc(4, 2.0)],
+        );
+        assert_eq!(ranked(top), vec![(2, 5.0), (3, 3.0)]);
+    }
+
+    #[test]
+    fn should_break_score_ties_by_ascending_doc_id() {
+        let mut top = TopK::new(10);
+        collect_all(&mut top, vec![doc(3, 1.0), doc(1, 1.0), doc(2, 1.0)]);
+        assert_eq!(ranked(top), vec![(1, 1.0), (2, 1.0), (3, 1.0)]);
+    }
+
+    #[test]
+    fn should_prefer_lower_doc_id_on_tie_at_capacity() {
+        // At capacity, a tied-score candidate with a higher id must not evict a
+        // lower id already held.
+        let mut top = TopK::new(1);
+        collect_all(&mut top, vec![doc(2, 1.0), doc(5, 1.0)]);
+        assert_eq!(ranked(top), vec![(2, 1.0)]);
+
+        // ...but a lower id does win the tie.
+        let mut top = TopK::new(1);
+        collect_all(&mut top, vec![doc(5, 1.0), doc(2, 1.0)]);
+        assert_eq!(ranked(top), vec![(2, 1.0)]);
+    }
+
+    #[test]
+    fn should_collect_nothing_when_limit_zero() {
+        let mut top = TopK::new(0);
+        collect_all(&mut top, vec![doc(1, 1.0), doc(2, 2.0)]);
+        assert!(top.finish().is_empty());
+    }
+
+    #[test]
+    fn should_report_min_competitive_score_only_when_full() {
+        let mut top = TopK::new(2);
+        assert_eq!(top.min_competitive_score(), None);
+        top.collect(doc(1, 3.0));
+        assert_eq!(top.min_competitive_score(), None);
+        top.collect(doc(2, 5.0));
+        // Full now: the worst (lowest) score is the bar to beat.
+        assert_eq!(top.min_competitive_score(), Some(3.0));
+        top.collect(doc(3, 4.0)); // evicts score 3.0
+        assert_eq!(top.min_competitive_score(), Some(4.0));
+    }
+}

--- a/vector/src/query_engine/collectors.rs
+++ b/vector/src/query_engine/collectors.rs
@@ -3,38 +3,42 @@
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
-use crate::query_engine::types::ScoredVectorId;
+use crate::query_engine::types::{Score, ScoredVectorId};
 use crate::serde::vector_id::VectorId;
 
 /// Consumes scored documents and produces the final ranked document set.
-pub(crate) trait Collector {
+///
+/// Generic over the [`Score`] type `S`, which defines the ranking direction
+/// (better scores compare as [`Ordering::Less`]).
+pub(crate) trait Collector<S: Score> {
     /// Offer one scored document to the collector.
-    fn collect(&mut self, scored: ScoredVectorId);
+    fn collect(&mut self, scored: ScoredVectorId<S>);
 
-    /// The minimum score a new document must beat to enter the result set, or
+    /// The raw score a new document must beat to enter the result set, or
     /// `None` while any score is still competitive (the collector is not full).
     ///
-    /// Drivers can use this to prune work. The scalar BM25 driver does not yet,
+    /// Sources can use this to prune work. The scalar BM25 source does not yet,
     /// but BlockMaxScore will, so it is part of the trait contract today.
     #[allow(dead_code)]
-    fn min_competitive_score(&self) -> Option<f32>;
+    fn min_competitive_score(&self) -> Option<S>;
 
     /// Consume the collector and return the ranked documents, best first.
-    fn finish(self) -> Vec<ScoredVectorId>;
+    fn finish(self) -> Vec<ScoredVectorId<S>>;
 }
 
 /// Streaming top-k collector.
 ///
-/// Keeps at most `limit` documents in a min-heap ordered so the worst
-/// (lowest-score, then highest-doc-id) candidate sits at the top and is evicted
-/// first. [`finish`](Collector::finish) returns them sorted by descending
-/// score, ties broken by ascending doc id.
-pub(crate) struct TopK {
+/// Keeps at most `limit` documents in a heap ordered so the worst candidate
+/// sits at the top and is evicted first. Because [`Score`] orders best-first
+/// (better = lesser), "worst" means the *greatest* score, ties broken by the
+/// highest doc id. [`finish`](Collector::finish) returns the survivors sorted
+/// best first (ascending score), ties broken by ascending doc id.
+pub(crate) struct TopK<S: Score> {
     limit: usize,
-    heap: BinaryHeap<WorstFirst>,
+    heap: BinaryHeap<WorstFirst<S>>,
 }
 
-impl TopK {
+impl<S: Score> TopK<S> {
     pub(crate) fn new(limit: usize) -> Self {
         Self {
             limit,
@@ -43,8 +47,8 @@ impl TopK {
     }
 }
 
-impl Collector for TopK {
-    fn collect(&mut self, document: ScoredVectorId) {
+impl<S: Score> Collector<S> for TopK<S> {
+    fn collect(&mut self, document: ScoredVectorId<S>) {
         if self.limit == 0 {
             return;
         }
@@ -54,7 +58,7 @@ impl Collector for TopK {
         // worst entry; otherwise just push.
         if self.heap.len() == self.limit {
             if let Some(worst) = self.heap.peek()
-                && !is_better(score, id, worst.score, worst.id)
+                && !is_better(&score, &id, &worst.score, &worst.id)
             {
                 return;
             }
@@ -63,7 +67,7 @@ impl Collector for TopK {
         self.heap.push(WorstFirst { score, id });
     }
 
-    fn min_competitive_score(&self) -> Option<f32> {
+    fn min_competitive_score(&self) -> Option<S> {
         if self.heap.len() == self.limit {
             self.heap.peek().map(|worst| worst.score)
         } else {
@@ -71,8 +75,8 @@ impl Collector for TopK {
         }
     }
 
-    fn finish(self) -> Vec<ScoredVectorId> {
-        let mut docs: Vec<ScoredVectorId> = self
+    fn finish(self) -> Vec<ScoredVectorId<S>> {
+        let mut docs: Vec<ScoredVectorId<S>> = self
             .heap
             .into_iter()
             .map(|entry| ScoredVectorId {
@@ -80,85 +84,88 @@ impl Collector for TopK {
                 score: entry.score,
             })
             .collect();
-        // Descending score, ties broken by ascending doc id.
-        docs.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(Ordering::Equal)
-                .then_with(|| a.val.cmp(&b.val))
-        });
+        // Best first: ascending score (better = lesser), ties by ascending id.
+        docs.sort_by(|a, b| a.score.cmp(&b.score).then_with(|| a.val.cmp(&b.val)));
         docs
     }
 }
 
-/// Top-K heap entry ordered so `BinaryHeap::peek()` returns the worst
-/// (lowest-score, highest-doc-id) entry — the next to evict.
-struct WorstFirst {
-    score: f32,
+/// Top-K heap entry ordered so `BinaryHeap::peek()` returns the worst entry —
+/// the next to evict.
+struct WorstFirst<S: Score> {
+    score: S,
     id: VectorId,
 }
 
-impl PartialEq for WorstFirst {
+impl<S: Score> PartialEq for WorstFirst<S> {
     fn eq(&self, other: &Self) -> bool {
         self.cmp(other) == Ordering::Equal
     }
 }
 
-impl Eq for WorstFirst {}
+impl<S: Score> Eq for WorstFirst<S> {}
 
-impl PartialOrd for WorstFirst {
+impl<S: Score> PartialOrd for WorstFirst<S> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-impl Ord for WorstFirst {
+impl<S: Score> Ord for WorstFirst<S> {
     fn cmp(&self, other: &Self) -> Ordering {
         // BinaryHeap is a max-heap; we want the worst candidate at the top, so a
-        // candidate that is *worse* must compare *greater*. Worse means lower
-        // score, or — on a score tie — higher doc id (final results are sorted
-        // by ascending doc id on ties).
-        other
-            .score
-            .total_cmp(&self.score)
+        // candidate that is *worse* must compare *greater*. `Score` orders
+        // best-first, so worse means a greater score, or — on a tie — a higher
+        // doc id (final results are sorted by ascending doc id on ties).
+        self.score
+            .cmp(&other.score)
             .then_with(|| self.id.cmp(&other.id))
     }
 }
 
 /// Returns `true` when `(new_score, new_doc_id)` would rank ahead of
-/// `(other_score, other_doc_id)`: descending score, ties broken by ascending
-/// doc id.
-fn is_better(new_score: f32, new_id: VectorId, other_score: f32, other_id: VectorId) -> bool {
-    match new_score.partial_cmp(&other_score) {
-        Some(Ordering::Greater) => true,
-        Some(Ordering::Less) => false,
-        Some(Ordering::Equal) | None => new_id < other_id,
+/// `(other_score, other_doc_id)`: better (lesser) score, ties broken by
+/// ascending doc id.
+fn is_better<S: Score>(
+    new_score: &S,
+    new_id: &VectorId,
+    other_score: &S,
+    other_id: &VectorId,
+) -> bool {
+    match new_score.cmp(other_score) {
+        Ordering::Less => true,
+        Ordering::Greater => false,
+        Ordering::Equal => new_id < other_id,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::query_engine::bm25::BM25Score;
 
-    fn doc(id: u64, score: f32) -> ScoredVectorId {
+    // `BM25Score` (higher raw value = better) exercises the full `Score`
+    // contract, including its order inversion: a numerically higher score must
+    // rank ahead, so these tests read as "higher score wins".
+    fn doc(id: u64, score: f32) -> ScoredVectorId<BM25Score> {
         ScoredVectorId {
             val: VectorId::from_raw(id),
-            score,
+            score: BM25Score(score),
         }
     }
 
-    fn collect_all(collector: &mut TopK, docs: Vec<ScoredVectorId>) {
+    fn collect_all(collector: &mut TopK<BM25Score>, docs: Vec<ScoredVectorId<BM25Score>>) {
         for d in docs {
             collector.collect(d);
         }
     }
 
-    /// Final ordering is by descending score, with ties broken by ascending id.
-    fn ranked(collector: TopK) -> Vec<(u64, f32)> {
+    /// Final ordering is best first (highest BM25 score), ties by ascending id.
+    fn ranked(collector: TopK<BM25Score>) -> Vec<(u64, f32)> {
         collector
             .finish()
             .into_iter()
-            .map(|d| (d.val.id(), d.score))
+            .map(|d| (d.val.id(), d.score.score()))
             .collect()
     }
 
@@ -208,8 +215,8 @@ mod tests {
         assert_eq!(top.min_competitive_score(), None);
         top.collect(doc(2, 5.0));
         // Full now: the worst (lowest) score is the bar to beat.
-        assert_eq!(top.min_competitive_score(), Some(3.0));
+        assert_eq!(top.min_competitive_score().map(|s| s.score()), Some(3.0));
         top.collect(doc(3, 4.0)); // evicts score 3.0
-        assert_eq!(top.min_competitive_score(), Some(4.0));
+        assert_eq!(top.min_competitive_score().map(|s| s.score()), Some(4.0));
     }
 }

--- a/vector/src/query_engine/driver.rs
+++ b/vector/src/query_engine/driver.rs
@@ -1,3 +1,0 @@
-//! Shared `QueryDriver` traits and types.
-//!
-//! Populated in a later refactor step; see `query-engine-refactor.md`.

--- a/vector/src/query_engine/filter.rs
+++ b/vector/src/query_engine/filter.rs
@@ -1,7 +1,7 @@
 //! Prepared query filter (`PreparedFilter`).
 //!
 //! Lowers a [`Filter`] AST into precomputed metadata bitmaps so the query
-//! drivers can answer per-document membership with a cheap
+//! operators can answer per-item membership with a cheap
 //! [`PreparedFilter::matches`] check. Negations are kept as exclusion bitmaps
 //! rather than complemented positive sets, so building a filter never has to
 //! enumerate the entire corpus universe.
@@ -19,14 +19,14 @@ use crate::storage::VectorDbStorageReadExt;
 
 /// Executable form of a query [`Filter`].
 ///
-/// A document matches when it is present in `positive` (or `positive` is
+/// An item matches when it is present in `positive` (or `positive` is
 /// `None`, meaning "no positive constraint") and absent from every bitmap in
 /// `negative`. Equivalently, the matching set is `positive ∩ ¬(⋃ negative)`.
 pub(crate) struct PreparedFilter {
-    /// Documents allowed by the positive (union/intersection) part of the
+    /// Items allowed by the positive (union/intersection) part of the
     /// filter. `None` imposes no positive constraint (matches all ids).
     positive: Option<RoaringTreemap>,
-    /// Documents excluded by negations. A document matches only if it is
+    /// Items excluded by negations. An item matches only if it is
     /// absent from every bitmap here.
     negative: Vec<RoaringTreemap>,
 }
@@ -40,7 +40,7 @@ enum Single {
 
 impl PreparedFilter {
     /// Build a prepared filter from an optional filter expression. `None`
-    /// matches every document.
+    /// matches every item.
     pub(crate) async fn build(expr: Option<&Filter>, storage: &dyn StorageRead) -> Result<Self> {
         match expr {
             None => Ok(Self::match_all()),

--- a/vector/src/query_engine/lookup.rs
+++ b/vector/src/query_engine/lookup.rs
@@ -11,23 +11,26 @@ use tracing::warn;
 
 use crate::error::Result;
 use crate::query_engine::operator::{BoxedOperator, Operator};
-use crate::query_engine::types::{ScoredVector, ScoredVectorId};
+use crate::query_engine::types::{Score, ScoredVector, ScoredVectorId};
 use crate::serde::vector_data::VectorDataValue;
 use crate::storage::VectorDbStorageReadExt;
 use crate::{Attribute, Vector};
 
 /// Resolves ranked vector ids to their forward-index data.
-pub(crate) struct LookupOperator {
+///
+/// Generic over the [`Score`] type `S`, which it passes through unchanged from
+/// each [`ScoredVectorId`] to the produced [`ScoredVector`].
+pub(crate) struct LookupOperator<S: Score> {
     storage: Arc<dyn StorageRead>,
     dimensions: usize,
-    child: BoxedOperator<Vec<ScoredVectorId>>,
+    child: BoxedOperator<Vec<ScoredVectorId<S>>>,
 }
 
-impl LookupOperator {
+impl<S: Score> LookupOperator<S> {
     pub(crate) fn new(
         storage: Arc<dyn StorageRead>,
         dimensions: usize,
-        child: BoxedOperator<Vec<ScoredVectorId>>,
+        child: BoxedOperator<Vec<ScoredVectorId<S>>>,
     ) -> Self {
         Self {
             storage,
@@ -38,14 +41,14 @@ impl LookupOperator {
 }
 
 #[async_trait::async_trait]
-impl Operator<Vec<ScoredVector>> for LookupOperator {
+impl<S: Score + Send + Sync + 'static> Operator<Vec<ScoredVector<S>>> for LookupOperator<S> {
     /// Loads the forward-index data for each scored id, preserving order.
     ///
     /// Assumes every id still exists in the forward index — deletes are resolved
     /// upstream by the scoring operator — so a missing entry (e.g. a concurrent
     /// compaction) is logged as a warning and skipped rather than treated as a
     /// normal delete.
-    async fn execute(&self) -> Result<Vec<ScoredVector>> {
+    async fn execute(&self) -> Result<Vec<ScoredVector<S>>> {
         let scored = self.child.execute().await?;
 
         let loaded = futures::future::join_all(
@@ -91,17 +94,20 @@ mod tests {
     use crate::AttributeValue;
     use crate::db::VectorDb;
     use crate::model::{Config, MetadataFieldSpec, Vector};
+    use crate::query_engine::bm25::BM25Score;
     use crate::serde::FieldType;
     use crate::serde::collection_meta::DistanceMetric;
     use crate::serde::vector_id::VectorId;
     use common::StorageConfig;
 
-    /// A child operator that yields a fixed list of scored ids.
-    struct Fixed(Vec<ScoredVectorId>);
+    /// A child operator that yields a fixed list of scored ids. Uses `BM25Score`
+    /// as an arbitrary concrete [`Score`]; `LookupOperator` only passes it
+    /// through, so the choice does not affect what is exercised here.
+    struct Fixed(Vec<ScoredVectorId<BM25Score>>);
 
     #[async_trait::async_trait]
-    impl Operator<Vec<ScoredVectorId>> for Fixed {
-        async fn execute(&self) -> Result<Vec<ScoredVectorId>> {
+    impl Operator<Vec<ScoredVectorId<BM25Score>>> for Fixed {
+        async fn execute(&self) -> Result<Vec<ScoredVectorId<BM25Score>>> {
             Ok(self
                 .0
                 .iter()
@@ -148,7 +154,10 @@ mod tests {
     }
 
     /// Build a `LookupOperator` from the db's storage snapshot, fed `child` ids.
-    fn lookup_op(db: &VectorDb, child: Vec<ScoredVectorId>) -> LookupOperator {
+    fn lookup_op(
+        db: &VectorDb,
+        child: Vec<ScoredVectorId<BM25Score>>,
+    ) -> LookupOperator<BM25Score> {
         let engine = db.query_engine();
         LookupOperator::new(
             engine.storage.clone(),
@@ -169,11 +178,11 @@ mod tests {
             vec![
                 ScoredVectorId {
                     val: d2,
-                    score: 2.0,
+                    score: BM25Score(2.0),
                 },
                 ScoredVectorId {
                     val: d1,
-                    score: 1.0,
+                    score: BM25Score(1.0),
                 },
             ],
         )
@@ -184,13 +193,13 @@ mod tests {
         // order + scores preserved, ids resolved, attributes loaded
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].val.id, "d2");
-        assert_eq!(results[0].score, 2.0);
+        assert_eq!(results[0].score.score(), 2.0);
         assert_eq!(
             results[0].val.attribute("category"),
             Some(&AttributeValue::String("b".to_string()))
         );
         assert_eq!(results[1].val.id, "d1");
-        assert_eq!(results[1].score, 1.0);
+        assert_eq!(results[1].score.score(), 1.0);
     }
 
     #[tokio::test]
@@ -204,11 +213,11 @@ mod tests {
             vec![
                 ScoredVectorId {
                     val: missing,
-                    score: 5.0,
+                    score: BM25Score(5.0),
                 },
                 ScoredVectorId {
                     val: d1,
-                    score: 1.0,
+                    score: BM25Score(1.0),
                 },
             ],
         )

--- a/vector/src/query_engine/lookup.rs
+++ b/vector/src/query_engine/lookup.rs
@@ -1,0 +1,223 @@
+//! Forward-index lookup operator (`LookupOperator`).
+//!
+//! Pulls a ranked set of [`ScoredVectorId`]s from its child operator and loads
+//! each one's forward-index `VectorDataValue`, producing [`ScoredVector`]s in
+//! the same order.
+
+use std::sync::Arc;
+
+use common::storage::StorageRead;
+use tracing::warn;
+
+use crate::error::Result;
+use crate::query_engine::operator::{BoxedOperator, Operator};
+use crate::query_engine::types::{ScoredVector, ScoredVectorId};
+use crate::serde::vector_data::VectorDataValue;
+use crate::storage::VectorDbStorageReadExt;
+use crate::{Attribute, Vector};
+
+/// Resolves ranked vector ids to their forward-index data.
+pub(crate) struct LookupOperator {
+    storage: Arc<dyn StorageRead>,
+    dimensions: usize,
+    child: BoxedOperator<Vec<ScoredVectorId>>,
+}
+
+impl LookupOperator {
+    pub(crate) fn new(
+        storage: Arc<dyn StorageRead>,
+        dimensions: usize,
+        child: BoxedOperator<Vec<ScoredVectorId>>,
+    ) -> Self {
+        Self {
+            storage,
+            dimensions,
+            child,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Operator<Vec<ScoredVector>> for LookupOperator {
+    /// Loads the forward-index data for each scored id, preserving order.
+    ///
+    /// Assumes every id still exists in the forward index — deletes are resolved
+    /// upstream by the scoring operator — so a missing entry (e.g. a concurrent
+    /// compaction) is logged as a warning and skipped rather than treated as a
+    /// normal delete.
+    async fn execute(&self) -> Result<Vec<ScoredVector>> {
+        let scored = self.child.execute().await?;
+
+        let loaded = futures::future::join_all(
+            scored
+                .iter()
+                .map(|entry| self.storage.get_vector_data(entry.val, self.dimensions)),
+        )
+        .await;
+
+        let mut results = Vec::with_capacity(scored.len());
+        for (entry, vector_data) in scored.into_iter().zip(loaded) {
+            let Some(vector_data) = vector_data? else {
+                warn!(
+                    id = entry.val.id(),
+                    "ranked document missing from forward index; skipping"
+                );
+                continue;
+            };
+            results.push(ScoredVector {
+                val: vector_data_to_vector(&vector_data),
+                score: entry.score,
+            });
+        }
+        Ok(results)
+    }
+}
+
+/// Convert a stored `VectorDataValue` into the public `Vector` shape.
+pub(crate) fn vector_data_to_vector(vector_data: &VectorDataValue) -> Vector {
+    let attributes = vector_data
+        .fields()
+        .map(|field| Attribute::new(field.field_name.clone(), field.value.clone().into()))
+        .collect();
+    Vector {
+        id: vector_data.external_id().to_string(),
+        attributes,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::AttributeValue;
+    use crate::db::VectorDb;
+    use crate::model::{Config, MetadataFieldSpec, Vector};
+    use crate::serde::FieldType;
+    use crate::serde::collection_meta::DistanceMetric;
+    use crate::serde::vector_id::VectorId;
+    use common::StorageConfig;
+
+    /// A child operator that yields a fixed list of scored ids.
+    struct Fixed(Vec<ScoredVectorId>);
+
+    #[async_trait::async_trait]
+    impl Operator<Vec<ScoredVectorId>> for Fixed {
+        async fn execute(&self) -> Result<Vec<ScoredVectorId>> {
+            Ok(self
+                .0
+                .iter()
+                .map(|entry| ScoredVectorId {
+                    val: entry.val,
+                    score: entry.score,
+                })
+                .collect())
+        }
+    }
+
+    fn config() -> Config {
+        Config {
+            storage: StorageConfig::InMemory,
+            dimensions: 3,
+            distance_metric: DistanceMetric::L2,
+            metadata_fields: vec![MetadataFieldSpec::new("category", FieldType::String, true)],
+            ..Default::default()
+        }
+    }
+
+    fn doc(id: &str, category: &str) -> Vector {
+        Vector::builder(id, vec![0.0; 3])
+            .attribute("category", category)
+            .build()
+    }
+
+    async fn seeded_db() -> VectorDb {
+        let db = VectorDb::open(config()).await.unwrap();
+        db.write(vec![doc("d1", "a"), doc("d2", "b")])
+            .await
+            .unwrap();
+        db.flush().await.unwrap();
+        db
+    }
+
+    async fn internal_id(db: &VectorDb, external: &str) -> VectorId {
+        db.query_engine()
+            .storage
+            .lookup_internal_id(external)
+            .await
+            .unwrap()
+            .unwrap()
+    }
+
+    /// Build a `LookupOperator` from the db's storage snapshot, fed `child` ids.
+    fn lookup_op(db: &VectorDb, child: Vec<ScoredVectorId>) -> LookupOperator {
+        let engine = db.query_engine();
+        LookupOperator::new(
+            engine.storage.clone(),
+            engine.options.dimensions as usize,
+            Box::new(Fixed(child)),
+        )
+    }
+
+    #[tokio::test]
+    async fn should_resolve_ids_to_vectors_in_order() {
+        let db = seeded_db().await;
+        let d1 = internal_id(&db, "d1").await;
+        let d2 = internal_id(&db, "d2").await;
+
+        // child yields d2 (higher score) then d1
+        let results = lookup_op(
+            &db,
+            vec![
+                ScoredVectorId {
+                    val: d2,
+                    score: 2.0,
+                },
+                ScoredVectorId {
+                    val: d1,
+                    score: 1.0,
+                },
+            ],
+        )
+        .execute()
+        .await
+        .unwrap();
+
+        // order + scores preserved, ids resolved, attributes loaded
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].val.id, "d2");
+        assert_eq!(results[0].score, 2.0);
+        assert_eq!(
+            results[0].val.attribute("category"),
+            Some(&AttributeValue::String("b".to_string()))
+        );
+        assert_eq!(results[1].val.id, "d1");
+        assert_eq!(results[1].score, 1.0);
+    }
+
+    #[tokio::test]
+    async fn should_skip_ids_missing_from_forward_index() {
+        let db = seeded_db().await;
+        let d1 = internal_id(&db, "d1").await;
+        let missing = VectorId::data_vector_id(9_999_999);
+
+        let results = lookup_op(
+            &db,
+            vec![
+                ScoredVectorId {
+                    val: missing,
+                    score: 5.0,
+                },
+                ScoredVectorId {
+                    val: d1,
+                    score: 1.0,
+                },
+            ],
+        )
+        .execute()
+        .await
+        .unwrap();
+
+        // the missing id is dropped; the present one survives
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].val.id, "d1");
+    }
+}

--- a/vector/src/query_engine/materializer.rs
+++ b/vector/src/query_engine/materializer.rs
@@ -1,3 +1,0 @@
-//! Forward-index result materialization (`ResultMaterializer`).
-//!
-//! Populated in a later refactor step; see `query-engine-refactor.md`.

--- a/vector/src/query_engine/mod.rs
+++ b/vector/src/query_engine/mod.rs
@@ -9,23 +9,20 @@ mod types;
 
 use crate::Vector;
 use crate::error::{Error, Result};
-use crate::math::distance;
-use crate::metric_names::{QUERY_SEARCH_DURATION_SECONDS, QUERY_VECTORS_SCORED_TOTAL};
+use crate::metric_names::QUERY_SEARCH_DURATION_SECONDS;
 use crate::model::{Bm25Query, Query, ScoreBy, SearchOptions, SearchResult};
+use crate::query_engine::ann::{ANNOperator, ExhaustiveNNOperator};
 use crate::query_engine::bm25::BM25Operator;
 use crate::query_engine::filter::PreparedFilter;
 use crate::query_engine::lookup::LookupOperator;
-use crate::query_engine::operator::Operator;
+use crate::query_engine::operator::{BoxedOperator, Operator};
 use crate::query_engine::project::ProjectOperator;
 use crate::serde::collection_meta::DistanceMetric;
 use crate::serde::vector_bitmap::VectorBitmap;
-use crate::serde::vector_id::VectorId;
 use crate::storage::VectorDbStorageReadExt;
-use crate::write::indexer::tree::centroids::{LeveledCentroidIndex, search_centroids};
-use crate::write::indexer::tree::posting_list::{Posting, PostingList};
+use crate::write::indexer::tree::centroids::LeveledCentroidIndex;
 use common::storage::StorageRead;
-use std::cmp::Reverse;
-use std::collections::{BinaryHeap, HashSet};
+use std::marker::PhantomData;
 use std::sync::Arc;
 use std::time::Instant;
 use tracing::debug;
@@ -70,14 +67,6 @@ impl QueryEngine {
         }
     }
 
-    /// Normalize the query vector if required by distance metric.
-    /// Returns a (possibly normalized) copy of the query vector.
-    fn normalize_query_if_needed(&self, query: &[f32]) -> Vec<f32> {
-        let mut v = query.to_vec();
-        self.options.distance_metric.normalize_if_needed(&mut v);
-        v
-    }
-
     pub(crate) async fn get(&self, id: &str) -> Result<Option<Vector>> {
         // 1. Lookup internal ID from IdDictionary
         let Some(internal_id) = self.storage.lookup_internal_id(id).await? else {
@@ -114,52 +103,28 @@ impl QueryEngine {
                 ));
             }
         };
-        if ann_vector.len() != self.options.dimensions as usize {
-            return Err(Error::InvalidInput(format!(
-                "Query dimension mismatch: expected {}, got {}",
-                self.options.dimensions,
-                ann_vector.len()
-            )));
-        }
-
-        // Normalize query vector if required.
-        let query_vector = self.normalize_query_if_needed(ann_vector);
-
-        // Brute-force: compute distance from query to every live centroid
-        let centroid_candidates = self.search_centroids(&query_vector, usize::MAX).await?;
-        let centroid_ids: Vec<VectorId> = centroid_candidates
-            .iter()
-            .take(nprobe)
-            .map(|posting| posting.id())
-            .collect();
-
-        if centroid_ids.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let centroid_ids = self.prune_centroids(
-            &centroid_candidates
-                .into_iter()
-                .take(nprobe)
-                .collect::<Vec<_>>(),
-            &query_vector,
+        let filter = PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
+        let source = ExhaustiveNNOperator::new(
+            self.storage.clone(),
+            self.centroid_index.clone(),
+            self.options.clone(),
+            ann_vector.clone(),
+            filter,
+            nprobe,
+            query.limit,
         );
-
-        let mut sorted_lists = self.load_and_score(&centroid_ids, &query_vector).await?;
-        if sorted_lists.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Apply metadata filter
-        let prepared_filter =
-            PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
-        for list in sorted_lists.iter_mut() {
-            list.retain(|candidate| prepared_filter.matches(candidate.internal_id.id()));
-        }
-
-        let mut results = self.resolve_top_k(sorted_lists, query.limit).await?;
-        project::apply_field_selection(&mut results, &query.include_fields);
-        Ok(results)
+        let lookup = LookupOperator::new(
+            self.storage.clone(),
+            self.options.dimensions as usize,
+            Box::new(source),
+        );
+        let project = ProjectOperator::new(query.include_fields.clone(), Box::new(lookup));
+        Ok(project
+            .execute()
+            .await?
+            .into_iter()
+            .map(SearchResult::from)
+            .collect())
     }
 
     pub(crate) async fn search_with_options(
@@ -179,93 +144,72 @@ impl QueryEngine {
         query: &Query,
         options: SearchOptions,
     ) -> Result<Vec<SearchResult>> {
-        match &query.score_by {
-            ScoreBy::Ann(vector) => self.search_ann(vector, query, options).await,
-            ScoreBy::Bm25(bm25) => self.search_bm25(bm25, query).await,
-        }
-    }
-
-    async fn search_ann(
-        &self,
-        ann_vector: &[f32],
-        query: &Query,
-        options: SearchOptions,
-    ) -> Result<Vec<SearchResult>> {
-        let nprobe = options.nprobe.unwrap_or_else(|| query.limit.clamp(10, 100));
-        // 1. Validate query dimensions
-        if ann_vector.len() != self.options.dimensions as usize {
-            return Err(Error::InvalidInput(format!(
-                "Query dimension mismatch: expected {}, got {}",
-                self.options.dimensions,
-                ann_vector.len()
-            )));
-        }
-
-        // 2. Normalize query vector if required.
-        let query_vector = self.normalize_query_if_needed(ann_vector);
-
-        // 3. Search HNSW for nearest centroids
-        let num_centroids = nprobe;
         let t = Instant::now();
-        let centroid_candidates = self.search_centroids(&query_vector, num_centroids).await?;
-        debug!(
-            "searched for {} centroids, found: {}, elapsed_ms: {:?}",
-            num_centroids,
-            centroid_candidates.len(),
-            t.elapsed().as_millis()
-        );
-
-        if centroid_candidates.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // 3. Dynamic pruning: skip posting lists whose centroids are far from query
-        let original_ncentroids = centroid_candidates.len();
-        let centroid_ids = self.prune_centroids(&centroid_candidates, &query_vector);
-        debug!(
-            "before pruning: {} centroids, after dynamic pruning: {} centroids",
-            original_ncentroids,
-            centroid_ids.len()
-        );
-
-        // 5. Load posting lists and score candidates
-        let mut sorted_lists = self.load_and_score(&centroid_ids, &query_vector).await?;
-
-        if sorted_lists.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // 6. Apply metadata filter (if provided)
-        let prepared_filter =
-            PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
-        for list in sorted_lists.iter_mut() {
-            list.retain(|candidate| prepared_filter.matches(candidate.internal_id.id()));
-        }
-
-        // 7. K-way merge and resolve top-k forward index lookups
-        let mut results = self.resolve_top_k(sorted_lists, query.limit).await?;
-        project::apply_field_selection(&mut results, &query.include_fields);
+        let plan = self.plan(query, options).await?;
+        let results = plan.execute().await?;
         debug!(
             op = "search_with_options",
-            elapsed_ms = t.elapsed().as_millis()
+            elapsed_ms = t.elapsed().as_millis() as u64
         );
         Ok(results)
     }
 
+    async fn plan(
+        &self,
+        query: &Query,
+        options: SearchOptions,
+    ) -> Result<BoxedOperator<Vec<SearchResult>>> {
+        match &query.score_by {
+            ScoreBy::Ann(vector) => self.plan_ann(vector, query, options).await,
+            ScoreBy::Bm25(bm25) => self.plan_bm25(bm25, query).await,
+        }
+    }
+
+    async fn plan_ann(
+        &self,
+        ann_vector: &[f32],
+        query: &Query,
+        options: SearchOptions,
+    ) -> Result<BoxedOperator<Vec<SearchResult>>> {
+        let nprobe = options.nprobe.unwrap_or_else(|| query.limit.clamp(10, 100));
+        // Chain: ann -> lookup -> project. The source validates the query,
+        // probes the `nprobe` nearest centroids (with dynamic pruning), and
+        // ranks the candidates; lookup/project then materialize the results.
+        // TODO: defer filter resolution to execution time
+        let filter = PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
+        let source = ANNOperator::new(
+            self.storage.clone(),
+            self.centroid_index.clone(),
+            self.options.clone(),
+            ann_vector.to_vec(),
+            filter,
+            nprobe,
+            query.limit,
+        );
+        let lookup = LookupOperator::new(
+            self.storage.clone(),
+            self.options.dimensions as usize,
+            Box::new(source),
+        );
+        let project = ProjectOperator::new(query.include_fields.clone(), Box::new(lookup));
+        let plan = LeafOperator::new(project);
+        Ok(Box::new(plan))
+    }
+
     /// BM25 search path (RFC-0006 Milestone 0).
     ///
-    /// Assembles the operator chain `project -> lookup -> bm25` and runs it.
+    /// Assembles the operator chain `bm25 -> lookup -> project` and runs it.
     /// The BM25 operator scores and ranks ids (metadata filtering and FTS delete
-    /// resolution happen there, before scoring), the lookup operator resolves
-    /// the forward-index data, and the project operator applies field selection.
-    async fn search_bm25(&self, bm25: &Bm25Query, query: &Query) -> Result<Vec<SearchResult>> {
-        let t = Instant::now();
-        if query.limit == 0 {
-            return Ok(Vec::new());
-        }
-
+    /// resolution happen there, before scoring); lookup/project then materialize
+    /// the forward-index data and apply field selection.
+    async fn plan_bm25(
+        &self,
+        bm25: &Bm25Query,
+        query: &Query,
+    ) -> Result<BoxedOperator<Vec<SearchResult>>> {
+        // TODO: defer filter resolution to execution time
         let filter = PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
-        let scorer = BM25Operator::new(
+        let source = BM25Operator::new(
             self.storage.clone(),
             bm25.clone(),
             filter,
@@ -275,236 +219,35 @@ impl QueryEngine {
         let lookup = LookupOperator::new(
             self.storage.clone(),
             self.options.dimensions as usize,
-            Box::new(scorer),
+            Box::new(source),
         );
         let project = ProjectOperator::new(query.include_fields.clone(), Box::new(lookup));
-
-        let results = project
-            .execute()
-            .await?
-            .into_iter()
-            .map(SearchResult::from)
-            .collect();
-
-        debug!(
-            op = "search_bm25",
-            elapsed_ms = t.elapsed().as_millis() as u64
-        );
-        Ok(results)
-    }
-
-    /// Apply query-aware dynamic pruning
-    /// (SPANN §3.2: https://arxiv.org/pdf/2111.08566).
-    ///
-    /// Given candidate centroid IDs (already sorted closest-first), computes
-    /// the raw distance from the query to each centroid and keeps only those
-    /// satisfying `dist(q, c) <= (1 + epsilon) * dist(q, closest)`.
-    ///
-    /// Returns the pruned centroid IDs. If pruning is disabled (`None`), returns
-    /// the input unchanged.
-    pub(crate) fn prune_centroids(&self, centroid_ids: &[Posting], query: &[f32]) -> Vec<VectorId> {
-        let epsilon = match self.options.query_pruning_factor {
-            Some(e) => e,
-            None => return centroid_ids.iter().map(|posting| posting.id()).collect(),
-        };
-
-        let metric = self.options.distance_metric;
-
-        // Compute raw distance (lower = closer) from query to each centroid.
-        let mut scored: Vec<(VectorId, f32)> = centroid_ids
-            .iter()
-            .map(|posting| {
-                (
-                    posting.id(),
-                    distance::raw_distance(query, posting.vector(), metric),
-                )
-            })
-            .collect();
-        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal));
-
-        if scored.is_empty() {
-            return Vec::new();
-        }
-
-        let closest_dist = scored[0].1;
-        // Skip pruning when closest distance is non-positive (can happen with
-        // DotProduct metric) since the multiplicative threshold is meaningless.
-        if closest_dist < 0.0 {
-            return scored.into_iter().map(|(id, _)| id).collect();
-        }
-
-        let threshold = match metric {
-            // raw_distance uses squared L2, so preserve epsilon semantics in
-            // Euclidean space by squaring the multiplicative factor.
-            DistanceMetric::L2 | DistanceMetric::Cosine => (1.0 + epsilon).powi(2) * closest_dist,
-            DistanceMetric::DotProduct => (1.0 + epsilon) * closest_dist,
-        };
-        scored
-            .into_iter()
-            .take_while(|&(_, d)| d <= threshold)
-            .map(|(id, _)| id)
-            .collect()
-    }
-
-    async fn search_centroids(&self, query: &[f32], k: usize) -> Result<Vec<Posting>> {
-        search_centroids(self.centroid_index.as_ref(), query, k).await
-    }
-
-    /// Spawn a task per centroid to load its posting list and score all candidates
-    /// against the query vector. Returns per-centroid sorted candidate lists.
-    async fn load_and_score(
-        &self,
-        centroid_ids: &[VectorId],
-        query: &[f32],
-    ) -> Result<Vec<Vec<ScoredCandidate>>> {
-        let dimensions = self.options.dimensions as usize;
-        let metric = self.options.distance_metric;
-        let query_vec: Vec<f32> = query.to_vec();
-
-        let t = Instant::now();
-        let mut handles = Vec::with_capacity(centroid_ids.len());
-        for &cid in centroid_ids {
-            let snap = self.storage.clone();
-            let q = query_vec.clone();
-            handles.push(tokio::spawn(async move {
-                let posting_list =
-                    PostingList::from_value(snap.get_posting_list(cid, dimensions).await?, false);
-                let mut scored: Vec<ScoredCandidate> = posting_list
-                    .iter()
-                    .map(|posting| {
-                        let d = distance::compute_distance(&q, posting.vector(), metric);
-                        ScoredCandidate {
-                            internal_id: posting.id(),
-                            distance: d,
-                        }
-                    })
-                    .collect();
-                scored.sort_unstable_by_key(|a| a.distance);
-                Ok::<_, Error>(scored)
-            }));
-        }
-
-        let results = futures::future::join_all(handles).await;
-        let elapsed = t.elapsed();
-        debug!(
-            op = "search/load_and_score/load",
-            elapsed_ms = elapsed.as_millis()
-        );
-        let mut sorted_lists: Vec<Vec<ScoredCandidate>> = Vec::with_capacity(results.len());
-        let mut total_scored: u64 = 0;
-        for result in results {
-            let scored =
-                result.map_err(|e| Error::Internal(format!("task join error: {}", e)))??;
-            total_scored += scored.len() as u64;
-            if !scored.is_empty() {
-                sorted_lists.push(scored);
-            }
-        }
-        metrics::counter!(QUERY_VECTORS_SCORED_TOTAL).increment(total_scored);
-
-        Ok(sorted_lists)
-    }
-
-    /// K-way merge the per-centroid sorted lists and resolve top-k forward
-    /// index lookups. Only merges as far into the lists as needed to produce
-    /// k results, deduplicating by `internal_id` along the way.
-    async fn resolve_top_k(
-        &self,
-        sorted_lists: Vec<Vec<ScoredCandidate>>,
-        k: usize,
-    ) -> Result<Vec<SearchResult>> {
-        let dimensions = self.options.dimensions as usize;
-
-        // Seed the min-heap with the first element of each sorted list.
-        let mut heap = BinaryHeap::new();
-        for list in sorted_lists {
-            let mut iter = list.into_iter();
-            if let Some(first) = iter.next() {
-                heap.push(Reverse(MergeEntry(first, iter)));
-            }
-        }
-
-        let mut results = Vec::with_capacity(k);
-        let mut seen = HashSet::new();
-
-        // Pop candidates from the heap in score order, batch-resolve k at a
-        // time, and stop as soon as we have k results.
-        loop {
-            // Drain up to k unique candidates from the merge heap.
-            let mut batch = Vec::with_capacity(k - results.len());
-            while batch.len() < k - results.len() {
-                let Some(Reverse(MergeEntry(candidate, mut iter))) = heap.pop() else {
-                    break;
-                };
-                if let Some(next) = iter.next() {
-                    heap.push(Reverse(MergeEntry(next, iter)));
-                }
-                if seen.insert(candidate.internal_id) {
-                    batch.push(candidate);
-                }
-            }
-
-            if batch.is_empty() {
-                break;
-            }
-
-            // Resolve forward index lookups for the batch concurrently.
-            let t = Instant::now();
-            let futures: Vec<_> = batch
-                .iter()
-                .map(|sr| self.storage.get_vector_data(sr.internal_id, dimensions))
-                .collect();
-            let loaded = futures::future::join_all(futures).await;
-            let elapsed = t.elapsed();
-            debug!(
-                op = "query/resolve_top_k/load",
-                elapsed_ms = elapsed.as_millis() as u64,
-            );
-
-            for (sr, vector_data) in batch.iter().zip(loaded) {
-                let Some(vector_data) = vector_data? else {
-                    continue;
-                };
-                results.push(SearchResult {
-                    score: sr.distance.score(),
-                    vector: lookup::vector_data_to_vector(&vector_data),
-                });
-
-                if results.len() == k {
-                    return Ok(results);
-                }
-            }
-        }
-
-        Ok(results)
+        let plan = LeafOperator::new(project);
+        Ok(Box::new(plan))
     }
 }
 
-struct ScoredCandidate {
-    internal_id: VectorId,
-    distance: distance::VectorDistance,
+struct LeafOperator<T: Into<SearchResult>, O: Operator<Vec<T>>> {
+    child: O,
+    phantom: PhantomData<T>,
 }
 
-/// Entry for k-way merge of sorted scored candidate lists.
-struct MergeEntry(ScoredCandidate, std::vec::IntoIter<ScoredCandidate>);
-
-impl PartialEq for MergeEntry {
-    fn eq(&self, other: &Self) -> bool {
-        self.0.distance == other.0.distance
+impl<T: Into<SearchResult>, O: Operator<Vec<T>>> LeafOperator<T, O> {
+    fn new(child: O) -> Self {
+        Self {
+            child,
+            phantom: PhantomData,
+        }
     }
 }
 
-impl Eq for MergeEntry {}
-
-impl PartialOrd for MergeEntry {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for MergeEntry {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.0.distance.cmp(&other.0.distance)
+#[async_trait::async_trait]
+impl<T: Into<SearchResult> + Send + Sync + 'static, O: Operator<Vec<T>> + Send + Sync + 'static>
+    Operator<Vec<SearchResult>> for LeafOperator<T, O>
+{
+    async fn execute(&self) -> Result<Vec<SearchResult>> {
+        let results = self.child.execute().await?;
+        Ok(results.into_iter().map(|r| r.into()).collect())
     }
 }
 
@@ -514,13 +257,7 @@ mod tests {
     use crate::db::{VectorDb, VectorDbRead};
     use crate::model::{Config, Query, VECTOR_FIELD_NAME, Vector};
     use crate::serde::collection_meta::DistanceMetric;
-    use crate::serde::vector_id::VectorId;
-    use crate::write::indexer::tree::posting_list::Posting;
     use common::{StorageBuilder, StorageConfig};
-
-    fn data_id(id: u64) -> VectorId {
-        VectorId::data_vector_id(id)
-    }
 
     fn create_config(dimensions: u16, metric: DistanceMetric) -> Config {
         Config {
@@ -530,113 +267,6 @@ mod tests {
             metadata_fields: vec![],
             ..Default::default()
         }
-    }
-
-    // --- Prune tests ---
-
-    #[tokio::test]
-    async fn should_prune_centroids_beyond_epsilon_threshold() {
-        // given - 4 centroids at known L2 distances from query [0,0,0]:
-        //   c0 = [1,0,0]  -> dist = 1.0
-        //   c1 = [1.4,0,0] -> dist = 1.4
-        //   c2 = [2,0,0]  -> dist = 2.0
-        //   c3 = [5,0,0]  -> dist = 5.0
-        // epsilon = 0.5 => threshold = 1.5 * 1.0 = 1.5
-        // Expected: c0 (1.0) and c1 (1.4) survive; c2 (2.0) and c3 (5.0) pruned.
-        let config = Config {
-            query_pruning_factor: Some(0.5),
-            ..create_config(3, DistanceMetric::L2)
-        };
-        let centroids = vec![
-            vec![1.0, 0.0, 0.0],
-            vec![1.4, 0.0, 0.0],
-            vec![2.0, 0.0, 0.0],
-            vec![5.0, 0.0, 0.0],
-        ];
-        let db = {
-            let sb = StorageBuilder::new(&config.storage).await.unwrap();
-            VectorDb::open_with_centroids(config, centroids, sb)
-        }
-        .await
-        .unwrap();
-
-        let query = [0.0, 0.0, 0.0];
-        let engine = db.query_engine();
-        let all_centroids = vec![
-            Posting::from_vec(data_id(1), vec![1.0, 0.0, 0.0]),
-            Posting::from_vec(data_id(2), vec![1.4, 0.0, 0.0]),
-            Posting::from_vec(data_id(3), vec![2.0, 0.0, 0.0]),
-            Posting::from_vec(data_id(4), vec![5.0, 0.0, 0.0]),
-        ];
-
-        // when
-        let pruned = engine.prune_centroids(&all_centroids, &query);
-
-        // then
-        assert_eq!(pruned.len(), 2);
-        assert_eq!(pruned[0], data_id(1)); // closest
-        assert_eq!(pruned[1], data_id(2)); // within threshold
-    }
-
-    #[tokio::test]
-    async fn should_skip_pruning_when_epsilon_is_none() {
-        // given - no pruning configured
-        let config = create_config(3, DistanceMetric::L2);
-        let centroids = vec![vec![1.0, 0.0, 0.0], vec![100.0, 0.0, 0.0]];
-        let db = {
-            let sb = StorageBuilder::new(&config.storage).await.unwrap();
-            VectorDb::open_with_centroids(config, centroids, sb)
-        }
-        .await
-        .unwrap();
-
-        let query = [0.0, 0.0, 0.0];
-        let engine = db.query_engine();
-        let all_centroids = vec![
-            Posting::from_vec(data_id(1), vec![1.0, 0.0, 0.0]),
-            Posting::from_vec(data_id(2), vec![100.0, 0.0, 0.0]),
-        ];
-
-        // when
-        let result = engine.prune_centroids(&all_centroids, &query);
-
-        // then - all centroids returned regardless of distance
-        assert_eq!(result.len(), 2);
-    }
-
-    #[tokio::test]
-    async fn should_prune_centroids_returns_sorted_by_distance() {
-        // given - pass centroid IDs in non-distance order
-        let config = Config {
-            query_pruning_factor: Some(10.0), // large epsilon, keeps all
-            ..create_config(3, DistanceMetric::L2)
-        };
-        let centroids = vec![
-            vec![5.0, 0.0, 0.0], // c0: far
-            vec![1.0, 0.0, 0.0], // c1: close
-            vec![3.0, 0.0, 0.0], // c2: medium
-        ];
-        let db = {
-            let sb = StorageBuilder::new(&config.storage).await.unwrap();
-            VectorDb::open_with_centroids(config, centroids, sb)
-        }
-        .await
-        .unwrap();
-
-        let query = [0.0, 0.0, 0.0];
-        let engine = db.query_engine();
-        // pass centroids in reverse distance order: far, medium, close
-        let ids = vec![
-            Posting::from_vec(data_id(1), vec![5.0, 0.0, 0.0]),
-            Posting::from_vec(data_id(3), vec![3.0, 0.0, 0.0]),
-            Posting::from_vec(data_id(2), vec![1.0, 0.0, 0.0]),
-        ];
-
-        // when
-        let result = engine.prune_centroids(&ids, &query);
-
-        // then - sorted by ascending distance: c1 (1.0), c2 (3.0), c0 (5.0)
-        assert_eq!(result, vec![data_id(2), data_id(3), data_id(1)]);
     }
 
     // --- Search tests ---

--- a/vector/src/query_engine/mod.rs
+++ b/vector/src/query_engine/mod.rs
@@ -1,31 +1,30 @@
 mod ann;
 mod bm25;
 mod collectors;
-mod driver;
 mod filter;
-mod materializer;
+mod lookup;
+mod operator;
+mod project;
+mod types;
 
+use crate::Vector;
 use crate::error::{Error, Result};
-use crate::math::bm25 as bm25_math;
 use crate::math::distance;
 use crate::metric_names::{QUERY_SEARCH_DURATION_SECONDS, QUERY_VECTORS_SCORED_TOTAL};
-use crate::model::{Bm25Query, FieldSelection, Query, ScoreBy, SearchOptions, SearchResult};
+use crate::model::{Bm25Query, Query, ScoreBy, SearchOptions, SearchResult};
+use crate::query_engine::bm25::BM25Operator;
 use crate::query_engine::filter::PreparedFilter;
+use crate::query_engine::lookup::LookupOperator;
+use crate::query_engine::operator::Operator;
+use crate::query_engine::project::ProjectOperator;
 use crate::serde::collection_meta::DistanceMetric;
-use crate::serde::field_stats::FieldStatsValue;
-use crate::serde::key::{FieldStatsKey, TermPostingsKey, TermStatsKey};
-use crate::serde::term_postings::{PostingEntry, TermPostingsValue};
-use crate::serde::term_stats::TermStatsValue;
 use crate::serde::vector_bitmap::VectorBitmap;
-use crate::serde::vector_data::VectorDataValue;
 use crate::serde::vector_id::VectorId;
 use crate::storage::VectorDbStorageReadExt;
-use crate::text;
 use crate::write::indexer::tree::centroids::{LeveledCentroidIndex, search_centroids};
 use crate::write::indexer::tree::posting_list::{Posting, PostingList};
-use crate::{Attribute, Vector};
 use common::storage::StorageRead;
-use std::cmp::{Ordering, Reverse};
+use std::cmp::Reverse;
 use std::collections::{BinaryHeap, HashSet};
 use std::sync::Arc;
 use std::time::Instant;
@@ -53,7 +52,6 @@ pub(crate) struct QueryEngine {
     storage: Arc<dyn StorageRead>,
     /// FTS deletions bitmap published by the flusher, used by the BM25 query
     /// path to hide deleted/replaced docs without a per-query storage read.
-    #[allow(dead_code)]
     deletions: Arc<VectorBitmap>,
 }
 
@@ -100,18 +98,7 @@ impl QueryEngine {
             return Ok(None);
         };
 
-        Ok(Some(Self::vector_data_to_vector(&vector_data)))
-    }
-
-    fn vector_data_to_vector(vector_data: &VectorDataValue) -> Vector {
-        let attributes = vector_data
-            .fields()
-            .map(|field| Attribute::new(field.field_name.clone(), field.value.clone().into()))
-            .collect();
-        Vector {
-            id: vector_data.external_id().to_string(),
-            attributes,
-        }
+        Ok(Some(lookup::vector_data_to_vector(&vector_data)))
     }
 
     pub(crate) async fn search_exact_nprobe(
@@ -171,7 +158,7 @@ impl QueryEngine {
         }
 
         let mut results = self.resolve_top_k(sorted_lists, query.limit).await?;
-        Self::apply_field_selection(&mut results, &query.include_fields);
+        project::apply_field_selection(&mut results, &query.include_fields);
         Ok(results)
     }
 
@@ -257,7 +244,7 @@ impl QueryEngine {
 
         // 7. K-way merge and resolve top-k forward index lookups
         let mut results = self.resolve_top_k(sorted_lists, query.limit).await?;
-        Self::apply_field_selection(&mut results, &query.include_fields);
+        project::apply_field_selection(&mut results, &query.include_fields);
         debug!(
             op = "search_with_options",
             elapsed_ms = t.elapsed().as_millis()
@@ -267,210 +254,43 @@ impl QueryEngine {
 
     /// BM25 search path (RFC-0006 Milestone 0).
     ///
-    /// Iterates the union of per-term posting lists document by document in
-    /// descending `doc_id` order, accumulates each document's BM25 score in a
-    /// single pass, and maintains a top-K min-heap. Metadata filtering is
-    /// applied via a cached allow-list bitmap that is recomputed in 10K-wide
-    /// `doc_id` windows as the loop advances.
+    /// Assembles the operator chain `project -> lookup -> bm25` and runs it.
+    /// The BM25 operator scores and ranks ids (metadata filtering and FTS delete
+    /// resolution happen there, before scoring), the lookup operator resolves
+    /// the forward-index data, and the project operator applies field selection.
     async fn search_bm25(&self, bm25: &Bm25Query, query: &Query) -> Result<Vec<SearchResult>> {
         let t = Instant::now();
         if query.limit == 0 {
             return Ok(Vec::new());
         }
 
-        let terms = dedupe_query_terms(&bm25.query);
-        if terms.is_empty() {
-            return Ok(Vec::new());
-        }
+        let filter = PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
+        let scorer = BM25Operator::new(
+            self.storage.clone(),
+            bm25.clone(),
+            filter,
+            self.deletions.clone(),
+            query.limit,
+        );
+        let lookup = LookupOperator::new(
+            self.storage.clone(),
+            self.options.dimensions as usize,
+            Box::new(scorer),
+        );
+        let project = ProjectOperator::new(query.include_fields.clone(), Box::new(lookup));
 
-        // Per-field corpus stats are required to compute IDF / avgdl.
-        let field_stats = self.load_field_stats(&bm25.field).await?;
-        let n_docs = field_stats.count.max(0) as u64;
-        if n_docs == 0 || field_stats.total_length <= 0 {
-            return Ok(Vec::new());
-        }
-        let avgdl = field_stats.total_length as f32 / n_docs as f32;
+        let results = project
+            .execute()
+            .await?
+            .into_iter()
+            .map(SearchResult::from)
+            .collect();
 
-        // Build one stream per query term with the term's pre-computed IDF.
-        let mut streams = self.open_term_streams(&bm25.field, &terms, n_docs).await?;
-        if streams.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        // Max-heap of (current head doc_id, stream index) so we can pop all
-        // streams sharing the next-highest doc_id together.
-        let mut head_heap: BinaryHeap<StreamHead> = BinaryHeap::with_capacity(streams.len());
-        for (idx, stream) in streams.iter().enumerate() {
-            if let Some(doc_id) = stream.peek_doc_id() {
-                head_heap.push(StreamHead {
-                    doc_id,
-                    stream_idx: idx,
-                });
-            }
-        }
-
-        // Prepared metadata filter. `matches` answers per-doc membership
-        // without materialising the full corpus universe, so the BM25 loop can
-        // check each candidate as it is scored.
-        let prepared_filter =
-            PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
-
-        // Min-heap (via `WorstFirst` ordering) tracking the K worst candidates
-        // accepted so far. `peek()` is the candidate to evict.
-        let mut top_k: BinaryHeap<WorstFirst> = BinaryHeap::with_capacity(query.limit);
-        let dimensions = self.options.dimensions as usize;
-
-        // Reused per-doc buffer so we don't allocate a fresh Vec each iteration.
-        let mut hits: Vec<bm25_math::Bm25TermEntry> = Vec::with_capacity(streams.len());
-
-        while head_heap.peek().is_some() {
-            let doc_id = head_heap.peek().expect("non-empty").doc_id;
-
-            // Drain every stream sharing this doc_id into a per-doc hit buffer.
-            hits.clear();
-            while let Some(top) = head_heap.peek().copied() {
-                if top.doc_id != doc_id {
-                    break;
-                }
-                head_heap.pop();
-                let stream = &mut streams[top.stream_idx];
-                let entry = stream
-                    .pop()
-                    .expect("stream head was on heap but pop returned None");
-                hits.push(bm25_math::Bm25TermEntry {
-                    freq: entry.freq,
-                    norm: entry.norm,
-                    idf: stream.idf,
-                });
-                if let Some(next) = stream.peek_doc_id() {
-                    head_heap.push(StreamHead {
-                        doc_id: next,
-                        stream_idx: top.stream_idx,
-                    });
-                }
-            }
-
-            // Apply the metadata filter BEFORE scoring so excluded docs
-            // don't pay the BM25 cost.
-            if !prepared_filter.matches(doc_id) {
-                continue;
-            }
-
-            // The in-memory FTS deletions bitmap is the authority for delete
-            // resolution on this path. `doc_id` is the raw internal id from
-            // the posting, which is the same id space the bitmap indexes
-            // (data vectors are level 0, so the raw u64 equals
-            // `VectorId::data_vector_id(doc_id).id()`). Skip deleted/replaced
-            // docs before paying the scoring cost; this — not the forward
-            // index — hides deleted documents.
-            if self.deletions.contains(doc_id) {
-                continue;
-            }
-
-            // Single BM25 evaluation per document.
-            let score = bm25_math::score(&hits, avgdl);
-
-            // Skip candidates that cannot enter the current top-K.
-            if top_k.len() == query.limit
-                && let Some(worst) = top_k.peek()
-                && !is_better(score, doc_id, worst.score, worst.doc_id)
-            {
-                continue;
-            }
-
-            // The bound check above already guaranteed this entry beats the
-            // current worst when the heap is full, so just evict and push.
-            // We defer the forward-index `get_vector_data` lookup until after
-            // the loop so it runs only for the K survivors rather than every
-            // scored candidate.
-            if top_k.len() == query.limit {
-                top_k.pop();
-            }
-            top_k.push(WorstFirst { score, doc_id });
-        }
-
-        // Fetch the forward-index `VectorData` for only the K survivors. The
-        // deletions bitmap above already resolved deletes, so the get None
-        // branch is a defensive fallback (e.g. a concurrent compaction) rather
-        // than the primary delete mechanism.
-        let mut results: Vec<SearchResult> = Vec::with_capacity(top_k.len());
-        for candidate in top_k.into_iter() {
-            let vector_id = VectorId::data_vector_id(candidate.doc_id);
-            let Some(vector_data) = self.storage.get_vector_data(vector_id, dimensions).await?
-            else {
-                continue;
-            };
-            results.push(SearchResult {
-                score: candidate.score,
-                vector: Self::vector_data_to_vector(&vector_data),
-            });
-        }
-
-        // Order results: descending score, ties broken by ascending doc id
-        // (matches the existing ANN ordering convention).
-        results.sort_by(|a, b| {
-            b.score
-                .partial_cmp(&a.score)
-                .unwrap_or(Ordering::Equal)
-                .then_with(|| a.vector.id.cmp(&b.vector.id))
-        });
-        Self::apply_field_selection(&mut results, &query.include_fields);
         debug!(
             op = "search_bm25",
             elapsed_ms = t.elapsed().as_millis() as u64
         );
         Ok(results)
-    }
-
-    /// Load postings + term stats for each query term and wrap them as
-    /// `PostingStream`s carrying pre-computed IDF. Streams for which the
-    /// term has no documents are omitted.
-    async fn open_term_streams(
-        &self,
-        field: &str,
-        terms: &[String],
-        n_docs: u64,
-    ) -> Result<Vec<PostingStream>> {
-        let mut streams = Vec::with_capacity(terms.len());
-        for term in terms {
-            let postings = self.load_term_postings(field, term).await?;
-            let stats = self.load_term_stats(field, term).await?;
-            let n_t = stats.freq.max(0) as u64;
-            if n_t == 0 {
-                continue;
-            }
-            // Block iteration order is already descending by doc id.
-            let entries: Vec<PostingEntry> = postings.iter_entries().copied().collect();
-            if entries.is_empty() {
-                continue;
-            }
-            streams.push(PostingStream::new(entries, bm25_math::idf(n_docs, n_t)));
-        }
-        Ok(streams)
-    }
-
-    async fn load_field_stats(&self, field: &str) -> Result<FieldStatsValue> {
-        let key = FieldStatsKey::new(field).encode();
-        match self.storage.get(key).await? {
-            Some(record) => Ok(FieldStatsValue::decode_from_bytes(&record.value)?),
-            None => Ok(FieldStatsValue::default()),
-        }
-    }
-
-    async fn load_term_stats(&self, field: &str, term: &str) -> Result<TermStatsValue> {
-        let key = TermStatsKey::new(field, term).encode();
-        match self.storage.get(key).await? {
-            Some(record) => Ok(TermStatsValue::decode_from_bytes(&record.value)?),
-            None => Ok(TermStatsValue::default()),
-        }
-    }
-
-    async fn load_term_postings(&self, field: &str, term: &str) -> Result<TermPostingsValue> {
-        let key = TermPostingsKey::new(field, term).encode();
-        match self.storage.get(key).await? {
-            Some(record) => Ok(TermPostingsValue::decode_from_bytes(&record.value)?),
-            None => Ok(TermPostingsValue::default()),
-        }
     }
 
     /// Apply query-aware dynamic pruning
@@ -647,7 +467,7 @@ impl QueryEngine {
                 };
                 results.push(SearchResult {
                     score: sr.distance.score(),
-                    vector: Self::vector_data_to_vector(&vector_data),
+                    vector: lookup::vector_data_to_vector(&vector_data),
                 });
 
                 if results.len() == k {
@@ -657,26 +477,6 @@ impl QueryEngine {
         }
 
         Ok(results)
-    }
-
-    /// Apply field projection to search results.
-    fn apply_field_selection(results: &mut [SearchResult], selection: &FieldSelection) {
-        match selection {
-            FieldSelection::All => {}
-            FieldSelection::None => {
-                for result in results.iter_mut() {
-                    result.vector.attributes.clear();
-                }
-            }
-            FieldSelection::Fields(names) => {
-                for result in results.iter_mut() {
-                    result
-                        .vector
-                        .attributes
-                        .retain(|attr| names.contains(&attr.name));
-                }
-            }
-        }
     }
 }
 
@@ -706,126 +506,6 @@ impl Ord for MergeEntry {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.0.distance.cmp(&other.0.distance)
     }
-}
-
-/// A term's postings paired with the term's precomputed IDF.
-///
-/// Yields entries in descending `doc_id` order — the same order the
-/// underlying `TermPostingsValue` blocks are stored in (RFC-0006).
-struct PostingStream {
-    /// All entries in descending `doc_id` order.
-    entries: Vec<PostingEntry>,
-    /// Index of the next entry to yield (`pop`).
-    cursor: usize,
-    /// IDF for this stream's term in the current corpus.
-    idf: f32,
-}
-
-impl PostingStream {
-    fn new(entries: Vec<PostingEntry>, idf: f32) -> Self {
-        Self {
-            entries,
-            cursor: 0,
-            idf,
-        }
-    }
-
-    fn peek_doc_id(&self) -> Option<u64> {
-        self.entries.get(self.cursor).map(|e| e.doc_id)
-    }
-
-    /// Consume the current head and advance to the next entry.
-    fn pop(&mut self) -> Option<PostingEntry> {
-        let current = *self.entries.get(self.cursor)?;
-        self.cursor += 1;
-        Some(current)
-    }
-}
-
-/// Heap entry referring to the current head of a `PostingStream` by index.
-///
-/// Ordered by `doc_id` descending so the max-heap returns the
-/// next-highest-id head across all streams.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-struct StreamHead {
-    doc_id: u64,
-    stream_idx: usize,
-}
-
-impl Ord for StreamHead {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.doc_id
-            .cmp(&other.doc_id)
-            .then_with(|| other.stream_idx.cmp(&self.stream_idx))
-    }
-}
-
-impl PartialOrd for StreamHead {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-/// Top-K candidate ordered so `BinaryHeap::peek()` returns the worst
-/// (lowest-score, highest-doc-id) entry — the one to evict next.
-///
-/// Only the score and `doc_id` are carried through the scoring loop; the
-/// forward-index `VectorData` is fetched lazily for the K survivors after the
-/// loop completes (see `search_bm25`).
-struct WorstFirst {
-    score: f32,
-    doc_id: u64,
-}
-
-impl PartialEq for WorstFirst {
-    fn eq(&self, other: &Self) -> bool {
-        self.cmp(other) == Ordering::Equal
-    }
-}
-
-impl Eq for WorstFirst {}
-
-impl PartialOrd for WorstFirst {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for WorstFirst {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // BinaryHeap is a max-heap; we want the "worst" candidate at the
-        // top, so a candidate that is *worse* must compare *greater*. Worse
-        // means lower score, or — on a score tie — higher doc id (since the
-        // final results are sorted by ascending doc id on ties).
-        other
-            .score
-            .total_cmp(&self.score)
-            .then_with(|| self.doc_id.cmp(&other.doc_id))
-    }
-}
-
-/// Returns `true` when `(new_score, new_doc_id)` would rank ahead of
-/// `(other_score, other_doc_id)` in the final BM25 result ordering
-/// (descending score, ties broken by ascending doc id).
-fn is_better(new_score: f32, new_doc_id: u64, other_score: f32, other_doc_id: u64) -> bool {
-    match new_score.partial_cmp(&other_score) {
-        Some(Ordering::Greater) => true,
-        Some(Ordering::Less) => false,
-        Some(Ordering::Equal) | None => new_doc_id < other_doc_id,
-    }
-}
-
-/// Tokenize a BM25 query string and drop duplicate terms while preserving
-/// first-seen order.
-fn dedupe_query_terms(query: &str) -> Vec<String> {
-    let mut seen: HashSet<String> = HashSet::new();
-    let mut unique = Vec::new();
-    for term in text::tokenize(query) {
-        if seen.insert(term.clone()) {
-            unique.push(term);
-        }
-    }
-    unique
 }
 
 #[cfg(test)]
@@ -1599,5 +1279,49 @@ mod tests {
                 results[i].score
             );
         }
+    }
+
+    #[tokio::test]
+    async fn should_search_bm25_end_to_end() {
+        // given - a text field and a few documents
+        let config = Config {
+            storage: StorageConfig::InMemory,
+            dimensions: 3,
+            distance_metric: DistanceMetric::L2,
+            metadata_fields: vec![MetadataFieldSpec::new("body", FieldType::Text, false)],
+            ..Default::default()
+        };
+        let db = VectorDb::open(config).await.unwrap();
+        db.write(vec![
+            Vector::builder("d1", vec![0.0; 3])
+                .attribute("body", "the quick brown fox")
+                .build(),
+            Vector::builder("d2", vec![0.0; 3])
+                .attribute("body", "a fox and another fox")
+                .build(),
+            Vector::builder("d3", vec![0.0; 3])
+                .attribute("body", "completely unrelated text")
+                .build(),
+        ])
+        .await
+        .unwrap();
+        db.flush().await.unwrap();
+
+        // when - run a BM25 query through the full project -> lookup -> bm25 chain
+        let results = db
+            .search(&Query::bm25("body", "fox").with_limit(10))
+            .await
+            .unwrap();
+
+        // then - only matching docs, with the denser match ranked first
+        let ids: Vec<&str> = results.iter().map(|r| r.vector.id.as_str()).collect();
+        assert_eq!(ids, vec!["d2", "d1"]);
+        // scores are non-increasing
+        assert!(results[0].score >= results[1].score);
+        // the text field is materialized in the result by default
+        assert_eq!(
+            results[0].vector.attribute("body"),
+            Some(&AttributeValue::String("a fox and another fox".to_string()))
+        );
     }
 }

--- a/vector/src/query_engine/operator.rs
+++ b/vector/src/query_engine/operator.rs
@@ -1,0 +1,18 @@
+//! The `Operator` execution interface.
+//!
+//! Query execution is modelled as a chain of operators. Each operator produces a
+//! typed result and may pull from a child operator. For example, a BM25 search runs as a
+//! `project -> lookup -> bm25` chain that is driven by calling
+//! [`Operator::execute`] on the root.
+
+/// A node in the query execution chain, producing a value of type `T`.
+#[async_trait::async_trait]
+pub(crate) trait Operator<T> {
+    async fn execute(&self) -> crate::Result<T>;
+}
+
+/// A boxed child operator.
+///
+/// `Send + Sync` so the enclosing query future stays `Send`: `VectorDbRead` is
+/// an `#[async_trait]` trait, whose methods return boxed `Send` futures.
+pub(crate) type BoxedOperator<T> = Box<dyn Operator<T> + Send + Sync>;

--- a/vector/src/query_engine/project.rs
+++ b/vector/src/query_engine/project.rs
@@ -1,0 +1,134 @@
+//! Field-projection operator (`ProjectOperator`).
+//!
+//! Applies the query's [`FieldSelection`] to the vectors produced by its child
+//! operator, trimming each result's attributes in place.
+
+use crate::Vector;
+use crate::error::Result;
+use crate::model::{FieldSelection, SearchResult};
+use crate::query_engine::operator::{BoxedOperator, Operator};
+use crate::query_engine::types::ScoredVector;
+
+/// Projects (field-selects) the vectors produced by a child operator.
+pub(crate) struct ProjectOperator {
+    selection: FieldSelection,
+    child: BoxedOperator<Vec<ScoredVector>>,
+}
+
+impl ProjectOperator {
+    pub(crate) fn new(selection: FieldSelection, child: BoxedOperator<Vec<ScoredVector>>) -> Self {
+        Self { selection, child }
+    }
+}
+
+#[async_trait::async_trait]
+impl Operator<Vec<ScoredVector>> for ProjectOperator {
+    async fn execute(&self) -> Result<Vec<ScoredVector>> {
+        let mut scored = self.child.execute().await?;
+        for vector in &mut scored {
+            project_vector(&mut vector.val, &self.selection);
+        }
+        Ok(scored)
+    }
+}
+
+/// Trim a single vector's attributes according to `selection`.
+fn project_vector(vector: &mut Vector, selection: &FieldSelection) {
+    match selection {
+        FieldSelection::All => {}
+        FieldSelection::None => vector.attributes.clear(),
+        FieldSelection::Fields(names) => {
+            vector.attributes.retain(|attr| names.contains(&attr.name))
+        }
+    }
+}
+
+/// Apply field projection to search results in place.
+///
+/// Shared with the ANN path, which is not yet expressed as an operator chain.
+pub(crate) fn apply_field_selection(results: &mut [SearchResult], selection: &FieldSelection) {
+    for result in results.iter_mut() {
+        project_vector(&mut result.vector, selection);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Attribute, AttributeValue};
+
+    /// A child operator that yields a fixed list of scored vectors.
+    struct Fixed(Vec<ScoredVector>);
+
+    #[async_trait::async_trait]
+    impl Operator<Vec<ScoredVector>> for Fixed {
+        async fn execute(&self) -> Result<Vec<ScoredVector>> {
+            Ok(self
+                .0
+                .iter()
+                .map(|entry| ScoredVector {
+                    val: entry.val.clone(),
+                    score: entry.score,
+                })
+                .collect())
+        }
+    }
+
+    /// A vector carrying exactly two attributes, `a` and `b`.
+    fn vector(id: &str) -> Vector {
+        Vector {
+            id: id.to_string(),
+            attributes: vec![
+                Attribute::new("a", AttributeValue::String("x".to_string())),
+                Attribute::new("b", AttributeValue::String("y".to_string())),
+            ],
+        }
+    }
+
+    fn sorted_attr_names(vector: &Vector) -> Vec<String> {
+        let mut names: Vec<String> = vector.attributes.iter().map(|a| a.name.clone()).collect();
+        names.sort();
+        names
+    }
+
+    async fn project(selection: FieldSelection) -> Vec<ScoredVector> {
+        let child = Fixed(vec![ScoredVector {
+            val: vector("d1"),
+            score: 1.0,
+        }]);
+        ProjectOperator::new(selection, Box::new(child))
+            .execute()
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn should_keep_all_fields() {
+        let out = project(FieldSelection::All).await;
+        assert_eq!(sorted_attr_names(&out[0].val), vec!["a", "b"]);
+    }
+
+    #[tokio::test]
+    async fn should_clear_all_fields() {
+        let out = project(FieldSelection::None).await;
+        assert!(out[0].val.attributes.is_empty());
+    }
+
+    #[tokio::test]
+    async fn should_retain_only_selected_fields() {
+        let out = project(FieldSelection::Fields(vec!["a".to_string()])).await;
+        assert_eq!(sorted_attr_names(&out[0].val), vec!["a"]);
+    }
+
+    #[test]
+    fn should_apply_field_selection_to_search_results() {
+        let mut results = vec![SearchResult {
+            score: 1.0,
+            vector: vector("d1"),
+        }];
+
+        apply_field_selection(&mut results, &FieldSelection::Fields(vec!["b".to_string()]));
+
+        assert_eq!(sorted_attr_names(&results[0].vector), vec!["b"]);
+    }
+}

--- a/vector/src/query_engine/project.rs
+++ b/vector/src/query_engine/project.rs
@@ -5,25 +5,30 @@
 
 use crate::Vector;
 use crate::error::Result;
-use crate::model::{FieldSelection, SearchResult};
+use crate::model::FieldSelection;
 use crate::query_engine::operator::{BoxedOperator, Operator};
-use crate::query_engine::types::ScoredVector;
+use crate::query_engine::types::{Score, ScoredVector};
 
 /// Projects (field-selects) the vectors produced by a child operator.
-pub(crate) struct ProjectOperator {
+///
+/// Generic over the [`Score`] type `S`, which it passes through unchanged.
+pub(crate) struct ProjectOperator<S: Score> {
     selection: FieldSelection,
-    child: BoxedOperator<Vec<ScoredVector>>,
+    child: BoxedOperator<Vec<ScoredVector<S>>>,
 }
 
-impl ProjectOperator {
-    pub(crate) fn new(selection: FieldSelection, child: BoxedOperator<Vec<ScoredVector>>) -> Self {
+impl<S: Score> ProjectOperator<S> {
+    pub(crate) fn new(
+        selection: FieldSelection,
+        child: BoxedOperator<Vec<ScoredVector<S>>>,
+    ) -> Self {
         Self { selection, child }
     }
 }
 
 #[async_trait::async_trait]
-impl Operator<Vec<ScoredVector>> for ProjectOperator {
-    async fn execute(&self) -> Result<Vec<ScoredVector>> {
+impl<S: Score + Send + Sync + 'static> Operator<Vec<ScoredVector<S>>> for ProjectOperator<S> {
+    async fn execute(&self) -> Result<Vec<ScoredVector<S>>> {
         let mut scored = self.child.execute().await?;
         for vector in &mut scored {
             project_vector(&mut vector.val, &self.selection);
@@ -43,26 +48,20 @@ fn project_vector(vector: &mut Vector, selection: &FieldSelection) {
     }
 }
 
-/// Apply field projection to search results in place.
-///
-/// Shared with the ANN path, which is not yet expressed as an operator chain.
-pub(crate) fn apply_field_selection(results: &mut [SearchResult], selection: &FieldSelection) {
-    for result in results.iter_mut() {
-        project_vector(&mut result.vector, selection);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::query_engine::bm25::BM25Score;
     use crate::{Attribute, AttributeValue};
 
-    /// A child operator that yields a fixed list of scored vectors.
-    struct Fixed(Vec<ScoredVector>);
+    /// A child operator that yields a fixed list of scored vectors. Uses
+    /// `BM25Score` as an arbitrary concrete [`Score`]; `ProjectOperator` only
+    /// touches `val`, so the choice does not affect what is exercised here.
+    struct Fixed(Vec<ScoredVector<BM25Score>>);
 
     #[async_trait::async_trait]
-    impl Operator<Vec<ScoredVector>> for Fixed {
-        async fn execute(&self) -> Result<Vec<ScoredVector>> {
+    impl Operator<Vec<ScoredVector<BM25Score>>> for Fixed {
+        async fn execute(&self) -> Result<Vec<ScoredVector<BM25Score>>> {
             Ok(self
                 .0
                 .iter()
@@ -91,10 +90,10 @@ mod tests {
         names
     }
 
-    async fn project(selection: FieldSelection) -> Vec<ScoredVector> {
+    async fn project(selection: FieldSelection) -> Vec<ScoredVector<BM25Score>> {
         let child = Fixed(vec![ScoredVector {
             val: vector("d1"),
-            score: 1.0,
+            score: BM25Score(1.0),
         }]);
         ProjectOperator::new(selection, Box::new(child))
             .execute()
@@ -118,17 +117,5 @@ mod tests {
     async fn should_retain_only_selected_fields() {
         let out = project(FieldSelection::Fields(vec!["a".to_string()])).await;
         assert_eq!(sorted_attr_names(&out[0].val), vec!["a"]);
-    }
-
-    #[test]
-    fn should_apply_field_selection_to_search_results() {
-        let mut results = vec![SearchResult {
-            score: 1.0,
-            vector: vector("d1"),
-        }];
-
-        apply_field_selection(&mut results, &FieldSelection::Fields(vec!["b".to_string()]));
-
-        assert_eq!(sorted_attr_names(&results[0].vector), vec!["b"]);
     }
 }

--- a/vector/src/query_engine/types.rs
+++ b/vector/src/query_engine/types.rs
@@ -1,0 +1,31 @@
+//! Shared query-driver types.
+//!
+//! A *driver* (see `ann.rs` / `bm25.rs`) executes one scoring strategy and
+//! pushes [`ScoredVectorId`]s into a [`Collector`](super::collectors::Collector).
+//! The collector owns ranking and top-k selection; the driver only produces
+//! scored document ids.
+
+use crate::serde::vector_id::VectorId;
+use crate::{SearchResult, Vector};
+
+/// A single scored document produced by a query driver.
+///
+/// Drivers emit these as they score candidates; ordering and top-k selection
+/// are the collector's responsibility.
+pub(crate) struct Scored<T> {
+    pub(crate) val: T,
+    pub(crate) score: f32,
+}
+
+pub(crate) type ScoredVectorId = Scored<VectorId>;
+
+pub(crate) type ScoredVector = Scored<Vector>;
+
+impl From<ScoredVector> for SearchResult {
+    fn from(val: ScoredVector) -> SearchResult {
+        SearchResult {
+            score: val.score,
+            vector: val.val,
+        }
+    }
+}

--- a/vector/src/query_engine/types.rs
+++ b/vector/src/query_engine/types.rs
@@ -1,30 +1,39 @@
-//! Shared query-driver types.
+//! Shared query types.
 //!
-//! A *driver* (see `ann.rs` / `bm25.rs`) executes one scoring strategy and
-//! pushes [`ScoredVectorId`]s into a [`Collector`](super::collectors::Collector).
-//! The collector owns ranking and top-k selection; the driver only produces
-//! scored document ids.
 
 use crate::serde::vector_id::VectorId;
 use crate::{SearchResult, Vector};
 
-/// A single scored document produced by a query driver.
+/// A score with a defined "better" direction.
 ///
-/// Drivers emit these as they score candidates; ordering and top-k selection
-/// are the collector's responsibility.
-pub(crate) struct Scored<T> {
-    pub(crate) val: T,
-    pub(crate) score: f32,
+/// Implementors order from **best to worst**, so a *better* score compares as
+/// [`Ordering::Less`](std::cmp::Ordering::Less). This lets ranking machinery
+/// (e.g. [`TopK`](super::collectors::TopK)) stay metric-agnostic — it always
+/// keeps the best scores. [`score`](Score::score) returns the raw `f32`
+/// surfaced to callers (`SearchResult.score`), independent of ordering
+/// direction.
+pub(crate) trait Score: Ord + PartialOrd + Eq + PartialEq + Copy {
+    fn score(&self) -> f32;
 }
 
-pub(crate) type ScoredVectorId = Scored<VectorId>;
+/// A single scored document produced by a query source.
+///
+/// Sources emit these as they score candidates; ordering and top-k selection
+/// are the collector's responsibility. `S` is the [`Score`] type and carries
+/// the metric's ordering direction.
+pub(crate) struct Scored<T, S> {
+    pub(crate) val: T,
+    pub(crate) score: S,
+}
 
-pub(crate) type ScoredVector = Scored<Vector>;
+pub(crate) type ScoredVectorId<S> = Scored<VectorId, S>;
 
-impl From<ScoredVector> for SearchResult {
-    fn from(val: ScoredVector) -> SearchResult {
+pub(crate) type ScoredVector<S> = Scored<Vector, S>;
+
+impl<S: Score> From<ScoredVector<S>> for SearchResult {
+    fn from(val: ScoredVector<S>) -> SearchResult {
         SearchResult {
-            score: val.score,
+            score: val.score.score(),
             vector: val.val,
         }
     }

--- a/vector/src/serde/term_postings.rs
+++ b/vector/src/serde/term_postings.rs
@@ -2,8 +2,8 @@
 //!
 //! A term's posting list is a sequence of typed blocks written one after
 //! another to the end of the value buffer. Each `Postings` block holds up to
-//! [`TARGET_POSTINGS_PER_BLOCK`] `(doc_id, freq, norm)` triples in strictly
-//! descending `doc_id` order. Each `Postings` block is preceded by a `Skip`
+//! [`TARGET_POSTINGS_PER_BLOCK`] `(id, freq, norm)` triples in strictly
+//! descending `id` order. Each `Postings` block is preceded by a `Skip`
 //! block that summarises the postings block's last id and serialized byte
 //! length, so a future query path can iterate without parsing the full
 //! payload. Multiple `(Skip, Postings)` pairs may appear in a single value;
@@ -24,23 +24,23 @@
 //! Postings (type = 0x00) payload
 //! ┌──────────────────────────────────────────────────────────────────┐
 //! │  count:        u32   (1..=256 entries actually used)             │
-//! │  base_id:      u64   (highest doc id in block)                   │
-//! │  docs_encoding: u8   (0 = bitpacked gaps, 1 = u64 varint gaps)   │
-//! │  -- if docs_encoding == 0:                                        │
-//! │     docs_bits:    u8                                              │
-//! │     docs_packed:  docs_bits * 32 bytes (BitPacker8x of 256 gaps) │
-//! │  -- if docs_encoding == 1:                                        │
-//! │     docs_varint:  count u64 LEB128 unsigned varints              │
+//! │  base_id:      u64   (highest id in block)                       │
+//! │  ids_encoding: u8   (0 = bitpacked gaps, 1 = u64 varint gaps)    │
+//! │  -- if ids_encoding == 0:                                        │
+//! │     ids_bits:    u8                                              │
+//! │     ids_packed:  ids_bits * 32 bytes (BitPacker8x of 256 gaps)   │
+//! │  -- if ids_encoding == 1:                                        │
+//! │     ids_varint:  count u64 LEB128 unsigned varints               │
 //! │  freqs_bits:   u8                                                │
 //! │  freqs_packed: freqs_bits * 32 bytes (BitPacker8x of 256 freqs)  │
 //! │  norms:        count bytes                                       │
 //! └──────────────────────────────────────────────────────────────────┘
 //!
-//! `docs_*` carries gaps between consecutive doc ids in descending order:
-//! `gap[0] = 0` (the delta from the first doc id to itself) and
-//! `gap[i] = doc_ids[i-1] - doc_ids[i]` for `i > 0`. The encoder builds the
+//! `ids_*` carries gaps between consecutive ids in descending order:
+//! `gap[0] = 0` (the delta from the first id to itself) and
+//! `gap[i] = ids[i-1] - ids[i]` for `i > 0`. The encoder builds the
 //! gap array first, then picks bitpacked when every gap fits in `u32` and
-//! falls back to per-gap LEB128 unsigned varints (`docs_encoding = 1`)
+//! falls back to per-gap LEB128 unsigned varints (`ids_encoding = 1`)
 //! otherwise.
 //!
 //! Skip (type = 0x01) payload
@@ -61,15 +61,15 @@
 //! value's bytes — preserving the global descending-id ordering.
 //!
 //! TODO(rfc-0006 milestone 1+): once the FTS compaction filter lands, it
-//! will rewrite postings into uniform 256-document `Postings` blocks (each
+//! will rewrite postings into uniform 256-entry `Postings` blocks (each
 //! preceded by a refreshed `Skip`) and prune any stale ids removed via the
 //! deletions bitmap. The variable-size last block today is a Milestone 0
 //! artifact of merge-by-concat with batches of arbitrary size.
 
+use super::EncodingError;
+use crate::serde::vector_id::VectorId;
 use bitpacking::{BitPacker, BitPacker8x};
 use bytes::{BufMut, Bytes, BytesMut};
-
-use super::EncodingError;
 
 const BLOCK_LEN: usize = BitPacker8x::BLOCK_LEN;
 
@@ -80,40 +80,43 @@ pub(crate) const TARGET_POSTINGS_PER_BLOCK: usize = BLOCK_LEN;
 const BLOCK_TYPE_POSTINGS: u8 = 0x00;
 const BLOCK_TYPE_SKIP: u8 = 0x01;
 
-/// Doc-id `gaps` packed via [`BitPacker8x`]. Used when every gap fits in `u32`.
-const DOC_ENCODING_BITPACKED: u8 = 0;
+/// id `gaps` packed via [`BitPacker8x`]. Used when every gap fits in `u32`.
+const IDS_ENCODING_BITPACKED: u8 = 0;
 
-/// Doc-id `gaps` written one-by-one as unsigned LEB128 `u64` varints. Used
+/// id `gaps` written one-by-one as unsigned LEB128 `u64` varints. Used
 /// when at least one gap exceeds [`u32::MAX`].
-const DOC_ENCODING_VARINT: u8 = 1;
+const IDS_ENCODING_VARINT: u8 = 1;
 
 /// A single posting entry within a `Postings` block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PostingEntry {
-    pub(crate) doc_id: u64,
+    pub(crate) id: VectorId,
     pub(crate) freq: u32,
     pub(crate) norm: u8,
 }
 
-/// A `Postings` block: a run of `PostingEntry` in descending `doc_id` order.
+/// A `Postings` block: a run of `PostingEntry` in descending `id` order.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct PostingsBlock {
-    /// Entries, sorted by descending `doc_id`.
+    /// Entries, sorted by descending `id`.
     pub(crate) entries: Vec<PostingEntry>,
 }
 
 impl PostingsBlock {
     pub(crate) fn from_descending(entries: Vec<PostingEntry>) -> Self {
         debug_assert!(
-            entries.windows(2).all(|w| w[0].doc_id > w[1].doc_id),
+            entries.windows(2).all(|w| w[0].id > w[1].id),
             "PostingsBlock entries must be strictly descending"
         );
         debug_assert!(entries.len() <= BLOCK_LEN);
         Self { entries }
     }
 
-    pub(crate) fn last_id(&self) -> u64 {
-        self.entries.last().map(|e| e.doc_id).unwrap_or(0)
+    pub(crate) fn last_id(&self) -> VectorId {
+        self.entries
+            .last()
+            .map(|e| e.id)
+            .unwrap_or(VectorId::data_vector_id(0))
     }
 
     /// Encode just the payload (no type tag or length prefix).
@@ -125,18 +128,18 @@ impl PostingsBlock {
             return;
         }
 
-        let base_id = self.entries[0].doc_id;
+        let base_id = self.entries[0].id.id();
         buf.put_u64_le(base_id);
 
-        // Build the gap array first so we can choose the doc-id encoding
-        // based on the max gap. `gap[0]` is always 0 (the first doc id is
+        // Build the gap array first so we can choose the id encoding
+        // based on the max gap. `gap[0]` is always 0 (the first id is
         // its own delta); subsequent gaps are positive because the block is
         // strictly descending.
         let mut gaps = Vec::with_capacity(count);
         gaps.push(0u64);
         let mut max_gap = 0u64;
         for window in self.entries.windows(2) {
-            let g = window[0].doc_id - window[1].doc_id;
+            let g = window[0].id.id() - window[1].id.id();
             max_gap = max_gap.max(g);
             gaps.push(g);
         }
@@ -144,22 +147,22 @@ impl PostingsBlock {
         let bitpacker = BitPacker8x::new();
 
         if max_gap <= u32::MAX as u64 {
-            buf.put_u8(DOC_ENCODING_BITPACKED);
+            buf.put_u8(IDS_ENCODING_BITPACKED);
             // Pad the tail with zeros — zero is `<= max_gap`, so this never
             // widens num_bits beyond what the real data requires.
-            let mut docs = [0u32; BLOCK_LEN];
+            let mut ids = [0u32; BLOCK_LEN];
             for (i, &g) in gaps.iter().enumerate() {
-                docs[i] = g as u32;
+                ids[i] = g as u32;
             }
-            let docs_bits = bitpacker.num_bits(&docs);
-            buf.put_u8(docs_bits);
-            let docs_bytes = docs_bits as usize * (BLOCK_LEN / 8);
-            let mut packed = vec![0u8; docs_bytes];
-            let written = bitpacker.compress(&docs, &mut packed, docs_bits);
-            debug_assert_eq!(written, docs_bytes);
+            let ids_bits = bitpacker.num_bits(&ids);
+            buf.put_u8(ids_bits);
+            let ids_bytes = ids_bits as usize * (BLOCK_LEN / 8);
+            let mut packed = vec![0u8; ids_bytes];
+            let written = bitpacker.compress(&ids, &mut packed, ids_bits);
+            debug_assert_eq!(written, ids_bytes);
             buf.extend_from_slice(&packed);
         } else {
-            buf.put_u8(DOC_ENCODING_VARINT);
+            buf.put_u8(IDS_ENCODING_VARINT);
             for &g in &gaps {
                 write_u64_varint(buf, g);
             }
@@ -218,41 +221,41 @@ impl PostingsBlock {
 
         let bitpacker = BitPacker8x::new();
 
-        // docs_encoding byte
+        // ids_encoding byte
         if cursor.is_empty() {
             return Err(EncodingError {
-                message: "postings block payload too short for docs_encoding".to_string(),
+                message: "postings block payload too short for ids_encoding".to_string(),
             });
         }
-        let docs_encoding = cursor[0];
+        let ids_encoding = cursor[0];
         cursor = &cursor[1..];
 
-        let gaps: Vec<u64> = match docs_encoding {
-            DOC_ENCODING_BITPACKED => {
+        let gaps: Vec<u64> = match ids_encoding {
+            IDS_ENCODING_BITPACKED => {
                 if cursor.is_empty() {
                     return Err(EncodingError {
-                        message: "postings block payload too short for docs_bits".to_string(),
+                        message: "postings block payload too short for ids_bits".to_string(),
                     });
                 }
-                let docs_bits = cursor[0];
+                let ids_bits = cursor[0];
                 cursor = &cursor[1..];
-                let docs_bytes = docs_bits as usize * (BLOCK_LEN / 8);
-                if cursor.len() < docs_bytes {
+                let ids_bytes = ids_bits as usize * (BLOCK_LEN / 8);
+                if cursor.len() < ids_bytes {
                     return Err(EncodingError {
                         message: format!(
-                            "postings block truncated within docs section: need {}, have {}",
-                            docs_bytes,
+                            "postings block truncated within ids section: need {}, have {}",
+                            ids_bytes,
                             cursor.len()
                         ),
                     });
                 }
-                let mut docs = [0u32; BLOCK_LEN];
-                let consumed = bitpacker.decompress(&cursor[..docs_bytes], &mut docs, docs_bits);
-                debug_assert_eq!(consumed, docs_bytes);
-                cursor = &cursor[docs_bytes..];
-                docs[..count].iter().map(|&g| g as u64).collect()
+                let mut ids = [0u32; BLOCK_LEN];
+                let consumed = bitpacker.decompress(&cursor[..ids_bytes], &mut ids, ids_bits);
+                debug_assert_eq!(consumed, ids_bytes);
+                cursor = &cursor[ids_bytes..];
+                ids[..count].iter().map(|&g| g as u64).collect()
             }
-            DOC_ENCODING_VARINT => {
+            IDS_ENCODING_VARINT => {
                 let mut gaps = Vec::with_capacity(count);
                 for _ in 0..count {
                     let (g, used) = read_u64_varint(cursor)?;
@@ -263,23 +266,23 @@ impl PostingsBlock {
             }
             other => {
                 return Err(EncodingError {
-                    message: format!("unknown postings docs_encoding: 0x{:02x}", other),
+                    message: format!("unknown postings ids_encoding: 0x{:02x}", other),
                 });
             }
         };
 
-        // Reconstruct doc ids from gaps. `gap[0]` is 0 so doc_ids[0] == base_id.
-        let mut doc_ids = Vec::with_capacity(count);
+        // Reconstruct ids from gaps. `gap[0]` is 0 so ids[0] == base_id.
+        let mut ids = Vec::with_capacity(count);
         let mut current = base_id;
         for (i, &g) in gaps.iter().enumerate() {
             if i == 0 {
-                doc_ids.push(current);
+                ids.push(current);
                 continue;
             }
             current = current.checked_sub(g).ok_or_else(|| EncodingError {
-                message: format!("gap {} underflows running doc id {}", g, current),
+                message: format!("gap {} underflows running id {}", g, current),
             })?;
-            doc_ids.push(current);
+            ids.push(current);
         }
 
         // freqs
@@ -320,7 +323,7 @@ impl PostingsBlock {
         let mut entries = Vec::with_capacity(count);
         for i in 0..count {
             entries.push(PostingEntry {
-                doc_id: doc_ids[i],
+                id: VectorId::from_raw(ids[i]),
                 freq: freqs[i],
                 norm: norms[i],
             });
@@ -368,13 +371,13 @@ fn read_u64_varint(buf: &[u8]) -> Result<(u64, usize), EncodingError> {
 /// For Milestone 0 `impacts` is reserved per the RFC shape but always empty.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct SkipBlock {
-    pub(crate) last_id: u64,
+    pub(crate) last_id: VectorId,
     pub(crate) length: u64,
 }
 
 impl SkipBlock {
     fn encode_payload(&self, buf: &mut BytesMut) {
-        buf.put_u64_le(self.last_id);
+        buf.put_u64_le(self.last_id.id());
         buf.put_u16_le(0); // impacts_count, always 0 in M0
         buf.put_u64_le(self.length);
     }
@@ -389,9 +392,9 @@ impl SkipBlock {
                 ),
             });
         }
-        let last_id = u64::from_le_bytes([
+        let last_id = VectorId::from_raw(u64::from_le_bytes([
             buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
-        ]);
+        ]));
         let impacts_count = u16::from_le_bytes([buf[8], buf[9]]);
         // Milestone 0 always writes 0 impacts; tolerate but ignore higher counts.
         let mut cursor = &buf[10..];
@@ -424,7 +427,7 @@ pub(crate) enum TermPostingsBlock {
 
 /// Decoded view of a term's posting list.
 ///
-/// Blocks appear in descending `doc_id` order: each `Skip` is immediately
+/// Blocks appear in descending `id` order: each `Skip` is immediately
 /// followed by the `Postings` block it describes, and successive pairs cover
 /// strictly lower id ranges.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -442,9 +445,9 @@ impl TermPostingsValue {
         if postings.is_empty() {
             return Self::default();
         }
-        postings.sort_unstable_by_key(|p| std::cmp::Reverse(p.doc_id));
-        // De-dup defensively; a single document should appear at most once per term per batch.
-        postings.dedup_by_key(|e| e.doc_id);
+        postings.sort_unstable_by_key(|p| std::cmp::Reverse(p.id));
+        // De-dup defensively; a single id should appear at most once per term per batch.
+        postings.dedup_by_key(|e| e.id);
 
         let mut blocks = Vec::new();
         for chunk in postings.chunks(TARGET_POSTINGS_PER_BLOCK) {
@@ -461,7 +464,7 @@ impl TermPostingsValue {
         Self { blocks }
     }
 
-    /// Iterate all decoded posting entries in descending `doc_id` order across blocks.
+    /// Iterate all decoded posting entries in descending `id` order across blocks.
     pub(crate) fn iter_entries(&self) -> impl Iterator<Item = &PostingEntry> {
         self.blocks.iter().flat_map(|block| match block {
             TermPostingsBlock::Postings(p) => p.entries.iter(),
@@ -564,8 +567,12 @@ pub(crate) fn merge_batch_term_postings(existing: Option<Bytes>, operands: &[Byt
 mod tests {
     use super::*;
 
-    fn entry(doc_id: u64, freq: u32, norm: u8) -> PostingEntry {
-        PostingEntry { doc_id, freq, norm }
+    fn entry(id: u64, freq: u32, norm: u8) -> PostingEntry {
+        PostingEntry {
+            id: VectorId::from_raw(id),
+            freq,
+            norm,
+        }
     }
 
     #[test]
@@ -598,7 +605,7 @@ mod tests {
         assert_eq!(decoded.blocks.len(), 2);
         assert!(matches!(decoded.blocks[0], TermPostingsBlock::Skip(_)));
         assert!(matches!(decoded.blocks[1], TermPostingsBlock::Postings(_)));
-        // Entries descending by doc id with original freq/norm preserved.
+        // Entries descending by id with original freq/norm preserved.
         let entries: Vec<_> = decoded.iter_entries().copied().collect();
         assert_eq!(
             entries,
@@ -625,7 +632,7 @@ mod tests {
         assert_eq!(entries.len(), n);
         // Strictly descending
         for w in entries.windows(2) {
-            assert!(w[0].doc_id > w[1].doc_id);
+            assert!(w[0].id > w[1].id);
         }
     }
 
@@ -663,7 +670,7 @@ mod tests {
         let decoded = TermPostingsValue::decode_from_bytes(&merged).unwrap();
 
         // then - ids are globally descending
-        let ids: Vec<u64> = decoded.iter_entries().map(|e| e.doc_id).collect();
+        let ids: Vec<u64> = decoded.iter_entries().map(|e| e.id.id()).collect();
         assert_eq!(ids, vec![11, 10, 2, 1]);
     }
 
@@ -678,7 +685,7 @@ mod tests {
         let decoded = TermPostingsValue::decode_from_bytes(&merged).unwrap();
 
         // then - ids globally descending
-        let ids: Vec<u64> = decoded.iter_entries().map(|e| e.doc_id).collect();
+        let ids: Vec<u64> = decoded.iter_entries().map(|e| e.id.id()).collect();
         assert_eq!(ids, vec![5, 1]);
     }
 
@@ -718,7 +725,7 @@ mod tests {
             .unwrap();
 
         // then - last_id is the lowest id in the following postings block; length matches
-        assert_eq!(skip.last_id, 10);
+        assert_eq!(skip.last_id.id(), 10);
         let postings_payload_len = {
             let postings = value
                 .blocks
@@ -736,7 +743,7 @@ mod tests {
     }
 
     #[test]
-    fn should_use_bitpacked_doc_encoding_when_gaps_fit_in_u32() {
+    fn should_use_bitpacked_id_encoding_when_gaps_fit_in_u32() {
         // given
         let value = TermPostingsValue::from_postings(vec![
             entry(100, 1, 1),
@@ -744,41 +751,41 @@ mod tests {
             entry(1, 1, 1),
         ]);
 
-        // when - inspect the raw payload for the docs_encoding byte
+        // when - inspect the raw payload for the ids_encoding byte
         let TermPostingsBlock::Postings(p) = &value.blocks[1] else {
             panic!("expected postings block")
         };
         let mut payload = BytesMut::new();
         p.encode_payload(&mut payload);
-        // count(4) + base_id(8) = 12, then docs_encoding byte
-        let docs_encoding = payload[12];
+        // count(4) + base_id(8) = 12, then ids_encoding byte
+        let ids_encoding = payload[12];
 
         // then
-        assert_eq!(docs_encoding, DOC_ENCODING_BITPACKED);
+        assert_eq!(ids_encoding, IDS_ENCODING_BITPACKED);
 
         // and - encode/decode round-trips identical entries
         let encoded = value.encode_to_bytes();
         let decoded = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
-        let ids: Vec<u64> = decoded.iter_entries().map(|e| e.doc_id).collect();
+        let ids: Vec<u64> = decoded.iter_entries().map(|e| e.id.id()).collect();
         assert_eq!(ids, vec![100, 50, 1]);
     }
 
     #[test]
-    fn should_switch_to_varint_doc_encoding_when_gap_exceeds_u32() {
+    fn should_switch_to_varint_id_encoding_when_gap_exceeds_u32() {
         // given - gap between two consecutive entries exceeds u32::MAX
         let huge = (u32::MAX as u64) + 2; // gap will be 1 too big for u32
         let value = TermPostingsValue::from_postings(vec![entry(huge, 1, 5), entry(0, 2, 7)]);
 
-        // when - inspect docs_encoding byte
+        // when - inspect ids_encoding byte
         let TermPostingsBlock::Postings(p) = &value.blocks[1] else {
             panic!("expected postings block")
         };
         let mut payload = BytesMut::new();
         p.encode_payload(&mut payload);
-        let docs_encoding = payload[12];
+        let ids_encoding = payload[12];
 
         // then
-        assert_eq!(docs_encoding, DOC_ENCODING_VARINT);
+        assert_eq!(ids_encoding, IDS_ENCODING_VARINT);
 
         // and - encode/decode preserves the original entries (huge id and all)
         let encoded = value.encode_to_bytes();
@@ -830,7 +837,7 @@ mod tests {
         assert_eq!(entries.len(), postings.len());
         // Original postings sorted descending should match decoded order.
         let mut expected = postings;
-        expected.sort_unstable_by_key(|e| std::cmp::Reverse(e.doc_id));
+        expected.sort_unstable_by_key(|e| std::cmp::Reverse(e.id));
         assert_eq!(entries, expected);
     }
 }

--- a/vector/src/serde/vector_id.rs
+++ b/vector/src/serde/vector_id.rs
@@ -57,6 +57,10 @@ impl VectorId {
         vector_id
     }
 
+    pub const fn from_raw(id: u64) -> Self {
+        Self { id }
+    }
+
     pub(crate) fn encode_level_prefix(buf: &mut BytesMut, level: u8) {
         buf.put_u8(level);
     }

--- a/vector/src/server/handlers.rs
+++ b/vector/src/server/handlers.rs
@@ -131,7 +131,7 @@ pub(crate) async fn handle_get_vector<T: VectorDbRead + Send + Sync + 'static>(
         None => {
             let body = serde_json::json!({
                 "status": "error",
-                "message": format!("Document '{}' not found", id)
+                "message": format!("Vector '{}' not found", id)
             });
             Err((StatusCode::NOT_FOUND, ApiResponse::Json(axum::Json(body))))
         }

--- a/vector/src/write/indexer/tree/state.rs
+++ b/vector/src/write/indexer/tree/state.rs
@@ -658,7 +658,7 @@ impl FtsIndexDelta {
                     .entry(key.clone())
                     .or_default()
                     .push(PostingEntry {
-                        doc_id: vector_id.id(),
+                        id: vector_id,
                         freq: freq_u32,
                         norm,
                     });


### PR DESCRIPTION
## Summary

Splits bm25/ann search into chain of operators like: project -> lookup -> ann/bm25.
This allows us to reuse the same projection/lookup operators or both ann and bm25, and
split up planning from query execution.

The search operators (`ANNOperator`, `BM25Operator`) each share a similar structure. The
operators traverse indexes and score vectors, and stream the scored vectors into an impl of
`Collector`, which does the actual TopK aggregation. The final top k are returned to the parent
operator which looks up vectors in the forward index.

## Test Plan

- unit tests for each operator
- e2e benchmarks/functional tests show no regression

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
