### PR TITLE
Add log inspection api

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -18,7 +18,7 @@ pub use storage::factory::{
     create_object_store, create_storage_read,
 };
 pub use storage::loader::{LoadMetadata, LoadResult, LoadSpec, Loadable, Loader};
-pub use storage::sst_blocks::{BlockOpCounts, CountResult, count_in_range};
+pub use storage::sst_blocks::{BlockOpCounts, CountResult, WalkStats, count_in_range};
 pub use storage::{
     CheckpointInfo, MergeRecordOp, PutRecordOp, Record, Storage, StorageError, StorageIterator,
     StorageRead, StorageResult, Ttl, WriteOptions, WriteResult,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -18,7 +18,9 @@ pub use storage::factory::{
     create_object_store, create_storage_read,
 };
 pub use storage::loader::{LoadMetadata, LoadResult, LoadSpec, Loadable, Loader};
-pub use storage::sst_blocks::{BlockOpCounts, CountResult, WalkStats, count_in_range};
+pub use storage::sst_blocks::{
+    BlockOpCounts, CountResult, L0Stats, SortedRunStats, WalkStats, count_in_range,
+};
 pub use storage::{
     CheckpointInfo, MergeRecordOp, PutRecordOp, Record, Storage, StorageError, StorageIterator,
     StorageRead, StorageResult, Ttl, WriteOptions, WriteResult,

--- a/common/src/storage/sst_blocks.rs
+++ b/common/src/storage/sst_blocks.rs
@@ -82,41 +82,80 @@ impl BlockOpCounts {
     }
 }
 
-/// LSM traversal statistics for a single [`count_in_range`] walk.
-///
-/// Captures how much of the tree the walk had to touch to produce the
-/// count — the raw material for read-amplification analysis. `l0_ssts` and
-/// `sorted_runs` are summed over the trees the walk visited: the
-/// unsegmented default tree plus every configured segment whose prefix
-/// interval overlaps `query` (see [`count_in_range`]). For a query confined
-/// to one segment's prefix — the LogDb case — they describe that one
-/// segment's shape. The remaining fields are scoped to the query range.
-///
-/// L0 SSTs are not range-partitioned within a tree, so the walk opens
-/// *every* L0 SST of a visited tree regardless of overlap — `ssts_opened`
-/// reflects that, which is why a large L0 directly inflates read
-/// amplification.
+/// Distribution of a key's in-query records across the **L0 tier** of the
+/// walked tree(s). L0 SSTs are not range-partitioned, so a read must consult
+/// every L0 SST — `ssts_total` therefore counts all of them.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub struct WalkStats {
-    /// L0 SSTs across the trees walked (tree shape; not query-scoped).
-    pub l0_ssts: u32,
-    /// Sorted runs across the trees walked (tree shape; not query-scoped).
-    pub sorted_runs: u32,
-    /// SST views opened during the walk: every L0 SST plus each sorted
-    /// run's views covering `query`. Opening reads the SST's index and
-    /// stats footer, so this counts even when no block overlaps.
-    pub ssts_opened: u32,
-    /// Opened SSTs that contributed at least one in-query row. The key's
-    /// records in `query` were physically spread across this many SSTs.
-    pub ssts_contributing: u32,
-    /// Data blocks read (`read_block`) during the walk. The cheap
-    /// stats/last-entry paths do not count here.
-    pub blocks_read: u32,
+pub struct L0Stats {
+    /// L0 SSTs in the tier — all of them, since L0 isn't range-partitioned.
+    pub ssts_total: u32,
+    /// Of those, how many actually held an in-query record for the key
+    /// (data locality: fewer ⇒ better-localized).
+    pub ssts_with_data: u32,
+    /// Across the SSTs that held data, how many data blocks the in-query
+    /// records span — block-level locality. Divided by `ssts_with_data` it
+    /// gives the average blocks-per-SST a read must touch.
+    pub blocks_with_data: u32,
+    /// In-query records (physical puts) found in L0.
+    pub records: u64,
 }
 
-impl WalkStats {
-    fn note_block_read(&mut self) {
-        self.blocks_read += 1;
+/// Distribution of a key's in-query records across the **sorted-run tier**.
+/// Sorted runs are range-partitioned, so only the SST views covering the
+/// query are checked.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SortedRunStats {
+    /// Sorted runs overlapping the query (a read merges across these).
+    pub runs: u32,
+    /// SST views across those runs that cover the query.
+    pub ssts_total: u32,
+    /// Of those, how many actually held an in-query record for the key.
+    pub ssts_with_data: u32,
+    /// Across the SSTs that held data, how many data blocks the in-query
+    /// records span — block-level locality.
+    pub blocks_with_data: u32,
+    /// In-query records (physical puts) found in the sorted runs.
+    pub records: u64,
+}
+
+/// LSM data-distribution statistics for a single [`count_in_range`] walk.
+///
+/// Characterizes the *shape of the data* the query touched — how the key's
+/// records are split between the L0 tier and the sorted-run tier — rather
+/// than the cost of the count that produced it. Both tiers are summed over
+/// the trees the walk visited: the unsegmented default tree plus every
+/// configured segment whose prefix interval overlaps `query` (see
+/// [`count_in_range`]). For a query confined to one segment's prefix — the
+/// LogDb case — they describe that one segment's tree.
+///
+/// `l0.records + sorted_runs.records` is the count contributed by persisted
+/// SSTs; writes not yet flushed are accounted separately by the caller.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WalkStats {
+    /// The L0 tier's contribution; see [`L0Stats`].
+    pub l0: L0Stats,
+    /// The sorted-run tier's contribution; see [`SortedRunStats`].
+    pub sorted_runs: SortedRunStats,
+}
+
+/// Private per-tier accumulator the walk threads through `count_view`. The
+/// public [`L0Stats`] / [`SortedRunStats`] are assembled from these.
+#[derive(Default)]
+struct TierWalk {
+    ssts_total: u32,
+    ssts_with_data: u32,
+    blocks_with_data: u32,
+    records: u64,
+}
+
+impl TierWalk {
+    /// Records one block's in-query contribution: its records, and — when it
+    /// holds at least one in-query row — that it's a data-spanning block.
+    fn add_block(&mut self, counts: BlockOpCounts) {
+        self.records += counts.num_puts;
+        if counts.num_rows() > 0 {
+            self.blocks_with_data += 1;
+        }
     }
 }
 
@@ -194,7 +233,7 @@ pub async fn count_in_range(
 
 /// Walks one LSM tree (a default tree or a single segment's tree): every L0
 /// SST plus the covering views of each sorted run. Accumulates counts,
-/// `covered_to`, and traversal stats into `result`.
+/// `covered_to`, and per-tier data-distribution stats into `result`.
 async fn walk_tree(
     sst_reader: &SstReader,
     l0: &VecDeque<SsTableView>,
@@ -202,16 +241,33 @@ async fn walk_tree(
     query: &BytesRange,
     result: &mut CountResult,
 ) -> StorageResult<()> {
-    result.stats.l0_ssts += l0.len() as u32;
-    result.stats.sorted_runs += compacted.len() as u32;
+    // L0: not range-partitioned, so every SST is checked.
+    let mut l0_walk = TierWalk::default();
     for view in l0 {
-        count_view(sst_reader, view, query, result).await?;
+        count_view(sst_reader, view, query, result, &mut l0_walk).await?;
     }
+    result.stats.l0.ssts_total += l0_walk.ssts_total;
+    result.stats.l0.ssts_with_data += l0_walk.ssts_with_data;
+    result.stats.l0.blocks_with_data += l0_walk.blocks_with_data;
+    result.stats.l0.records += l0_walk.records;
+
+    // Sorted runs: range-partitioned, so only the views covering the query
+    // are checked. A run counts as overlapping if it yields any such view.
+    let mut sr_walk = TierWalk::default();
     for run in compacted {
+        let mut overlaps = false;
         for view in run.tables_covering_range::<BytesRange>(query.clone()) {
-            count_view(sst_reader, view, query, result).await?;
+            overlaps = true;
+            count_view(sst_reader, view, query, result, &mut sr_walk).await?;
+        }
+        if overlaps {
+            result.stats.sorted_runs.runs += 1;
         }
     }
+    result.stats.sorted_runs.ssts_total += sr_walk.ssts_total;
+    result.stats.sorted_runs.ssts_with_data += sr_walk.ssts_with_data;
+    result.stats.sorted_runs.blocks_with_data += sr_walk.blocks_with_data;
+    result.stats.sorted_runs.records += sr_walk.records;
     Ok(())
 }
 
@@ -242,14 +298,15 @@ async fn count_view(
     view: &SsTableView,
     query: &BytesRange,
     result: &mut CountResult,
+    tier: &mut TierWalk,
 ) -> StorageResult<()> {
     let sst_file = sst_reader
         .open_with_handle(view.sst.clone())
         .map_err(StorageError::from_storage)?;
     let sst_id = sst_file.id();
-    // Opening already fetched the index and stats footer, so this SST is
-    // "touched" even if no block ends up overlapping the query.
-    result.stats.ssts_opened += 1;
+    // This SST belongs to the tier (its index/stats footer were read) even
+    // if no block ends up overlapping the query.
+    tier.ssts_total += 1;
 
     let Some(stats) = sst_file.stats().await.map_err(StorageError::from_storage)? else {
         tracing::warn!(?sst_id, "SST has no stats block; skipping");
@@ -282,15 +339,14 @@ async fn count_view(
             && contained
             && let Some(last) = last_entry.as_ref()
         {
-            result
-                .counts
-                .add(block_counts_from_stats(&stats, i, sst_id));
+            let block_counts = block_counts_from_stats(&stats, i, sst_id);
+            result.counts.add(block_counts);
+            tier.add_block(block_counts);
             bump_covered_to(&mut result.covered_to, last.clone());
             witness_pos = Some(pos);
             break;
         }
 
-        result.stats.note_block_read();
         let rows = sst_file
             .read_block(i)
             .await
@@ -298,6 +354,7 @@ async fn count_view(
         let (block_counts, block_max) = count_rows_in_range_with_max(&rows, query);
         if let Some(max) = block_max {
             result.counts.add(block_counts);
+            tier.add_block(block_counts);
             bump_covered_to(&mut result.covered_to, max);
             witness_pos = Some(pos);
             break;
@@ -310,25 +367,23 @@ async fn count_view(
         // No SST contents in query.
         return Ok(());
     };
-    result.stats.ssts_contributing += 1;
+    tier.ssts_with_data += 1;
 
     // Forward pass for blocks below the witness. Cheap stats path when
     // contained; read for boundary blocks (needed to filter rows by query).
     for &i in &overlapping[..witness_pos] {
         let key_range = block_key_range(&index, i, last_entry.as_ref());
-        if range_contains(query, &key_range) {
-            result
-                .counts
-                .add(block_counts_from_stats(&stats, i, sst_id));
+        let block_counts = if range_contains(query, &key_range) {
+            block_counts_from_stats(&stats, i, sst_id)
         } else {
-            result.stats.note_block_read();
             let rows = sst_file
                 .read_block(i)
                 .await
                 .map_err(StorageError::from_storage)?;
-            let (block_counts, _) = count_rows_in_range_with_max(&rows, query);
-            result.counts.add(block_counts);
-        }
+            count_rows_in_range_with_max(&rows, query).0
+        };
+        result.counts.add(block_counts);
+        tier.add_block(block_counts);
     }
 
     Ok(())
@@ -684,22 +739,22 @@ mod tests {
         .await
         .unwrap();
 
-        // Two flushes, no compaction → two L0 SSTs, zero sorted runs.
-        assert_eq!(result.stats.l0_ssts, 2);
-        assert_eq!(result.stats.sorted_runs, 0);
-        // Unbounded query reaches both SSTs and both contribute.
-        assert_eq!(result.stats.ssts_opened, 2);
-        assert_eq!(result.stats.ssts_contributing, 2);
-        // Each SST hits the free-witness shortcut (its last block is
-        // contained), and every other block is contained → stats path. So
-        // an unbounded full-SST count touches no data blocks.
-        assert_eq!(result.stats.blocks_read, 0);
+        // Two flushes, no compaction → all data in two L0 SSTs, no runs.
+        assert_eq!(result.stats.l0.ssts_total, 2);
+        assert_eq!(result.stats.l0.ssts_with_data, 2, "both SSTs contribute");
+        assert_eq!(
+            result.stats.l0.blocks_with_data, 2,
+            "two small SSTs, one block of data each"
+        );
+        assert_eq!(result.stats.l0.records, 4, "two records per batch");
+        assert_eq!(result.stats.sorted_runs, SortedRunStats::default());
     }
 
     #[tokio::test]
-    async fn walk_stats_opens_every_l0_even_when_query_misses() {
+    async fn walk_stats_check_every_l0_but_attribute_data_to_one() {
         // L0 is not range-partitioned: a query matching only the second SST
-        // must still open the first to know it has nothing in range.
+        // must still check the first to know it has nothing in range — but
+        // only the second holds data.
         let a: &[(&[u8], &[u8])] = &[(b"k000", b"v0"), (b"k001", b"v1")];
         let b: &[(&[u8], &[u8])] = &[(b"k100", b"v2"), (b"k101", b"v3")];
         let (db, object_store) = build_db_with_l0_batches(&[a, b]).await;
@@ -713,17 +768,18 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.counts.num_puts, 2, "only the k1xx batch matches");
-        assert_eq!(result.stats.ssts_opened, 2, "both L0 SSTs are opened");
+        assert_eq!(result.stats.l0.ssts_total, 2, "both L0 SSTs are present");
         assert_eq!(
-            result.stats.ssts_contributing, 1,
+            result.stats.l0.ssts_with_data, 1,
             "only the second SST holds in-range rows"
         );
+        assert_eq!(result.stats.l0.records, 2);
     }
 
     #[tokio::test]
-    async fn walk_stats_count_block_reads_on_boundary_slice() {
-        // A subrange that slices interior blocks forces real block reads to
-        // filter rows precisely (the cheap stats path can't be used).
+    async fn walk_stats_attribute_records_on_boundary_slice() {
+        // A subrange that slices interior blocks still attributes the exact
+        // record count to the (single) L0 SST it lives in.
         let entries = many_entries(250);
         let entries_ref: Vec<(&[u8], &[u8])> = entries
             .iter()
@@ -740,13 +796,16 @@ mod tests {
         .unwrap();
 
         assert_eq!(result.counts.num_puts, 50);
-        assert_eq!(result.stats.ssts_opened, 1);
-        assert_eq!(result.stats.ssts_contributing, 1);
+        assert_eq!(result.stats.l0.ssts_total, 1);
+        assert_eq!(result.stats.l0.ssts_with_data, 1);
+        // 50 records of ~30 bytes over 1 KiB blocks span multiple blocks.
         assert!(
-            result.stats.blocks_read >= 1,
-            "boundary slice must read at least one data block, got {}",
-            result.stats.blocks_read
+            result.stats.l0.blocks_with_data >= 2,
+            "a 50-record slice should span several blocks, got {}",
+            result.stats.l0.blocks_with_data
         );
+        assert_eq!(result.stats.l0.records, 50);
+        assert_eq!(result.stats.sorted_runs, SortedRunStats::default());
     }
 
     /// Routes writes into per-segment trees by a fixed-length key prefix,
@@ -828,18 +887,15 @@ mod tests {
         .unwrap();
         assert_eq!(result.counts.num_puts, 3, "the three aa-* rows");
         assert_eq!(result.covered_to.as_deref(), Some(b"aa-3" as &[u8]));
+        // The data and its stats come from the walked segment's tree, not
+        // the empty default tree.
         assert!(
-            result.stats.ssts_opened >= 1,
-            "must open the aa segment's SST"
+            result.stats.l0.ssts_total >= 1,
+            "must check the aa segment's L0 SST"
         );
-        assert_eq!(
-            result.stats.ssts_contributing, 1,
-            "only the aa segment holds in-range rows"
-        );
-        assert!(
-            result.stats.l0_ssts >= 1,
-            "tree shape must reflect the walked segment, not the empty default tree"
-        );
+        assert_eq!(result.stats.l0.ssts_with_data, 1);
+        assert_eq!(result.stats.l0.blocks_with_data, 1, "three rows, one block");
+        assert_eq!(result.stats.l0.records, 3);
     }
 
     #[tokio::test]

--- a/common/src/storage/sst_blocks.rs
+++ b/common/src/storage/sst_blocks.rs
@@ -53,10 +53,11 @@
 //! append-only model where physical ops equal logical records. If an
 //! update or delete API is added to LogDb, revisit.
 
+use std::collections::VecDeque;
 use std::ops::Bound;
 
 use bytes::Bytes;
-use slatedb::manifest::{SsTableView, VersionedManifest};
+use slatedb::manifest::{SortedRun, SsTableView, VersionedManifest};
 use slatedb::{RowEntry, SstReader, SstStats, ValueDeletable};
 
 use crate::{BytesRange, StorageError, StorageResult};
@@ -84,18 +85,22 @@ impl BlockOpCounts {
 /// LSM traversal statistics for a single [`count_in_range`] walk.
 ///
 /// Captures how much of the tree the walk had to touch to produce the
-/// count — the raw material for read-amplification analysis. `l0_ssts`
-/// and `sorted_runs` describe the manifest's shape (global to the DB, not
-/// scoped to `query`); the remaining fields are scoped to the query range.
+/// count — the raw material for read-amplification analysis. `l0_ssts` and
+/// `sorted_runs` are summed over the trees the walk visited: the
+/// unsegmented default tree plus every configured segment whose prefix
+/// interval overlaps `query` (see [`count_in_range`]). For a query confined
+/// to one segment's prefix — the LogDb case — they describe that one
+/// segment's shape. The remaining fields are scoped to the query range.
 ///
-/// L0 SSTs are not range-partitioned, so the walk opens *every* L0 SST
-/// regardless of overlap — `ssts_opened` reflects that, which is why a
-/// large L0 directly inflates read amplification.
+/// L0 SSTs are not range-partitioned within a tree, so the walk opens
+/// *every* L0 SST of a visited tree regardless of overlap — `ssts_opened`
+/// reflects that, which is why a large L0 directly inflates read
+/// amplification.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct WalkStats {
-    /// L0 SSTs present in the manifest (tree shape; not query-scoped).
+    /// L0 SSTs across the trees walked (tree shape; not query-scoped).
     pub l0_ssts: u32,
-    /// Sorted runs present in the manifest (tree shape; not query-scoped).
+    /// Sorted runs across the trees walked (tree shape; not query-scoped).
     pub sorted_runs: u32,
     /// SST views opened during the walk: every L0 SST plus each sorted
     /// run's views covering `query`. Opening reads the SST's index and
@@ -136,27 +141,100 @@ pub struct CountResult {
 /// Counts every physical write operation in the manifest whose key falls
 /// in `query`, and returns a witness of how far up the walk observed data.
 ///
-/// Covers L0 SSTs and the views returned by each compacted sorted run's
-/// `tables_covering_range(query)`. SSTs without a stats block (predating
-/// RFC 0020) are skipped with a tracing warning, so the result undercounts
-/// in that case.
+/// SlateDB stores data in two places: the unsegmented *default* tree
+/// ([`VersionedManifest::l0`] / [`compacted`](VersionedManifest::compacted))
+/// and, when a `PrefixExtractor` is configured, one independent LSM tree per
+/// *segment* ([`VersionedManifest::segments`]) — each owning the key
+/// interval `[prefix, prefix++)`. With an extractor every write routes to a
+/// segment and the default tree is empty by construction, so a walk that
+/// only consulted the default tree would miss all the data. This walks the
+/// default tree and every segment whose interval overlaps `query`; for a
+/// query confined to one routing prefix (the LogDb case) that is exactly one
+/// segment.
+///
+/// Within each tree it covers L0 SSTs and the views returned by each
+/// compacted sorted run's `tables_covering_range(query)`. SSTs without a
+/// stats block (predating RFC 0020) are skipped with a tracing warning, so
+/// the result undercounts in that case.
 pub async fn count_in_range(
     manifest: &VersionedManifest,
     sst_reader: &SstReader,
     query: &BytesRange,
 ) -> StorageResult<CountResult> {
     let mut result = CountResult::default();
-    result.stats.l0_ssts = manifest.l0().len() as u32;
-    result.stats.sorted_runs = manifest.compacted().len() as u32;
-    for view in manifest.l0() {
-        count_view(sst_reader, view, query, &mut result).await?;
-    }
-    for run in manifest.compacted() {
-        for view in run.tables_covering_range::<BytesRange>(query.clone()) {
-            count_view(sst_reader, view, query, &mut result).await?;
+
+    // The unsegmented default tree. Empty when an extractor is configured,
+    // but walking it keeps the no-extractor case correct.
+    walk_tree(
+        sst_reader,
+        manifest.l0(),
+        manifest.compacted(),
+        query,
+        &mut result,
+    )
+    .await?;
+
+    // Each configured segment owns a disjoint prefix interval; walk only
+    // those the query touches. This is where the data lives once a segment
+    // extractor routes writes away from the default tree.
+    for segment in manifest.segments() {
+        if ranges_overlap(query, &prefix_range(segment.prefix())) {
+            walk_tree(
+                sst_reader,
+                segment.l0(),
+                segment.compacted(),
+                query,
+                &mut result,
+            )
+            .await?;
         }
     }
     Ok(result)
+}
+
+/// Walks one LSM tree (a default tree or a single segment's tree): every L0
+/// SST plus the covering views of each sorted run. Accumulates counts,
+/// `covered_to`, and traversal stats into `result`.
+async fn walk_tree(
+    sst_reader: &SstReader,
+    l0: &VecDeque<SsTableView>,
+    compacted: &[SortedRun],
+    query: &BytesRange,
+    result: &mut CountResult,
+) -> StorageResult<()> {
+    result.stats.l0_ssts += l0.len() as u32;
+    result.stats.sorted_runs += compacted.len() as u32;
+    for view in l0 {
+        count_view(sst_reader, view, query, result).await?;
+    }
+    for run in compacted {
+        for view in run.tables_covering_range::<BytesRange>(query.clone()) {
+            count_view(sst_reader, view, query, result).await?;
+        }
+    }
+    Ok(())
+}
+
+/// The key interval a segment owns: `[prefix, prefix++)`, where `prefix++`
+/// is the smallest key strictly greater than every key beginning with
+/// `prefix` (increment the last non-`0xFF` byte, dropping trailing `0xFF`s).
+/// An all-`0xFF` or empty prefix has no upper bound.
+fn prefix_range(prefix: &[u8]) -> BytesRange {
+    let start = Bound::Included(Bytes::copy_from_slice(prefix));
+    let mut end = prefix.to_vec();
+    loop {
+        match end.last().copied() {
+            None => return BytesRange::new(start, Bound::Unbounded),
+            Some(0xFF) => {
+                end.pop();
+            }
+            Some(b) => {
+                let last = end.len() - 1;
+                end[last] = b + 1;
+                return BytesRange::new(start, Bound::Excluded(Bytes::from(end)));
+            }
+        }
+    }
 }
 
 async fn count_view(
@@ -668,6 +746,99 @@ mod tests {
             result.stats.blocks_read >= 1,
             "boundary slice must read at least one data block, got {}",
             result.stats.blocks_read
+        );
+    }
+
+    /// Routes writes into per-segment trees by a fixed-length key prefix,
+    /// mirroring how LogDb's `LogSegmentExtractor` partitions the keyspace.
+    #[derive(Debug)]
+    struct FixedPrefixExtractor(usize);
+
+    impl slatedb::PrefixExtractor for FixedPrefixExtractor {
+        fn name(&self) -> &str {
+            "test/fixed-prefix"
+        }
+
+        fn prefix_len(&self, target: &slatedb::PrefixTarget) -> Option<usize> {
+            let len = match target {
+                slatedb::PrefixTarget::Point(b) => b.as_ref().len(),
+                slatedb::PrefixTarget::Prefix(b) => b.as_ref().len(),
+            };
+            (len >= self.0).then_some(self.0)
+        }
+    }
+
+    /// Builds a DB whose writes are routed into per-segment trees by their
+    /// first `prefix_len` bytes, then flushed to L0.
+    async fn build_segmented_db(
+        entries: &[(&[u8], &[u8])],
+        prefix_len: usize,
+    ) -> (Arc<Db>, Arc<InMemory>) {
+        let object_store: Arc<InMemory> = Arc::new(InMemory::new());
+        let db = DbBuilder::new(PATH, object_store.clone())
+            .with_sst_block_size(SstBlockSize::Block1Kib)
+            .with_segment_extractor(Arc::new(FixedPrefixExtractor(prefix_len)))
+            .build()
+            .await
+            .unwrap();
+        for (k, v) in entries {
+            db.put_with_options(*k, *v, &PutOptions::default(), &WriteOptions::default())
+                .await
+                .unwrap();
+        }
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+        (Arc::new(db), object_store)
+    }
+
+    #[tokio::test]
+    async fn walks_per_segment_trees_when_extractor_configured() {
+        // Regression: with a segment extractor, writes route into per-segment
+        // trees and the default tree is empty. A walk that consulted only the
+        // default tree (manifest.l0()/compacted()) would count zero — this is
+        // the production LogDb layout, since LogDb always installs an
+        // extractor.
+        let entries: &[(&[u8], &[u8])] = &[
+            (b"aa-1", b"v"),
+            (b"aa-2", b"v"),
+            (b"aa-3", b"v"),
+            (b"bb-1", b"v"),
+        ];
+        let (db, object_store) = build_segmented_db(entries, 2).await;
+        let manifest = db.manifest();
+
+        // Precondition: data lives in segments, not the default tree.
+        assert!(
+            manifest.l0().is_empty() && manifest.compacted().is_empty(),
+            "default tree must be empty under a segment extractor"
+        );
+        assert_eq!(manifest.segments().len(), 2, "one segment per prefix");
+
+        // A query confined to the `aa` prefix must find exactly its three
+        // rows and walk only that segment's tree (not the `bb` segment).
+        let result = count_in_range(
+            &manifest,
+            &sst_reader(object_store),
+            &mk_range(b"aa", b"ab"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(result.counts.num_puts, 3, "the three aa-* rows");
+        assert_eq!(result.covered_to.as_deref(), Some(b"aa-3" as &[u8]));
+        assert!(
+            result.stats.ssts_opened >= 1,
+            "must open the aa segment's SST"
+        );
+        assert_eq!(
+            result.stats.ssts_contributing, 1,
+            "only the aa segment holds in-range rows"
+        );
+        assert!(
+            result.stats.l0_ssts >= 1,
+            "tree shape must reflect the walked segment, not the empty default tree"
         );
     }
 

--- a/common/src/storage/sst_blocks.rs
+++ b/common/src/storage/sst_blocks.rs
@@ -81,6 +81,40 @@ impl BlockOpCounts {
     }
 }
 
+/// LSM traversal statistics for a single [`count_in_range`] walk.
+///
+/// Captures how much of the tree the walk had to touch to produce the
+/// count — the raw material for read-amplification analysis. `l0_ssts`
+/// and `sorted_runs` describe the manifest's shape (global to the DB, not
+/// scoped to `query`); the remaining fields are scoped to the query range.
+///
+/// L0 SSTs are not range-partitioned, so the walk opens *every* L0 SST
+/// regardless of overlap — `ssts_opened` reflects that, which is why a
+/// large L0 directly inflates read amplification.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WalkStats {
+    /// L0 SSTs present in the manifest (tree shape; not query-scoped).
+    pub l0_ssts: u32,
+    /// Sorted runs present in the manifest (tree shape; not query-scoped).
+    pub sorted_runs: u32,
+    /// SST views opened during the walk: every L0 SST plus each sorted
+    /// run's views covering `query`. Opening reads the SST's index and
+    /// stats footer, so this counts even when no block overlaps.
+    pub ssts_opened: u32,
+    /// Opened SSTs that contributed at least one in-query row. The key's
+    /// records in `query` were physically spread across this many SSTs.
+    pub ssts_contributing: u32,
+    /// Data blocks read (`read_block`) during the walk. The cheap
+    /// stats/last-entry paths do not count here.
+    pub blocks_read: u32,
+}
+
+impl WalkStats {
+    fn note_block_read(&mut self) {
+        self.blocks_read += 1;
+    }
+}
+
 /// Result of a [`count_in_range`] walk: aggregate counts plus a witness
 /// of the highest key actually observed.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
@@ -95,6 +129,8 @@ pub struct CountResult {
     /// Callers that need exact counts including not-yet-persisted writes
     /// can combine this with a scan over `(covered_to, range.end)`.
     pub covered_to: Option<Bytes>,
+    /// LSM traversal statistics for this walk; see [`WalkStats`].
+    pub stats: WalkStats,
 }
 
 /// Counts every physical write operation in the manifest whose key falls
@@ -110,6 +146,8 @@ pub async fn count_in_range(
     query: &BytesRange,
 ) -> StorageResult<CountResult> {
     let mut result = CountResult::default();
+    result.stats.l0_ssts = manifest.l0().len() as u32;
+    result.stats.sorted_runs = manifest.compacted().len() as u32;
     for view in manifest.l0() {
         count_view(sst_reader, view, query, &mut result).await?;
     }
@@ -131,6 +169,9 @@ async fn count_view(
         .open_with_handle(view.sst.clone())
         .map_err(StorageError::from_storage)?;
     let sst_id = sst_file.id();
+    // Opening already fetched the index and stats footer, so this SST is
+    // "touched" even if no block ends up overlapping the query.
+    result.stats.ssts_opened += 1;
 
     let Some(stats) = sst_file.stats().await.map_err(StorageError::from_storage)? else {
         tracing::warn!(?sst_id, "SST has no stats block; skipping");
@@ -171,6 +212,7 @@ async fn count_view(
             break;
         }
 
+        result.stats.note_block_read();
         let rows = sst_file
             .read_block(i)
             .await
@@ -190,6 +232,7 @@ async fn count_view(
         // No SST contents in query.
         return Ok(());
     };
+    result.stats.ssts_contributing += 1;
 
     // Forward pass for blocks below the witness. Cheap stats path when
     // contained; read for boundary blocks (needed to filter rows by query).
@@ -200,6 +243,7 @@ async fn count_view(
                 .counts
                 .add(block_counts_from_stats(&stats, i, sst_id));
         } else {
+            result.stats.note_block_read();
             let rows = sst_file
                 .read_block(i)
                 .await
@@ -521,6 +565,110 @@ mod tests {
         assert_eq!(result.counts.num_puts, 10);
         // covered_to comes from the SST with the highest last_entry — `k\x09`.
         assert_eq!(result.covered_to.as_deref(), Some(&b"k\x09"[..]));
+    }
+
+    /// Flushes `batches` separately so each becomes its own L0 SST, then
+    /// returns the DB + object store. Keys are taken verbatim from each
+    /// batch so callers control which SST a key lands in.
+    async fn build_db_with_l0_batches(batches: &[&[(&[u8], &[u8])]]) -> (Arc<Db>, Arc<InMemory>) {
+        let object_store: Arc<InMemory> = Arc::new(InMemory::new());
+        let db = DbBuilder::new(PATH, object_store.clone())
+            .with_sst_block_size(SstBlockSize::Block1Kib)
+            .build()
+            .await
+            .unwrap();
+        for batch in batches {
+            for (k, v) in *batch {
+                db.put_with_options(*k, *v, &PutOptions::default(), &WriteOptions::default())
+                    .await
+                    .unwrap();
+            }
+            db.flush_with_options(FlushOptions {
+                flush_type: FlushType::MemTable,
+            })
+            .await
+            .unwrap();
+        }
+        (Arc::new(db), object_store)
+    }
+
+    #[tokio::test]
+    async fn walk_stats_report_manifest_shape() {
+        let a: &[(&[u8], &[u8])] = &[(b"k000", b"v0"), (b"k001", b"v1")];
+        let b: &[(&[u8], &[u8])] = &[(b"k100", b"v2"), (b"k101", b"v3")];
+        let (db, object_store) = build_db_with_l0_batches(&[a, b]).await;
+
+        let result = count_in_range(
+            &db.manifest(),
+            &sst_reader(object_store),
+            &BytesRange::unbounded(),
+        )
+        .await
+        .unwrap();
+
+        // Two flushes, no compaction → two L0 SSTs, zero sorted runs.
+        assert_eq!(result.stats.l0_ssts, 2);
+        assert_eq!(result.stats.sorted_runs, 0);
+        // Unbounded query reaches both SSTs and both contribute.
+        assert_eq!(result.stats.ssts_opened, 2);
+        assert_eq!(result.stats.ssts_contributing, 2);
+        // Each SST hits the free-witness shortcut (its last block is
+        // contained), and every other block is contained → stats path. So
+        // an unbounded full-SST count touches no data blocks.
+        assert_eq!(result.stats.blocks_read, 0);
+    }
+
+    #[tokio::test]
+    async fn walk_stats_opens_every_l0_even_when_query_misses() {
+        // L0 is not range-partitioned: a query matching only the second SST
+        // must still open the first to know it has nothing in range.
+        let a: &[(&[u8], &[u8])] = &[(b"k000", b"v0"), (b"k001", b"v1")];
+        let b: &[(&[u8], &[u8])] = &[(b"k100", b"v2"), (b"k101", b"v3")];
+        let (db, object_store) = build_db_with_l0_batches(&[a, b]).await;
+
+        let result = count_in_range(
+            &db.manifest(),
+            &sst_reader(object_store),
+            &mk_range(b"k100", b"k200"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.counts.num_puts, 2, "only the k1xx batch matches");
+        assert_eq!(result.stats.ssts_opened, 2, "both L0 SSTs are opened");
+        assert_eq!(
+            result.stats.ssts_contributing, 1,
+            "only the second SST holds in-range rows"
+        );
+    }
+
+    #[tokio::test]
+    async fn walk_stats_count_block_reads_on_boundary_slice() {
+        // A subrange that slices interior blocks forces real block reads to
+        // filter rows precisely (the cheap stats path can't be used).
+        let entries = many_entries(250);
+        let entries_ref: Vec<(&[u8], &[u8])> = entries
+            .iter()
+            .map(|(k, v)| (k.as_slice(), v.as_slice()))
+            .collect();
+        let (db, object_store) = build_db_with_entries(&entries_ref).await;
+
+        let result = count_in_range(
+            &db.manifest(),
+            &sst_reader(object_store),
+            &mk_range(b"k100", b"k150"),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.counts.num_puts, 50);
+        assert_eq!(result.stats.ssts_opened, 1);
+        assert_eq!(result.stats.ssts_contributing, 1);
+        assert!(
+            result.stats.blocks_read >= 1,
+            "boundary slice must read at least one data block, got {}",
+            result.stats.blocks_read
+        );
     }
 
     #[tokio::test]

--- a/common/src/storage/sst_blocks.rs
+++ b/common/src/storage/sst_blocks.rs
@@ -120,13 +120,19 @@ pub struct SortedRunStats {
 
 /// LSM data-distribution statistics for a single [`count_in_range`] walk.
 ///
-/// Characterizes the *shape of the data* the query touched — how the key's
-/// records are split between the L0 tier and the sorted-run tier — rather
-/// than the cost of the count that produced it. Both tiers are summed over
-/// the trees the walk visited: the unsegmented default tree plus every
-/// configured segment whose prefix interval overlaps `query` (see
-/// [`count_in_range`]). For a query confined to one segment's prefix — the
-/// LogDb case — they describe that one segment's tree.
+/// A *tier* here is one of the two kinds of level a SlateDB tree holds: the
+/// **L0 tier** — the freshly-flushed SSTs, which are not range-partitioned
+/// and may overlap each other in key space — and the **sorted-run tier** —
+/// the compacted sorted runs, each a range-partitioned, non-overlapping run
+/// of SSTs. A read consults both.
+///
+/// These stats characterize the *shape of the data* the query touched — how
+/// the key's records are split between those two tiers — rather than the
+/// cost of the count that produced it. Both tiers are summed over the trees
+/// the walk visited: the unsegmented default tree plus every configured
+/// segment whose prefix interval overlaps `query` (see [`count_in_range`]).
+/// For a query confined to one segment's prefix — the LogDb case — they
+/// describe that one segment's tree.
 ///
 /// `l0.records + sorted_runs.records` is the count contributed by persisted
 /// SSTs; writes not yet flushed are accounted separately by the caller.
@@ -138,8 +144,9 @@ pub struct WalkStats {
     pub sorted_runs: SortedRunStats,
 }
 
-/// Private per-tier accumulator the walk threads through `count_view`. The
-/// public [`L0Stats`] / [`SortedRunStats`] are assembled from these.
+/// Private accumulator for one tier (L0 or sorted-run — see [`WalkStats`])
+/// that the walk threads through `count_view`. The public [`L0Stats`] /
+/// [`SortedRunStats`] are assembled from these.
 #[derive(Default)]
 struct TierWalk {
     ssts_total: u32,
@@ -173,7 +180,7 @@ pub struct CountResult {
     /// Callers that need exact counts including not-yet-persisted writes
     /// can combine this with a scan over `(covered_to, range.end)`.
     pub covered_to: Option<Bytes>,
-    /// LSM traversal statistics for this walk; see [`WalkStats`].
+    /// Per-tier record distribution for this walk; see [`WalkStats`].
     pub stats: WalkStats,
 }
 

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -73,6 +73,7 @@ pub use listing::{LogKey, LogKeyIterator};
 pub use log::{LogDb, LogDbBuilder};
 pub use model::{AppendOutput, LogEntry, Record, Segment, SegmentId, Sequence};
 
+pub use common::{L0Stats, SortedRunStats};
 pub use reader::{
     Inspection, LogDbReader, LogIterator, LogRead, SegmentInspection, SegmentReadStats,
 };

--- a/log/src/lib.rs
+++ b/log/src/lib.rs
@@ -73,7 +73,9 @@ pub use listing::{LogKey, LogKeyIterator};
 pub use log::{LogDb, LogDbBuilder};
 pub use model::{AppendOutput, LogEntry, Record, Segment, SegmentId, Sequence};
 
-pub use reader::{LogDbReader, LogIterator, LogRead};
+pub use reader::{
+    Inspection, LogDbReader, LogIterator, LogRead, SegmentInspection, SegmentReadStats,
+};
 
 // Re-export proto types for use by clients
 #[cfg(feature = "http-server")]

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -2458,12 +2458,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn slate_inspect_reports_read_amplification() {
-        // Slatedb-backed inspect surfaces the LSM traversal the count walk
-        // performed: manifest shape plus per-segment SSTs opened/contributing.
-        // Built with its own Db handle so we can force a memtable->L0 flush;
-        // a plain `log.flush()` only flushes the WAL, leaving the data in the
-        // memtable where the manifest walk would never see it.
+    async fn slate_inspect_reports_record_distribution() {
+        // Slatedb-backed inspect reports how a segment's records are spread
+        // across the L0 and sorted-run tiers. Built with its own Db handle so
+        // we can force a memtable->L0 flush; a plain `log.flush()` only
+        // flushes the WAL, leaving the data in the memtable where the SST
+        // walk would never see it.
         use common::storage::slate::SlateDbStorage;
         use slatedb::config::{DbReaderOptions, FlushOptions, FlushType};
         use slatedb::object_store::memory::InMemory;

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -2430,8 +2430,13 @@ mod tests {
 
         let path = "/test/inspect_read_amp";
         let object_store: Arc<dyn slatedb::object_store::ObjectStore> = Arc::new(InMemory::new());
+        // Install the routing extractor so this matches production: writes
+        // land in per-segment trees, not the default tree. Without it the
+        // count walk would still pass via the default tree and never exercise
+        // the segment path.
         let db = Arc::new(
             DbBuilder::new(path, object_store.clone())
+                .with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())
                 .build()
                 .await
                 .unwrap(),
@@ -2584,8 +2589,11 @@ mod tests {
 
         let path = "/test/slate_with_direct";
         let object_store: Arc<dyn slatedb::object_store::ObjectStore> = Arc::new(InMemory::new());
+        // Route writes into per-segment trees as production does; the count
+        // walk must find data in segments, not the (empty) default tree.
         let db = Arc::new(
             DbBuilder::new(path, object_store.clone())
+                .with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())
                 .build()
                 .await
                 .unwrap(),

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -814,7 +814,7 @@ mod tests {
 
     use super::*;
     use crate::config::Config;
-    use crate::reader::LogDbReader;
+    use crate::reader::{LogDbReader, SegmentReadStats};
 
     fn test_config() -> Config {
         Config {
@@ -2482,10 +2482,13 @@ mod tests {
         // The data may land in L0 or be compacted into a sorted run by the
         // writer's compaction scheduler; either way it becomes visible in the
         // manifest as a persisted SST. Wait for that.
-        let persisted = |i: &Inspection| i.l0_ssts >= 1 || i.sorted_runs >= 1;
+        // Records land in L0 or get compacted into a sorted run by the
+        // writer's scheduler; either way they become visible as persisted
+        // SST records. Wait for that.
         let mut inspection = log.inspect(Bytes::from("k"), ..).await.unwrap();
         for _ in 0..200 {
-            if persisted(&inspection) {
+            let r = &inspection.reads;
+            if r.l0.records + r.sorted_runs.records >= 10 {
                 break;
             }
             tokio::time::sleep(Duration::from_millis(10)).await;
@@ -2493,12 +2496,6 @@ mod tests {
         }
 
         assert_eq!(inspection.total, 10);
-        assert!(
-            persisted(&inspection),
-            "flushed data should be visible as an L0 SST or sorted run (l0={}, sr={})",
-            inspection.l0_ssts,
-            inspection.sorted_runs
-        );
         assert_eq!(
             inspection.segments.len(),
             1,
@@ -2508,12 +2505,23 @@ mod tests {
         assert_eq!(seg.count, 10);
         let reads = seg
             .reads
-            .expect("slatedb-backed read should report SST traversal stats");
-        assert!(reads.ssts_opened >= 1, "at least the flushed SST is opened");
-        assert!(
-            reads.ssts_contributing >= 1,
-            "the SST holding k's rows must contribute"
+            .expect("slatedb-backed read should report tier distribution");
+        // All 10 records are persisted in this one segment's tree, split
+        // across the L0 and sorted-run tiers.
+        assert_eq!(
+            reads.l0.records + reads.sorted_runs.records,
+            10,
+            "every record is attributed to a tier (l0={}, sr={})",
+            reads.l0.records,
+            reads.sorted_runs.records
         );
+        let tier_ssts = reads.l0.ssts_with_data + reads.sorted_runs.ssts_with_data;
+        assert!(
+            tier_ssts >= 1,
+            "the records must live in at least one tier's SST"
+        );
+        // The top-level aggregate mirrors the single segment.
+        assert_eq!(inspection.reads, reads);
     }
 
     #[tokio::test]
@@ -2551,8 +2559,11 @@ mod tests {
 
         let inspection = log.inspect(Bytes::from("k"), ..).await.unwrap();
         assert_eq!(inspection.total, 4);
-        assert_eq!(inspection.l0_ssts, 0, "no manifest walk on the scan path");
-        assert_eq!(inspection.sorted_runs, 0);
+        assert_eq!(
+            inspection.reads,
+            SegmentReadStats::default(),
+            "no SST walk on the scan path, so the aggregate is empty"
+        );
         assert_eq!(inspection.segments.len(), 1);
         let seg = &inspection.segments[0];
         assert_eq!(seg.count, 4);

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -29,7 +29,7 @@ use crate::listing::ListingCache;
 use crate::listing::LogKeyIterator;
 use crate::model::{AppendOutput, Record, Segment, SegmentId, Sequence};
 use crate::range::{normalize_segment_id, normalize_sequence};
-use crate::reader::{LogIterator, LogRead, LogReadView};
+use crate::reader::{Inspection, LogIterator, LogRead, LogReadView};
 use crate::segment::SegmentCache;
 use crate::serde::SEQ_BLOCK_KEY;
 use crate::view_tracker::{ViewEntry, ViewTracker};
@@ -499,11 +499,15 @@ impl LogRead for LogDb {
         Ok(view.scan_with_options(key, seq_range, &options))
     }
 
-    async fn count(&self, key: Bytes, seq_range: impl RangeBounds<Sequence> + Send) -> Result<u64> {
+    async fn inspect(
+        &self,
+        key: Bytes,
+        seq_range: impl RangeBounds<Sequence> + Send,
+    ) -> Result<Inspection> {
         self.sync_reads().await?;
         let seq_range = normalize_sequence(&seq_range);
         let view = self.read_view.read().await;
-        view.count(key, seq_range).await
+        view.inspect(key, seq_range).await
     }
 
     async fn list_keys(
@@ -2410,6 +2414,147 @@ mod tests {
         let reader = LogDbReader::new_with_direct(storage, direct).await.unwrap();
         assert_eq!(reader.count(Bytes::from("k"), ..).await.unwrap(), 10);
         assert_eq!(reader.count(Bytes::from("k"), 2..7).await.unwrap(), 5);
+    }
+
+    #[tokio::test]
+    async fn slate_inspect_reports_read_amplification() {
+        // Slatedb-backed inspect surfaces the LSM traversal the count walk
+        // performed: manifest shape plus per-segment SSTs opened/contributing.
+        // Built with its own Db handle so we can force a memtable->L0 flush;
+        // a plain `log.flush()` only flushes the WAL, leaving the data in the
+        // memtable where the manifest walk would never see it.
+        use common::storage::slate::SlateDbStorage;
+        use slatedb::config::{DbReaderOptions, FlushOptions, FlushType};
+        use slatedb::object_store::memory::InMemory;
+        use slatedb::{DbBuilder, DbReader, SstReader};
+
+        let path = "/test/inspect_read_amp";
+        let object_store: Arc<dyn slatedb::object_store::ObjectStore> = Arc::new(InMemory::new());
+        let db = Arc::new(
+            DbBuilder::new(path, object_store.clone())
+                .build()
+                .await
+                .unwrap(),
+        );
+        let storage: Arc<dyn common::Storage> = Arc::new(SlateDbStorage::new(db.clone()));
+
+        let reader = DbReader::builder(path, object_store.clone())
+            .with_options(DbReaderOptions {
+                manifest_poll_interval: Duration::from_millis(5),
+                ..Default::default()
+            })
+            .build()
+            .await
+            .unwrap();
+        let sst_reader = SstReader::new(path, object_store, None, None);
+        let direct = Arc::new(crate::direct::LogDirect::from_components(
+            Arc::new(reader),
+            sst_reader,
+        ));
+
+        let log = LogDb::new_with_direct(storage, direct).await.unwrap();
+        log.try_append(
+            (0..10u8)
+                .map(|i| Record {
+                    key: Bytes::from("k"),
+                    value: Bytes::from(vec![i]),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+        log.flush().await.unwrap();
+        // Push the memtable into an L0 SST so the manifest walk has data.
+        db.flush_with_options(FlushOptions {
+            flush_type: FlushType::MemTable,
+        })
+        .await
+        .unwrap();
+
+        // The DbReader's manifest snapshot polls at 5ms; loop until it has
+        // picked up the flushed SST so the read-amp assertions don't race
+        // the poll. `count` is already correct meanwhile via the tail scan.
+        // The data may land in L0 or be compacted into a sorted run by the
+        // writer's compaction scheduler; either way it becomes visible in the
+        // manifest as a persisted SST. Wait for that.
+        let persisted = |i: &Inspection| i.l0_ssts >= 1 || i.sorted_runs >= 1;
+        let mut inspection = log.inspect(Bytes::from("k"), ..).await.unwrap();
+        for _ in 0..200 {
+            if persisted(&inspection) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            inspection = log.inspect(Bytes::from("k"), ..).await.unwrap();
+        }
+
+        assert_eq!(inspection.total, 10);
+        assert!(
+            persisted(&inspection),
+            "flushed data should be visible as an L0 SST or sorted run (l0={}, sr={})",
+            inspection.l0_ssts,
+            inspection.sorted_runs
+        );
+        assert_eq!(
+            inspection.segments.len(),
+            1,
+            "default segmentation keeps everything in segment 0"
+        );
+        let seg = &inspection.segments[0];
+        assert_eq!(seg.count, 10);
+        let reads = seg
+            .reads
+            .expect("slatedb-backed read should report SST traversal stats");
+        assert!(reads.ssts_opened >= 1, "at least the flushed SST is opened");
+        assert!(
+            reads.ssts_contributing >= 1,
+            "the SST holding k's rows must contribute"
+        );
+    }
+
+    #[tokio::test]
+    async fn inspect_reports_no_sst_stats_without_direct() {
+        // In-memory backend has no LogDirect, so count falls back to a scan
+        // and per-segment read stats are unavailable (reads = None).
+        let storage = StorageBuilder::new(&StorageConfig::InMemory)
+            .await
+            .unwrap()
+            .build()
+            .await
+            .unwrap();
+        let log = LogDb::from_storage(
+            storage,
+            None,
+            SegmentConfig::default(),
+            RetentionConfig::default(),
+            ReadVisibility::Memory,
+            Arc::new(SystemClock),
+            None,
+        )
+        .await
+        .unwrap();
+        log.try_append(
+            (0..4u8)
+                .map(|i| Record {
+                    key: Bytes::from("k"),
+                    value: Bytes::from(vec![i]),
+                })
+                .collect(),
+        )
+        .await
+        .unwrap();
+        log.flush().await.unwrap();
+
+        let inspection = log.inspect(Bytes::from("k"), ..).await.unwrap();
+        assert_eq!(inspection.total, 4);
+        assert_eq!(inspection.l0_ssts, 0, "no manifest walk on the scan path");
+        assert_eq!(inspection.sorted_runs, 0);
+        assert_eq!(inspection.segments.len(), 1);
+        let seg = &inspection.segments[0];
+        assert_eq!(seg.count, 4);
+        assert!(
+            seg.reads.is_none(),
+            "scan fallback has no SST-level detail to report"
+        );
     }
 
     /// Helper: creates a SlateDB-backed storage using an in-memory object store.

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -28,6 +28,63 @@ use crate::storage::{LogStorageRead as _, SegmentIterator};
 use common::storage::factory::create_storage_read;
 use common::{StorageRead, StorageReaderRuntime, StorageSemantics};
 
+/// Per-segment LSM read-amplification statistics, produced by the
+/// `count_in_range` walk over persisted SSTs.
+///
+/// Present only when the read went through the SST-walk path (a
+/// `LogDirect` handle is available). A scan fallback — the in-memory
+/// backend, or a SlateDB config whose object store is in-memory — reports
+/// `None` via [`SegmentInspection::reads`], since no manifest walk occurs.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SegmentReadStats {
+    /// SST views opened while counting this segment's slice. Includes every
+    /// L0 SST (L0 is not range-partitioned, so each must be consulted) plus
+    /// the sorted-run views covering the query.
+    pub ssts_opened: u32,
+    /// Opened SSTs that held at least one in-range row for this key — i.e.
+    /// how many SSTs the key's records were physically spread across.
+    pub ssts_contributing: u32,
+    /// Data blocks read to count this segment's slice precisely. Blocks
+    /// resolved via the cheap stats/last-entry path do not count here.
+    pub blocks_read: u32,
+}
+
+/// How a single covering segment contributed to an [`Inspection`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SegmentInspection {
+    /// The segment that produced these records.
+    pub segment_id: SegmentId,
+    /// Records for the key found in this segment's slice of the query.
+    pub count: u64,
+    /// Records counted by the memtable/lagging-snapshot tail scan rather
+    /// than the SST walk — writes not yet reflected in persisted SSTs. Kept
+    /// separate so `reads` stays an honest account of persisted-tree I/O.
+    pub tail_scanned: u64,
+    /// LSM read-amplification for the SST walk, or `None` when the count was
+    /// produced entirely by a scan (no `LogDirect`; see [`SegmentReadStats`]).
+    pub reads: Option<SegmentReadStats>,
+}
+
+/// Result of [`LogRead::inspect`]: the record count for a key/range plus a
+/// breakdown of how the query flowed through the LSM tree.
+///
+/// [`total`](Inspection::total) is exactly what [`LogRead::count`] returns;
+/// the remaining fields expose the tree shape and per-segment read
+/// amplification the walk observed, for tuning segmentation and compaction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Inspection {
+    /// Total records for the key in the queried range.
+    pub total: u64,
+    /// L0 SSTs in the manifest at query time (whole-DB tree shape, not
+    /// scoped to the query). `0` when no SST walk ran.
+    pub l0_ssts: u32,
+    /// Sorted runs in the manifest at query time (whole-DB tree shape).
+    /// `0` when no SST walk ran.
+    pub sorted_runs: u32,
+    /// Per covering-segment breakdown, in ascending segment order.
+    pub segments: Vec<SegmentInspection>,
+}
+
 /// Trait for read operations on the log.
 ///
 /// This trait defines the common read interface shared by [`LogDb`](crate::LogDb)
@@ -115,6 +172,11 @@ pub trait LogRead {
     /// Returns the exact number of entries in the specified range. Useful
     /// for computing lag (how far behind a consumer is) or progress metrics.
     ///
+    /// This is a thin wrapper over [`inspect`](LogRead::inspect), returning
+    /// only [`Inspection::total`]. The two do identical work; use `inspect`
+    /// when you also want the per-segment distribution and read-amplification
+    /// breakdown.
+    ///
     /// # Arguments
     ///
     /// * `key` - The key identifying the log stream to count.
@@ -123,7 +185,32 @@ pub trait LogRead {
     /// # Errors
     ///
     /// Returns an error if the count fails due to storage issues.
-    async fn count(&self, key: Bytes, seq_range: impl RangeBounds<Sequence> + Send) -> Result<u64>;
+    async fn count(&self, key: Bytes, seq_range: impl RangeBounds<Sequence> + Send) -> Result<u64> {
+        Ok(self.inspect(key, seq_range).await?.total)
+    }
+
+    /// Inspects entries for a key within a sequence number range, returning
+    /// the record count plus a breakdown of how the query flowed through the
+    /// LSM tree.
+    ///
+    /// Like [`count`](LogRead::count) but also reports, per covering segment,
+    /// the record distribution and the read amplification the underlying
+    /// SST walk incurred (SSTs opened, SSTs that contributed rows, data
+    /// blocks read), along with the manifest's tree shape. See [`Inspection`].
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - The key identifying the log stream to inspect.
+    /// * `seq_range` - The sequence number range to inspect.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the operation fails due to storage issues.
+    async fn inspect(
+        &self,
+        key: Bytes,
+        seq_range: impl RangeBounds<Sequence> + Send,
+    ) -> Result<Inspection>;
 
     /// Lists distinct keys within a segment range.
     ///
@@ -221,6 +308,15 @@ fn segment_window(segments: &[LogSegment], i: usize, query: &Range<Sequence>) ->
     lo..hi
 }
 
+/// Internal result of inspecting one segment: the public per-segment
+/// breakdown plus the global tree-shape counters (lifted to the top-level
+/// [`Inspection`] by the caller, since they're identical across segments).
+struct SegmentWalk {
+    inspection: SegmentInspection,
+    l0_ssts: u32,
+    sorted_runs: u32,
+}
+
 /// Shared read component used by both `LogDb` and `LogDbReader`.
 ///
 /// Contains the storage and segment cache needed for read operations.
@@ -281,67 +377,112 @@ impl LogReadView {
         LogIterator::open(Arc::clone(&self.storage), &self.segments, key, seq_range)
     }
 
-    /// Counts entries for `key` in `seq_range`, exact.
+    /// Inspects entries for `key` in `seq_range`: exact count plus the
+    /// per-segment read-amplification breakdown.
     ///
     /// Fans out across overlapping segments — clipped to each segment's
     /// window. When [`LogDirect`] is available, walks persisted SSTs via
-    /// `count_in_range` for the bulk count and scans `(covered_to, seg_hi)`
-    /// to pick up anything still in the memtable. Otherwise falls back to
-    /// a plain scan tally.
-    pub(crate) async fn count(&self, key: Bytes, seq_range: Range<Sequence>) -> Result<u64> {
+    /// `count_in_range` (capturing traversal stats) for the bulk count and
+    /// scans `(covered_to, seg_hi)` to pick up anything still in the
+    /// memtable. Otherwise falls back to a plain scan tally with no
+    /// SST-level detail.
+    pub(crate) async fn inspect(
+        &self,
+        key: Bytes,
+        seq_range: Range<Sequence>,
+    ) -> Result<Inspection> {
         let segments = self.segments.find_covering(&seq_range);
-        let mut total = 0u64;
+        let mut inspection = Inspection {
+            total: 0,
+            l0_ssts: 0,
+            sorted_runs: 0,
+            segments: Vec::new(),
+        };
         for (i, segment) in segments.iter().enumerate() {
             let window = segment_window(&segments, i, &seq_range);
             if window.start >= window.end {
                 continue;
             }
-            let n = match self.direct.as_deref() {
+            let seg = match self.direct.as_deref() {
                 Some(direct) => {
-                    self.count_segment_via_direct(direct, segment, &key, window)
+                    self.inspect_segment_via_direct(direct, segment, &key, window)
                         .await?
                 }
-                None => self.storage.count_entries(segment, &key, window).await?,
+                None => {
+                    let count = self.storage.count_entries(segment, &key, window).await?;
+                    SegmentWalk {
+                        inspection: SegmentInspection {
+                            segment_id: segment.id(),
+                            count,
+                            tail_scanned: 0,
+                            reads: None,
+                        },
+                        // No manifest walk on the scan-fallback path.
+                        l0_ssts: 0,
+                        sorted_runs: 0,
+                    }
+                }
             };
-            total = total.saturating_add(n);
+            inspection.total = inspection.total.saturating_add(seg.inspection.count);
+            // Tree shape is global to the DB, so it's identical across every
+            // segment that walked the manifest — take the largest seen.
+            inspection.l0_ssts = inspection.l0_ssts.max(seg.l0_ssts);
+            inspection.sorted_runs = inspection.sorted_runs.max(seg.sorted_runs);
+            inspection.segments.push(seg.inspection);
         }
-        Ok(total)
+        Ok(inspection)
     }
 
-    /// Counts entries in a single segment slice using [`LogDirect`].
+    /// Inspects entries in a single segment slice using [`LogDirect`].
     ///
     /// Walks persisted SSTs via `count_in_range` and tops up with a tail
     /// scan above the witness key. The tail scan covers two cases at once:
     /// writes still in the memtable, and writes flushed since `direct`'s
     /// manifest snapshot was taken (the DbReader polls, so its view can lag
-    /// the writer).
-    async fn count_segment_via_direct(
+    /// the writer). The tail's contribution is reported separately as
+    /// [`SegmentInspection::tail_scanned`] so the SST stats stay honest.
+    async fn inspect_segment_via_direct(
         &self,
         direct: &LogDirect,
         segment: &LogSegment,
         key: &Bytes,
         window: Range<Sequence>,
-    ) -> Result<u64> {
+    ) -> Result<SegmentWalk> {
         let byte_range = LogEntryKey::scan_range(segment, key, window.clone());
         let result = direct.count_in_range(&byte_range).await?;
         // LogDb is append-only, so only puts contribute. Tombstones or
         // merges in this byte range would indicate an unsupported op.
-        let mut total = result.counts.num_puts;
+        let sst_count = result.counts.num_puts;
 
-        let scan_lo = match result.covered_to {
-            Some(covered_key) => LogEntryKey::deserialize(&covered_key, segment.meta().start_seq)?
+        let scan_lo = match &result.covered_to {
+            Some(covered_key) => LogEntryKey::deserialize(covered_key, segment.meta().start_seq)?
                 .sequence
                 .saturating_add(1),
             None => window.start,
         };
-        if scan_lo < window.end {
-            total = total.saturating_add(
-                self.storage
-                    .count_entries(segment, key, scan_lo..window.end)
-                    .await?,
-            );
-        }
-        Ok(total)
+        let tail_scanned = if scan_lo < window.end {
+            self.storage
+                .count_entries(segment, key, scan_lo..window.end)
+                .await?
+        } else {
+            0
+        };
+
+        let stats = result.stats;
+        Ok(SegmentWalk {
+            inspection: SegmentInspection {
+                segment_id: segment.id(),
+                count: sst_count.saturating_add(tail_scanned),
+                tail_scanned,
+                reads: Some(SegmentReadStats {
+                    ssts_opened: stats.ssts_opened,
+                    ssts_contributing: stats.ssts_contributing,
+                    blocks_read: stats.blocks_read,
+                }),
+            },
+            l0_ssts: stats.l0_ssts,
+            sorted_runs: stats.sorted_runs,
+        })
     }
 
     /// Lists distinct keys within a segment range.
@@ -606,10 +747,14 @@ impl LogRead for LogDbReader {
         Ok(view.scan_with_options(key, seq_range, &options))
     }
 
-    async fn count(&self, key: Bytes, seq_range: impl RangeBounds<Sequence> + Send) -> Result<u64> {
+    async fn inspect(
+        &self,
+        key: Bytes,
+        seq_range: impl RangeBounds<Sequence> + Send,
+    ) -> Result<Inspection> {
         let seq_range = normalize_sequence(&seq_range);
         let view = self.read_view.read().await;
-        view.count(key, seq_range).await
+        view.inspect(key, seq_range).await
     }
 
     async fn list_keys(

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -186,10 +186,11 @@ pub trait LogRead {
     /// Returns the exact number of entries in the specified range. Useful
     /// for computing lag (how far behind a consumer is) or progress metrics.
     ///
-    /// This is a thin wrapper over [`inspect`](LogRead::inspect), returning
-    /// only [`Inspection::total`]. The two do identical work; use `inspect`
-    /// when you also want the per-segment distribution and read-amplification
-    /// breakdown.
+    /// Provided for every `LogRead` implementor: it runs the same LSM walk as
+    /// [`inspect`](LogRead::inspect) and returns only [`Inspection::total`].
+    /// Reach for `inspect` directly when you also want the per-segment record
+    /// distribution. Implementors may override this if they can count more
+    /// cheaply, but the default is correct for all of them.
     ///
     /// # Arguments
     ///
@@ -204,13 +205,14 @@ pub trait LogRead {
     }
 
     /// Inspects entries for a key within a sequence number range, returning
-    /// the record count plus a breakdown of how the query flowed through the
+    /// the record count plus a breakdown of how that data is laid out in the
     /// LSM tree.
     ///
     /// Like [`count`](LogRead::count) but also reports, per covering segment,
-    /// the record distribution and the read amplification the underlying
-    /// SST walk incurred (SSTs opened, SSTs that contributed rows, data
-    /// blocks read), along with the manifest's tree shape. See [`Inspection`].
+    /// how the key's records are distributed across the L0 and sorted-run
+    /// tiers (record counts, SSTs holding data, blocks spanned). See
+    /// [`Inspection`]. Useful for understanding read amplification and tuning
+    /// segmentation/compaction.
     ///
     /// # Arguments
     ///
@@ -383,11 +385,11 @@ impl LogReadView {
     }
 
     /// Inspects entries for `key` in `seq_range`: exact count plus the
-    /// per-segment read-amplification breakdown.
+    /// per-segment record-distribution breakdown.
     ///
     /// Fans out across overlapping segments — clipped to each segment's
     /// window. When [`LogDirect`] is available, walks persisted SSTs via
-    /// `count_in_range` (capturing traversal stats) for the bulk count and
+    /// `count_in_range` (capturing per-tier stats) for the bulk count and
     /// scans `(covered_to, seg_hi)` to pick up anything still in the
     /// memtable. Otherwise falls back to a plain scan tally with no
     /// SST-level detail.

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -26,27 +26,41 @@ use crate::segment::{LogSegment, SegmentCache};
 use crate::serde::LogEntryKey;
 use crate::storage::{LogStorageRead as _, SegmentIterator};
 use common::storage::factory::create_storage_read;
-use common::{StorageRead, StorageReaderRuntime, StorageSemantics};
+use common::{L0Stats, SortedRunStats, StorageRead, StorageReaderRuntime, StorageSemantics};
 
-/// Per-segment LSM read-amplification statistics, produced by the
-/// `count_in_range` walk over persisted SSTs.
+/// How a key's records in one segment's slice of the query are distributed
+/// across that segment's LSM tree — the L0 tier vs the sorted-run tier.
 ///
-/// Present only when the read went through the SST-walk path (a
-/// `LogDirect` handle is available). A scan fallback — the in-memory
-/// backend, or a SlateDB config whose object store is in-memory — reports
-/// `None` via [`SegmentInspection::reads`], since no manifest walk occurs.
+/// Present only when the read went through the SST-walk path (a `LogDirect`
+/// handle is available). A scan fallback — the in-memory backend, or a
+/// SlateDB config whose object store is in-memory — reports `None` via
+/// [`SegmentInspection::reads`], since no manifest walk occurs.
+///
+/// `l0.records + sorted_runs.records` is the persisted-SST portion of the
+/// segment's count; not-yet-flushed writes are reported as
+/// [`SegmentInspection::tail_scanned`].
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct SegmentReadStats {
-    /// SST views opened while counting this segment's slice. Includes every
-    /// L0 SST (L0 is not range-partitioned, so each must be consulted) plus
-    /// the sorted-run views covering the query.
-    pub ssts_opened: u32,
-    /// Opened SSTs that held at least one in-range row for this key — i.e.
-    /// how many SSTs the key's records were physically spread across.
-    pub ssts_contributing: u32,
-    /// Data blocks read to count this segment's slice precisely. Blocks
-    /// resolved via the cheap stats/last-entry path do not count here.
-    pub blocks_read: u32,
+    /// The L0 tier's record distribution; see [`L0Stats`].
+    pub l0: L0Stats,
+    /// The sorted-run tier's record distribution; see [`SortedRunStats`].
+    pub sorted_runs: SortedRunStats,
+}
+
+impl SegmentReadStats {
+    /// Folds another segment's distribution into this one, summing every
+    /// tier counter. Used to build the aggregate [`Inspection::reads`].
+    fn add(&mut self, other: &SegmentReadStats) {
+        self.l0.ssts_total += other.l0.ssts_total;
+        self.l0.ssts_with_data += other.l0.ssts_with_data;
+        self.l0.blocks_with_data += other.l0.blocks_with_data;
+        self.l0.records += other.l0.records;
+        self.sorted_runs.runs += other.sorted_runs.runs;
+        self.sorted_runs.ssts_total += other.sorted_runs.ssts_total;
+        self.sorted_runs.ssts_with_data += other.sorted_runs.ssts_with_data;
+        self.sorted_runs.blocks_with_data += other.sorted_runs.blocks_with_data;
+        self.sorted_runs.records += other.sorted_runs.records;
+    }
 }
 
 /// How a single covering segment contributed to an [`Inspection`].
@@ -58,30 +72,30 @@ pub struct SegmentInspection {
     pub count: u64,
     /// Records counted by the memtable/lagging-snapshot tail scan rather
     /// than the SST walk — writes not yet reflected in persisted SSTs. Kept
-    /// separate so `reads` stays an honest account of persisted-tree I/O.
+    /// separate so `reads` stays an honest account of persisted data.
     pub tail_scanned: u64,
-    /// LSM read-amplification for the SST walk, or `None` when the count was
-    /// produced entirely by a scan (no `LogDirect`; see [`SegmentReadStats`]).
+    /// How the segment's persisted records split across L0 and sorted runs,
+    /// or `None` when the count was produced entirely by a scan (no
+    /// `LogDirect`; see [`SegmentReadStats`]).
     pub reads: Option<SegmentReadStats>,
 }
 
 /// Result of [`LogRead::inspect`]: the record count for a key/range plus a
-/// breakdown of how the query flowed through the LSM tree.
+/// per-segment breakdown of how that data is distributed across the LSM
+/// tree, for tuning segmentation and compaction.
 ///
-/// [`total`](Inspection::total) is exactly what [`LogRead::count`] returns;
-/// the remaining fields expose the tree shape and per-segment read
-/// amplification the walk observed, for tuning segmentation and compaction.
+/// [`total`](Inspection::total) is exactly what [`LogRead::count`] returns.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Inspection {
     /// Total records for the key in the queried range.
     pub total: u64,
-    /// L0 SSTs in the manifest at query time (whole-DB tree shape, not
-    /// scoped to the query). `0` when no SST walk ran.
-    pub l0_ssts: u32,
-    /// Sorted runs in the manifest at query time (whole-DB tree shape).
-    /// `0` when no SST walk ran.
-    pub sorted_runs: u32,
-    /// Per covering-segment breakdown, in ascending segment order.
+    /// Tier distribution summed across all covering segments. Only segments
+    /// counted via the SST-walk path contribute (see
+    /// [`SegmentInspection::reads`]); on the scan-fallback path this stays
+    /// zero while [`total`](Inspection::total) is still exact.
+    pub reads: SegmentReadStats,
+    /// Per covering-segment breakdown, in ascending segment order — the
+    /// primary view, since each segment is its own LSM tree.
     pub segments: Vec<SegmentInspection>,
 }
 
@@ -308,15 +322,6 @@ fn segment_window(segments: &[LogSegment], i: usize, query: &Range<Sequence>) ->
     lo..hi
 }
 
-/// Internal result of inspecting one segment: the public per-segment
-/// breakdown plus the global tree-shape counters (lifted to the top-level
-/// [`Inspection`] by the caller, since they're identical across segments).
-struct SegmentWalk {
-    inspection: SegmentInspection,
-    l0_ssts: u32,
-    sorted_runs: u32,
-}
-
 /// Shared read component used by both `LogDb` and `LogDbReader`.
 ///
 /// Contains the storage and segment cache needed for read operations.
@@ -394,8 +399,7 @@ impl LogReadView {
         let segments = self.segments.find_covering(&seq_range);
         let mut inspection = Inspection {
             total: 0,
-            l0_ssts: 0,
-            sorted_runs: 0,
+            reads: SegmentReadStats::default(),
             segments: Vec::new(),
         };
         for (i, segment) in segments.iter().enumerate() {
@@ -408,27 +412,20 @@ impl LogReadView {
                     self.inspect_segment_via_direct(direct, segment, &key, window)
                         .await?
                 }
-                None => {
-                    let count = self.storage.count_entries(segment, &key, window).await?;
-                    SegmentWalk {
-                        inspection: SegmentInspection {
-                            segment_id: segment.id(),
-                            count,
-                            tail_scanned: 0,
-                            reads: None,
-                        },
-                        // No manifest walk on the scan-fallback path.
-                        l0_ssts: 0,
-                        sorted_runs: 0,
-                    }
-                }
+                None => SegmentInspection {
+                    segment_id: segment.id(),
+                    count: self.storage.count_entries(segment, &key, window).await?,
+                    tail_scanned: 0,
+                    // No manifest walk on the scan-fallback path.
+                    reads: None,
+                },
             };
-            inspection.total = inspection.total.saturating_add(seg.inspection.count);
-            // Tree shape is global to the DB, so it's identical across every
-            // segment that walked the manifest — take the largest seen.
-            inspection.l0_ssts = inspection.l0_ssts.max(seg.l0_ssts);
-            inspection.sorted_runs = inspection.sorted_runs.max(seg.sorted_runs);
-            inspection.segments.push(seg.inspection);
+            inspection.total = inspection.total.saturating_add(seg.count);
+            // Aggregate the per-segment tier distribution into the total.
+            if let Some(reads) = &seg.reads {
+                inspection.reads.add(reads);
+            }
+            inspection.segments.push(seg);
         }
         Ok(inspection)
     }
@@ -447,7 +444,7 @@ impl LogReadView {
         segment: &LogSegment,
         key: &Bytes,
         window: Range<Sequence>,
-    ) -> Result<SegmentWalk> {
+    ) -> Result<SegmentInspection> {
         let byte_range = LogEntryKey::scan_range(segment, key, window.clone());
         let result = direct.count_in_range(&byte_range).await?;
         // LogDb is append-only, so only puts contribute. Tombstones or
@@ -469,19 +466,14 @@ impl LogReadView {
         };
 
         let stats = result.stats;
-        Ok(SegmentWalk {
-            inspection: SegmentInspection {
-                segment_id: segment.id(),
-                count: sst_count.saturating_add(tail_scanned),
-                tail_scanned,
-                reads: Some(SegmentReadStats {
-                    ssts_opened: stats.ssts_opened,
-                    ssts_contributing: stats.ssts_contributing,
-                    blocks_read: stats.blocks_read,
-                }),
-            },
-            l0_ssts: stats.l0_ssts,
-            sorted_runs: stats.sorted_runs,
+        Ok(SegmentInspection {
+            segment_id: segment.id(),
+            count: sst_count.saturating_add(tail_scanned),
+            tail_scanned,
+            reads: Some(SegmentReadStats {
+                l0: stats.l0,
+                sorted_runs: stats.sorted_runs,
+            }),
         })
     }
 


### PR DESCRIPTION
The `count` API walks the LSM tree in order to count the number of records for a log within a sequence range. It's useful to surface details from the walk as well in order to understand the structure and layout of the data in the log. This can help for example with tuning GC. To that end, this patch adds an `inspect` API which exposes the segments that were traversed and the l0s/srs consulted within each segment. Finally, we modify `count` to delegate to it.