### PR TITLE
Expose slatedb split cache

### DIFF
--- a/bencher/src/config.rs
+++ b/bencher/src/config.rs
@@ -59,6 +59,7 @@ impl ReporterConfig {
             object_store: self.object_store.clone(),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         })
     }
 }

--- a/common/src/storage/config.rs
+++ b/common/src/storage/config.rs
@@ -9,6 +9,10 @@ use serde::{Deserialize, Serialize};
 /// Top-level storage configuration.
 ///
 /// Defaults to `SlateDb` with a local `/tmp/opendata-storage` directory.
+// The `SlateDb` variant is large (it carries object-store and two cache
+// configs), but `StorageConfig` is constructed rarely at startup and never
+// moved in a hot path, so the size asymmetry with `InMemory` doesn't matter.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum StorageConfig {
@@ -25,6 +29,7 @@ impl Default for StorageConfig {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         })
     }
 }
@@ -46,20 +51,54 @@ pub struct SlateDbStorageConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub settings_path: Option<String>,
 
-    /// Optional block cache for SST block lookups.
+    /// Optional cache for SST *data* block lookups.
     ///
-    /// When configured, reduces object store reads by caching hot blocks
-    /// in memory and/or on local disk.
+    /// When configured, reduces object store reads by caching hot data blocks
+    /// in memory and/or on local disk. Maps to the `block_cache` side of
+    /// SlateDB's [`slatedb::db_cache::SplitCache`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub block_cache: Option<BlockCacheConfig>,
+
+    /// Optional cache for SST *metadata* — indexes, filters, and stats blocks.
+    ///
+    /// Maps to the `meta_cache` side of SlateDB's
+    /// [`slatedb::db_cache::SplitCache`]. Metadata blocks are small but
+    /// consulted on every read, so a dedicated cache keeps them resident
+    /// instead of competing with large data blocks for capacity. An in-memory
+    /// [`BlockCacheConfig::FoyerMemory`] is usually the right choice: size it
+    /// to comfortably hold the live index + filter set and it effectively
+    /// never evicts.
+    ///
+    /// When either `block_cache` or `meta_cache` is set, the two are combined
+    /// into a `SplitCache` that routes data blocks to `block_cache` and
+    /// index/filter/stats blocks to `meta_cache`. A side left unset simply
+    /// caches nothing for that class of block.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub meta_cache: Option<BlockCacheConfig>,
 }
 
-/// Block cache configuration for SlateDB.
+/// Cache configuration for SlateDB. Used for both the data-block cache
+/// (`block_cache`) and the metadata cache (`meta_cache`).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "type")]
 pub enum BlockCacheConfig {
     /// Two-tier cache using foyer: in-memory + on-disk (ideally NVMe).
     FoyerHybrid(FoyerHybridCacheConfig),
+    /// Single-tier in-memory cache using foyer. Lowest-latency option, with
+    /// no durable tier — contents are rebuilt on restart (cheap when paired
+    /// with cache warming). A good fit for the metadata cache.
+    FoyerMemory(FoyerMemoryCacheConfig),
+}
+
+/// Configuration for foyer's in-memory (single-tier) cache.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FoyerMemoryCacheConfig {
+    /// In-memory cache capacity in bytes.
+    pub capacity: u64,
+    /// Number of shards. When absent, foyer derives a default from the
+    /// available CPU count.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub shards: Option<usize>,
 }
 
 /// Write policy for foyer's hybrid cache.
@@ -125,6 +164,7 @@ impl Default for SlateDbStorageConfig {
             object_store: ObjectStoreConfig::default(),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         }
     }
 }
@@ -142,6 +182,7 @@ impl StorageConfig {
                 object_store: config.object_store.clone(),
                 settings_path: config.settings_path.clone(),
                 block_cache: config.block_cache.clone(),
+                meta_cache: config.meta_cache.clone(),
             }),
         }
     }
@@ -311,6 +352,7 @@ object_store:
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         });
 
         // when
@@ -320,9 +362,10 @@ object_store:
         assert!(yaml.contains("type: SlateDb"));
         assert!(yaml.contains("path: my-data"));
         assert!(yaml.contains("type: Local"));
-        // settings_path and block_cache should be omitted when None
+        // settings_path and caches should be omitted when None
         assert!(!yaml.contains("settings_path"));
         assert!(!yaml.contains("block_cache"));
+        assert!(!yaml.contains("meta_cache"));
     }
 
     #[test]
@@ -355,6 +398,7 @@ block_cache:
                         // effective buffer pool = memory_capacity / 32
                         assert_eq!(foyer.effective_buffer_pool_size(), 8589934592 / 32);
                     }
+                    other => panic!("expected FoyerHybrid, got {other:?}"),
                 }
             }
             _ => panic!("Expected SlateDb config"),
@@ -396,6 +440,7 @@ block_cache:
                         // explicit value overrides derivation
                         assert_eq!(foyer.effective_buffer_pool_size(), 134217728);
                     }
+                    other => panic!("expected FoyerHybrid, got {other:?}"),
                 }
             }
             _ => panic!("Expected SlateDb config"),
@@ -434,8 +479,76 @@ object_store:
         match config {
             StorageConfig::SlateDb(slate_config) => {
                 assert!(slate_config.block_cache.is_none());
+                assert!(slate_config.meta_cache.is_none());
             }
             _ => panic!("Expected SlateDb config"),
         }
+    }
+
+    #[test]
+    fn should_deserialize_split_cache_with_hybrid_data_and_memory_meta() {
+        // given: a data block_cache on disk-backed hybrid, plus a small
+        // in-memory meta_cache for index/filter/stats blocks.
+        let yaml = r#"
+type: SlateDb
+path: data
+object_store:
+  type: InMemory
+block_cache:
+  type: FoyerHybrid
+  memory_capacity: 536870912
+  disk_capacity: 10737418240
+  disk_path: /mnt/nvme/data-cache
+meta_cache:
+  type: FoyerMemory
+  capacity: 134217728
+"#;
+
+        // when
+        let config: StorageConfig = serde_yaml::from_str(yaml).unwrap();
+
+        // then
+        let StorageConfig::SlateDb(slate_config) = config else {
+            panic!("Expected SlateDb config");
+        };
+        match slate_config.block_cache.expect("block_cache should be set") {
+            BlockCacheConfig::FoyerHybrid(foyer) => {
+                assert_eq!(foyer.memory_capacity, 536870912);
+                assert_eq!(foyer.disk_path, "/mnt/nvme/data-cache");
+            }
+            other => panic!("expected FoyerHybrid data cache, got {other:?}"),
+        }
+        match slate_config.meta_cache.expect("meta_cache should be set") {
+            BlockCacheConfig::FoyerMemory(mem) => {
+                assert_eq!(mem.capacity, 134217728);
+                assert!(mem.shards.is_none());
+            }
+            other => panic!("expected FoyerMemory meta cache, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn should_roundtrip_split_cache_config() {
+        // given
+        let config = StorageConfig::SlateDb(SlateDbStorageConfig {
+            path: "data".to_string(),
+            object_store: ObjectStoreConfig::InMemory,
+            settings_path: None,
+            block_cache: Some(BlockCacheConfig::FoyerMemory(FoyerMemoryCacheConfig {
+                capacity: 64 * 1024 * 1024,
+                shards: Some(8),
+            })),
+            meta_cache: Some(BlockCacheConfig::FoyerMemory(FoyerMemoryCacheConfig {
+                capacity: 16 * 1024 * 1024,
+                shards: None,
+            })),
+        });
+
+        // when
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        let parsed: StorageConfig = serde_yaml::from_str(&yaml).unwrap();
+
+        // then
+        assert_eq!(config, parsed);
     }
 }

--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -15,28 +15,11 @@ use slatedb::config::Settings;
 pub use slatedb::db_cache::DbCache;
 pub use slatedb::db_cache::foyer::{FoyerCache, FoyerCacheOptions};
 pub use slatedb::db_cache::foyer_hybrid::FoyerHybridCache;
-pub use slatedb::db_cache::{CachedEntry, CachedKey};
+pub use slatedb::db_cache::{CachedEntry, CachedKey, SplitCache};
 use slatedb::object_store::{self, ObjectStore};
 pub use slatedb::{CompactorBuilder, DbBuilder};
 use tracing::info;
 use uuid::Uuid;
-
-/// Handle to a foyer hybrid cache that we own and must close explicitly on
-/// shutdown. Cloneable because foyer's `HybridCache` is Arc-backed.
-///
-/// TODO(slatedb 0.13): remove this and the surrounding plumbing. SlateDB 0.13
-/// adds a `close()` hook to the `DbCache` trait and drives cache shutdown from
-/// `Db::close()` / `DbReader::close()`, so callers won't need to hold a side
-/// handle to the hybrid cache just to close it deterministically.
-pub(crate) type OwnedHybridCache = foyer::HybridCache<CachedKey, CachedEntry>;
-
-/// Block cache we constructed internally — keep the `HybridCache` handle so
-/// we can call `close().await` from `StorageRead::close()` instead of relying
-/// on foyer's Drop-based close, which races the runtime shutdown.
-struct ManagedBlockCache {
-    db_cache: Arc<dyn DbCache>,
-    hybrid: OwnedHybridCache,
-}
 
 /// Builder for creating storage instances from configuration.
 ///
@@ -70,7 +53,6 @@ struct ManagedBlockCache {
 pub struct StorageBuilder {
     inner: StorageBuilderInner,
     semantics: StorageSemantics,
-    managed_cache: Option<OwnedHybridCache>,
 }
 
 enum StorageBuilderInner {
@@ -82,11 +64,12 @@ impl StorageBuilder {
     /// Creates a new `StorageBuilder` from a [`StorageConfig`].
     ///
     /// For SlateDB configs this creates a [`DbBuilder`] with the configured
-    /// path, object store, settings, and block cache (if configured). For
-    /// InMemory configs it stores a sentinel so that `build()` returns an
-    /// `InMemoryStorage`.
+    /// path, object store, settings, and caches (if configured). When either
+    /// `block_cache` or `meta_cache` is set, the two are combined into a
+    /// [`SplitCache`] so data blocks and SST metadata can use independent
+    /// policies. For InMemory configs it stores a sentinel so that `build()`
+    /// returns an `InMemoryStorage`.
     pub async fn new(config: &StorageConfig) -> StorageResult<Self> {
-        let mut managed_cache: Option<OwnedHybridCache> = None;
         let inner = match config {
             StorageConfig::InMemory => StorageBuilderInner::InMemory,
             StorageConfig::SlateDb(slate_config) => {
@@ -106,11 +89,10 @@ impl StorageBuilder {
                 );
                 let mut db_builder =
                     DbBuilder::new(slate_config.path.clone(), object_store).with_settings(settings);
-                if let Some(managed) =
-                    create_block_cache_from_config(&slate_config.block_cache).await?
+                if let Some(cache) =
+                    build_split_cache(&slate_config.block_cache, &slate_config.meta_cache).await?
                 {
-                    db_builder = db_builder.with_db_cache(managed.db_cache);
-                    managed_cache = Some(managed.hybrid);
+                    db_builder = db_builder.with_db_cache(cache);
                 }
                 StorageBuilderInner::SlateDb(Box::new(db_builder))
             }
@@ -118,7 +100,6 @@ impl StorageBuilder {
         Ok(Self {
             inner,
             semantics: StorageSemantics::default(),
-            managed_cache,
         })
     }
 
@@ -165,10 +146,7 @@ impl StorageBuilder {
                 let db = db_builder.build().await.map_err(|e| {
                     StorageError::Storage(format!("Failed to create SlateDB: {}", e))
                 })?;
-                Ok(Arc::new(SlateDbStorage::new_with_managed_cache(
-                    Arc::new(db),
-                    self.managed_cache,
-                )))
+                Ok(Arc::new(SlateDbStorage::new(Arc::new(db))))
             }
         }
     }
@@ -351,36 +329,59 @@ pub async fn create_storage_read(
                 let adapter = SlateDbStorage::merge_operator_adapter(op);
                 builder = builder.with_merge_operator(Arc::new(adapter));
             }
-            // Prefer runtime-provided cache, fall back to config. The
-            // runtime-provided cache is owned by the caller, so we don't hold
-            // a handle to close it on shutdown.
-            let mut managed_cache: Option<OwnedHybridCache> = None;
+            // Prefer the runtime-provided cache (owned by the caller); fall
+            // back to the config-driven split cache. SlateDB drives cache
+            // shutdown from `DbReader::close()`, so we don't hold a handle.
             if let Some(cache) = runtime.block_cache {
                 builder = builder.with_db_cache(cache);
-            } else if let Some(managed) =
-                create_block_cache_from_config(&slate_config.block_cache).await?
+            } else if let Some(cache) =
+                build_split_cache(&slate_config.block_cache, &slate_config.meta_cache).await?
             {
-                builder = builder.with_db_cache(managed.db_cache);
-                managed_cache = Some(managed.hybrid);
+                builder = builder.with_db_cache(cache);
             }
             let reader = builder.build().await.map_err(|e| {
                 StorageError::Storage(format!("Failed to create SlateDB reader: {}", e))
             })?;
-            Ok(Arc::new(SlateDbStorageReader::new_with_managed_cache(
-                Arc::new(reader),
-                managed_cache,
-            )))
+            Ok(Arc::new(SlateDbStorageReader::new(Arc::new(reader))))
         }
     }
 }
 
-/// Creates a block cache from the serializable config, if present. Returns
-/// both the `DbCache` trait object handed to SlateDB and a `HybridCache`
-/// handle the caller keeps so it can close the cache deterministically on
-/// shutdown.
-async fn create_block_cache_from_config(
+/// Builds the combined SlateDB cache from the serializable data- and
+/// metadata-cache configs.
+///
+/// When either side is configured, both are built (a `None` side caches
+/// nothing for its block class) and wrapped in a [`SplitCache`] that routes
+/// data blocks to the data cache and index/filter/stats blocks to the meta
+/// cache. Returns `None` only when neither side is configured, so callers can
+/// skip `with_db_cache` entirely.
+///
+/// SlateDB drives cache shutdown from `Db::close()` / `DbReader::close()`, so
+/// callers do not need to retain a handle to close the cache themselves.
+async fn build_split_cache(
+    data: &Option<BlockCacheConfig>,
+    meta: &Option<BlockCacheConfig>,
+) -> StorageResult<Option<Arc<dyn DbCache>>> {
+    if data.is_none() && meta.is_none() {
+        return Ok(None);
+    }
+    let data_cache = build_cache(data, "data").await?;
+    let meta_cache = build_cache(meta, "meta").await?;
+    let split = SplitCache::new()
+        .with_block_cache(data_cache)
+        .with_meta_cache(meta_cache)
+        .build();
+    Ok(Some(Arc::new(split) as Arc<dyn DbCache>))
+}
+
+/// Builds a single [`DbCache`] from one cache config, or `None` when absent.
+///
+/// `label` distinguishes the data vs metadata cache in logs and in the foyer
+/// cache name.
+async fn build_cache(
     config: &Option<BlockCacheConfig>,
-) -> StorageResult<Option<ManagedBlockCache>> {
+    label: &str,
+) -> StorageResult<Option<Arc<dyn DbCache>>> {
     let Some(config) = config else {
         return Ok(None);
     };
@@ -442,7 +443,7 @@ async fn create_block_cache_from_config(
             };
 
             let cache = HybridCacheBuilder::new()
-                .with_name("slatedb_block_cache")
+                .with_name(format!("slatedb_{label}_cache"))
                 .with_metrics_registry(Box::new(MetricsRsRegistry))
                 .with_policy(policy)
                 .memory(memory_capacity)
@@ -462,6 +463,7 @@ async fn create_block_cache_from_config(
                 })?;
 
             info!(
+                cache = label,
                 memory_mb = foyer_config.memory_capacity / (1024 * 1024),
                 disk_mb = foyer_config.disk_capacity / (1024 * 1024),
                 disk_path = %foyer_config.disk_path,
@@ -470,15 +472,34 @@ async fn create_block_cache_from_config(
                 buffer_pool_mb = foyer_config.effective_buffer_pool_size() / (1024 * 1024),
                 submit_queue_threshold_mb =
                     foyer_config.submit_queue_size_threshold / (1024 * 1024),
-                "hybrid block cache enabled"
+                "hybrid cache enabled"
             );
 
-            let db_cache =
-                Arc::new(FoyerHybridCache::new_with_cache(cache.clone())) as Arc<dyn DbCache>;
-            Ok(Some(ManagedBlockCache {
-                db_cache,
-                hybrid: cache,
-            }))
+            Ok(Some(
+                Arc::new(FoyerHybridCache::new_with_cache(cache)) as Arc<dyn DbCache>
+            ))
+        }
+        BlockCacheConfig::FoyerMemory(mem_config) => {
+            let max_capacity = mem_config.capacity;
+            let opts = match mem_config.shards {
+                Some(shards) => FoyerCacheOptions {
+                    max_capacity,
+                    shards,
+                },
+                None => FoyerCacheOptions {
+                    max_capacity,
+                    ..FoyerCacheOptions::default()
+                },
+            };
+            info!(
+                cache = label,
+                capacity_mb = max_capacity / (1024 * 1024),
+                shards = opts.shards,
+                "in-memory cache enabled"
+            );
+            Ok(Some(
+                Arc::new(FoyerCache::new_with_opts(opts)) as Arc<dyn DbCache>
+            ))
         }
     }
 }
@@ -487,7 +508,8 @@ async fn create_block_cache_from_config(
 mod tests {
     use super::*;
     use crate::storage::config::{
-        FoyerHybridCacheConfig, LocalObjectStoreConfig, SlateDbStorageConfig,
+        FoyerHybridCacheConfig, FoyerMemoryCacheConfig, LocalObjectStoreConfig,
+        SlateDbStorageConfig,
     };
 
     fn foyer_cache_config(
@@ -514,6 +536,7 @@ mod tests {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         })
     }
 
@@ -534,6 +557,7 @@ mod tests {
                 4 * 1024 * 1024,
                 cache_dir.to_str().unwrap().to_string(),
             ))),
+            meta_cache: None,
         });
 
         let storage = StorageBuilder::new(&config).await.unwrap().build().await;
@@ -542,6 +566,47 @@ mod tests {
             storage.is_ok(),
             "expected config-driven block cache to work"
         );
+    }
+
+    #[tokio::test]
+    async fn should_create_storage_with_split_cache() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache_dir = tmp.path().join("data-cache");
+        std::fs::create_dir_all(&cache_dir).unwrap();
+
+        // Hybrid data cache + in-memory meta cache combined into a SplitCache.
+        let config = StorageConfig::SlateDb(SlateDbStorageConfig {
+            path: "data".to_string(),
+            object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
+                path: tmp.path().join("obj").to_str().unwrap().to_string(),
+            }),
+            settings_path: None,
+            block_cache: Some(BlockCacheConfig::FoyerHybrid(foyer_cache_config(
+                1024 * 1024,
+                4 * 1024 * 1024,
+                cache_dir.to_str().unwrap().to_string(),
+            ))),
+            meta_cache: Some(BlockCacheConfig::FoyerMemory(FoyerMemoryCacheConfig {
+                capacity: 1024 * 1024,
+                shards: None,
+            })),
+        });
+
+        let storage = StorageBuilder::new(&config).await.unwrap().build().await;
+
+        assert!(storage.is_ok(), "expected split cache to build");
+    }
+
+    #[tokio::test]
+    async fn should_build_split_cache_with_only_meta_cache() {
+        // A meta-only config still produces a SplitCache (data side caches
+        // nothing); build_split_cache returns Some.
+        let meta = Some(BlockCacheConfig::FoyerMemory(FoyerMemoryCacheConfig {
+            capacity: 1024 * 1024,
+            shards: Some(1),
+        }));
+        let cache = build_split_cache(&None, &meta).await.unwrap();
+        assert!(cache.is_some(), "meta-only config should yield a cache");
     }
 
     #[tokio::test]
@@ -561,6 +626,7 @@ mod tests {
                 4 * 1024 * 1024,
                 cache_dir.to_str().unwrap().to_string(),
             ))),
+            meta_cache: None,
         };
 
         // First open a writer so the reader has a manifest to read
@@ -598,7 +664,7 @@ mod tests {
             "/tmp/unused".to_string(),
         ));
 
-        let result = create_block_cache_from_config(&Some(config)).await;
+        let result = build_cache(&Some(config), "data").await;
         assert!(result.is_err());
     }
 
@@ -619,6 +685,7 @@ mod tests {
                 4 * 1024 * 1024,
                 bad_disk_path.to_string(),
             ))),
+            meta_cache: None,
         })
     }
 
@@ -665,6 +732,7 @@ mod tests {
                 4 * 1024 * 1024,
                 bad_path.to_str().unwrap().to_string(),
             ))),
+            meta_cache: None,
         };
 
         // First open a writer (without cache) so the reader has a manifest
@@ -713,6 +781,7 @@ mod tests {
                 4 * 1024 * 1024,
                 bad_path.to_str().unwrap().to_string(),
             ))),
+            meta_cache: None,
         };
 
         // First open a writer (without cache) so the reader has a manifest
@@ -749,9 +818,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn should_return_none_when_no_block_cache_configured() {
-        let result = create_block_cache_from_config(&None).await.unwrap();
+    async fn should_return_none_when_no_cache_configured() {
+        let result = build_split_cache(&None, &None).await.unwrap();
         assert!(result.is_none());
+        // And the single-cache builder returns None for an absent config.
+        assert!(build_cache(&None, "data").await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use crate::storage::factory::OwnedHybridCache;
 use crate::storage::{MergeOptions, PutOptions};
 use crate::{
     BytesRange, CheckpointInfo, Record, StorageError, StorageIterator, StorageRead, StorageResult,
@@ -19,7 +18,6 @@ use slatedb::{
     MergeOperatorError, WriteBatch, config::WriteOptions as SlateDbWriteOptions,
 };
 use tokio::sync::watch;
-use tracing::warn;
 
 /// Adapter that wraps our `MergeOperator` trait to implement SlateDB's `MergeOperator` trait.
 ///
@@ -78,24 +76,11 @@ pub struct SlateDbStorage {
     pub(super) db: Arc<Db>,
     durable_tx: watch::Sender<u64>,
     durable_bridge_abort: tokio::task::AbortHandle,
-    // TODO(slatedb 0.13): remove once DbCache exposes a close() hook and
-    // SlateDb::close() drives cache shutdown itself.
-    managed_cache: Option<OwnedHybridCache>,
 }
 
 impl SlateDbStorage {
     /// Creates a new SlateDbStorage instance wrapping the given SlateDB database.
     pub fn new(db: Arc<Db>) -> Self {
-        Self::new_with_managed_cache(db, None)
-    }
-
-    /// Creates a new SlateDbStorage that will explicitly close the given foyer
-    /// hybrid cache during [`StorageRead::close`]. See [`OwnedHybridCache`] for
-    /// why this exists.
-    pub(crate) fn new_with_managed_cache(
-        db: Arc<Db>,
-        managed_cache: Option<OwnedHybridCache>,
-    ) -> Self {
         let slate_rx = db.subscribe();
         let (durable_tx, _) = watch::channel(slate_rx.borrow().durable_seq);
         let task = tokio::spawn({
@@ -119,7 +104,6 @@ impl SlateDbStorage {
             db,
             durable_tx,
             durable_bridge_abort: task.abort_handle(),
-            managed_cache,
         }
     }
 
@@ -178,16 +162,9 @@ impl StorageRead for SlateDbStorage {
     async fn close(&self) -> StorageResult<()> {
         // Stop durable bridge first so no status subscriber outlives DB close.
         self.durable_bridge_abort.abort();
+        // `Db::close()` drives block-cache shutdown (including flushing any
+        // hybrid disk tier), so we don't manage the cache lifecycle here.
         self.db.close().await.map_err(StorageError::from_storage)?;
-        // Close the cache after SlateDB so no inserts race the flushers. Log
-        // and swallow errors: cache flush failures only cost cache warmth, not
-        // durability, and we'd rather not fail shutdown over it.
-        // TODO(slatedb 0.13): remove once DbCache owns its close lifecycle.
-        if let Some(cache) = &self.managed_cache
-            && let Err(e) = cache.close().await
-        {
-            warn!(error = ?e, "foyer hybrid cache close failed");
-        }
         Ok(())
     }
 }
@@ -399,27 +376,12 @@ impl From<MergeOptions> for slatedb::config::MergeOptions {
 /// allowing multiple readers to coexist with a single writer.
 pub struct SlateDbStorageReader {
     reader: Arc<DbReader>,
-    // TODO(slatedb 0.13): remove once DbCache exposes a close() hook and
-    // DbReader::close() drives cache shutdown itself.
-    managed_cache: Option<OwnedHybridCache>,
 }
 
 impl SlateDbStorageReader {
     /// Creates a new SlateDbStorageReader wrapping the given DbReader.
     pub fn new(reader: Arc<DbReader>) -> Self {
-        Self::new_with_managed_cache(reader, None)
-    }
-
-    /// Creates a reader that will explicitly close the given foyer hybrid
-    /// cache during [`StorageRead::close`].
-    pub(crate) fn new_with_managed_cache(
-        reader: Arc<DbReader>,
-        managed_cache: Option<OwnedHybridCache>,
-    ) -> Self {
-        Self {
-            reader,
-            managed_cache,
-        }
+        Self { reader }
     }
 }
 
@@ -453,17 +415,11 @@ impl StorageRead for SlateDbStorageReader {
     }
 
     async fn close(&self) -> StorageResult<()> {
+        // `DbReader::close()` drives block-cache shutdown itself.
         self.reader
             .close()
             .await
             .map_err(StorageError::from_storage)?;
-        // Close the cache after the reader so no inserts race the flushers.
-        // TODO(slatedb 0.13): remove once DbCache owns its close lifecycle.
-        if let Some(cache) = &self.managed_cache
-            && let Err(e) = cache.close().await
-        {
-            warn!(error = ?e, "foyer hybrid cache close failed");
-        }
         Ok(())
     }
 }

--- a/log/c/src/ffi.rs
+++ b/log/c/src/ffi.rs
@@ -329,6 +329,7 @@ pub(crate) unsafe fn build_storage_config(
                 object_store: os_config,
                 settings_path: settings,
                 block_cache: None,
+                meta_cache: None,
             }))
         }
         _ => Err(error_result(

--- a/log/src/segment_extractor.rs
+++ b/log/src/segment_extractor.rs
@@ -354,6 +354,7 @@ mod integration_tests {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         };
         (StorageConfig::SlateDb(slate.clone()), slate)
     }

--- a/log/src/server/config.rs
+++ b/log/src/server/config.rs
@@ -49,6 +49,7 @@ impl CliArgs {
                 }),
                 settings_path: None,
                 block_cache: None,
+                meta_cache: None,
             })
         } else {
             // Local filesystem storage
@@ -59,6 +60,7 @@ impl CliArgs {
                 }),
                 settings_path: None,
                 block_cache: None,
+                meta_cache: None,
             })
         };
 

--- a/log/tests/durable_sequence.rs
+++ b/log/tests/durable_sequence.rs
@@ -21,6 +21,7 @@ fn slatedb_config(dir: &TempDir, read_visibility: ReadVisibility) -> Config {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         }),
         read_visibility,
         ..Default::default()

--- a/log/tests/http_api_formats.rs
+++ b/log/tests/http_api_formats.rs
@@ -775,6 +775,7 @@ async fn setup_slatedb_test_app() -> Router {
             object_store: ObjectStoreConfig::InMemory,
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         }),
         ..Default::default()
     };

--- a/log/tests/reader_writer.rs
+++ b/log/tests/reader_writer.rs
@@ -22,6 +22,7 @@ fn local_storage_config(dir: &TempDir) -> StorageConfig {
         }),
         settings_path: None,
         block_cache: None,
+        meta_cache: None,
     })
 }
 

--- a/log/tests/retention_slatedb_smoke.rs
+++ b/log/tests/retention_slatedb_smoke.rs
@@ -18,6 +18,7 @@ fn local_storage_config(dir: &TempDir) -> StorageConfig {
         }),
         settings_path: None,
         block_cache: None,
+        meta_cache: None,
     })
 }
 

--- a/timeseries/src/reader.rs
+++ b/timeseries/src/reader.rs
@@ -591,6 +591,7 @@ mod tests {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         });
 
         // 1. Open writer and write data
@@ -705,6 +706,7 @@ mod tests {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         });
 
         let writer = TimeSeriesDb::open(Config {
@@ -874,6 +876,7 @@ mod tests {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         });
 
         let writer = TimeSeriesDb::open(Config {

--- a/timeseries/src/testing/mod.rs
+++ b/timeseries/src/testing/mod.rs
@@ -98,6 +98,7 @@ pub async fn create_test_tsdb_with_config(object_store: ObjectStoreConfig) -> Te
         object_store,
         settings_path: None,
         block_cache: None,
+        meta_cache: None,
     });
     let storage = StorageBuilder::new(&config)
         .await

--- a/timeseries/src/timeseries.rs
+++ b/timeseries/src/timeseries.rs
@@ -299,6 +299,7 @@ mod tests {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         });
 
         // Write a series and close without calling flush()

--- a/vector/bench/src/recall.rs
+++ b/vector/bench/src/recall.rs
@@ -661,6 +661,7 @@ impl Dataset {
                     object_store: writer.object_store.clone(),
                     settings_path: reader.settings_path,
                     block_cache: reader.block_cache,
+                    meta_cache: reader.meta_cache,
                 }))
             }
             (_, storage) => Ok(storage),

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -1182,6 +1182,7 @@ mod tests {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         });
 
         let config = Config {
@@ -1229,6 +1230,7 @@ mod tests {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         });
 
         let config = Config {
@@ -1742,6 +1744,7 @@ mod tests {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         });
         let config = Config {
             storage: storage_config.clone(),

--- a/vector/src/reader.rs
+++ b/vector/src/reader.rs
@@ -163,6 +163,7 @@ mod tests {
             }),
             settings_path: None,
             block_cache: None,
+            meta_cache: None,
         })
     }
 


### PR DESCRIPTION
This patch exposes a separate meta cache configured through SlateDb.