### PR TITLE
[vector]: segment vector db into separate default/ann/fts segments

### DIFF
--- a/vector/src/admin.rs
+++ b/vector/src/admin.rs
@@ -23,9 +23,13 @@ impl VectorDbAdmin {
     /// Open a vector database for administrative operations.
     pub async fn open(config: Config) -> Result<Self> {
         let merge_op = VectorDbMergeOperator::new(config.dimensions as usize);
-        let storage = StorageBuilder::new(&config.storage)
+        let builder = StorageBuilder::new(&config.storage)
             .await
-            .map_err(|e| Error::Storage(format!("Failed to create storage: {e}")))?
+            .map_err(|e| Error::Storage(format!("Failed to create storage: {e}")))?;
+        // Install the same segment extractor the writer uses (RFC-0006); the
+        // extractor name is persisted in the manifest and validated on open, so
+        // an admin client opening a segmented database must match it.
+        let storage = crate::storage::segment_extractor::builder_with_vector_segments(builder)
             .with_semantics(StorageSemantics::new().with_merge_operator(Arc::new(merge_op)))
             .build()
             .await

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -209,7 +209,10 @@ impl VectorDb {
         builder: StorageBuilder,
     ) -> Result<Self> {
         let merge_op = VectorDbMergeOperator::new(config.dimensions as usize);
-        let storage = builder
+        // Route each vector segment (Default/ANN/FTS) into its own SlateDB
+        // segment so the FTS segment can be compacted independently (RFC-0006).
+        // No-op for the in-memory backend.
+        let storage = crate::storage::segment_extractor::builder_with_vector_segments(builder)
             .with_semantics(StorageSemantics::new().with_merge_operator(Arc::new(merge_op)))
             .build()
             .await
@@ -482,7 +485,7 @@ impl VectorDb {
         snapshot: &dyn StorageRead,
     ) -> Result<HashMap<String, VectorId>> {
         // Create prefix for all IdDictionary records
-        let mut prefix_buf = bytes::BytesMut::with_capacity(3);
+        let mut prefix_buf = bytes::BytesMut::with_capacity(crate::serde::PREFIX_AND_TAG_LEN);
         crate::serde::RecordType::IdDictionary.write_prefix(&mut prefix_buf);
         let prefix = prefix_buf.freeze();
 

--- a/vector/src/serde/key.rs
+++ b/vector/src/serde/key.rs
@@ -16,7 +16,7 @@ use std::ops::Bound::{Excluded, Included};
 
 /// CollectionMeta key - singleton record storing collection schema.
 ///
-/// Key layout: `[subsystem | version | tag]` (3 bytes)
+/// Key layout: `[subsystem | segment | version | tag]` (4 bytes)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CollectionMetaKey;
 
@@ -26,7 +26,7 @@ impl RecordKey for CollectionMetaKey {
 
 impl CollectionMetaKey {
     pub fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(3);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         buf.freeze()
     }
@@ -44,7 +44,7 @@ impl CollectionMetaKey {
 
 /// Centroids key - singleton record storing centroid tree metadata.
 ///
-/// Key layout: `[subsystem | version | tag]` (3 bytes)
+/// Key layout: `[subsystem | segment | version | tag]` (4 bytes)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CentroidsKey;
 
@@ -58,7 +58,7 @@ impl CentroidsKey {
     }
 
     pub fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(3);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         buf.freeze()
     }
@@ -82,7 +82,7 @@ impl Default for CentroidsKey {
 
 /// Deletions key - singleton record storing the FTS deletions bitmap.
 ///
-/// Key layout: `[subsystem | version | tag]` (3 bytes)
+/// Key layout: `[subsystem | segment | version | tag]` (4 bytes)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeletionsKey;
 
@@ -96,7 +96,7 @@ impl DeletionsKey {
     }
 
     pub fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(3);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         buf.freeze()
     }
@@ -120,7 +120,7 @@ impl Default for DeletionsKey {
 
 /// PostingList key - maps centroid ID to vector IDs.
 ///
-/// Key layout: `[subsystem | version | tag | centroid_id:u64-BE]` (11 bytes)
+/// Key layout: `[subsystem | segment | version | tag | centroid_id:u64-BE]` (12 bytes)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PostingListKey {
     pub(crate) centroid_id: VectorId,
@@ -137,7 +137,7 @@ impl PostingListKey {
     }
 
     pub(crate) fn encode_prefix_for_level(level: u8) -> Bytes {
-        let mut buf = BytesMut::with_capacity(4);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN + 1);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         VectorId::encode_level_prefix(&mut buf, level);
         buf.freeze()
@@ -150,7 +150,7 @@ impl PostingListKey {
     }
 
     pub fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(11);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN + 8);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         self.centroid_id.encode(&mut buf);
         buf.freeze()
@@ -170,7 +170,7 @@ impl PostingListKey {
 
     /// Returns a range covering all posting list keys.
     pub fn all_posting_lists_range() -> BytesRange {
-        let mut buf = BytesMut::with_capacity(3);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         BytesRange::prefix(buf.freeze())
     }
@@ -178,7 +178,7 @@ impl PostingListKey {
 
 /// IdDictionary key - maps external string IDs to internal u64 vector IDs.
 ///
-/// Key layout: `[subsystem | version | tag | external_id:TerminatedBytes]` (variable)
+/// Key layout: `[subsystem | segment | version | tag | external_id:TerminatedBytes]` (variable)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IdDictionaryKey {
     pub external_id: String,
@@ -227,7 +227,7 @@ impl IdDictionaryKey {
 
     /// Returns a range covering all ID dictionary keys.
     pub fn all_ids_range() -> BytesRange {
-        let mut buf = BytesMut::with_capacity(3);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         BytesRange::prefix(buf.freeze())
     }
@@ -247,7 +247,7 @@ impl IdDictionaryKey {
 
 /// VectorData key - stores raw vector bytes.
 ///
-/// Key layout: `[subsystem | version | tag | vector_id:u64-BE]` (11 bytes)
+/// Key layout: `[subsystem | segment | version | tag | vector_id:u64-BE]` (12 bytes)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VectorDataKey {
     pub(crate) vector_id: VectorId,
@@ -264,7 +264,7 @@ impl VectorDataKey {
     }
 
     pub(crate) fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(11);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN + 8);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         self.vector_id.encode(&mut buf);
         buf.freeze()
@@ -285,7 +285,7 @@ impl VectorDataKey {
     /// Returns a range covering all vector data keys.
     #[allow(dead_code)]
     pub(crate) fn all_vectors_range() -> BytesRange {
-        let mut buf = BytesMut::with_capacity(3);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         BytesRange::prefix(buf.freeze())
     }
@@ -293,7 +293,7 @@ impl VectorDataKey {
 
 /// VectorIndexData key - stores durable posting assignments for a data vector.
 ///
-/// Key layout: `[subsystem | version | tag | vector_id:u64-BE]` (11 bytes)
+/// Key layout: `[subsystem | segment | version | tag | vector_id:u64-BE]` (12 bytes)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VectorIndexDataKey {
     pub(crate) vector_id: VectorId,
@@ -310,7 +310,7 @@ impl VectorIndexDataKey {
     }
 
     pub(crate) fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(11);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN + 8);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         self.vector_id.encode(&mut buf);
         buf.freeze()
@@ -331,7 +331,7 @@ impl VectorIndexDataKey {
 
 /// MetadataIndex key - inverted index mapping metadata values to vector IDs.
 ///
-/// Key layout: `[subsystem | version | tag | field:TerminatedBytes | value:FieldValue]` (variable)
+/// Key layout: `[subsystem | segment | version | tag | field:TerminatedBytes | value:FieldValue]` (variable)
 #[derive(Debug, Clone, PartialEq)]
 pub struct MetadataIndexKey {
     pub field: String,
@@ -392,7 +392,7 @@ impl MetadataIndexKey {
 
     /// Returns a range covering all metadata index keys.
     pub fn all_indexes_range() -> BytesRange {
-        let mut buf = BytesMut::with_capacity(3);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         BytesRange::prefix(buf.freeze())
     }
@@ -400,7 +400,7 @@ impl MetadataIndexKey {
 
 /// SeqBlock key - singleton record storing sequence allocation state.
 ///
-/// Key layout: `[subsystem | version | tag]` (3 bytes)
+/// Key layout: `[subsystem | segment | version | tag]` (4 bytes)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SeqBlockKey;
 
@@ -410,7 +410,7 @@ impl RecordKey for SeqBlockKey {
 
 impl SeqBlockKey {
     pub fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(3);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         buf.freeze()
     }
@@ -428,7 +428,7 @@ impl SeqBlockKey {
 
 /// CentroidSeqBlock key - singleton record storing centroid sequence allocation state.
 ///
-/// Key layout: `[subsystem | version | tag]` (3 bytes)
+/// Key layout: `[subsystem | segment | version | tag]` (4 bytes)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CentroidSeqBlockKey;
 
@@ -438,7 +438,7 @@ impl RecordKey for CentroidSeqBlockKey {
 
 impl CentroidSeqBlockKey {
     pub fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(3);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         buf.freeze()
     }
@@ -456,7 +456,7 @@ impl CentroidSeqBlockKey {
 
 /// CentroidStats key - per-centroid vector count for rebalance triggers.
 ///
-/// Key layout: `[subsystem | version | tag | level:u8 | centroid_id:u64-BE]` (12 bytes)
+/// Key layout: `[subsystem | segment | version | tag | centroid_id:u64-BE]` (12 bytes)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CentroidStatsKey {
     pub(crate) centroid_id: VectorId,
@@ -473,7 +473,7 @@ impl CentroidStatsKey {
     }
 
     pub(crate) fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(12);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN + 8);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         self.centroid_id.encode(&mut buf);
         buf.freeze()
@@ -493,7 +493,7 @@ impl CentroidStatsKey {
 
 /// CentroidInfo key - per-centroid metadata for the centroid tree.
 ///
-/// Key layout: `[subsystem | version | tag | centroid_id:u64-BE]` (11 bytes)
+/// Key layout: `[subsystem | segment | version | tag | centroid_id:u64-BE]` (12 bytes)
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CentroidInfoKey {
     pub(crate) centroid_id: VectorId,
@@ -510,7 +510,7 @@ impl CentroidInfoKey {
     }
 
     pub(crate) fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(11);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN + 8);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         self.centroid_id.encode(&mut buf);
         buf.freeze()
@@ -530,7 +530,7 @@ impl CentroidInfoKey {
     /// Returns a range covering all centroid info keys.
     #[allow(dead_code)]
     pub(crate) fn all_centroid_infos_range() -> BytesRange {
-        let mut buf = BytesMut::with_capacity(3);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         Self::RECORD_TYPE.write_prefix(&mut buf);
         BytesRange::prefix(buf.freeze())
     }
@@ -777,7 +777,7 @@ mod tests {
 
         // then
         assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 3);
+        assert_eq!(encoded.len(), 4);
     }
 
     #[test]
@@ -830,7 +830,7 @@ mod tests {
 
         // then
         assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 3);
+        assert_eq!(encoded.len(), 4);
     }
 
     #[test]
@@ -844,7 +844,7 @@ mod tests {
 
         // then
         assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 3);
+        assert_eq!(encoded.len(), 4);
     }
 
     #[test]
@@ -888,7 +888,7 @@ mod tests {
 
         // then
         assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 11);
+        assert_eq!(encoded.len(), 12);
     }
 
     #[test]
@@ -919,7 +919,7 @@ mod tests {
 
         // then
         assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 11);
+        assert_eq!(encoded.len(), 12);
     }
 
     #[test]
@@ -1019,7 +1019,7 @@ mod tests {
 
         // then
         assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 3);
+        assert_eq!(encoded.len(), 4);
     }
 
     #[test]
@@ -1033,7 +1033,7 @@ mod tests {
 
         // then
         assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 3);
+        assert_eq!(encoded.len(), 4);
     }
 
     #[test]
@@ -1061,7 +1061,7 @@ mod tests {
 
         // then
         assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 11);
+        assert_eq!(encoded.len(), 12);
     }
 
     #[test]
@@ -1092,7 +1092,7 @@ mod tests {
 
         // then
         assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 11);
+        assert_eq!(encoded.len(), 12);
     }
 
     #[test]
@@ -1181,9 +1181,10 @@ mod tests {
 
     #[test]
     fn should_reject_wrong_version() {
-        // given
+        // given - layout is [subsystem | segment | version | tag]
         let mut buf = BytesMut::new();
         buf.put_u8(crate::serde::SUBSYSTEM);
+        buf.put_u8(RecordType::CollectionMeta.segment().as_byte());
         buf.put_u8(0x99); // Wrong version
         buf.put_u8(RecordType::CollectionMeta.tag().as_byte());
 

--- a/vector/src/serde/mod.rs
+++ b/vector/src/serde/mod.rs
@@ -25,12 +25,20 @@ use bytes::{BufMut, Bytes, BytesMut};
 pub use common::serde::encoding::{
     EncodingError, decode_optional_utf8, decode_utf8, encode_optional_utf8, encode_utf8,
 };
-use common::serde::key_prefix::{KEY_PREFIX_LEN, KeyPrefix};
 use common::serde::record_tag::RecordTag;
 
-/// Offset of the first subsystem-defined field after the 2-byte common prefix
-/// plus the 1-byte vector tag.
-pub const PREFIX_AND_TAG_LEN: usize = KEY_PREFIX_LEN + 1;
+/// Length of the fixed key prefix `[subsystem | segment | version | tag]` that
+/// precedes the subsystem-defined suffix of every vector key.
+///
+/// RFC-0006 inserts the 1-byte segment id between the subsystem and version
+/// bytes (see [`Segment`]), growing the prefix from 3 to 4 bytes.
+pub const PREFIX_AND_TAG_LEN: usize = 4;
+
+/// Byte offsets within the fixed key prefix `[subsystem | segment | version | tag]`.
+const SUBSYSTEM_OFFSET: usize = 0;
+const SEGMENT_OFFSET: usize = 1;
+const VERSION_OFFSET: usize = 2;
+const TAG_OFFSET: usize = 3;
 
 /// Key format version (currently 0x01)
 pub const KEY_VERSION: u8 = 0x01;
@@ -99,8 +107,8 @@ impl RecordType {
         }
     }
 
-    /// Decodes the record type from the tag byte that follows the 2-byte key
-    /// prefix in a vector key.
+    /// Decodes the record type from the tag byte that follows the
+    /// `[subsystem | segment | version]` prefix bytes in a vector key.
     pub fn from_tag_byte(byte: u8) -> Result<Self, EncodingError> {
         let tag = RecordTag::from_byte(byte)?;
         RecordType::from_id(tag.record_type())
@@ -111,13 +119,43 @@ impl RecordType {
         RecordTag::new(self.id(), 0)
     }
 
-    /// Writes the 3-byte vector record prefix `[subsystem, version, tag]`.
+    /// Returns the storage [`Segment`] this record type lives in (RFC-0006).
+    ///
+    /// The segment is encoded as the second byte of every vector key so the
+    /// SlateDB segment extractor can route each segment's records into a
+    /// dedicated SlateDB segment.
+    pub fn segment(&self) -> Segment {
+        match self {
+            RecordType::CollectionMeta
+            | RecordType::VectorIndexData
+            | RecordType::IdDictionary
+            | RecordType::VectorData
+            | RecordType::MetadataIndex
+            | RecordType::SeqBlock => Segment::Default,
+            RecordType::CentroidSeqBlock
+            | RecordType::PostingList
+            | RecordType::CentroidStats
+            | RecordType::Centroids
+            | RecordType::CentroidInfo => Segment::Ann,
+            RecordType::Deletions
+            | RecordType::FtsTerm
+            | RecordType::FtsVectorFieldStats
+            | RecordType::FtsFieldStats => Segment::Fts,
+        }
+    }
+
+    /// Writes the 4-byte vector record prefix `[subsystem | segment | version | tag]`.
+    ///
+    /// RFC-0006 places the 1-byte segment id between the subsystem and version
+    /// bytes so all record types within a segment share a common routing prefix.
     pub fn write_prefix(&self, buf: &mut BytesMut) {
-        KeyPrefix::new(SUBSYSTEM, KEY_VERSION).write_to(buf);
+        buf.put_u8(SUBSYSTEM);
+        buf.put_u8(self.segment().as_byte());
+        buf.put_u8(KEY_VERSION);
         buf.put_u8(self.tag().as_byte());
     }
 
-    /// Encodes the 3-byte vector record prefix into a fresh `Bytes`.
+    /// Encodes the 4-byte vector record prefix into a fresh `Bytes`.
     pub fn encode_prefix(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
         self.write_prefix(&mut buf);
@@ -125,16 +163,85 @@ impl RecordType {
     }
 }
 
-/// Reads the tag byte that follows the 2-byte key prefix, validating that the
-/// preceding 2 bytes are the vector subsystem and current key version.
+/// Reads the record tag byte from a vector key, validating the subsystem,
+/// version, and segment bytes that precede it.
+///
+/// The key layout is `[subsystem | segment | version | tag | ...]` (RFC-0006).
+/// The segment id is redundant with the record type, but we validate that the
+/// two agree to catch mis-routed or corrupt keys early.
 pub fn parse_record_tag(buf: &[u8]) -> Result<RecordTag, EncodingError> {
-    KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
     if buf.len() < PREFIX_AND_TAG_LEN {
         return Err(EncodingError {
             message: "Buffer too short for record tag".to_string(),
         });
     }
-    Ok(RecordTag::from_byte(buf[KEY_PREFIX_LEN])?)
+    if buf[SUBSYSTEM_OFFSET] != SUBSYSTEM {
+        return Err(EncodingError {
+            message: format!(
+                "invalid subsystem: expected 0x{:02x}, got 0x{:02x}",
+                SUBSYSTEM, buf[SUBSYSTEM_OFFSET]
+            ),
+        });
+    }
+    if buf[VERSION_OFFSET] != KEY_VERSION {
+        return Err(EncodingError {
+            message: format!(
+                "invalid key version: expected 0x{:02x}, got 0x{:02x}",
+                KEY_VERSION, buf[VERSION_OFFSET]
+            ),
+        });
+    }
+    let tag = RecordTag::from_byte(buf[TAG_OFFSET])?;
+    let record_type = RecordType::from_id(tag.record_type())?;
+    let segment = Segment::from_byte(buf[SEGMENT_OFFSET])?;
+    if segment != record_type.segment() {
+        return Err(EncodingError {
+            message: format!(
+                "segment mismatch for {:?}: key has {:?}, expected {:?}",
+                record_type,
+                segment,
+                record_type.segment()
+            ),
+        });
+    }
+    Ok(tag)
+}
+
+/// Logical storage segment for a vector record (RFC-0006 segmentation).
+///
+/// The segment id is encoded as the second byte of every vector key
+/// (`[subsystem | segment | version | tag | ...]`). The SlateDB segment
+/// extractor routes each segment's records into its own SlateDB segment, which
+/// lets the FTS segment be compacted aggressively (to apply accumulated
+/// deletes) without rewriting the ANN or default-segment data.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Segment {
+    /// Singletons, the forward index, and the metadata (inverted) index.
+    Default = 0x00,
+    /// ANN posting lists and the centroid tree.
+    Ann = 0x01,
+    /// Full-text-search postings, statistics, and the deletions bitmap.
+    Fts = 0x02,
+}
+
+impl Segment {
+    /// Returns the on-disk segment id byte.
+    pub fn as_byte(self) -> u8 {
+        self as u8
+    }
+
+    /// Decodes a segment id byte.
+    pub fn from_byte(byte: u8) -> Result<Self, EncodingError> {
+        match byte {
+            0x00 => Ok(Segment::Default),
+            0x01 => Ok(Segment::Ann),
+            0x02 => Ok(Segment::Fts),
+            _ => Err(EncodingError {
+                message: format!("Invalid segment id: 0x{:02x}", byte),
+            }),
+        }
+    }
 }
 
 /// Trait for record keys that have a record type.
@@ -758,6 +865,64 @@ mod tests {
             RecordType::from_id(decoded.record_type()).unwrap(),
             RecordType::CollectionMeta
         );
+    }
+
+    #[test]
+    fn should_write_segment_byte_in_prefix() {
+        // given - record types in each of the three segments
+        let cases = [
+            (RecordType::CollectionMeta, Segment::Default),
+            (RecordType::PostingList, Segment::Ann),
+            (RecordType::CentroidInfo, Segment::Ann),
+            (RecordType::Deletions, Segment::Fts),
+            (RecordType::FtsTerm, Segment::Fts),
+            (RecordType::FtsFieldStats, Segment::Fts),
+        ];
+
+        for (record_type, expected_segment) in cases {
+            // when
+            let prefix = record_type.encode_prefix();
+
+            // then - layout is [subsystem | segment | version | tag]
+            assert_eq!(prefix.len(), PREFIX_AND_TAG_LEN);
+            assert_eq!(prefix[SUBSYSTEM_OFFSET], SUBSYSTEM);
+            assert_eq!(prefix[SEGMENT_OFFSET], expected_segment.as_byte());
+            assert_eq!(prefix[VERSION_OFFSET], KEY_VERSION);
+            assert_eq!(
+                RecordType::from_id(
+                    RecordTag::from_byte(prefix[TAG_OFFSET])
+                        .unwrap()
+                        .record_type()
+                )
+                .unwrap(),
+                record_type
+            );
+            // and the central tag parser accepts the well-formed prefix
+            assert!(parse_record_tag(&prefix).is_ok());
+        }
+    }
+
+    #[test]
+    fn should_reject_key_with_mismatched_segment() {
+        // given - a CollectionMeta prefix (Default segment) with the segment
+        // byte corrupted to the FTS segment
+        let mut prefix = RecordType::CollectionMeta.encode_prefix().to_vec();
+        prefix[SEGMENT_OFFSET] = Segment::Fts.as_byte();
+
+        // when
+        let result = parse_record_tag(&prefix);
+
+        // then
+        assert!(result.is_err());
+        assert!(result.unwrap_err().message.contains("segment mismatch"));
+    }
+
+    #[test]
+    fn should_round_trip_segment_id_byte() {
+        for segment in [Segment::Default, Segment::Ann, Segment::Fts] {
+            assert_eq!(Segment::from_byte(segment.as_byte()).unwrap(), segment);
+        }
+        assert!(Segment::from_byte(0x99).is_err());
     }
 
     #[test]

--- a/vector/src/storage/mod.rs
+++ b/vector/src/storage/mod.rs
@@ -22,6 +22,7 @@ use std::ops::Bound::Included;
 
 pub(crate) mod merge_operator;
 pub(crate) mod record;
+pub(crate) mod segment_extractor;
 
 /// Extension trait for StorageRead that provides vector database-specific loading methods.
 ///
@@ -157,7 +158,7 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
     /// Returns a list of `(level, centroid_id)` to accumulated vector count.
     #[allow(dead_code)]
     async fn scan_all_centroid_stats(&self) -> Result<Vec<(VectorId, CentroidStatsValue)>> {
-        let mut prefix_buf = bytes::BytesMut::with_capacity(3);
+        let mut prefix_buf = bytes::BytesMut::with_capacity(crate::serde::PREFIX_AND_TAG_LEN);
         crate::serde::RecordType::CentroidStats.write_prefix(&mut prefix_buf);
         let prefix = prefix_buf.freeze();
 
@@ -177,7 +178,7 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
     }
 
     async fn scan_all_centroid_info(&self) -> Result<Vec<(VectorId, CentroidInfoValue)>> {
-        let mut prefix_buf = bytes::BytesMut::with_capacity(3);
+        let mut prefix_buf = bytes::BytesMut::with_capacity(crate::serde::PREFIX_AND_TAG_LEN);
         crate::serde::RecordType::CentroidInfo.write_prefix(&mut prefix_buf);
         let prefix = prefix_buf.freeze();
 
@@ -197,7 +198,7 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
         &self,
         dimensions: usize,
     ) -> Result<Vec<(VectorId, PostingListValue)>> {
-        let mut prefix_buf = bytes::BytesMut::with_capacity(3);
+        let mut prefix_buf = bytes::BytesMut::with_capacity(crate::serde::PREFIX_AND_TAG_LEN);
         crate::serde::RecordType::PostingList.write_prefix(&mut prefix_buf);
         let prefix = prefix_buf.freeze();
 

--- a/vector/src/storage/segment_extractor.rs
+++ b/vector/src/storage/segment_extractor.rs
@@ -1,0 +1,262 @@
+//! SlateDB segment extractor for the vector subsystem (RFC-0006).
+//!
+//! Implements [`slatedb::PrefixExtractor`] over the vector key layout, mapping
+//! every record to the 3-byte routing prefix `[subsystem, segment, version]`.
+//! When configured on the `slatedb::DbBuilder`, the extractor causes SlateDB to
+//! route writes for each vector [`Segment`](crate::serde::Segment) into its own
+//! SlateDB segment, so the FTS segment can be compacted (and its accumulated
+//! deletes applied) as a unit without rewriting the ANN or default-segment data.
+//!
+//! See `vector/rfcs/0006-text-search.md` for the key layout this extractor
+//! relies on, and `slatedb::prefix_extractor::PrefixExtractor` for the contract
+//! the impl satisfies. The `log` crate's `segment_extractor` is the sibling
+//! implementation this is modeled on.
+//!
+//! # Naming
+//!
+//! The extractor's [`name`](slatedb::PrefixExtractor::name) is persisted in the
+//! SlateDB manifest and validated on open. Changes to the routing logic
+//! (including any future bump of the vector `KEY_VERSION`) must change the name
+//! as well, so a database created under different routing rules is rejected with
+//! a `SegmentExtractorMismatch` error rather than silently mis-routed.
+
+use std::sync::Arc;
+
+use common::StorageBuilder;
+use slatedb::{PrefixExtractor, PrefixTarget};
+
+use crate::serde::{KEY_VERSION, SUBSYSTEM};
+
+/// Routing prefix length: `[subsystem(1), segment(1), version(1)]`.
+///
+/// The `record_tag` byte at position 3 deliberately sits *outside* the
+/// extracted prefix so all record types within a segment share one routing
+/// prefix and land in the same SlateDB segment.
+pub(crate) const ROUTING_PREFIX_LEN: usize = 3;
+
+/// Stable, persisted identifier for this extractor's routing rules. Bump
+/// whenever the routing logic changes in a way that would re-route existing
+/// keys (e.g. a new `KEY_VERSION` with a different prefix shape).
+const EXTRACTOR_NAME: &str = "opendata-vector/v1";
+
+/// Prefix extractor routing vector records to per-segment SlateDB segments.
+///
+/// Every well-formed vector key has the shape `[SUBSYSTEM, segment, KEY_VERSION,
+/// record_tag, ...]` by construction, so this extractor returns
+/// `Some(3)` for any well-formed `PrefixTarget::Point` and for any 3+ byte
+/// `PrefixTarget::Prefix` matching the subsystem and version bytes.
+///
+/// **Point inputs that don't match are a bug.** SlateDB rejects writes whose
+/// segment extractor returns `None` (or `Some(0)`), so a malformed key would
+/// surface as a confusing downstream error rather than a clear failure at the
+/// origin. We panic on mismatched `Point` inputs to make the bug obvious. Short
+/// or non-conforming `Prefix` scan inputs are permitted to return `None` — the
+/// trait contract allows it and slatedb simply skips prefix-based filtering.
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct VectorSegmentExtractor;
+
+impl VectorSegmentExtractor {
+    /// Returns a shared `Arc<dyn PrefixExtractor>` for handing to
+    /// `slatedb::DbBuilder::with_segment_extractor`.
+    pub(crate) fn shared() -> Arc<dyn PrefixExtractor> {
+        Arc::new(Self)
+    }
+}
+
+impl PrefixExtractor for VectorSegmentExtractor {
+    fn name(&self) -> &str {
+        EXTRACTOR_NAME
+    }
+
+    fn prefix_len(&self, target: &PrefixTarget) -> Option<usize> {
+        match target {
+            // Stored keys and point-read targets must be well-formed vector
+            // keys. A mismatch is a VectorDb bug; panic with the offending bytes
+            // rather than letting slatedb reject the write later with an opaque
+            // error.
+            PrefixTarget::Point(b) => {
+                let bytes = b.as_ref();
+                assert!(
+                    bytes.len() >= ROUTING_PREFIX_LEN
+                        && bytes[0] == SUBSYSTEM
+                        && bytes[2] == KEY_VERSION,
+                    "VectorSegmentExtractor: malformed vector key (subsystem/version mismatch \
+                     or under {} bytes): {:02x?}",
+                    ROUTING_PREFIX_LEN,
+                    bytes
+                );
+                Some(ROUTING_PREFIX_LEN)
+            }
+            // Scan prefixes are caller-supplied; a too-short or non-matching
+            // prefix is benign — return `None` so any prefix-based filter is
+            // skipped (no false negatives, per the trait contract).
+            PrefixTarget::Prefix(b) => {
+                let bytes = b.as_ref();
+                if bytes.len() < ROUTING_PREFIX_LEN
+                    || bytes[0] != SUBSYSTEM
+                    || bytes[2] != KEY_VERSION
+                {
+                    None
+                } else {
+                    Some(ROUTING_PREFIX_LEN)
+                }
+            }
+        }
+    }
+}
+
+/// Installs the [`VectorSegmentExtractor`] on the builder's underlying SlateDB
+/// `DbBuilder`, so every vector record is routed to a per-segment SlateDB
+/// segment. No-op for the in-memory backend.
+///
+/// Every SlateDB-backed writer that opens a vector database must install this
+/// (the extractor name is persisted in the manifest and validated on open).
+pub(crate) fn builder_with_vector_segments(builder: StorageBuilder) -> StorageBuilder {
+    builder.map_slatedb(|db| db.with_segment_extractor(VectorSegmentExtractor::shared()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde::key::{CollectionMetaKey, DeletionsKey, PostingListKey};
+    use crate::serde::vector_id::VectorId;
+    use bytes::Bytes;
+
+    fn point(bytes: &[u8]) -> PrefixTarget {
+        PrefixTarget::Point(Bytes::copy_from_slice(bytes))
+    }
+
+    fn prefix(bytes: &[u8]) -> PrefixTarget {
+        PrefixTarget::Prefix(Bytes::copy_from_slice(bytes))
+    }
+
+    #[test]
+    fn should_return_stable_name() {
+        // when / then — must match the persisted manifest value
+        assert_eq!(VectorSegmentExtractor.name(), "opendata-vector/v1");
+    }
+
+    #[test]
+    fn should_extract_three_bytes_from_well_formed_key() {
+        // given
+        let extractor = VectorSegmentExtractor;
+        let key = PostingListKey::new(VectorId::centroid_id(1, 7)).encode();
+
+        // when
+        let n = extractor.prefix_len(&point(&key));
+
+        // then — routing prefix is [SUBSYSTEM, segment, KEY_VERSION]
+        assert_eq!(n, Some(ROUTING_PREFIX_LEN));
+        let extracted = &key[..n.unwrap()];
+        assert_eq!(extracted[0], SUBSYSTEM);
+        assert_eq!(extracted[1], crate::serde::Segment::Ann.as_byte());
+        assert_eq!(extracted[2], KEY_VERSION);
+    }
+
+    #[test]
+    fn should_route_different_segments_to_different_prefixes() {
+        // given — a Default-segment key and an FTS-segment key
+        let extractor = VectorSegmentExtractor;
+        let default_key = CollectionMetaKey.encode();
+        let fts_key = DeletionsKey::new().encode();
+
+        // when
+        let n1 = extractor.prefix_len(&point(&default_key)).unwrap();
+        let n2 = extractor.prefix_len(&point(&fts_key)).unwrap();
+
+        // then — both extract 3-byte prefixes, but the prefixes differ (the
+        // segment byte at index 1 differs)
+        assert_eq!(n1, ROUTING_PREFIX_LEN);
+        assert_eq!(n2, ROUTING_PREFIX_LEN);
+        assert_ne!(&default_key[..n1], &fts_key[..n2]);
+    }
+
+    #[test]
+    fn should_return_some_for_well_formed_scan_prefix() {
+        // given — a 3-byte scan prefix targeting the ANN segment
+        let extractor = VectorSegmentExtractor;
+        let scan_prefix = [SUBSYSTEM, crate::serde::Segment::Ann.as_byte(), KEY_VERSION];
+
+        // when / then
+        assert_eq!(
+            extractor.prefix_len(&prefix(&scan_prefix)),
+            Some(ROUTING_PREFIX_LEN)
+        );
+    }
+
+    #[test]
+    fn should_return_none_for_prefix_shorter_than_routing_prefix() {
+        // given — a 2-byte scan prefix
+        let extractor = VectorSegmentExtractor;
+        let short = [SUBSYSTEM, crate::serde::Segment::Default.as_byte()];
+
+        // when / then — short Prefix returns None (scan-side, benign)
+        assert_eq!(extractor.prefix_len(&prefix(&short)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_prefix_with_wrong_subsystem() {
+        // given
+        let extractor = VectorSegmentExtractor;
+        let bad = [0xFF, 0x00, KEY_VERSION, 0x10];
+
+        // when / then — non-vector Prefix returns None
+        assert_eq!(extractor.prefix_len(&prefix(&bad)), None);
+    }
+
+    #[test]
+    fn should_return_none_for_prefix_with_wrong_version() {
+        // given
+        let extractor = VectorSegmentExtractor;
+        let bad = [SUBSYSTEM, 0x00, 0xFF, 0x10];
+
+        // when / then — Prefix with wrong version returns None
+        assert_eq!(extractor.prefix_len(&prefix(&bad)), None);
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed vector key")]
+    fn should_panic_on_point_shorter_than_routing_prefix() {
+        let extractor = VectorSegmentExtractor;
+        let short = [SUBSYSTEM, 0x00];
+        let _ = extractor.prefix_len(&point(&short));
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed vector key")]
+    fn should_panic_on_point_with_wrong_subsystem() {
+        let extractor = VectorSegmentExtractor;
+        let bad = [0xFF, 0x00, KEY_VERSION, 0x10];
+        let _ = extractor.prefix_len(&point(&bad));
+    }
+
+    #[test]
+    #[should_panic(expected = "malformed vector key")]
+    fn should_panic_on_point_with_wrong_version() {
+        let extractor = VectorSegmentExtractor;
+        let bad = [SUBSYSTEM, 0x00, 0xFF, 0x10];
+        let _ = extractor.prefix_len(&point(&bad));
+    }
+
+    #[test]
+    fn should_satisfy_prefix_extension_invariant_for_well_formed_prefix() {
+        // given — a 3-byte scan prefix that targets the FTS segment
+        let extractor = VectorSegmentExtractor;
+        let scan_prefix = [SUBSYSTEM, crate::serde::Segment::Fts.as_byte(), KEY_VERSION];
+
+        // when
+        let n = extractor.prefix_len(&prefix(&scan_prefix)).unwrap();
+        assert_eq!(n, ROUTING_PREFIX_LEN);
+
+        // then — any extension q of scan_prefix must satisfy Point(q) = Some(n)
+        // and q[..n] == scan_prefix[..n].
+        let extension: Vec<u8> = scan_prefix
+            .iter()
+            .copied()
+            .chain([0xC0, 0x00, 0x01])
+            .collect();
+        let point_n = extractor.prefix_len(&point(&extension)).unwrap();
+        assert_eq!(point_n, n);
+        assert_eq!(&extension[..point_n], &scan_prefix[..n]);
+    }
+}


### PR DESCRIPTION
- adds a segment prefix to seach key
- configures the segment extractor on the db