### PR TITLE
[common] make compactor configurable + expose slatedb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1.0"
 serde_with = { version = "3", features = ["base64"] }
 serde_yaml = "0.9"
 foyer = "0.22"
-slatedb = "0.13.0"
+slatedb = { version = "0.13.0", features = ["compaction_filters"] }
 slatedb-common = "0.13.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full", "test-util"] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,7 +15,7 @@ pub use storage::config::{
 };
 pub use storage::factory::{
     CompactorBuilder, DbBuilder, StorageBuilder, StorageReaderRuntime, StorageSemantics,
-    create_object_store, create_storage_read,
+    create_object_store, create_storage_read, new_slatedb_compactor_builder,
 };
 pub use storage::loader::{LoadMetadata, LoadResult, LoadSpec, Loadable, Loader};
 pub use storage::sst_blocks::{BlockOpCounts, CountResult, count_in_range};

--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -5,7 +5,7 @@
 
 use std::sync::Arc;
 
-use super::config::{BlockCacheConfig, ObjectStoreConfig, StorageConfig};
+use super::config::{BlockCacheConfig, ObjectStoreConfig, SlateDbStorageConfig, StorageConfig};
 use super::in_memory::InMemoryStorage;
 use super::metrics_recorder::{MetricsRsRecorder, MixtricsBridge as MetricsRsRegistry};
 use super::slate::{SlateDbStorage, SlateDbStorageReader};
@@ -74,15 +74,7 @@ impl StorageBuilder {
             StorageConfig::InMemory => StorageBuilderInner::InMemory,
             StorageConfig::SlateDb(slate_config) => {
                 let object_store = create_object_store(&slate_config.object_store)?;
-                let settings = match &slate_config.settings_path {
-                    Some(path) => Settings::from_file(path).map_err(|e| {
-                        StorageError::Storage(format!(
-                            "Failed to load SlateDB settings from {}: {}",
-                            path, e
-                        ))
-                    })?,
-                    None => Settings::load().unwrap_or_default(),
-                };
+                let settings = load_slatedb_settings(slate_config)?;
                 info!(
                     "create slatedb storage with config: {:?}, settings: {:?}",
                     slate_config, settings
@@ -244,6 +236,37 @@ impl StorageSemantics {
     pub fn with_merge_operator(mut self, op: Arc<dyn MergeOperator>) -> Self {
         self.merge_operator = Some(op);
         self
+    }
+}
+
+pub fn new_slatedb_compactor_builder(
+    config: &StorageConfig,
+) -> StorageResult<Option<CompactorBuilder<String>>> {
+    match config {
+        StorageConfig::InMemory => Ok(None),
+        StorageConfig::SlateDb(slate_config) => {
+            let object_store = create_object_store(&slate_config.object_store)?;
+            let settings = load_slatedb_settings(slate_config)?;
+            match settings.compactor_options {
+                Some(compactor_options) => Ok(Some(
+                    CompactorBuilder::new(slate_config.path.clone(), object_store)
+                        .with_options(compactor_options),
+                )),
+                None => Ok(None),
+            }
+        }
+    }
+}
+
+fn load_slatedb_settings(slate_config: &SlateDbStorageConfig) -> StorageResult<Settings> {
+    match &slate_config.settings_path {
+        Some(path) => Ok(Settings::from_file(path).map_err(|e| {
+            StorageError::Storage(format!(
+                "Failed to load SlateDB settings from {}: {}",
+                path, e
+            ))
+        })?),
+        None => Ok(Settings::load().unwrap_or_default()),
     }
 }
 
@@ -833,5 +856,28 @@ mod tests {
         let storage = StorageBuilder::new(&config).await.unwrap().build().await;
 
         assert!(storage.is_ok());
+    }
+
+    #[test]
+    fn new_slatedb_compactor_builder_should_be_none_for_in_memory() {
+        // given / when - the in-memory backend has no compactor to configure
+        let builder = new_slatedb_compactor_builder(&StorageConfig::InMemory).unwrap();
+
+        // then
+        assert!(builder.is_none());
+    }
+
+    #[tokio::test]
+    async fn new_slatedb_compactor_builder_should_be_some_for_slatedb() {
+        // given - a SlateDb config (default settings enable compaction)
+        let tmp = tempfile::tempdir().unwrap();
+        let config = slatedb_config_with_local_dir(tmp.path());
+
+        // when
+        let builder = new_slatedb_compactor_builder(&config).unwrap();
+
+        // then - a compactor builder is produced for consumers to configure and
+        // install via `StorageBuilder::map_slatedb`.
+        assert!(builder.is_some());
     }
 }

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -7,6 +7,7 @@ pub mod slate;
 pub mod sst_blocks;
 pub mod util;
 
+use std::any::Any;
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -225,7 +226,7 @@ pub trait StorageIterator {
 /// access and point-in-time snapshots. By extracting these common operations,
 /// we can write code that works with both storage types.
 #[async_trait]
-pub trait StorageRead: Send + Sync {
+pub trait StorageRead: Any + Send + Sync {
     /// Retrieves a single record by exact key.
     ///
     /// Returns `Ok(None)` if the key is not present.

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -107,6 +107,12 @@ impl SlateDbStorage {
         }
     }
 
+    /// Returns the underlying SlateDB instance. Useful for callers that need to access
+    /// slatedb-specific features like `DbStatus`
+    pub fn db(&self) -> &Arc<Db> {
+        &self.db
+    }
+
     /// Creates a SlateDB `MergeOperator` from our common `MergeOperator` trait.
     ///
     /// This adapter can be used when constructing a SlateDB database with a merge operator:


### PR DESCRIPTION
Couple of tweaks to storage apis in common:
- adds new_slatedb_compactor_builder which returns a slate CompactorBuilder given the opendata config. Callers can pass that in to map_slatedb to configure a custom compactor.
- StorageRead extends Any so that callers can get back to the underlying storage impl. This is useful for accessing low-level slatedb fns like `status`