### PR TITLE
[vector]: fts segment compaction policy and filter

### DIFF
--- a/vector/src/admin.rs
+++ b/vector/src/admin.rs
@@ -2,11 +2,10 @@ use crate::db::VectorDb;
 use crate::error::{Error, Result};
 use crate::model::Config;
 use crate::serde::vector_id::VectorId;
-use crate::storage::merge_operator::VectorDbMergeOperator;
 use crate::write::indexer::tree::Indexer;
 use crate::write::indexer::tree::validator::validate as validate_tree_index;
 use common::Storage;
-use common::{StorageBuilder, StorageSemantics};
+use common::StorageBuilder;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -22,18 +21,22 @@ pub struct VectorDbAdmin {
 impl VectorDbAdmin {
     /// Open a vector database for administrative operations.
     pub async fn open(config: Config) -> Result<Self> {
-        let merge_op = VectorDbMergeOperator::new(config.dimensions as usize);
         let builder = StorageBuilder::new(&config.storage)
             .await
             .map_err(|e| Error::Storage(format!("Failed to create storage: {e}")))?;
-        // Install the same segment extractor the writer uses (RFC-0006); the
-        // extractor name is persisted in the manifest and validated on open, so
-        // an admin client opening a segmented database must match it.
-        let storage = crate::storage::segment_extractor::builder_with_vector_segments(builder)
-            .with_semantics(StorageSemantics::new().with_merge_operator(Arc::new(merge_op)))
-            .build()
-            .await
-            .map_err(|e| Error::Storage(format!("Failed to create storage: {e}")))?;
+        // Build storage with the shared vector wiring (per-segment routing
+        // extractor, merge operator, FTS compaction filter). The extractor name
+        // is persisted in the manifest and validated on open, so an admin client
+        // opening a segmented database must match it.
+        //
+        // The writer's custom compaction *scheduler* (which forces a major FTS
+        // compaction once deletes cross the threshold) is deliberately NOT
+        // installed here — we pass `None`. It is driven by an in-memory delete
+        // tracker that only the writer's flusher updates; with no flusher the
+        // admin client has no signal to act on, so it keeps SlateDB's default
+        // size-tiered scheduler. The filter still runs correctly on whatever
+        // compactions size-tiered schedules.
+        let storage = crate::storage::build_vector_storage(&config, builder, None).await?;
         Ok(Self { config, storage })
     }
 

--- a/vector/src/db.rs
+++ b/vector/src/db.rs
@@ -30,7 +30,6 @@ use crate::serde::posting_list::{PostingListValue, PostingUpdate};
 use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_id::{LEAF_LEVEL, ROOT_VECTOR_ID, VectorId};
 use crate::storage::VectorDbStorageReadExt;
-use crate::storage::merge_operator::VectorDbMergeOperator;
 use crate::text;
 use crate::write::delta::{TextAttributeSummary, VectorDbOp, VectorDbOpDelta, VectorWrite};
 use crate::write::flusher::VectorDbFlusher;
@@ -45,9 +44,9 @@ use crate::write::indexer::tree::state::VectorIndexState;
 use async_trait::async_trait;
 use common::Record;
 use common::SequenceAllocator;
+use common::StorageBuilder;
 use common::coordinator::{Durability, WriteCoordinator, WriteCoordinatorConfig};
 use common::storage::{Storage, StorageRead, StorageSnapshot};
-use common::{StorageBuilder, StorageSemantics};
 use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
@@ -142,6 +141,23 @@ pub struct VectorDb {
 
     /// snapshot state for queries
     last_applied_snapshot: Arc<Mutex<LastAppliedSnapshot>>,
+
+    /// Background task that refreshes the FTS compaction scheduler's
+    /// delete-pressure tracker from the persisted per-field `FieldStats`
+    /// (RFC-0006). Wrapped so it is aborted when the database is dropped — it
+    /// holds an `Arc<dyn Storage>` clone and would otherwise keep polling.
+    /// `VectorDb` deliberately does *not* implement `Drop` itself (that would
+    /// forbid the field moves in `close`); the guard's own `Drop` handles it.
+    fts_stats_poller: AbortOnDrop,
+}
+
+/// Aborts the wrapped background task when dropped.
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 impl VectorDb {
@@ -208,17 +224,20 @@ impl VectorDb {
         centroids: Vec<Vec<f32>>,
         builder: StorageBuilder,
     ) -> Result<Self> {
-        let merge_op = VectorDbMergeOperator::new(config.dimensions as usize);
-        // Route each vector segment (Default/ANN/FTS) into its own SlateDB
-        // segment so the FTS segment can be compacted independently (RFC-0006).
-        // No-op for the in-memory backend.
-        let storage = crate::storage::segment_extractor::builder_with_vector_segments(builder)
-            .with_semantics(StorageSemantics::new().with_merge_operator(Arc::new(merge_op)))
-            .build()
-            .await
-            .map_err(|e| Error::Storage(format!("Failed to create storage: {e}")))?;
+        // In-memory FTS delete-pressure counters, shared between the custom
+        // compaction scheduler (which reads them to decide when to force a major
+        // FTS compaction) and the flusher (which refreshes them after each
+        // flush). The writer drives the scheduler, so the tracker is passed to
+        // `build_vector_storage` to enable it. RFC-0006.
+        let fts_delete_tracker = crate::storage::compaction_scheduler::FtsDeleteTracker::shared();
+        let storage = crate::storage::build_vector_storage(
+            &config,
+            builder,
+            Some(fts_delete_tracker.clone()),
+        )
+        .await?;
 
-        Self::load_or_init_db(storage, config, centroids).await
+        Self::load_or_init_db(storage, config, centroids, fts_delete_tracker).await
     }
 
     /// Create a vector database with the given storage, configuration, and centroids.
@@ -231,6 +250,7 @@ impl VectorDb {
         storage: Arc<dyn Storage>,
         config: Config,
         centroids: Vec<Vec<f32>>,
+        fts_delete_tracker: Arc<crate::storage::compaction_scheduler::FtsDeleteTracker>,
     ) -> Result<Self> {
         let seq_key = SeqBlockKey.encode();
         let id_allocator = SequenceAllocator::load(storage.as_ref(), seq_key).await?;
@@ -282,6 +302,18 @@ impl VectorDb {
             last_applied_snapshot.clone(),
         );
 
+        // Poll the persisted per-field FieldStats into the scheduler's in-memory
+        // delete-pressure tracker (RFC-0006). Kept separate from the flush path
+        // so the scheduler's view is refreshed even when no writes are flowing
+        // (e.g. while a forced compaction is draining deletes).
+        let fts_stats_poller = AbortOnDrop(
+            crate::storage::compaction_scheduler::spawn_fts_field_stats_poller(
+                Arc::clone(&storage),
+                fts_delete_tracker,
+                config.fts_stats_poll_interval,
+            ),
+        );
+
         let coordinator_config = WriteCoordinatorConfig {
             queue_capacity: 1000,
             flush_interval: Duration::from_secs(5),
@@ -301,6 +333,7 @@ impl VectorDb {
             storage,
             write_coordinator,
             last_applied_snapshot,
+            fts_stats_poller,
         })
     }
 
@@ -867,6 +900,10 @@ impl VectorDb {
     /// closed. For SlateDB-backed storage, this also releases the database
     /// fence.
     pub async fn close(self) -> Result<()> {
+        // Stop the FieldStats poller before closing storage so it can't issue a
+        // read against a closing/fenced db (the guard's Drop would also abort it,
+        // but only after `storage.close()`).
+        self.fts_stats_poller.0.abort();
         self.flush().await?;
         self.write_coordinator
             .stop()
@@ -973,6 +1010,7 @@ mod tests {
     use crate::serde::key::{IdDictionaryKey, VectorDataKey};
     use crate::serde::vector_data::VectorDataValue;
     use crate::serde::vector_id::VectorId;
+    use crate::storage::merge_operator::VectorDbMergeOperator;
     use common::StorageConfig;
     use opendata_macros::storage_test;
     use std::time::Duration;
@@ -1023,9 +1061,14 @@ mod tests {
         // given
         let config = create_test_config();
         let centroids = create_test_centroids(3);
-        let db = VectorDb::load_or_init_db(Arc::clone(&storage), config, centroids)
-            .await
-            .unwrap();
+        let db = VectorDb::load_or_init_db(
+            Arc::clone(&storage),
+            config,
+            centroids,
+            crate::storage::compaction_scheduler::FtsDeleteTracker::shared(),
+        )
+        .await
+        .unwrap();
 
         let vectors = vec![
             Vector::builder("vec-1", vec![1.0, 0.0, 0.0])
@@ -1064,9 +1107,14 @@ mod tests {
         // given
         let config = create_test_config();
         let centroids = create_test_centroids(3);
-        let db = VectorDb::load_or_init_db(Arc::clone(&storage), config, centroids)
-            .await
-            .unwrap();
+        let db = VectorDb::load_or_init_db(
+            Arc::clone(&storage),
+            config,
+            centroids,
+            crate::storage::compaction_scheduler::FtsDeleteTracker::shared(),
+        )
+        .await
+        .unwrap();
 
         // First write
         let vector1 = Vector::builder("vec-1", vec![1.0, 0.0, 0.0])
@@ -1140,10 +1188,14 @@ mod tests {
         let centroids = create_test_centroids(3);
 
         {
-            let db =
-                VectorDb::load_or_init_db(Arc::clone(&storage), config.clone(), centroids.clone())
-                    .await
-                    .unwrap();
+            let db = VectorDb::load_or_init_db(
+                Arc::clone(&storage),
+                config.clone(),
+                centroids.clone(),
+                crate::storage::compaction_scheduler::FtsDeleteTracker::shared(),
+            )
+            .await
+            .unwrap();
             let vectors = vec![
                 Vector::builder("vec-1", vec![1.0, 0.0, 0.0])
                     .attribute("category", "shoes")
@@ -1159,9 +1211,14 @@ mod tests {
         }
 
         // when - reopen database (centroids should be loaded from storage)
-        let db2 = VectorDb::load_or_init_db(Arc::clone(&storage), config, vec![])
-            .await
-            .unwrap();
+        let db2 = VectorDb::load_or_init_db(
+            Arc::clone(&storage),
+            config,
+            vec![],
+            crate::storage::compaction_scheduler::FtsDeleteTracker::shared(),
+        )
+        .await
+        .unwrap();
 
         // then - should be able to search (dictionary and centroids loaded from storage)
         let results = db2
@@ -1482,9 +1539,14 @@ mod tests {
         // given
         let config = create_test_config();
         let centroids = create_test_centroids(3);
-        let db = VectorDb::load_or_init_db(Arc::clone(&storage), config, centroids)
-            .await
-            .unwrap();
+        let db = VectorDb::load_or_init_db(
+            Arc::clone(&storage),
+            config,
+            centroids,
+            crate::storage::compaction_scheduler::FtsDeleteTracker::shared(),
+        )
+        .await
+        .unwrap();
         db.write(vec![
             Vector::builder("vec-1", vec![1.0, 0.0, 0.0])
                 .attribute("category", "shoes")
@@ -1639,9 +1701,14 @@ mod tests {
         // given
         let config = create_test_config();
         let centroids = create_test_centroids(3);
-        let db = VectorDb::load_or_init_db(Arc::clone(&storage), config, centroids)
-            .await
-            .unwrap();
+        let db = VectorDb::load_or_init_db(
+            Arc::clone(&storage),
+            config,
+            centroids,
+            crate::storage::compaction_scheduler::FtsDeleteTracker::shared(),
+        )
+        .await
+        .unwrap();
         db.write(vec![
             Vector::builder("a", vec![1.0, 0.0, 0.0])
                 .attribute("category", "x")
@@ -1694,9 +1761,14 @@ mod tests {
         // given
         let config = create_test_config();
         let centroids = create_test_centroids(3);
-        let db = VectorDb::load_or_init_db(Arc::clone(&storage), config, centroids)
-            .await
-            .unwrap();
+        let db = VectorDb::load_or_init_db(
+            Arc::clone(&storage),
+            config,
+            centroids,
+            crate::storage::compaction_scheduler::FtsDeleteTracker::shared(),
+        )
+        .await
+        .unwrap();
         db.write(vec![
             Vector::builder("id-1", vec![1.0, 0.0, 0.0])
                 .attribute("category", "shoes")

--- a/vector/src/model.rs
+++ b/vector/src/model.rs
@@ -234,6 +234,24 @@ pub struct Config {
     /// names are accepted with types inferred from the first write.
     pub metadata_fields: Vec<MetadataFieldSpec>,
 
+    /// Fraction of outstanding FTS deletes (relative to live vectors) above
+    /// which a major compaction of the FTS segment is forced (RFC-0006).
+    ///
+    /// The custom compaction scheduler watches the in-memory deletions-bitmap
+    /// cardinality versus the live-vector count; once the ratio reaches this
+    /// threshold it triggers a full compaction of the FTS segment to apply the
+    /// accumulated deletes and shrink the in-memory bitmap. Defaults to `0.20`
+    /// (20%). Only affects SlateDB storage with compaction enabled.
+    #[serde(default = "default_delete_compaction_threshold")]
+    pub delete_compaction_threshold: f64,
+
+    /// How often the FieldStats poller refreshes the FTS compaction scheduler's
+    /// in-memory per-field delete-pressure tracker from the persisted
+    /// `FieldStats` records (RFC-0006). Defaults to 5s. Only affects SlateDB
+    /// storage with compaction enabled.
+    #[serde(default = "default_fts_stats_poll_interval", with = "duration_secs")]
+    pub fts_stats_poll_interval: Duration,
+
     /// Buffer consumer configuration. When `Some`, the server starts a
     /// background task that ingests vectors from an `opendata-buffer` queue.
     #[cfg(feature = "buffer")]
@@ -253,10 +271,23 @@ impl Default for Config {
             split_search_neighbourhood: 0,
             query_pruning_factor: None,
             metadata_fields: Vec::new(),
+            delete_compaction_threshold: default_delete_compaction_threshold(),
+            fts_stats_poll_interval: default_fts_stats_poll_interval(),
             #[cfg(feature = "buffer")]
             buffer_consumer: None,
         }
     }
+}
+
+/// Default fraction of outstanding FTS deletes that triggers a major
+/// compaction of the FTS segment (RFC-0006, 20%).
+pub(crate) fn default_delete_compaction_threshold() -> f64 {
+    0.20
+}
+
+/// Default FTS field-stats poll interval (RFC-0006, 5s).
+pub(crate) fn default_fts_stats_poll_interval() -> Duration {
+    Duration::from_secs(5)
 }
 
 /// Configuration for the embedded buffer consumer task.

--- a/vector/src/serde/key.rs
+++ b/vector/src/serde/key.rs
@@ -80,9 +80,17 @@ impl Default for CentroidsKey {
     }
 }
 
+/// Trailing discriminator bytes for the two singleton records that share the
+/// `Deletions` tag (RFC-0006). The sentinel's `0x00` sorts before the bitmap's
+/// `0xff`, so a last-run compaction always observes the sentinel first.
+pub(crate) const DELETIONS_SENTINEL_DISCRIMINATOR: u8 = 0x00;
+pub(crate) const DELETIONS_DISCRIMINATOR: u8 = 0xff;
+
 /// Deletions key - singleton record storing the FTS deletions bitmap.
 ///
-/// Key layout: `[subsystem | segment | version | tag]` (4 bytes)
+/// Key layout: `[subsystem | segment | version | tag | 0xff]` (5 bytes). The
+/// trailing `0xff` sorts the bitmap *after* the [`DeletionsSentinelKey`], which
+/// shares the same prefix and tag.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeletionsKey;
 
@@ -96,23 +104,85 @@ impl DeletionsKey {
     }
 
     pub fn encode(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN);
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN + 1);
         Self::RECORD_TYPE.write_prefix(&mut buf);
+        buf.put_u8(DELETIONS_DISCRIMINATOR);
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < PREFIX_AND_TAG_LEN {
+        if buf.len() < PREFIX_AND_TAG_LEN + 1 {
             return Err(EncodingError {
                 message: "Buffer too short for DeletionsKey".to_string(),
             });
         }
         validate_key_prefix::<Self>(buf)?;
+        if buf[PREFIX_AND_TAG_LEN] != DELETIONS_DISCRIMINATOR {
+            return Err(EncodingError {
+                message: format!(
+                    "DeletionsKey discriminator mismatch: expected {:#04x}, got {:#04x}",
+                    DELETIONS_DISCRIMINATOR, buf[PREFIX_AND_TAG_LEN]
+                ),
+            });
+        }
         Ok(DeletionsKey)
     }
 }
 
 impl Default for DeletionsKey {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Deletions sentinel key - singleton marker written on *every* FTS write batch.
+///
+/// Key layout: `[subsystem | segment | version | tag | 0x00]` (5 bytes). It
+/// shares the `Deletions` tag with [`DeletionsKey`], but its trailing `0x00`
+/// sorts it first among all FTS records. The compaction filter uses it as a
+/// start-of-stream marker: it must observe the sentinel before any other FTS
+/// key, which proves the compaction was not resumed mid-stream and anchors the
+/// start of the filter's phase state machine. Its value is an opaque dummy
+/// (RFC-0006).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeletionsSentinelKey;
+
+impl RecordKey for DeletionsSentinelKey {
+    const RECORD_TYPE: RecordType = RecordType::Deletions;
+}
+
+impl DeletionsSentinelKey {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn encode(&self) -> Bytes {
+        let mut buf = BytesMut::with_capacity(PREFIX_AND_TAG_LEN + 1);
+        Self::RECORD_TYPE.write_prefix(&mut buf);
+        buf.put_u8(DELETIONS_SENTINEL_DISCRIMINATOR);
+        buf.freeze()
+    }
+
+    pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
+        if buf.len() < PREFIX_AND_TAG_LEN + 1 {
+            return Err(EncodingError {
+                message: "Buffer too short for DeletionsSentinelKey".to_string(),
+            });
+        }
+        validate_key_prefix::<Self>(buf)?;
+        if buf[PREFIX_AND_TAG_LEN] != DELETIONS_SENTINEL_DISCRIMINATOR {
+            return Err(EncodingError {
+                message: format!(
+                    "DeletionsSentinelKey discriminator mismatch: expected {:#04x}, got {:#04x}",
+                    DELETIONS_SENTINEL_DISCRIMINATOR, buf[PREFIX_AND_TAG_LEN]
+                ),
+            });
+        }
+        Ok(DeletionsSentinelKey)
+    }
+}
+
+impl Default for DeletionsSentinelKey {
     fn default() -> Self {
         Self::new()
     }
@@ -653,6 +723,17 @@ impl VectorFieldStatsKey {
         self.vector_id.encode(&mut buf);
         buf.freeze()
     }
+
+    pub(crate) fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
+        if buf.len() < PREFIX_AND_TAG_LEN + 8 {
+            return Err(EncodingError {
+                message: "Buffer too short for VectorFieldStatsKey".to_string(),
+            });
+        }
+        validate_key_prefix::<Self>(buf)?;
+        let vector_id = VectorId::decode(&mut &buf[PREFIX_AND_TAG_LEN..])?;
+        Ok(Self { vector_id })
+    }
 }
 
 /// FieldStats key — `[prefix | field_len:u16 LE | field]`. Per-field FTS
@@ -842,9 +923,37 @@ mod tests {
         let encoded = key.encode();
         let decoded = DeletionsKey::decode(&encoded).unwrap();
 
-        // then
+        // then - prefix + tag + the `0xff` deletions discriminator
         assert_eq!(decoded, key);
-        assert_eq!(encoded.len(), 4);
+        assert_eq!(encoded.len(), PREFIX_AND_TAG_LEN + 1);
+        assert_eq!(*encoded.last().unwrap(), DELETIONS_DISCRIMINATOR);
+    }
+
+    #[test]
+    fn should_round_trip_deletions_sentinel_key() {
+        // given
+        let key = DeletionsSentinelKey::new();
+
+        // when
+        let encoded = key.encode();
+        let decoded = DeletionsSentinelKey::decode(&encoded).unwrap();
+
+        // then - prefix + tag + the `0x00` sentinel discriminator
+        assert_eq!(decoded, key);
+        assert_eq!(encoded.len(), PREFIX_AND_TAG_LEN + 1);
+        assert_eq!(*encoded.last().unwrap(), DELETIONS_SENTINEL_DISCRIMINATOR);
+    }
+
+    #[test]
+    fn should_sort_sentinel_before_deletions() {
+        // given - the sentinel and the deletions bitmap share the same record tag
+        // when - both are encoded
+        let sentinel = DeletionsSentinelKey::new().encode();
+        let deletions = DeletionsKey::new().encode();
+
+        // then - the sentinel sorts strictly before the deletions bitmap, so a
+        // last-run compaction always observes it first
+        assert!(sentinel < deletions);
     }
 
     #[test]
@@ -1177,6 +1286,32 @@ mod tests {
 
         // then
         assert_eq!(decoded, key);
+    }
+
+    #[test]
+    fn should_encode_and_decode_vector_field_stats_key() {
+        // given
+        let key = VectorFieldStatsKey::new(VectorId::data_vector_id(42));
+
+        // when
+        let encoded = key.encode();
+        let decoded = VectorFieldStatsKey::decode(&encoded).unwrap();
+
+        // then - round-trips and the suffix is exactly the 8-byte BE vector id
+        assert_eq!(decoded, key);
+        assert_eq!(encoded.len(), PREFIX_AND_TAG_LEN + 8);
+    }
+
+    #[test]
+    fn should_reject_truncated_vector_field_stats_key() {
+        // given - a valid key with its final id byte chopped off
+        let encoded = VectorFieldStatsKey::new(VectorId::data_vector_id(42)).encode();
+
+        // when
+        let result = VectorFieldStatsKey::decode(&encoded[..encoded.len() - 1]);
+
+        // then
+        assert!(result.is_err());
     }
 
     #[test]

--- a/vector/src/serde/mod.rs
+++ b/vector/src/serde/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod term_postings;
 pub(crate) mod term_stats;
 pub mod vector_bitmap;
 pub mod vector_data;
+pub(crate) mod vector_field_stats;
 pub(crate) mod vector_id;
 pub mod vector_index_data;
 

--- a/vector/src/serde/vector_field_stats.rs
+++ b/vector/src/serde/vector_field_stats.rs
@@ -1,0 +1,144 @@
+//! `VectorFieldStats` value encoding/decoding for FTS (RFC-0006).
+//!
+//! A per-vector record (keyed by [`VectorFieldStatsKey`](crate::serde::key::VectorFieldStatsKey))
+//! recording, for each indexed `Text` field the document populated, the
+//! document's length in tokens. The indexer writes this as a PUT alongside the
+//! term postings/stats. The FTS compaction filter reads it when a vector is
+//! deleted to compute the corpus-level [`FieldStatsValue`](crate::serde::field_stats::FieldStatsValue)
+//! deltas (subtracting the document's count and length from each of its fields),
+//! then drops the record.
+//!
+//! ## Value Layout (little-endian)
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────────────────────┐
+//! │  count:  u16                                                 │
+//! │  count × {                                                   │
+//! │     field_len: u16                                          │
+//! │     field:     field_len bytes (UTF-8)                      │
+//! │     length:    u32   (document length in tokens)            │
+//! │  }                                                          │
+//! └──────────────────────────────────────────────────────────────┘
+//! ```
+//!
+//! Entries are written in ascending field-name order so the encoding is
+//! deterministic and round-trips stably.
+
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+
+use super::EncodingError;
+
+/// Per-vector text-field token lengths.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub(crate) struct VectorFieldStatsValue {
+    /// `(text field name, document length in tokens)` for every indexed `Text`
+    /// field the document populated, sorted ascending by field name.
+    pub(crate) lengths: Vec<(String, u32)>,
+}
+
+impl VectorFieldStatsValue {
+    // `new`/`encode_to_bytes` are written by the indexer's FTS write path
+    // (not yet landed); the compaction filter only reads via `decode_from_bytes`.
+    #[allow(dead_code)]
+    pub(crate) fn new(mut lengths: Vec<(String, u32)>) -> Self {
+        lengths.sort_by(|a, b| a.0.cmp(&b.0));
+        Self { lengths }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn encode_to_bytes(&self) -> Bytes {
+        let mut buf = BytesMut::new();
+        let count = u16::try_from(self.lengths.len())
+            .expect("VectorFieldStatsValue exceeds u16::MAX fields");
+        buf.put_u16_le(count);
+        for (field, length) in &self.lengths {
+            let field_len =
+                u16::try_from(field.len()).expect("FTS field name exceeds u16::MAX bytes");
+            buf.put_u16_le(field_len);
+            buf.extend_from_slice(field.as_bytes());
+            buf.put_u32_le(*length);
+        }
+        buf.freeze()
+    }
+
+    pub(crate) fn decode_from_bytes(buf: &[u8]) -> Result<Self, EncodingError> {
+        let mut cursor = buf;
+        if cursor.len() < 2 {
+            return Err(EncodingError {
+                message: "VectorFieldStatsValue too short for count".to_string(),
+            });
+        }
+        let count = cursor.get_u16_le() as usize;
+        let mut lengths = Vec::with_capacity(count);
+        for _ in 0..count {
+            if cursor.len() < 2 {
+                return Err(EncodingError {
+                    message: "VectorFieldStatsValue truncated at field length".to_string(),
+                });
+            }
+            let field_len = cursor.get_u16_le() as usize;
+            if cursor.len() < field_len + 4 {
+                return Err(EncodingError {
+                    message: "VectorFieldStatsValue truncated within field entry".to_string(),
+                });
+            }
+            let field = std::str::from_utf8(&cursor[..field_len])
+                .map_err(|e| EncodingError {
+                    message: format!("VectorFieldStatsValue field is not valid UTF-8: {e}"),
+                })?
+                .to_string();
+            cursor.advance(field_len);
+            let length = cursor.get_u32_le();
+            lengths.push((field, length));
+        }
+        Ok(Self { lengths })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_round_trip_vector_field_stats() {
+        // given
+        let value =
+            VectorFieldStatsValue::new(vec![("title".to_string(), 5), ("body".to_string(), 137)]);
+
+        // when
+        let encoded = value.encode_to_bytes();
+        let decoded = VectorFieldStatsValue::decode_from_bytes(&encoded).unwrap();
+
+        // then - decoded matches and entries are sorted by field name
+        assert_eq!(decoded, value);
+        assert_eq!(
+            decoded.lengths,
+            vec![("body".to_string(), 137), ("title".to_string(), 5)]
+        );
+    }
+
+    #[test]
+    fn should_round_trip_empty() {
+        // given
+        let value = VectorFieldStatsValue::default();
+
+        // when
+        let encoded = value.encode_to_bytes();
+        let decoded = VectorFieldStatsValue::decode_from_bytes(&encoded).unwrap();
+
+        // then
+        assert_eq!(decoded, value);
+        assert!(decoded.lengths.is_empty());
+    }
+
+    #[test]
+    fn should_reject_truncated_buffer() {
+        // given - claims 1 entry but has no field bytes
+        let mut buf = BytesMut::new();
+        buf.put_u16_le(1);
+        buf.put_u16_le(4); // field_len = 4 but no bytes follow
+
+        // when / then
+        assert!(VectorFieldStatsValue::decode_from_bytes(&buf).is_err());
+    }
+}

--- a/vector/src/serde/vector_index_data.rs
+++ b/vector/src/serde/vector_index_data.rs
@@ -13,10 +13,18 @@ use bytes::{BufMut, Bytes, BytesMut};
 pub(crate) struct VectorIndexDataValue {
     pub(crate) postings: Vec<VectorId>,
     pub(crate) indexed_fields: Vec<Field>,
+    /// Names of the `Text` (FTS) fields this vector populated, sorted ascending.
+    /// Read on delete/upsert so the indexer can apply the per-field `FieldStats`
+    /// delete deltas without re-tokenizing or reading the postings (RFC-0006).
+    pub(crate) fts_fields: Vec<String>,
 }
 
 impl VectorIndexDataValue {
-    pub(crate) fn new(postings: Vec<VectorId>, indexed_fields: Vec<Field>) -> Self {
+    pub(crate) fn new(
+        postings: Vec<VectorId>,
+        indexed_fields: Vec<Field>,
+        fts_fields: Vec<String>,
+    ) -> Self {
         for posting in &postings {
             assert!(posting.is_centroid());
         }
@@ -25,9 +33,12 @@ impl VectorIndexDataValue {
         }
         let mut indexed_fields = indexed_fields;
         indexed_fields.sort_by(|a, b| a.field_name.cmp(&b.field_name));
+        let mut fts_fields = fts_fields;
+        fts_fields.sort();
         Self {
             postings,
             indexed_fields,
+            fts_fields,
         }
     }
 
@@ -55,6 +66,13 @@ impl Encode for VectorIndexDataValue {
         buf.put_u16_le(field_count);
         for field in &self.indexed_fields {
             field.encode(buf);
+        }
+        let fts_count = u16::try_from(self.fts_fields.len()).expect("too many fts fields");
+        buf.put_u16_le(fts_count);
+        for name in &self.fts_fields {
+            let len = u16::try_from(name.len()).expect("fts field name exceeds u16::MAX bytes");
+            buf.put_u16_le(len);
+            buf.extend_from_slice(name.as_bytes());
         }
     }
 }
@@ -100,9 +118,40 @@ impl Decode for VectorIndexDataValue {
             }
             indexed_fields.push(field);
         }
+        if buf.len() < 2 {
+            return Err(EncodingError {
+                message: "Buffer too short for VectorIndexDataValue fts field count".to_string(),
+            });
+        }
+        let fts_count = u16::from_le_bytes([buf[0], buf[1]]) as usize;
+        *buf = &buf[2..];
+        let mut fts_fields = Vec::with_capacity(fts_count);
+        for _ in 0..fts_count {
+            if buf.len() < 2 {
+                return Err(EncodingError {
+                    message: "Buffer too short for VectorIndexDataValue fts field length"
+                        .to_string(),
+                });
+            }
+            let len = u16::from_le_bytes([buf[0], buf[1]]) as usize;
+            *buf = &buf[2..];
+            if buf.len() < len {
+                return Err(EncodingError {
+                    message: "Buffer too short for VectorIndexDataValue fts field name".to_string(),
+                });
+            }
+            let name = std::str::from_utf8(&buf[..len])
+                .map_err(|e| EncodingError {
+                    message: format!("VectorIndexDataValue fts field is not valid UTF-8: {e}"),
+                })?
+                .to_string();
+            *buf = &buf[len..];
+            fts_fields.push(name);
+        }
         Ok(Self {
             postings,
             indexed_fields,
+            fts_fields,
         })
     }
 }
@@ -117,14 +166,19 @@ mod tests {
         let value = VectorIndexDataValue::new(
             vec![VectorId::centroid_id(1, 10), VectorId::centroid_id(1, 11)],
             vec![Field::string("category", "shoes")],
+            vec!["title".to_string(), "body".to_string()],
         );
 
         // when
         let encoded = value.encode_to_bytes();
         let decoded = VectorIndexDataValue::decode_from_bytes(&encoded).unwrap();
 
-        // then
+        // then - round-trips and fts_fields are sorted
         assert_eq!(decoded, value);
+        assert_eq!(
+            decoded.fts_fields,
+            vec!["body".to_string(), "title".to_string()]
+        );
     }
 
     #[test]

--- a/vector/src/storage/compaction_filter.rs
+++ b/vector/src/storage/compaction_filter.rs
@@ -1,0 +1,892 @@
+//! FTS compaction filter for the vector subsystem (RFC-0006).
+//!
+//! Deletes are recorded lazily: a deleted vector's id is unioned into the
+//! [`Deletions`](crate::serde::RecordType::Deletions) bitmap, and the actual
+//! cleanup of its term postings and statistics is deferred to compaction. This
+//! [`CompactionFilter`] performs that cleanup as the FTS segment is compacted.
+//!
+//! [`VectorCompactionFilterSupplier`] is handed to the storage layer alongside
+//! the [`VectorSegmentExtractor`](super::segment_extractor::VectorSegmentExtractor),
+//! which routes the FTS records into their own segment so they can be compacted
+//! as a unit. SlateDB only exposes compaction filters through its
+//! `CompactorBuilder`, so the common storage builder installs it there.
+//!
+//! # Only at the last sorted run
+//!
+//! The supplier installs the real filter **only when the compaction's
+//! destination is the last (oldest) sorted run**; for every other compaction it
+//! installs a [`NoOpCompactionFilter`]. Applying deletes only at the last run
+//! guarantees that all of a deleted vector's keys — term postings, term stats,
+//! and per-vector field stats — are present together in the compaction, so a
+//! delete is observed and applied consistently in a single pass.
+//!
+//! # What it does (last-run compactions)
+//!
+//! For an FTS-segment compaction reaching the last sorted run, the filter (in
+//! key order):
+//!
+//! 1. **Accumulates and drops the deletions bitmap.** The `Deletions` record
+//!    (tag `0x0c`) sorts before every other FTS record, so by the time any
+//!    postings/stats entry is seen the bitmap holds every id deleted in this
+//!    compaction. The `Deletions` entries are dropped — every posting they
+//!    reference is in this compaction and has been pruned, so the ids can never
+//!    resurface.
+//! 2. **Prunes term postings.** Deleted ids are removed from each
+//!    [`TermPostingsValue`] and the survivors are re-packed into uniform blocks
+//!    via [`TermPostingsValue::from_postings`]. The number of removed documents
+//!    is recorded for the sibling `TermStats` key.
+//! 3. **Applies the term document-frequency delta** to the immediately
+//!    following [`TermStatsValue`] (the `TermStats` key for a `(field, term)`
+//!    sorts right after its `TermPostings` key — discriminator `0x01` > `0x00`).
+//! 4. **Drops per-vector field stats** ([`VectorFieldStatsValue`]) for deleted
+//!    vectors, folding a `count -1` / `total_length -len` / `deletes -1` into a
+//!    pending [`FieldStatsValue`] delta for each field the vector populated.
+//! 5. **Applies the field-stats delta** to each [`FieldStatsValue`]. The indexer
+//!    only ever *increments* `FieldStats` (`count`/`total_length` on insert,
+//!    `deletes` on delete, using the FTS field set recorded in `VectorIndexData`);
+//!    the filter retires deleted documents from all three here. All
+//!    `VectorFieldStats` (tag `0x0e`) sort before all `FieldStats` (tag `0x0f`),
+//!    so every delta is accumulated before it is applied.
+//!
+//! For any non-FTS key (the ANN and Default segments, or any malformed key) the
+//! filter is a strict no-op.
+//!
+//! # Merge-operand semantics
+//!
+//! SlateDB applies the merge operator *below* the compaction filter, but only up
+//! to the compaction's snapshot barrier (`retention_min_seq`). Merge operands
+//! sequenced above that barrier are passed through to the filter individually
+//! and **un-merged**, so the filter can be called multiple times for the same
+//! key within one compaction — each call carrying one operand, not the fully
+//! merged value. The design tolerates this because every FTS merge is structured
+//! so that pruning-then-merging equals merging-then-pruning:
+//!
+//! - **Postings** merge by byte concatenation in descending-id order. Each
+//!   operand is a self-contained, independently decodable `TermPostingsValue`,
+//!   so pruning deleted ids from each operand in turn yields the same result as
+//!   pruning the concatenation. The document-frequency decrement is accumulated
+//!   across every operand for the key into `pending_term_deltas`.
+//! - **Term / field stats** are *signed deltas* summed by the merge operator.
+//!   The full accumulated decrement is applied to the *first* stats operand seen
+//!   for a key (the pending entry is then removed, so later operands pass
+//!   through unchanged); because the operator sums them, the merged total is
+//!   correct regardless of which operand absorbed the decrement. Postings keys
+//!   sort before their sibling stats key, so the decrement is fully accumulated
+//!   before any stats operand is reached.
+//!
+//! # Limitations (RFC-0006 milestone 1)
+//!
+//! - The slatedb compaction filter cannot insert new keys, so the term/field
+//!   stat deltas can only be applied to a `TermStats`/`FieldStats` entry that is
+//!   already present in the compaction. Postings and their stats are always
+//!   written together, so this holds in practice; if a stats entry is somehow
+//!   absent the delta is dropped and the statistic is left slightly stale (BM25
+//!   tolerates document-frequency drift — see the RFC).
+//! - Block re-alignment uses the fixed 256-entry block size baked into the
+//!   posting encoder; the configurable `target_posting_block_size` from the RFC
+//!   is not yet wired.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use slatedb::{
+    CompactionFilter, CompactionFilterDecision, CompactionFilterError, CompactionFilterSupplier,
+    CompactionJobContext, RowEntry, ValueDeletable,
+};
+
+use crate::serde::deletions::DeletionsValue;
+use crate::serde::field_stats::FieldStatsValue;
+use crate::serde::key::{
+    DELETIONS_DISCRIMINATOR, DELETIONS_SENTINEL_DISCRIMINATOR, FieldStatsKey,
+    TERM_POSTINGS_DISCRIMINATOR, TERM_STATS_DISCRIMINATOR, VectorFieldStatsKey,
+};
+use crate::serde::term_postings::TermPostingsValue;
+use crate::serde::term_stats::TermStatsValue;
+use crate::serde::vector_bitmap::VectorBitmap;
+use crate::serde::vector_field_stats::VectorFieldStatsValue;
+use crate::serde::{EncodingError, RecordType, Segment, parse_record_tag};
+
+#[derive(Debug, PartialEq, Eq)]
+enum FilterPhase {
+    Init,
+    // transition from Init
+    CollectDeletes,
+    // transition from CollectDeletes or CollectTermStats with a smaller key
+    CollectPostings(Bytes),
+    // transition from CollectPostings with same key
+    CollectTermStats(Bytes),
+    // transition from CollectTermStats
+    CollectVectorFieldStats,
+    // transition from CollectFieldStats
+    CollectFieldStats,
+}
+
+/// Applies FTS deletes to postings and statistics during compaction.
+///
+/// One instance is created per compaction job by
+/// [`VectorCompactionFilterSupplier`] and is driven single-threaded over the
+/// job's entries in ascending key order.
+pub(crate) struct VectorCompactionFilter {
+    /// Union of every `Deletions` bitmap seen so far in this compaction; empty
+    /// until the (single, merged) bitmap is reached, and empty for the whole
+    /// compaction when no deletes were recorded. Only meaningful for
+    /// last-sorted-run compactions; see [`filter`](Self::filter).
+    deletions: VectorBitmap,
+    /// Pending per-term document-frequency decrements, keyed by the term key
+    /// with its trailing discriminator byte stripped so a `TermPostings` key and
+    /// its sibling `TermStats` key map to the same entry. Each value is the
+    /// (positive) number of documents to subtract.
+    pending_term_deltas: HashMap<Bytes, i64>,
+    /// Pending per-field corpus-stat deltas (`count`, `total_length`, `deletes`),
+    /// keyed by field name — the documents this compaction retires from each
+    /// field as it applies their deletes.
+    pending_field_deltas: HashMap<String, FieldStatsValue>,
+    retention_min_seq: Option<u64>,
+    phase: FilterPhase,
+}
+
+impl VectorCompactionFilter {
+    fn new(retention_min_seq: Option<u64>) -> Self {
+        Self {
+            deletions: VectorBitmap::new(),
+            pending_term_deltas: HashMap::new(),
+            pending_field_deltas: HashMap::new(),
+            retention_min_seq,
+            phase: FilterPhase::Init,
+        }
+    }
+
+    /// Returns `Ok` when the current phase satisfies `predicate`, else a filter
+    /// error. The filter advances through a fixed phase sequence as it sees the
+    /// FTS keys in sort order; a violation means the keys arrived out of the
+    /// expected order — most importantly, a compaction resumed past the sentinel
+    /// reaches a non-sentinel key while still in `Init` — so the compaction is
+    /// failed and restarts clean rather than applying a partial delete pass.
+    fn check_phase(
+        &self,
+        predicate: impl FnOnce(&FilterPhase) -> bool,
+    ) -> Result<(), CompactionFilterError> {
+        if predicate(&self.phase) {
+            Ok(())
+        } else {
+            Err(CompactionFilterError::FilterError(
+                format!("FTS compaction filter: unexpected phase {:?}", self.phase).into(),
+            ))
+        }
+    }
+
+    /// Advances `Init` -> `CollectDeletes` on the deletions sentinel.
+    ///
+    /// The sentinel is written on every FTS write batch and sorts before every
+    /// other FTS key, so a fresh last-run compaction always observes it first. It
+    /// carries no data — it only anchors the start of the key stream — and is
+    /// kept untouched.
+    fn handle_sentinel(
+        &mut self,
+        _entry: &RowEntry,
+    ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+        self.check_phase(|p| matches!(p, FilterPhase::Init))?;
+        self.phase = FilterPhase::CollectDeletes;
+        Ok(CompactionFilterDecision::Keep)
+    }
+
+    /// Unions the (single, merged) deletions bitmap into the running set and
+    /// drops it. Runs only after the sentinel, in `CollectDeletes`. The bitmap is
+    /// conditional — a batch with no deletes writes none — and the filter only
+    /// runs at the last sorted run, so every posting/stat the bitmap references is
+    /// present in this compaction and has been pruned; the ids can never
+    /// resurface, so the entry is always dropped.
+    fn handle_deletions(
+        &mut self,
+        entry: &RowEntry,
+    ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+        self.check_phase(|p| matches!(p, FilterPhase::CollectDeletes))?;
+        if let Some(bytes) = entry.value.as_bytes() {
+            let value = DeletionsValue::decode_from_bytes(&bytes).map_err(filter_err)?;
+            self.deletions.union_with(&value.0);
+        }
+        Ok(CompactionFilterDecision::Drop)
+    }
+
+    /// Removes deleted ids from a term's postings and records the
+    /// document-frequency decrement for the sibling `TermStats` key.
+    fn handle_postings(
+        &mut self,
+        entry: &RowEntry,
+    ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+        // Postings either start the term phase (right after deletions) or advance
+        // to a strictly larger `(field, term)` than the term just finished.
+        let term_key = term_map_key(&entry.key);
+        self.check_phase(|p| {
+            matches!(p, FilterPhase::CollectDeletes)
+                || matches!(p, FilterPhase::CollectTermStats(k) if term_key > *k)
+        })?;
+        self.phase = FilterPhase::CollectPostings(term_key);
+        // No deletes recorded in this compaction means there is nothing to prune.
+        if self.deletions.is_empty() {
+            return Ok(CompactionFilterDecision::Keep);
+        }
+        let Some(bytes) = entry.value.as_bytes() else {
+            return Err(CompactionFilterError::FilterError(
+                "unexpected empty postings val".into(),
+            ));
+        };
+        let value = TermPostingsValue::decode_from_bytes(&bytes).map_err(filter_err)?;
+
+        let mut retained = Vec::new();
+        let mut removed: i64 = 0;
+        for posting in value.iter_entries() {
+            if self.deletions.contains(posting.id.id()) {
+                removed += 1;
+            } else {
+                retained.push(*posting);
+            }
+        }
+        if removed == 0 {
+            return Ok(CompactionFilterDecision::Keep);
+        }
+
+        *self
+            .pending_term_deltas
+            .entry(term_map_key(&entry.key))
+            .or_insert(0) += removed;
+
+        if retained.is_empty() {
+            // No documents left for this term in this run; drop the operand.
+            // The sibling TermStats decrement is still applied when its key is
+            // reached.
+            return Ok(CompactionFilterDecision::Drop);
+        }
+        let rewritten = TermPostingsValue::from_postings(retained).encode_to_bytes();
+        Ok(replace_value(&entry.value, rewritten))
+    }
+
+    /// Applies the pending document-frequency decrement recorded by
+    /// [`handle_postings`](Self::handle_postings) to this `TermStats` entry.
+    fn handle_term_stats(
+        &mut self,
+        entry: &RowEntry,
+    ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+        // A term's stats key sorts immediately after its postings key, so it must
+        // arrive while collecting postings for the same `(field, term)`.
+        let term_key = term_map_key(&entry.key);
+        self.check_phase(|p| matches!(p, FilterPhase::CollectPostings(k) if *k == term_key))?;
+        self.phase = FilterPhase::CollectTermStats(term_key);
+        // A term whose documents were not deleted recorded no pending decrement;
+        // pass its stats through unchanged.
+        let Some(removed) = self.pending_term_deltas.remove(&term_map_key(&entry.key)) else {
+            return Ok(CompactionFilterDecision::Keep);
+        };
+        let Some(bytes) = entry.value.as_bytes() else {
+            return Err(CompactionFilterError::FilterError(
+                "malformed term stats".into(),
+            ));
+        };
+        let mut value = TermStatsValue::decode_from_bytes(&bytes).map_err(filter_err)?;
+        value.freq = value.freq.saturating_sub(removed);
+        Ok(replace_value(&entry.value, value.encode_to_bytes()))
+    }
+
+    /// Drops a deleted vector's per-field length record, folding the applied
+    /// delete into the pending corpus-stats deltas.
+    ///
+    /// The indexer increments `FieldStats` only (`count`/`total_length` on insert,
+    /// `deletes` on delete). When the filter applies a delete at the last sorted
+    /// run it retires that document from all three: `count −1`, `total_length
+    /// −len` (the filter alone knows the per-field token length, from this
+    /// record), and `deletes −1` (clearing the now-applied delete).
+    fn handle_vector_field_stats(
+        &mut self,
+        entry: &RowEntry,
+    ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+        // Per-vector field stats (tag 0x0e) sort after all term keys, so they
+        // follow deletions (when no term keys were present), the term phase, or
+        // earlier per-vector records, and repeat across vectors.
+        self.check_phase(|p| {
+            matches!(
+                p,
+                FilterPhase::CollectDeletes
+                    | FilterPhase::CollectTermStats(_)
+                    | FilterPhase::CollectVectorFieldStats
+            )
+        })?;
+        self.phase = FilterPhase::CollectVectorFieldStats;
+        if self.deletions.is_empty() {
+            return Ok(CompactionFilterDecision::Keep);
+        }
+        let key = VectorFieldStatsKey::decode(&entry.key).map_err(filter_err)?;
+        if !self.deletions.contains(key.vector_id.id()) {
+            return Ok(CompactionFilterDecision::Keep);
+        }
+        if let Some(bytes) = entry.value.as_bytes() {
+            let value = VectorFieldStatsValue::decode_from_bytes(&bytes).map_err(filter_err)?;
+            for (field, length) in value.lengths {
+                let delta = self.pending_field_deltas.entry(field).or_default();
+                delta.count = delta.count.saturating_sub(1);
+                delta.total_length = delta.total_length.saturating_sub(i64::from(length));
+                delta.deletes = delta.deletes.saturating_sub(1);
+            }
+        }
+        Ok(CompactionFilterDecision::Drop)
+    }
+
+    /// Applies the accumulated `(count, total_length, deletes)` delta for this
+    /// field — the filter retires the deleted documents the indexer had only
+    /// ever counted up.
+    fn handle_field_stats(
+        &mut self,
+        entry: &RowEntry,
+    ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+        // Per-field corpus stats (tag 0x0f) sort last, after all per-vector field
+        // stats, and repeat across fields. They may also follow the deletions or
+        // term phase directly when this compaction retired no vectors.
+        self.check_phase(|p| {
+            matches!(
+                p,
+                FilterPhase::CollectDeletes
+                    | FilterPhase::CollectTermStats(_)
+                    | FilterPhase::CollectVectorFieldStats
+                    | FilterPhase::CollectFieldStats
+            )
+        })?;
+        self.phase = FilterPhase::CollectFieldStats;
+        let key = FieldStatsKey::decode(&entry.key).map_err(filter_err)?;
+        // A field with no retired documents has no pending delta; pass it through.
+        let Some(delta) = self.pending_field_deltas.remove(&key.field) else {
+            return Ok(CompactionFilterDecision::Keep);
+        };
+        let Some(bytes) = entry.value.as_bytes() else {
+            return Err(CompactionFilterError::FilterError(
+                "malformed field stats".into(),
+            ));
+        };
+        let mut value = FieldStatsValue::decode_from_bytes(&bytes).map_err(filter_err)?;
+        value.count = value.count.saturating_add(delta.count);
+        value.total_length = value.total_length.saturating_add(delta.total_length);
+        value.deletes = value.deletes.saturating_add(delta.deletes);
+        Ok(replace_value(&entry.value, value.encode_to_bytes()))
+    }
+}
+
+#[async_trait]
+impl CompactionFilter for VectorCompactionFilter {
+    async fn filter(
+        &mut self,
+        entry: &RowEntry,
+    ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+        // Anything that isn't a well-formed FTS-segment vector key is left
+        // untouched — the filter must be a strict no-op for the ANN and Default
+        // segments (and for any non-vector key).
+        let record_type = match parse_record_tag(&entry.key) {
+            Ok(tag) => match RecordType::from_id(tag.record_type()) {
+                Ok(record_type) => record_type,
+                Err(_) => return Ok(CompactionFilterDecision::Keep),
+            },
+            Err(_) => return Ok(CompactionFilterDecision::Keep),
+        };
+        if record_type.segment() != Segment::Fts {
+            return Ok(CompactionFilterDecision::Keep);
+        }
+        if let Some(retention_min_seq) = self.retention_min_seq
+            && entry.seq > retention_min_seq
+        {
+            // any entries with seq higher than retention_min_seq may belong to some
+            // active snapshot for which the filter should still preserve snapshot-reads
+            return Ok(CompactionFilterDecision::Keep);
+        }
+
+        match record_type {
+            // The `Deletions` tag covers two records, discriminated by the
+            // trailing byte: the always-written sentinel (`0x00`, sorts first)
+            // and the conditional deletions bitmap (`0xff`).
+            RecordType::Deletions => match entry.key.last().copied() {
+                Some(DELETIONS_SENTINEL_DISCRIMINATOR) => self.handle_sentinel(entry),
+                Some(DELETIONS_DISCRIMINATOR) => self.handle_deletions(entry),
+                _ => Ok(CompactionFilterDecision::Keep),
+            },
+            RecordType::FtsTerm => match entry.key.last().copied() {
+                Some(TERM_POSTINGS_DISCRIMINATOR) => self.handle_postings(entry),
+                Some(TERM_STATS_DISCRIMINATOR) => self.handle_term_stats(entry),
+                _ => Ok(CompactionFilterDecision::Keep),
+            },
+            RecordType::FtsVectorFieldStats => self.handle_vector_field_stats(entry),
+            RecordType::FtsFieldStats => self.handle_field_stats(entry),
+            // parse_record_tag validated the segment is FTS, so no other record
+            // type can reach here; keep defensively rather than panicking mid
+            // compaction.
+            _ => Ok(CompactionFilterDecision::Keep),
+        }
+    }
+
+    async fn on_compaction_end(&mut self) -> Result<(), CompactionFilterError> {
+        // No terminal-phase invariant holds. A last-run compaction only sees keys
+        // at or below the snapshot barrier (`retention_min_seq`); everything fresher
+        // is kept un-pruned without advancing the phase. So a job whose entries are
+        // all above the barrier ends in `Init`, one that saw only the sentinel ends
+        // in `CollectDeletes`, and so on — every terminal phase is legitimate. The
+        // resume guard the sentinel provides is enforced eagerly in the handlers:
+        // any non-sentinel FTS key reached while still in `Init` fails `check_phase`
+        // (a resumed job that skipped the sentinel), so there is nothing left to
+        // assert here.
+        Ok(())
+    }
+}
+
+/// Per-compaction-job factory for [`VectorCompactionFilter`].
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct VectorCompactionFilterSupplier;
+
+impl VectorCompactionFilterSupplier {
+    /// Returns a shared `Arc<dyn CompactionFilterSupplier>` for handing to
+    /// `slatedb::DbBuilder::with_compaction_filter_supplier`.
+    pub(crate) fn shared() -> Arc<dyn CompactionFilterSupplier> {
+        Arc::new(Self)
+    }
+}
+
+#[async_trait]
+impl CompactionFilterSupplier for VectorCompactionFilterSupplier {
+    async fn create_compaction_filter(
+        &self,
+        context: &CompactionJobContext,
+    ) -> Result<Box<dyn CompactionFilter>, CompactionFilterError> {
+        // TODO: extend CompactionJobContext to include job spec and check for fts segment, and
+        //       for resumed fts last-sr jobs (and fail these)
+        // Apply FTS deletes only when compacting to the last (oldest) sorted run.
+        // There every key for a given vector — postings, term stats, per-vector
+        // field stats — is guaranteed present, so a delete observes all of a
+        // vector's keys in one pass and the cleanup is consistent. For any other
+        // compaction the filter is a strict no-op (RFC-0006).
+        if context.is_dest_last_run {
+            Ok(Box::new(VectorCompactionFilter::new(
+                context.retention_min_seq,
+            )))
+        } else {
+            Ok(Box::new(NoOpCompactionFilter))
+        }
+    }
+}
+
+/// No-op compaction filter installed for compactions whose destination is not
+/// the last sorted run — the FTS delete-cleanup filter only runs at the last
+/// run (see [`VectorCompactionFilterSupplier::create_compaction_filter`]).
+struct NoOpCompactionFilter;
+
+#[async_trait]
+impl CompactionFilter for NoOpCompactionFilter {
+    async fn filter(
+        &mut self,
+        _entry: &RowEntry,
+    ) -> Result<CompactionFilterDecision, CompactionFilterError> {
+        Ok(CompactionFilterDecision::Keep)
+    }
+
+    async fn on_compaction_end(&mut self) -> Result<(), CompactionFilterError> {
+        Ok(())
+    }
+}
+
+/// Strips the trailing discriminator byte from an `FtsTerm` key so a
+/// `TermPostings` key (`0x00`) and its sibling `TermStats` key (`0x01`) map to
+/// the same entry.
+fn term_map_key(key: &Bytes) -> Bytes {
+    key.slice(0..key.len() - 1)
+}
+
+/// Rebuilds a `Modify` decision with `new_value`, preserving the entry's
+/// existing value kind (`Merge` vs `Value`). Tombstones carry no payload, so
+/// they are left untouched.
+fn replace_value(original: &ValueDeletable, new_value: Bytes) -> CompactionFilterDecision {
+    match original {
+        ValueDeletable::Merge(_) => {
+            CompactionFilterDecision::Modify(ValueDeletable::Merge(new_value))
+        }
+        ValueDeletable::Value(_) => {
+            CompactionFilterDecision::Modify(ValueDeletable::Value(new_value))
+        }
+        ValueDeletable::Tombstone => panic!("unexpected tombstone"),
+    }
+}
+
+fn filter_err(e: EncodingError) -> CompactionFilterError {
+    CompactionFilterError::FilterError(format!("FTS compaction filter decode error: {e}").into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serde::key::{
+        DeletionsKey, DeletionsSentinelKey, FieldStatsKey, TermPostingsKey, TermStatsKey,
+    };
+    use crate::serde::term_postings::PostingEntry;
+    use crate::serde::vector_id::VectorId;
+
+    fn merge_entry(key: Bytes, value: Bytes) -> RowEntry {
+        RowEntry {
+            key,
+            value: ValueDeletable::Merge(value),
+            seq: 1,
+            create_ts: None,
+            expire_ts: None,
+        }
+    }
+
+    fn value_entry(key: Bytes, value: Bytes) -> RowEntry {
+        RowEntry {
+            key,
+            value: ValueDeletable::Value(value),
+            seq: 1,
+            create_ts: None,
+            expire_ts: None,
+        }
+    }
+
+    fn posting(id: u64, freq: u32, norm: u8) -> PostingEntry {
+        PostingEntry {
+            id: VectorId::data_vector_id(id),
+            freq,
+            norm,
+        }
+    }
+
+    fn deletions_entry(ids: &[u64]) -> RowEntry {
+        let mut bitmap = VectorBitmap::new();
+        for &id in ids {
+            bitmap.insert(id);
+        }
+        merge_entry(
+            DeletionsKey::new().encode(),
+            DeletionsValue::new(bitmap).encode_to_bytes().unwrap(),
+        )
+    }
+
+    /// The always-written sentinel (sorts first); the filter requires it before
+    /// any other FTS key.
+    fn sentinel_entry() -> RowEntry {
+        value_entry(
+            DeletionsSentinelKey::new().encode(),
+            Bytes::from_static(&[0u8]),
+        )
+    }
+
+    fn modified_bytes(decision: &CompactionFilterDecision) -> Bytes {
+        match decision {
+            CompactionFilterDecision::Modify(v) => v.as_bytes().expect("modify carried no bytes"),
+            other => panic!("expected Modify, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn should_keep_non_fts_segment_keys() {
+        // given - an ANN-segment posting list key
+        use crate::serde::key::PostingListKey;
+        let mut filter = VectorCompactionFilter::new(None);
+        let entry = merge_entry(
+            PostingListKey::new(VectorId::centroid_id(1, 7)).encode(),
+            Bytes::from_static(b"opaque-ann-bytes"),
+        );
+
+        // when
+        let decision = filter.filter(&entry).await.unwrap();
+
+        // then - untouched, and the deletions set is never consulted
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+        assert!(filter.deletions.is_empty());
+        assert_eq!(filter.phase, FilterPhase::Init);
+    }
+
+    #[tokio::test]
+    async fn should_accumulate_and_drop_deletions_at_last_run() {
+        // given - last-run compaction; the sentinel is seen first
+        let mut filter = VectorCompactionFilter::new(None);
+        let sentinel_decision = filter.filter(&sentinel_entry()).await.unwrap();
+        assert_eq!(sentinel_decision, CompactionFilterDecision::Keep);
+        assert_eq!(filter.phase, FilterPhase::CollectDeletes);
+
+        // when - the deletions bitmap follows
+        let decision = filter.filter(&deletions_entry(&[1, 2])).await.unwrap();
+
+        // then - the bitmap is accumulated and the record is dropped
+        assert_eq!(decision, CompactionFilterDecision::Drop);
+        assert!(filter.deletions.contains(1));
+        assert!(filter.deletions.contains(2));
+        assert_eq!(filter.phase, FilterPhase::CollectDeletes);
+    }
+
+    #[tokio::test]
+    async fn should_error_when_sentinel_not_seen() {
+        // given - a fresh filter that has not seen the sentinel (a compaction
+        // resumed past it, or otherwise missing its start marker)
+        let mut filter = VectorCompactionFilter::new(None);
+
+        // when - a non-sentinel FTS key is processed while still in Init
+        let result = filter.filter(&deletions_entry(&[1, 2])).await;
+
+        // then - the filter fails (forcing a clean restart) rather than applying
+        // a partial delete pass
+        assert!(result.is_err());
+        assert_eq!(filter.phase, FilterPhase::Init);
+    }
+
+    #[tokio::test]
+    async fn should_keep_everything_on_non_last_run_compactions() {
+        // given - the no-op filter the supplier installs when the destination is
+        // not the last sorted run (deletes are only applied at the last run)
+        let mut filter = NoOpCompactionFilter;
+
+        // when / then - even a Deletions entry is preserved untouched
+        assert_eq!(
+            filter.filter(&deletions_entry(&[1, 2])).await.unwrap(),
+            CompactionFilterDecision::Keep
+        );
+    }
+
+    #[tokio::test]
+    async fn should_prune_postings_and_decrement_term_stats() {
+        // given - {1,2} deleted; term "fox" has docs {1,2,3}
+        let mut filter = VectorCompactionFilter::new(None);
+        filter.filter(&sentinel_entry()).await.unwrap();
+        filter.filter(&deletions_entry(&[1, 2])).await.unwrap();
+
+        let postings = TermPostingsValue::from_postings(vec![
+            posting(1, 2, 10),
+            posting(2, 1, 20),
+            posting(3, 3, 30),
+        ])
+        .encode_to_bytes();
+        let postings_entry = merge_entry(TermPostingsKey::new("body", "fox").encode(), postings);
+
+        let stats_entry = merge_entry(
+            TermStatsKey::new("body", "fox").encode(),
+            TermStatsValue::new(3).encode_to_bytes(),
+        );
+
+        // when - postings first (sort before stats), then stats
+        let postings_decision = filter.filter(&postings_entry).await.unwrap();
+        let stats_decision = filter.filter(&stats_entry).await.unwrap();
+
+        // then - only doc 3 survives in the postings
+        let pruned =
+            TermPostingsValue::decode_from_bytes(&modified_bytes(&postings_decision)).unwrap();
+        let ids: Vec<u64> = pruned.iter_entries().map(|e| e.id.id()).collect();
+        assert_eq!(ids, vec![3]);
+
+        // and the document frequency dropped by the 2 removed docs (3 -> 1)
+        let stats = TermStatsValue::decode_from_bytes(&modified_bytes(&stats_decision)).unwrap();
+        assert_eq!(stats.freq, 1);
+    }
+
+    #[tokio::test]
+    async fn should_drop_postings_when_all_docs_deleted() {
+        // given - both docs of term "fox" are deleted
+        let mut filter = VectorCompactionFilter::new(None);
+        filter.filter(&sentinel_entry()).await.unwrap();
+        filter.filter(&deletions_entry(&[1, 2])).await.unwrap();
+
+        let postings = TermPostingsValue::from_postings(vec![posting(1, 1, 1), posting(2, 1, 1)])
+            .encode_to_bytes();
+        let postings_entry = merge_entry(TermPostingsKey::new("body", "fox").encode(), postings);
+        let stats_entry = merge_entry(
+            TermStatsKey::new("body", "fox").encode(),
+            TermStatsValue::new(2).encode_to_bytes(),
+        );
+
+        // when
+        let postings_decision = filter.filter(&postings_entry).await.unwrap();
+        let stats_decision = filter.filter(&stats_entry).await.unwrap();
+
+        // then - the empty postings operand is dropped, the stat still decremented to 0
+        assert_eq!(postings_decision, CompactionFilterDecision::Drop);
+        let stats = TermStatsValue::decode_from_bytes(&modified_bytes(&stats_decision)).unwrap();
+        assert_eq!(stats.freq, 0);
+    }
+
+    #[tokio::test]
+    async fn should_drop_vector_field_stats_and_apply_field_stats_delta() {
+        // given - vector 5 deleted, with text fields body(len 10), title(len 2)
+        let mut filter = VectorCompactionFilter::new(None);
+        filter.filter(&sentinel_entry()).await.unwrap();
+        filter.filter(&deletions_entry(&[5])).await.unwrap();
+
+        let vfs = value_entry(
+            VectorFieldStatsKey::new(VectorId::data_vector_id(5)).encode(),
+            VectorFieldStatsValue::new(vec![("body".to_string(), 10), ("title".to_string(), 2)])
+                .encode_to_bytes(),
+        );
+        // The indexer counted these docs up (count, total_length) on insert and
+        // bumped `deletes` on the delete; the filter now retires them. Start each
+        // field at 3 docs / 1 pending delete.
+        let body_stats = merge_entry(
+            FieldStatsKey::new("body").encode(),
+            FieldStatsValue::new(3, 30, 1).encode_to_bytes(),
+        );
+        let title_stats = merge_entry(
+            FieldStatsKey::new("title").encode(),
+            FieldStatsValue::new(3, 6, 1).encode_to_bytes(),
+        );
+
+        // when
+        let vfs_decision = filter.filter(&vfs).await.unwrap();
+        let body_decision = filter.filter(&body_stats).await.unwrap();
+        let title_decision = filter.filter(&title_stats).await.unwrap();
+
+        // then - the per-vector record is dropped
+        assert_eq!(vfs_decision, CompactionFilterDecision::Drop);
+        // and the filter retires the deleted document from all three stats:
+        // count -1, total_length -len, deletes -1.
+        let body = FieldStatsValue::decode_from_bytes(&modified_bytes(&body_decision)).unwrap();
+        assert_eq!(body, FieldStatsValue::new(2, 20, 0));
+        let title = FieldStatsValue::decode_from_bytes(&modified_bytes(&title_decision)).unwrap();
+        assert_eq!(title, FieldStatsValue::new(2, 4, 0));
+    }
+
+    #[tokio::test]
+    async fn should_keep_vector_field_stats_for_live_vectors() {
+        // given - vector 5 is deleted, vector 6 is not
+        let mut filter = VectorCompactionFilter::new(None);
+        filter.filter(&sentinel_entry()).await.unwrap();
+        filter.filter(&deletions_entry(&[5])).await.unwrap();
+        let live = value_entry(
+            VectorFieldStatsKey::new(VectorId::data_vector_id(6)).encode(),
+            VectorFieldStatsValue::new(vec![("body".to_string(), 7)]).encode_to_bytes(),
+        );
+
+        // when
+        let decision = filter.filter(&live).await.unwrap();
+
+        // then - the live vector's record is preserved and no delta accrues
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+        assert!(filter.pending_field_deltas.is_empty());
+    }
+
+    #[tokio::test]
+    async fn should_keep_entries_above_retention_watermark() {
+        // given - a retention watermark at seq 5
+        let mut filter = VectorCompactionFilter::new(Some(5));
+
+        // when - a sentinel above the watermark arrives (it may still be visible
+        // to an active snapshot, so the filter must preserve it untouched)
+        let mut above = sentinel_entry();
+        above.seq = 10;
+        let decision = filter.filter(&above).await.unwrap();
+
+        // then - kept untouched and not processed: no phase advance
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+        assert_eq!(filter.phase, FilterPhase::Init);
+
+        // and - the sentinel at the watermark is processed, advancing the phase
+        let mut at_watermark = sentinel_entry();
+        at_watermark.seq = 5;
+        let decision = filter.filter(&at_watermark).await.unwrap();
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+        assert_eq!(filter.phase, FilterPhase::CollectDeletes);
+
+        // and - a deletions bitmap above the watermark is preserved (not applied)
+        let mut bitmap_above = deletions_entry(&[1, 2]);
+        bitmap_above.seq = 10;
+        let decision = filter.filter(&bitmap_above).await.unwrap();
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+        assert!(filter.deletions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn should_advance_phases_through_a_full_compaction() {
+        // given - a deleted vector 5 with term "fox" in field "body"
+        let mut filter = VectorCompactionFilter::new(None);
+
+        // sentinel -> CollectDeletes
+        filter.filter(&sentinel_entry()).await.unwrap();
+        assert_eq!(filter.phase, FilterPhase::CollectDeletes);
+
+        // deletions bitmap (stays in CollectDeletes)
+        filter.filter(&deletions_entry(&[5])).await.unwrap();
+        assert_eq!(filter.phase, FilterPhase::CollectDeletes);
+
+        // term postings -> CollectPostings
+        let postings = merge_entry(
+            TermPostingsKey::new("body", "fox").encode(),
+            TermPostingsValue::from_postings(vec![posting(5, 1, 1)]).encode_to_bytes(),
+        );
+        filter.filter(&postings).await.unwrap();
+        assert!(matches!(filter.phase, FilterPhase::CollectPostings(_)));
+
+        // term stats (same key) -> CollectTermStats
+        let stats = merge_entry(
+            TermStatsKey::new("body", "fox").encode(),
+            TermStatsValue::new(1).encode_to_bytes(),
+        );
+        filter.filter(&stats).await.unwrap();
+        assert!(matches!(filter.phase, FilterPhase::CollectTermStats(_)));
+
+        // per-vector field stats -> CollectVectorFieldStats
+        let vfs = value_entry(
+            VectorFieldStatsKey::new(VectorId::data_vector_id(5)).encode(),
+            VectorFieldStatsValue::new(vec![("body".to_string(), 1)]).encode_to_bytes(),
+        );
+        filter.filter(&vfs).await.unwrap();
+        assert_eq!(filter.phase, FilterPhase::CollectVectorFieldStats);
+
+        // per-field corpus stats -> CollectFieldStats
+        let fs = merge_entry(
+            FieldStatsKey::new("body").encode(),
+            FieldStatsValue::new(1, 1, 1).encode_to_bytes(),
+        );
+        filter.filter(&fs).await.unwrap();
+        assert_eq!(filter.phase, FilterPhase::CollectFieldStats);
+    }
+
+    #[tokio::test]
+    async fn should_error_on_out_of_order_term_stats() {
+        // given - a term stats key whose postings were never seen (e.g. arriving
+        // for a different term than the one being collected)
+        let mut filter = VectorCompactionFilter::new(None);
+        filter.filter(&sentinel_entry()).await.unwrap();
+        let postings = merge_entry(
+            TermPostingsKey::new("body", "fox").encode(),
+            TermPostingsValue::from_postings(vec![posting(1, 1, 1)]).encode_to_bytes(),
+        );
+        filter.filter(&postings).await.unwrap();
+
+        // when - stats for a *different* term arrive while collecting "fox"
+        let mismatched_stats = merge_entry(
+            TermStatsKey::new("body", "wolf").encode(),
+            TermStatsValue::new(1).encode_to_bytes(),
+        );
+        let result = filter.filter(&mismatched_stats).await;
+
+        // then - the phase check fails the compaction
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn should_allow_field_stats_directly_after_terms_when_no_deletes() {
+        // given - an insert-only compaction: sentinel, postings, stats, then field
+        // stats with no deletions bitmap and no per-vector field stats in between
+        let mut filter = VectorCompactionFilter::new(None);
+        filter.filter(&sentinel_entry()).await.unwrap();
+        let postings = merge_entry(
+            TermPostingsKey::new("body", "fox").encode(),
+            TermPostingsValue::from_postings(vec![posting(1, 1, 1)]).encode_to_bytes(),
+        );
+        filter.filter(&postings).await.unwrap();
+        let stats = merge_entry(
+            TermStatsKey::new("body", "fox").encode(),
+            TermStatsValue::new(1).encode_to_bytes(),
+        );
+        filter.filter(&stats).await.unwrap();
+
+        // when - field stats follow the term phase directly (no vfs)
+        let field_stats = merge_entry(
+            FieldStatsKey::new("body").encode(),
+            FieldStatsValue::new(1, 3, 0).encode_to_bytes(),
+        );
+        let decision = filter.filter(&field_stats).await.unwrap();
+
+        // then - with no deletes there is no pending delta, so it passes through
+        // unchanged, and the phase advances to CollectFieldStats
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+        assert_eq!(filter.phase, FilterPhase::CollectFieldStats);
+    }
+}

--- a/vector/src/storage/compaction_scheduler.rs
+++ b/vector/src/storage/compaction_scheduler.rs
@@ -1,0 +1,584 @@
+//! FTS compaction *scheduling* policy for the vector subsystem (RFC-0006).
+//!
+//! Deletes are recorded lazily into the FTS deletions bitmap and the actual
+//! cleanup of postings/stats happens during compaction (see
+//! [`compaction_filter`](super::compaction_filter)). To bound the amount of
+//! garbage carried in the FTS segment — and the size of the in-memory deletions
+//! bitmap loaded for every query — Vector forces a *major* (full) compaction of
+//! the FTS segment once any indexed field's delete fraction crosses
+//! `delete_compaction_threshold` (default 20%).
+//!
+//! The trigger is computed per field from the persisted [`FieldStats`]
+//! (`count` = total documents written to the field that are still present, i.e.
+//! live + pending-deleted; `deletes` = outstanding deletes, a subset of
+//! `count`): a field is over threshold when `deletes > threshold * count`. If
+//! *any* indexed field is over threshold, a full FTS compaction is forced.
+//!
+//! [`VectorCompactionScheduler`] wraps SlateDB's size-tiered scheduler. On every
+//! `propose()` it reads the in-memory [`FtsDeleteTracker`] (the trigger signal
+//! must come from memory: `propose()` is synchronous and has no KV access);
+//! when a field is over threshold it plans a full compaction of the FTS segment
+//! via `CompactionScheduler::generate` + [`CompactionRequest::FullSegment`],
+//! merging it with the inner scheduler's proposals for the *other* segments so
+//! ANN/Default L0 compaction keeps flowing and writers don't stall. Otherwise it
+//! delegates entirely to the inner size-tiered scheduler.
+//!
+//! [`VectorCompactionSchedulerSupplier`] mirrors
+//! [`VectorCompactionFilterSupplier`](super::compaction_filter::VectorCompactionFilterSupplier):
+//! it is handed to the storage layer and builds one [`VectorCompactionScheduler`]
+//! per compactor, wrapping a fresh size-tiered scheduler built from the same
+//! [`CompactorOptions`].
+//!
+//! [`FieldStats`]: crate::serde::field_stats::FieldStatsValue
+//!
+//! # Re-triggering while a full compaction is in flight
+//!
+//! When the policy detects an active compaction already targeting the FTS
+//! segment it skips proposing a new one, to avoid log spam and redundant
+//! planning. Even without that check SlateDB's own conflict checker rejects a
+//! second compaction that reuses the same sources, so correctness does not
+//! depend on it. Once the forced compaction applies the deletes (at the last
+//! sorted run), the per-field `deletes` counters fall and the next poll clears
+//! the trigger.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use crate::serde::Segment;
+use crate::storage::VectorDbStorageReadExt;
+use crate::storage::segment_extractor::segment_routing_prefix;
+use bytes::Bytes;
+use common::Storage;
+use common::storage::slate::SlateDbStorage;
+use slatedb::compactor::{
+    Compaction, CompactionRequest, CompactionScheduler, CompactionSchedulerSupplier,
+    CompactionSpec, CompactorStateView, SizeTieredCompactionSchedulerSupplier, SourceId,
+};
+use slatedb::config::CompactorOptions;
+use slatedb::{Db, VersionedCompactions};
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+/// In-memory snapshot of the persisted per-field
+/// [`FieldStats`](crate::serde::field_stats::FieldStatsValue), describing
+/// current FTS delete pressure.
+///
+/// Shared as an `Arc` between the FieldStats poller (see
+/// [`spawn_fts_field_stats_poller`], which refreshes it periodically from
+/// storage) and the [`VectorCompactionScheduler`] (which reads it on every
+/// `propose()` — `propose()` is synchronous and cannot do KV reads, so the
+/// values must already be in memory). The map is replaced wholesale on each
+/// poll under a short-lived lock.
+#[derive(Debug)]
+pub(crate) struct FtsDeleteTracker {
+    /// field name -> `(count, deletes)`, where `count` is the total document
+    /// count for the field (live + pending-deleted) and `deletes` is the
+    /// outstanding (not-yet-compacted) delete count — a subset of `count`.
+    // fields: Mutex<HashMap<String, (i64, i64)>>,
+    state: Mutex<FtsDeleteTrackerState>,
+}
+
+#[derive(Debug)]
+pub(crate) enum FtsDeleteTrackerState {
+    Initializing,
+    CompactionInProgress,
+    Compacted { manifest_id: u64 },
+    Accumulating(HashMap<String, (i64, i64)>),
+}
+
+impl FtsDeleteTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: Mutex::new(FtsDeleteTrackerState::Initializing),
+        }
+    }
+
+    /// Returns a fresh shared tracker.
+    pub(crate) fn shared() -> Arc<Self> {
+        Arc::new(Self::new())
+    }
+
+    pub(crate) fn notify_compacting(&self, manifest_id: u64, in_flight: bool) {
+        let mut state = self.state.lock().unwrap();
+        if in_flight {
+            *state = FtsDeleteTrackerState::CompactionInProgress;
+        } else {
+            match &*state {
+                FtsDeleteTrackerState::Initializing => {
+                    *state = FtsDeleteTrackerState::Compacted { manifest_id }
+                }
+                FtsDeleteTrackerState::CompactionInProgress => {
+                    *state = FtsDeleteTrackerState::Compacted { manifest_id }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    /// Replaces the snapshot with the latest per-field `(count, deletes)`.
+    pub(crate) fn update_stats(
+        &self,
+        update_manifest_id: u64,
+        fields: HashMap<String, (i64, i64)>,
+    ) {
+        let mut state = self.state.lock().unwrap();
+        match &*state {
+            FtsDeleteTrackerState::Compacted { manifest_id, .. } => {
+                if update_manifest_id >= *manifest_id {
+                    *state = FtsDeleteTrackerState::Accumulating(fields);
+                }
+            }
+            FtsDeleteTrackerState::Accumulating(_) => {
+                *state = FtsDeleteTrackerState::Accumulating(fields);
+            }
+            _ => {}
+        }
+    }
+
+    /// Returns `true` when *any* field's outstanding-delete fraction exceeds
+    /// `threshold`, i.e. `deletes > threshold * count`. `count` is the field's
+    /// total document count (live + pending-deleted), so it is exactly the
+    /// `deletes + freq` denominator with `freq = count - deletes` (live docs).
+    /// Fields with no outstanding deletes never trigger.
+    pub(crate) fn should_force_full_compaction(&self, threshold: f64) -> bool {
+        let state = self.state.lock().unwrap();
+        let fields = match &*state {
+            FtsDeleteTrackerState::Accumulating(fields) => fields,
+            _ => return false,
+        };
+        fields
+            .values()
+            .any(|&(count, deletes)| field_over_threshold(count, deletes, threshold))
+    }
+}
+
+/// Pure per-field trigger test: `deletes > threshold * count`.
+///
+/// `count` is the field's total document count (live + pending-deleted); the
+/// indexer only counts documents up and the filter retires them on delete, so
+/// `deletes` is a subset of `count`. The fraction `deletes / count` is therefore
+/// the share of the field's documents that are pending deletes. A field with no
+/// outstanding deletes (or no documents) never triggers.
+fn field_over_threshold(count: i64, deletes: i64, threshold: f64) -> bool {
+    if deletes <= 0 || count <= 0 {
+        return false;
+    }
+    (deletes as f64) > threshold * (count as f64)
+}
+
+/// Spawns a background task that periodically scans the persisted per-field
+/// [`FieldStats`](crate::serde::field_stats::FieldStatsValue) from `storage` and
+/// refreshes `tracker`, so the (synchronous) compaction scheduler always has an
+/// up-to-date in-memory view of per-field delete pressure (RFC-0006).
+///
+/// Reads are best-effort: a transient error is logged and retried on the next
+/// tick. The returned [`JoinHandle`] should be aborted on shutdown (the caller
+/// holds it for the database's lifetime).
+pub(crate) fn spawn_fts_field_stats_poller(
+    storage: Arc<dyn Storage>,
+    tracker: Arc<FtsDeleteTracker>,
+    poll_interval: Duration,
+) -> JoinHandle<()> {
+    fn unwrap_slatedb(storage: &dyn Any) -> Arc<Db> {
+        let Some(slatedb) = storage.downcast_ref::<SlateDbStorage>() else {
+            panic!("storage is not an SlateDbStorage")
+        };
+        slatedb.db().clone()
+    }
+
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(poll_interval);
+        // If a tick is delayed (e.g. a slow scan), skip the backlog rather than
+        // firing a burst of catch-up reads.
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            ticker.tick().await;
+            let db = unwrap_slatedb(storage.as_ref());
+            let manifest = db.manifest();
+            match storage.scan_field_stats().await {
+                Ok(stats) => {
+                    let fields = stats
+                        .into_iter()
+                        .map(|(field, value)| (field, (value.count, value.deletes)))
+                        .collect();
+                    tracker.update_stats(manifest.id(), fields);
+                }
+                Err(e) => {
+                    debug!(error = %e, "FTS field-stats poll failed; retrying next tick");
+                }
+            }
+        }
+    })
+}
+
+/// Custom compaction scheduler that forces a full FTS-segment compaction when
+/// any indexed field's delete fraction crosses the configured threshold, and
+/// otherwise delegates to a wrapped size-tiered scheduler. See the module docs.
+pub(crate) struct VectorCompactionScheduler {
+    inner: Box<dyn CompactionScheduler + Send + Sync>,
+    tracker: Arc<FtsDeleteTracker>,
+    threshold: f64,
+    /// The 3-byte `[subsystem, segment, version]` routing prefix that names the
+    /// FTS SlateDB segment (shared with the segment extractor).
+    fts_segment_prefix: Bytes,
+}
+
+impl VectorCompactionScheduler {
+    fn new(
+        inner: Box<dyn CompactionScheduler + Send + Sync>,
+        tracker: Arc<FtsDeleteTracker>,
+        threshold: f64,
+        fts_segment_prefix: Bytes,
+    ) -> Self {
+        Self {
+            inner,
+            tracker,
+            threshold,
+            fts_segment_prefix,
+        }
+    }
+
+    fn fts_compactions<'a>(
+        &self,
+        compactions: &'a VersionedCompactions,
+    ) -> impl Iterator<Item = &'a Compaction> {
+        compactions
+            .recent_compactions()
+            .filter(|c| c.active())
+            .filter(|c| c.spec().segment() == &self.fts_segment_prefix)
+    }
+
+    /// Returns true if a compaction already targeting the FTS segment is active
+    /// (submitted or running). Best-effort: if the compactions snapshot is
+    /// absent we report `false` and let SlateDB's conflict checker dedup.
+    fn fts_compaction_in_flight(&self, state: &CompactorStateView) -> bool {
+        let Some(compactions) = state.compactions() else {
+            return false;
+        };
+        self.fts_compactions(compactions).next().is_some()
+    }
+
+    /// Returns true if there are any active compactions targeting the last SR in the FTS segment
+    fn fts_cleanup_compaction_in_flight(&self, state: &CompactorStateView) -> bool {
+        let Some(fts_segment) = state.manifest().segment(&self.fts_segment_prefix) else {
+            return false;
+        };
+        let Some(compactions) = state.compactions() else {
+            return false;
+        };
+        let Some(last_sr) = fts_segment.compacted().last() else {
+            return false;
+        };
+        self.fts_compactions(compactions).any(|c| {
+            c.spec()
+                .sources()
+                .contains(&SourceId::SortedRun(last_sr.id))
+        })
+    }
+}
+
+impl CompactionScheduler for VectorCompactionScheduler {
+    fn propose(&self, state: &CompactorStateView) -> Vec<CompactionSpec> {
+        self.tracker.notify_compacting(
+            state.manifest().id(),
+            self.fts_cleanup_compaction_in_flight(state),
+        );
+
+        if !self.tracker.should_force_full_compaction(self.threshold) {
+            return self.inner.propose(state);
+        }
+
+        // Don't re-propose while some FTS compaction is already running — it
+        // only spams logs; SlateDB would reject the duplicate sources anyway.
+        if self.fts_compaction_in_flight(state) {
+            debug!("FTS full compaction already in flight; delegating to size-tiered");
+            // TODO: this can starve the cleanup compaction
+            return self.inner.propose(state);
+        }
+
+        let request = CompactionRequest::FullSegment {
+            segment: self.fts_segment_prefix.clone(),
+        };
+        match self.generate(state, &request) {
+            Ok(fts_specs) if !fts_specs.is_empty() => {
+                debug!(
+                    num_specs = fts_specs.len(),
+                    "forcing full FTS-segment compaction (a field's deletes are over threshold)"
+                );
+                // Keep the inner scheduler's work for the OTHER segments so
+                // ANN/Default L0 compaction keeps flowing; drop any inner spec
+                // that targets the FTS segment to avoid source conflicts with
+                // the full compaction we just planned.
+                let mut specs: Vec<CompactionSpec> = self
+                    .inner
+                    .propose(state)
+                    .into_iter()
+                    .filter(|spec| spec.segment() != &self.fts_segment_prefix)
+                    .collect();
+                specs.extend(fts_specs);
+                specs
+            }
+            // No sorted runs to merge yet (e.g. all FTS data still in L0) — fall
+            // back to size-tiered, which will keep building SRs from L0.
+            Ok(_) => self.inner.propose(state),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "failed to plan full FTS-segment compaction; delegating to size-tiered"
+                );
+                self.inner.propose(state)
+            }
+        }
+    }
+
+    fn validate(
+        &self,
+        state: &CompactorStateView,
+        spec: &CompactionSpec,
+    ) -> Result<(), slatedb::Error> {
+        self.inner.validate(state, spec)
+    }
+}
+
+/// Per-compactor factory for [`VectorCompactionScheduler`]; mirrors
+/// [`VectorCompactionFilterSupplier`](super::compaction_filter::VectorCompactionFilterSupplier).
+pub(crate) struct VectorCompactionSchedulerSupplier {
+    tracker: Arc<FtsDeleteTracker>,
+    threshold: f64,
+    fts_segment_prefix: Bytes,
+}
+
+impl VectorCompactionSchedulerSupplier {
+    /// Creates a supplier sharing `tracker`, forcing a full FTS compaction once
+    /// any field's delete fraction reaches `threshold`.
+    pub(crate) fn new(tracker: Arc<FtsDeleteTracker>, threshold: f64) -> Self {
+        Self {
+            tracker,
+            threshold,
+            fts_segment_prefix: segment_routing_prefix(Segment::Fts),
+        }
+    }
+
+    /// Returns a shared `Arc<dyn CompactionSchedulerSupplier>` for handing to
+    /// the storage builder's compactor.
+    pub(crate) fn shared(
+        tracker: Arc<FtsDeleteTracker>,
+        threshold: f64,
+    ) -> Arc<dyn CompactionSchedulerSupplier> {
+        Arc::new(Self::new(tracker, threshold))
+    }
+}
+
+impl CompactionSchedulerSupplier for VectorCompactionSchedulerSupplier {
+    fn compaction_scheduler(
+        &self,
+        options: &CompactorOptions,
+    ) -> Box<dyn CompactionScheduler + Send + Sync> {
+        // Build the wrapped size-tiered scheduler from the SAME options this
+        // supplier receives, so the delegate behaves exactly as the default
+        // scheduler would for non-FTS segments.
+        let inner = SizeTieredCompactionSchedulerSupplier::new().compaction_scheduler(options);
+        Box::new(VectorCompactionScheduler::new(
+            inner,
+            self.tracker.clone(),
+            self.threshold,
+            self.fts_segment_prefix.clone(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tracker_with(fields: &[(&str, i64, i64)]) -> FtsDeleteTracker {
+        let tracker = FtsDeleteTracker::new();
+        tracker.notify_compacting(0, false);
+        tracker.update_stats(
+            1,
+            fields
+                .iter()
+                .map(|&(f, count, deletes)| (f.to_string(), (count, deletes)))
+                .collect(),
+        );
+        tracker
+    }
+
+    #[test]
+    fn should_not_force_when_no_deletes() {
+        // given - fields with live docs but no outstanding deletes
+        let tracker = tracker_with(&[("body", 100, 0), ("title", 50, 0)]);
+
+        // when / then
+        assert!(!tracker.should_force_full_compaction(0.20));
+    }
+
+    #[test]
+    fn should_not_force_below_threshold() {
+        // given - 1 delete out of 10 total docs = 10% < 20%
+        let tracker = tracker_with(&[("body", 10, 1)]);
+
+        // when / then
+        assert!(!tracker.should_force_full_compaction(0.20));
+    }
+
+    #[test]
+    fn should_force_above_threshold() {
+        // given - 3 deletes out of 10 total docs = 30% > 20%
+        let tracker = tracker_with(&[("body", 10, 3)]);
+
+        // when / then
+        assert!(tracker.should_force_full_compaction(0.20));
+    }
+
+    #[test]
+    fn should_force_when_any_field_over_threshold() {
+        // given - "body" is fine (1/10 = 10%), "title" is over (1/2 = 50%)
+        let tracker = tracker_with(&[("body", 10, 1), ("title", 2, 1)]);
+
+        // when / then - any field over threshold triggers
+        assert!(tracker.should_force_full_compaction(0.20));
+    }
+
+    #[test]
+    fn should_not_force_on_uninitialized_tracker() {
+        // given - no fields polled yet
+        let tracker = FtsDeleteTracker::new();
+
+        // when / then
+        assert!(!tracker.should_force_full_compaction(0.20));
+        assert!(!tracker.should_force_full_compaction(0.0));
+    }
+
+    #[test]
+    fn field_over_threshold_correctly_tracks_delete_pct() {
+        // deletes > pct * count, where count = total docs (deletes is a subset)
+        assert!(field_over_threshold(10, 3, 0.20)); // 3 > 0.2*10
+        assert!(!field_over_threshold(10, 1, 0.20)); // 1 !> 0.2*10
+        assert!(!field_over_threshold(100, 0, 0.0)); // no deletes -> never
+        // boundary: deletes == pct*count is NOT over (strict >)
+        assert!(!field_over_threshold(10, 2, 0.20)); // 2 !> 0.2*10
+    }
+
+    /// An over-threshold per-field snapshot (3 of 10 docs deleted = 30% > 20%),
+    /// used to prove an update *would* trigger a compaction if it were applied —
+    /// so a test that still sees `should_force == false` proves it was dropped.
+    fn over_threshold() -> HashMap<String, (i64, i64)> {
+        HashMap::from([("body".to_string(), (10, 3))])
+    }
+
+    #[test]
+    fn should_ignore_stats_received_while_initializing() {
+        // given - a fresh tracker that has not yet observed a baseline compaction
+        let tracker = FtsDeleteTracker::new();
+
+        // when - a poll delivers over-threshold stats before initialization
+        tracker.update_stats(10, over_threshold());
+
+        // then - the update is dropped; pre-baseline stats are never acted on
+        assert!(!tracker.should_force_full_compaction(0.20));
+        assert!(matches!(
+            *tracker.state.lock().unwrap(),
+            FtsDeleteTrackerState::Initializing
+        ));
+    }
+
+    #[test]
+    fn should_ignore_stats_received_during_compaction() {
+        // given - a tracker that has observed an in-flight FTS cleanup compaction
+        let tracker = FtsDeleteTracker::new();
+        tracker.notify_compacting(5, true);
+
+        // when - a poll delivers over-threshold stats mid-compaction
+        tracker.update_stats(10, over_threshold());
+
+        // then - dropped: the running compaction is about to invalidate these
+        // stats, so the scheduler must not act on them
+        assert!(!tracker.should_force_full_compaction(0.20));
+        assert!(matches!(
+            *tracker.state.lock().unwrap(),
+            FtsDeleteTrackerState::CompactionInProgress
+        ));
+    }
+
+    #[test]
+    fn should_reject_stats_polled_before_the_compaction_manifest() {
+        // given - a tracker that observed a cleanup compaction land at manifest 5
+        let tracker = FtsDeleteTracker::new();
+        *tracker.state.lock().unwrap() = FtsDeleteTrackerState::Compacted { manifest_id: 5 };
+
+        // when - a poll whose snapshot predates that manifest (id 4) arrives. Its
+        // stats still reflect the pre-compaction (un-cleaned) state.
+        tracker.update_stats(4, over_threshold());
+
+        // then - rejected as stale; the tracker stays Compacted and does not act
+        assert!(!tracker.should_force_full_compaction(0.20));
+        assert!(matches!(
+            *tracker.state.lock().unwrap(),
+            FtsDeleteTrackerState::Compacted { manifest_id: 5 }
+        ));
+    }
+
+    #[test]
+    fn should_accept_stats_polled_at_or_after_the_compaction_manifest() {
+        // given - a tracker that observed a cleanup compaction land at manifest 5
+        let tracker = FtsDeleteTracker::new();
+        *tracker.state.lock().unwrap() = FtsDeleteTrackerState::Compacted { manifest_id: 5 };
+
+        // when - a poll exactly at the compaction manifest (boundary: >=) arrives
+        tracker.update_stats(5, over_threshold());
+
+        // then - accepted: these stats reflect the post-compaction manifest
+        assert!(tracker.should_force_full_compaction(0.20));
+        assert!(matches!(
+            *tracker.state.lock().unwrap(),
+            FtsDeleteTrackerState::Accumulating(_)
+        ));
+    }
+
+    #[test]
+    fn should_stop_using_stats_once_a_compaction_starts() {
+        // given - a tracker accumulating over-threshold stats (would force now)
+        let tracker = tracker_with(&[("body", 10, 3)]);
+        assert!(tracker.should_force_full_compaction(0.20));
+
+        // when - the forced cleanup compaction begins
+        tracker.notify_compacting(10, true);
+
+        // then - the accumulated stats are stale (the compaction is rewriting the
+        // segment), so they are no longer used...
+        assert!(!tracker.should_force_full_compaction(0.20));
+        // ...and mid-compaction polls are ignored too
+        tracker.update_stats(99, over_threshold());
+        assert!(!tracker.should_force_full_compaction(0.20));
+    }
+
+    #[test]
+    fn should_apply_fresh_stats_while_accumulating() {
+        // given - an accumulating tracker currently below threshold
+        let tracker = tracker_with(&[("body", 10, 1)]);
+        assert!(!tracker.should_force_full_compaction(0.20));
+
+        // when - a newer poll shows deletes climbing over threshold
+        tracker.update_stats(2, over_threshold());
+
+        // then - fresh stats are applied immediately (no manifest gate while
+        // accumulating)
+        assert!(tracker.should_force_full_compaction(0.20));
+    }
+
+    #[test]
+    fn supplier_should_use_fts_segment_prefix() {
+        // given / when
+        let supplier = VectorCompactionSchedulerSupplier::new(FtsDeleteTracker::shared(), 0.20);
+
+        // then - the named segment matches the extractor's FTS routing prefix
+        assert_eq!(
+            supplier.fts_segment_prefix,
+            segment_routing_prefix(Segment::Fts)
+        );
+    }
+}

--- a/vector/src/storage/mod.rs
+++ b/vector/src/storage/mod.rs
@@ -1,14 +1,20 @@
 use async_trait::async_trait;
-use common::{BytesRange, StorageRead};
+use common::storage::slate::SlateDbStorage;
+use common::{
+    BytesRange, StorageBuilder, StorageRead, StorageSemantics, new_slatedb_compactor_builder,
+};
+use std::sync::Arc;
 
 use crate::error::{Error, Result};
+use crate::model::Config;
 use crate::serde::centroid_info::CentroidInfoValue;
 use crate::serde::centroid_stats::CentroidStatsValue;
 use crate::serde::centroids::CentroidsValue;
 use crate::serde::deletions::DeletionsValue;
+use crate::serde::field_stats::FieldStatsValue;
 use crate::serde::id_dictionary::IdDictionaryValue;
 use crate::serde::key::{
-    CentroidInfoKey, CentroidStatsKey, CentroidsKey, DeletionsKey, IdDictionaryKey,
+    CentroidInfoKey, CentroidStatsKey, CentroidsKey, DeletionsKey, FieldStatsKey, IdDictionaryKey,
     MetadataIndexKey, PostingListKey, VectorDataKey, VectorIndexDataKey,
 };
 use crate::serde::metadata_index::MetadataIndexValue;
@@ -20,6 +26,8 @@ use crate::serde::vector_index_data::VectorIndexDataValue;
 use bytes::{BufMut, BytesMut};
 use std::ops::Bound::Included;
 
+pub(crate) mod compaction_filter;
+pub(crate) mod compaction_scheduler;
 pub(crate) mod merge_operator;
 pub(crate) mod record;
 pub(crate) mod segment_extractor;
@@ -267,10 +275,96 @@ pub(crate) trait VectorDbStorageReadExt: StorageRead {
             None => Ok(VectorBitmap::new()),
         }
     }
+
+    /// Scan all per-field [`FieldStatsValue`] records, returning
+    /// `(field name, stats)` pairs. Used by the FieldStats poller to feed the
+    /// custom compaction scheduler's in-memory per-field tracker (RFC-0006).
+    async fn scan_field_stats(&self) -> Result<Vec<(String, FieldStatsValue)>> {
+        let mut prefix_buf = bytes::BytesMut::with_capacity(crate::serde::PREFIX_AND_TAG_LEN);
+        crate::serde::RecordType::FtsFieldStats.write_prefix(&mut prefix_buf);
+        let prefix = prefix_buf.freeze();
+
+        let range = common::BytesRange::prefix(prefix);
+        let records = self.scan(range).await?;
+
+        let mut stats = Vec::with_capacity(records.len());
+        for record in records {
+            let key = FieldStatsKey::decode(&record.key)?;
+            let value = FieldStatsValue::decode_from_bytes(&record.value)
+                .map_err(|e| Error::Encoding(format!("failed to decode FieldStatsValue: {e}")))?;
+            stats.push((key.field, value));
+        }
+        Ok(stats)
+    }
 }
 
 // Implement the trait for all types that implement StorageRead
 impl<T: ?Sized + StorageRead> VectorDbStorageReadExt for T {}
+
+/// Builds the storage backing a vector database, installing the shared vector
+/// wiring used by both [`VectorDb`](crate::VectorDb) and
+/// [`VectorDbAdmin`](crate::VectorDbAdmin):
+///
+/// - the per-segment routing extractor (Default/ANN/FTS each get their own
+///   SlateDB segment so the FTS segment can be compacted independently);
+/// - the merge operator (on both the `DbBuilder` write path and the compactor);
+/// - for SlateDB with compaction enabled, a compactor carrying the FTS
+///   delete-cleanup filter and — when `fts_delete_tracker` is `Some` — the
+///   custom scheduler that forces a major FTS compaction once outstanding
+///   deletes cross `config.delete_compaction_threshold` (RFC-0006).
+///
+/// Pass `Some(tracker)` for the writer, whose flusher refreshes the tracker
+/// after each flush; pass `None` for clients with no flusher (e.g.
+/// `VectorDbAdmin`), which then keep SlateDB's default size-tiered scheduler —
+/// the filter still runs on whatever compactions size-tiered schedules.
+///
+/// All compaction wiring is a no-op for the in-memory backend and when
+/// compaction is disabled.
+pub(crate) async fn build_vector_storage(
+    config: &Config,
+    builder: StorageBuilder,
+    fts_delete_tracker: Option<Arc<compaction_scheduler::FtsDeleteTracker>>,
+) -> Result<Arc<dyn common::Storage>> {
+    let merge_op: Arc<merge_operator::VectorDbMergeOperator> = Arc::new(
+        merge_operator::VectorDbMergeOperator::new(config.dimensions as usize),
+    );
+    // Route each vector segment into its own SlateDB segment.
+    let builder = segment_extractor::builder_with_vector_segments(builder);
+    // Build the FTS-aware compactor and install it via the `map_slatedb` escape
+    // hatch. `new_slatedb_compactor_builder` returns `None` for the in-memory
+    // backend and when compaction is disabled, leaving the builder untouched.
+    let builder = match new_slatedb_compactor_builder(&config.storage)
+        .map_err(|e| Error::Storage(format!("Failed to create compactor: {e}")))?
+    {
+        Some(compactor_builder) => {
+            let mut compactor_builder = compactor_builder.with_compaction_filter_supplier(
+                compaction_filter::VectorCompactionFilterSupplier::shared(),
+            );
+            if let Some(tracker) = fts_delete_tracker {
+                compactor_builder = compactor_builder.with_scheduler_supplier(
+                    compaction_scheduler::VectorCompactionSchedulerSupplier::shared(
+                        tracker,
+                        config.delete_compaction_threshold,
+                    ),
+                );
+            }
+            // The merge operator lets the compactor apply vector merges. (SlateDB
+            // also propagates the DbBuilder's merge operator onto the compactor,
+            // so this is belt-and-suspenders, but keeps the compactor builder
+            // self-contained.)
+            let compactor_builder = compactor_builder.with_merge_operator(Arc::new(
+                SlateDbStorage::merge_operator_adapter(merge_op.clone()),
+            ));
+            builder.map_slatedb(move |db| db.with_compactor_builder(compactor_builder))
+        }
+        None => builder,
+    };
+    builder
+        .with_semantics(StorageSemantics::new().with_merge_operator(merge_op))
+        .build()
+        .await
+        .map_err(|e| Error::Storage(format!("Failed to create storage: {e}")))
+}
 
 #[cfg(test)]
 mod tests {
@@ -283,7 +377,6 @@ mod tests {
     use crate::write::indexer::tree::posting_list::PostingList;
     use common::Storage;
     use common::storage::in_memory::InMemoryStorage;
-    use std::sync::Arc;
 
     #[tokio::test]
     async fn should_read_and_write_vector_data() {
@@ -358,6 +451,7 @@ mod tests {
                 "indexed_color",
                 "blue",
             )],
+            vec!["body".to_string()],
         );
 
         // when

--- a/vector/src/storage/segment_extractor.rs
+++ b/vector/src/storage/segment_extractor.rs
@@ -22,10 +22,11 @@
 
 use std::sync::Arc;
 
+use bytes::{BufMut, Bytes, BytesMut};
 use common::StorageBuilder;
 use slatedb::{PrefixExtractor, PrefixTarget};
 
-use crate::serde::{KEY_VERSION, SUBSYSTEM};
+use crate::serde::{KEY_VERSION, SUBSYSTEM, Segment};
 
 /// Routing prefix length: `[subsystem(1), segment(1), version(1)]`.
 ///
@@ -33,6 +34,22 @@ use crate::serde::{KEY_VERSION, SUBSYSTEM};
 /// extracted prefix so all record types within a segment share one routing
 /// prefix and land in the same SlateDB segment.
 pub(crate) const ROUTING_PREFIX_LEN: usize = 3;
+
+/// Builds the 3-byte routing prefix `[subsystem, segment, version]` that this
+/// extractor returns for every key in `segment`.
+///
+/// This is the single source of truth for a segment's routing prefix: both the
+/// extractor (which routes records into SlateDB segments) and the compaction
+/// policy (which names a segment for a full compaction via
+/// `CompactionRequest::FullSegment`) derive their prefixes from here so the two
+/// can't drift.
+pub(crate) fn segment_routing_prefix(segment: Segment) -> Bytes {
+    let mut buf = BytesMut::with_capacity(ROUTING_PREFIX_LEN);
+    buf.put_u8(SUBSYSTEM);
+    buf.put_u8(segment.as_byte());
+    buf.put_u8(KEY_VERSION);
+    buf.freeze()
+}
 
 /// Stable, persisted identifier for this extractor's routing rules. Bump
 /// whenever the routing logic changes in a way that would re-route existing
@@ -236,6 +253,25 @@ mod tests {
         let extractor = VectorSegmentExtractor;
         let bad = [SUBSYSTEM, 0x00, 0xFF, 0x10];
         let _ = extractor.prefix_len(&point(&bad));
+    }
+
+    #[test]
+    fn should_build_routing_prefix_matching_extracted_bytes() {
+        // given - an FTS-segment key and the standalone prefix helper
+        let extractor = VectorSegmentExtractor;
+        let fts_key = DeletionsKey::new().encode();
+
+        // when
+        let n = extractor.prefix_len(&point(&fts_key)).unwrap();
+        let helper_prefix = segment_routing_prefix(crate::serde::Segment::Fts);
+
+        // then - the helper produces exactly the bytes the extractor extracts,
+        // so the compaction policy and the extractor can never disagree on which
+        // SlateDB segment the FTS records live in.
+        assert_eq!(n, ROUTING_PREFIX_LEN);
+        assert_eq!(helper_prefix.len(), ROUTING_PREFIX_LEN);
+        assert_eq!(helper_prefix.as_ref(), &fts_key[..n]);
+        assert_eq!(helper_prefix[1], crate::serde::Segment::Fts.as_byte());
     }
 
     #[test]

--- a/vector/src/write/flusher.rs
+++ b/vector/src/write/flusher.rs
@@ -114,7 +114,11 @@ impl VectorDbFlusher {
 
         let snapshot = self.storage.snapshot().await.map_err(|e| e.to_string())?;
         self.validate(snapshot.clone()).await;
+        // Reload the in-memory deletions bitmap for the BM25 query path. The
+        // compaction scheduler's delete-pressure counters are maintained
+        // separately by the corpus-stats poller, not here (RFC-0006).
         let fts_deletions = Arc::new(snapshot.get_deletions().await.map_err(|e| e.to_string())?);
+
         let stored_reader = StoredCentroidReader::new(
             self.opts.dimensions as usize,
             snapshot.clone(),

--- a/vector/src/write/indexer/tree/split.rs
+++ b/vector/src/write/indexer/tree/split.rs
@@ -387,6 +387,7 @@ impl SplitCentroids {
                             p.id(),
                             vec![c_id],
                             index_data.indexed_fields.clone(),
+                            index_data.fts_fields.clone(),
                         );
                     } else {
                         // if this is a non-leaf level, then the posting vectors are centroids,

--- a/vector/src/write/indexer/tree/state.rs
+++ b/vector/src/write/indexer/tree/state.rs
@@ -8,8 +8,8 @@ use crate::serde::collection_meta::DistanceMetric;
 use crate::serde::deletions::DeletionsValue;
 use crate::serde::field_stats::FieldStatsValue;
 use crate::serde::key::{
-    CentroidInfoKey, CentroidStatsKey, CentroidsKey, DeletionsKey, FieldStatsKey, PostingListKey,
-    TermPostingsKey, TermStatsKey, VectorDataKey,
+    CentroidInfoKey, CentroidStatsKey, CentroidsKey, DeletionsKey, DeletionsSentinelKey,
+    FieldStatsKey, PostingListKey, TermPostingsKey, TermStatsKey, VectorDataKey,
 };
 use crate::serde::metadata_index::MetadataIndexValue;
 use crate::serde::posting_list::{PostingListValue, PostingUpdate};
@@ -159,11 +159,12 @@ impl ForwardIndexDelta {
         vector_id: VectorId,
         postings: Vec<VectorId>,
         indexed_fields: Vec<Field>,
+        fts_fields: Vec<String>,
     ) {
         assert!(vector_id.is_data_vector());
         self.vector_index_updates.insert(
             vector_id,
-            VectorIndexDataValue::new(postings, indexed_fields),
+            VectorIndexDataValue::new(postings, indexed_fields, fts_fields),
         );
     }
 
@@ -610,8 +611,12 @@ pub(crate) struct FtsIndexDelta {
     term_postings: HashMap<(String, String), Vec<PostingEntry>>,
     /// (field, term) -> signed delta to the term's document frequency.
     term_doc_freq_delta: HashMap<(String, String), i64>,
-    /// field -> (doc-count delta, total-length delta).
-    field_stats_delta: HashMap<String, (i64, i64)>,
+    /// field -> signed `(count, total_length, deletes)` corpus-stat delta. The
+    /// indexer only increments: inserts add `count +1` / `total_length +len`,
+    /// deletes (and the old side of an upsert) add `deletes +1`. The compaction
+    /// filter decrements all three when it applies the delete at the last sorted
+    /// run (RFC-0006).
+    field_stats_delta: HashMap<String, (i64, i64, i64)>,
     /// Internal vector ids deleted or replaced in this batch. On freeze these
     /// are merged into the singleton `Deletions` bitmap so the BM25 query path
     /// can hide them without retracting postings/term-stats.
@@ -665,8 +670,8 @@ impl FtsIndexDelta {
                 *self.term_doc_freq_delta.entry(key).or_default() += 1;
             }
             let entry = self.field_stats_delta.entry(field.clone()).or_default();
-            entry.0 += 1;
-            entry.1 += summary.length as i64;
+            entry.0 += 1; // count
+            entry.1 += summary.length as i64; // total_length
         }
     }
 
@@ -674,6 +679,22 @@ impl FtsIndexDelta {
     /// accumulated set is merged into the singleton `Deletions` bitmap.
     pub(crate) fn add_deleted_vector_id(&mut self, vector_id: VectorId) {
         self.deleted_vector_ids.insert(vector_id.id());
+    }
+
+    /// Record a `deletes +1` per-field `FieldStats` delta for a deleted (or
+    /// replaced) vector, given the set of FTS fields it populated (read from its
+    /// [`VectorIndexData`](crate::serde::vector_index_data::VectorIndexDataValue)).
+    ///
+    /// The indexer only ever *increments* `FieldStats` (count/total_length on
+    /// insert, deletes on delete); the compaction filter decrements all three
+    /// when it applies the delete at the last sorted run. So `count` here is
+    /// untouched — it tracks total documents written to the field and is
+    /// retired by the filter once the delete is compacted away (RFC-0006).
+    pub(crate) fn record_field_deletes(&mut self, fts_fields: &[String]) {
+        for field in fts_fields {
+            let entry = self.field_stats_delta.entry(field.clone()).or_default();
+            entry.2 += 1; // deletes
+        }
     }
 
     fn freeze(self, output_ops: &mut Vec<RecordOp>) {
@@ -692,6 +713,20 @@ impl FtsIndexDelta {
             has_text_fields: _,
         } = self;
 
+        // Always emit the deletions sentinel (a tiny dummy Put), even with no
+        // deletes. It sorts before every other FTS key, so a last-run compaction
+        // always observes it first — co-located with the data being compacted —
+        // anchoring the filter's phase machine and proving the compaction was not
+        // resumed mid-stream. The deletions bitmap itself stays conditional below,
+        // keeping ingest cheap (RFC-0006).
+        output_ops.push(RecordOp::Put(
+            Record::new(
+                DeletionsSentinelKey::new().encode(),
+                Bytes::from_static(&[0u8]),
+            )
+            .into(),
+        ));
+
         for ((field, term), entries) in term_postings {
             let value = TermPostingsValue::from_postings(entries);
             let key = TermPostingsKey::new(&field, &term).encode();
@@ -709,12 +744,12 @@ impl FtsIndexDelta {
             output_ops.push(RecordOp::Merge(Record::new(key, value).into()));
         }
 
-        for (field, (count_delta, total_delta)) in field_stats_delta {
-            if count_delta == 0 && total_delta == 0 {
+        for (field, (count, total_length, deletes)) in field_stats_delta {
+            if count == 0 && total_length == 0 && deletes == 0 {
                 continue;
             }
             let key = FieldStatsKey::new(&field).encode();
-            let value = FieldStatsValue::new(count_delta, total_delta, 0).encode_to_bytes();
+            let value = FieldStatsValue::new(count, total_length, deletes).encode_to_bytes();
             output_ops.push(RecordOp::Merge(Record::new(key, value).into()));
         }
 
@@ -1014,18 +1049,63 @@ mod tests {
         assert!(ops.is_empty());
     }
 
+    /// Returns the value of the first `Merge` op whose key matches, if any.
+    fn find_merge(ops: &[RecordOp], key: &[u8]) -> Option<Bytes> {
+        ops.iter().find_map(|op| match op {
+            RecordOp::Merge(m) if m.record.key.as_ref() == key => Some(m.record.value.clone()),
+            _ => None,
+        })
+    }
+
     #[test]
-    fn should_emit_deletions_when_collection_has_text_fields() {
-        // given - the same delete, but the collection declares text fields
+    fn should_emit_field_stats_on_insert() {
+        // given - one text doc indexed into field "body" (length 3)
         let mut delta = FtsIndexDelta::new(true);
-        delta.add_deleted_vector_id(VectorId::data_vector_id(7));
+        let mut summaries = HashMap::new();
+        summaries.insert(
+            "body".to_string(),
+            TextAttributeSummary {
+                terms: std::collections::BTreeMap::from([("fox".to_string(), 1usize)]),
+                length: 3,
+            },
+        );
+        delta.add_text_summaries(VectorId::data_vector_id(1), &summaries);
 
         // when
         let mut ops = Vec::new();
         delta.freeze(&mut ops);
 
-        // then - the deletions bitmap merge is emitted
-        assert_eq!(ops.len(), 1);
+        // then - FieldStats for "body": count +1, total_length +3, deletes 0
+        let body = find_merge(&ops, &FieldStatsKey::new("body").encode()).unwrap();
+        assert_eq!(
+            FieldStatsValue::decode_from_bytes(&body).unwrap(),
+            FieldStatsValue::new(1, 3, 0)
+        );
+    }
+
+    #[test]
+    fn should_emit_deletions_and_field_delete_deltas() {
+        // given - a deleted vector that populated fields "body" and "title"
+        let mut delta = FtsIndexDelta::new(true);
+        delta.add_deleted_vector_id(VectorId::data_vector_id(7));
+        delta.record_field_deletes(&["body".to_string(), "title".to_string()]);
+
+        // when
+        let mut ops = Vec::new();
+        delta.freeze(&mut ops);
+
+        // then - the deletions bitmap is emitted
+        assert!(find_merge(&ops, &DeletionsKey::new().encode()).is_some());
+        // and each field's FieldStats gains a pending delete; `count` is left to
+        // the compaction filter to retire when the delete is applied.
+        for field in ["body", "title"] {
+            let fs = find_merge(&ops, &FieldStatsKey::new(field).encode()).unwrap();
+            assert_eq!(
+                FieldStatsValue::decode_from_bytes(&fs).unwrap(),
+                FieldStatsValue::new(0, 0, 1),
+                "field {field}"
+            );
+        }
     }
 
     async fn setup() -> (Arc<dyn Storage>, VectorIndexState) {
@@ -1128,7 +1208,7 @@ mod tests {
     }
 
     fn make_index_value(postings: Vec<VectorId>) -> VectorIndexDataValue {
-        VectorIndexDataValue::new(postings, make_indexed_fields())
+        VectorIndexDataValue::new(postings, make_indexed_fields(), Vec::new())
     }
 
     fn make_indexed_fields() -> Vec<Field> {
@@ -1242,7 +1322,12 @@ mod tests {
 
         // when:
         let id = delta.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        delta.update_vector_index_data(id, vec![leaf_centroid(1)], make_indexed_fields());
+        delta.update_vector_index_data(
+            id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         delta.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -1265,7 +1350,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut delta = ForwardIndexDelta::new(&state);
         let id = delta.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        delta.update_vector_index_data(id, vec![leaf_centroid(1)], make_indexed_fields());
+        delta.update_vector_index_data(
+            id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         delta.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -1288,7 +1378,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut delta = ForwardIndexDelta::new(&state);
         let id = delta.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        delta.update_vector_index_data(id, vec![leaf_centroid(1)], make_indexed_fields());
+        delta.update_vector_index_data(
+            id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         delta.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -1314,7 +1409,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut delta = ForwardIndexDelta::new(&state);
         let old_id = delta.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        delta.update_vector_index_data(old_id, vec![leaf_centroid(1)], make_indexed_fields());
+        delta.update_vector_index_data(
+            old_id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         delta.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -1324,7 +1424,12 @@ mod tests {
         let mut delta = ForwardIndexDelta::new(&state);
         delta.delete_external_id_and_vector("v1".to_string(), old_id);
         let new_id = delta.add_vector("v1", &make_attributes(vec![3.0, 4.0]));
-        delta.update_vector_index_data(new_id, vec![leaf_centroid(1)], make_indexed_fields());
+        delta.update_vector_index_data(
+            new_id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         delta.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -1359,7 +1464,12 @@ mod tests {
         // when
         let mut delta = ForwardIndexDelta::new(&state);
         let id = delta.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        delta.update_vector_index_data(id, vec![leaf_centroid(1)], make_indexed_fields());
+        delta.update_vector_index_data(
+            id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         delta.delete_external_id_and_vector("v1".to_string(), id);
         let mut ops = vec![];
         delta.freeze(&mut state, &mut ops);
@@ -1943,7 +2053,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut seed = ForwardIndexDelta::new(&state);
         let stored_id = seed.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        seed.update_vector_index_data(stored_id, vec![leaf_centroid(1)], make_indexed_fields());
+        seed.update_vector_index_data(
+            stored_id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -1968,7 +2083,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut seed = ForwardIndexDelta::new(&state);
         let stored_id = seed.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        seed.update_vector_index_data(stored_id, vec![leaf_centroid(1)], make_indexed_fields());
+        seed.update_vector_index_data(
+            stored_id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -1986,7 +2106,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut seed = ForwardIndexDelta::new(&state);
         let vector_id = seed.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        seed.update_vector_index_data(vector_id, vec![leaf_centroid(1)], make_indexed_fields());
+        seed.update_vector_index_data(
+            vector_id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -2005,7 +2130,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut seed = ForwardIndexDelta::new(&state);
         let vector_id = seed.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        seed.update_vector_index_data(vector_id, vec![leaf_centroid(1)], make_indexed_fields());
+        seed.update_vector_index_data(
+            vector_id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -2030,7 +2160,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut seed = ForwardIndexDelta::new(&state);
         let vector_id = seed.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        seed.update_vector_index_data(vector_id, vec![leaf_centroid(1)], make_indexed_fields());
+        seed.update_vector_index_data(
+            vector_id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -2051,7 +2186,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut seed = ForwardIndexDelta::new(&state);
         let vector_id = seed.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        seed.update_vector_index_data(vector_id, vec![leaf_centroid(1)], make_indexed_fields());
+        seed.update_vector_index_data(
+            vector_id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -2070,7 +2210,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut seed = ForwardIndexDelta::new(&state);
         let vector_id = seed.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        seed.update_vector_index_data(vector_id, vec![leaf_centroid(1)], make_indexed_fields());
+        seed.update_vector_index_data(
+            vector_id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();
@@ -2079,6 +2224,7 @@ mod tests {
             vector_id,
             vec![leaf_centroid(2), leaf_centroid(3)],
             make_indexed_fields(),
+            Vec::new(),
         );
         let snapshot: Arc<dyn StorageRead> = storage.snapshot().await.unwrap();
         let view = vector_index_view(&delta, &state, &snapshot);
@@ -2096,7 +2242,12 @@ mod tests {
         let (storage, mut state) = setup().await;
         let mut seed = ForwardIndexDelta::new(&state);
         let vector_id = seed.add_vector("v1", &make_attributes(vec![1.0, 2.0]));
-        seed.update_vector_index_data(vector_id, vec![leaf_centroid(1)], make_indexed_fields());
+        seed.update_vector_index_data(
+            vector_id,
+            vec![leaf_centroid(1)],
+            make_indexed_fields(),
+            Vec::new(),
+        );
         let mut ops = vec![];
         seed.freeze(&mut state, &mut ops);
         storage.apply(ops).await.unwrap();

--- a/vector/src/write/indexer/tree/test_utils.rs
+++ b/vector/src/write/indexer/tree/test_utils.rs
@@ -204,6 +204,7 @@ impl IndexerOpTestHarnessBuilder {
                                     Field::string(field_spec.name.clone(), field_value.clone())
                                 })
                                 .collect(),
+                            Vec::new(),
                         );
                         delta.search_index.add_to_posting(
                             *centroid_id,

--- a/vector/src/write/indexer/tree/vector.rs
+++ b/vector/src/write/indexer/tree/vector.rs
@@ -168,6 +168,7 @@ impl WriteVectors {
                 vector_id,
                 vec![centroid],
                 Self::collect_indexed_fields(&self.opts, &insert.attributes),
+                insert.text_attribute_summaries.keys().cloned().collect(),
             );
             for (attr_name, attr_value) in &insert.attributes {
                 if attr_name == VECTOR_FIELD_NAME {
@@ -199,8 +200,13 @@ impl WriteVectors {
                 })?;
             delta.forward_index.delete_vector(old_vector_id);
             // RFC-0006: hide the replaced internal id on the FTS query path via
-            // the Deletions bitmap (postings/term-stats are left in place).
+            // the Deletions bitmap (postings/term-stats are left in place), and
+            // apply the per-field FieldStats delete deltas for the fields the
+            // replaced vector populated.
             delta.fts_index.add_deleted_vector_id(old_vector_id);
+            delta
+                .fts_index
+                .record_field_deletes(&old_vector_index_data.fts_fields);
             for old_centroid in old_vector_index_data.postings {
                 delta
                     .search_index
@@ -223,6 +229,7 @@ impl WriteVectors {
                 vector_id,
                 vec![centroid],
                 Self::collect_indexed_fields(&self.opts, &write.attributes),
+                write.text_attribute_summaries.keys().cloned().collect(),
             );
             for (attr_name, attr_value) in &write.attributes {
                 if attr_name == VECTOR_FIELD_NAME {
@@ -251,8 +258,13 @@ impl WriteVectors {
                 .forward_index
                 .delete_external_id_and_vector(external_id, vector_id);
             // RFC-0006: hide the deleted internal id on the FTS query path via
-            // the Deletions bitmap (postings/term-stats are left in place).
+            // the Deletions bitmap (postings/term-stats are left in place), and
+            // apply the per-field FieldStats delete deltas for the fields the
+            // deleted vector populated.
             delta.fts_index.add_deleted_vector_id(vector_id);
+            delta
+                .fts_index
+                .record_field_deletes(&old_vector_index_data.fts_fields);
             for old_centroid in old_vector_index_data.postings {
                 delta
                     .search_index
@@ -565,6 +577,7 @@ impl ReassignVectors {
                 r.reassignment.vector_id,
                 vec![r.new_centroid],
                 r.index_data.indexed_fields,
+                r.index_data.fts_fields,
             );
         }
         Ok(nreassigned)

--- a/vector/tests/fts_compaction_policy.rs
+++ b/vector/tests/fts_compaction_policy.rs
@@ -87,6 +87,7 @@ fn make_config(dir: &std::path::Path, settings_path: &std::path::Path) -> Config
             }),
             settings_path: Some(settings_path.to_str().unwrap().to_string()),
             block_cache: None,
+            ..Default::default()
         }),
         dimensions: DIMS,
         distance_metric: DistanceMetric::L2,

--- a/vector/tests/fts_compaction_policy.rs
+++ b/vector/tests/fts_compaction_policy.rs
@@ -1,0 +1,266 @@
+//! Integration test for the RFC-0006 Milestone 2 custom compaction *scheduler*.
+//!
+//! Opens a real SlateDB-backed `VectorDb` with a text field and an aggressive
+//! compaction configuration, inserts documents, deletes more than the default
+//! 20% `delete_compaction_threshold`, and drives flushes. It then observes —
+//! via a read-only `slatedb::admin::Admin` polling the *manifest* — that the FTS
+//! segment's compacted sorted runs are rewritten only after the deletes push the
+//! outstanding-delete fraction over the threshold, demonstrating that
+//! [`VectorCompactionPolicy`](vector) forced a major (full) FTS-segment
+//! compaction.
+//!
+//! # Observing through the manifest's per-segment view
+//!
+//! SlateDB's public `VersionedManifest` exposes per-segment LSM state via
+//! [`segments()`](slatedb::manifest::VersionedManifest::segments) and
+//! [`segment(prefix)`](slatedb::manifest::VersionedManifest::segment), so an
+//! external reader can read the FTS segment's compacted sorted runs — and the
+//! SST views backing them — directly.
+//!
+//! A full-segment compaction merges every sorted run into the segment's
+//! *lowest-id* run, so it does not necessarily change the run count or its id
+//! (a segment already holding a single run is recompacted in place under the
+//! same id). What it always does is rewrite that run's postings — pruning the
+//! deleted ids — into entirely new SSTs. The test therefore keys off the SST
+//! view ids: once none of the baseline SSTs survive in the segment's sorted
+//! runs, the compacted FTS data has been rewritten. Since no documents are
+//! written after the baseline is taken, that rewrite can only be the cleanup
+//! compaction reacting to the deletes.
+//!
+//! The forced compaction is a *background* event with no synchronous trigger or
+//! completion signal (the notify/reset protocol is a known RFC-0006 TODO), so
+//! the test is tolerant of background timing by polling the manifest with a
+//! bounded budget.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use common::storage::config::{LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig};
+use common::{StorageConfig, create_object_store};
+use slatedb::admin::Admin;
+use vector::{
+    AttributeValue, Config, DistanceMetric, FieldType, MetadataFieldSpec, Query, Vector, VectorDb,
+    VectorDbRead,
+};
+
+const DIMS: u16 = 3;
+const DB_PATH: &str = "data";
+
+/// The 3-byte FTS routing prefix `[SUBSYSTEM, Segment::Fts, KEY_VERSION]` the
+/// segment extractor and compaction policy use, and the prefix under which the
+/// FTS segment is keyed in the manifest's `segments` list. `vector`'s `serde`
+/// constants are crate-internal, so the FTS segment byte (`0x02`) and key
+/// version (`0x01`) are documented inline; the subsystem byte comes from the
+/// shared `common` registry. If any of those change this test will (correctly)
+/// stop matching and must be updated alongside the routing logic.
+fn fts_segment_prefix() -> Vec<u8> {
+    vec![common::serde::subsystem::VECTOR, 0x02, 0x01]
+}
+
+fn slatedb_settings_toml() -> String {
+    // Aggressive compaction tuning so a handful of flushes produce several FTS
+    // sorted runs and the compactor reacts quickly:
+    // - tiny L0 SSTs so each flush lands an SST,
+    // - frequent manifest/compactor polling,
+    // - `min_compaction_sources = 2` so size-tiered builds SRs from L0 fast.
+    r#"
+manifest_poll_interval = "100ms"
+l0_sst_size_bytes = 256
+
+[compactor_options]
+poll_interval = "100ms"
+max_concurrent_compactions = 4
+
+[compactor_options.size_tiered]
+min_compaction_sources = "2"
+max_compaction_sources = "32"
+"#
+    .to_string()
+}
+
+fn make_config(dir: &std::path::Path, settings_path: &std::path::Path) -> Config {
+    Config {
+        storage: StorageConfig::SlateDb(SlateDbStorageConfig {
+            path: DB_PATH.to_string(),
+            object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
+                path: dir.to_str().unwrap().to_string(),
+            }),
+            settings_path: Some(settings_path.to_str().unwrap().to_string()),
+            block_cache: None,
+        }),
+        dimensions: DIMS,
+        distance_metric: DistanceMetric::L2,
+        flush_interval: Duration::from_secs(60),
+        split_threshold_vectors: 10_000,
+        merge_threshold_vectors: 0,
+        split_search_neighbourhood: 0,
+        metadata_fields: vec![MetadataFieldSpec::new("body", FieldType::Text, false)],
+        // default delete_compaction_threshold = 0.20
+        // Poll the field stats aggressively so the scheduler's in-memory tracker
+        // reflects the deletes quickly within the test's polling budget.
+        fts_stats_poll_interval: Duration::from_millis(200),
+        ..Default::default()
+    }
+}
+
+fn doc(id: &str) -> Vector {
+    // Use a shared term so every doc lands in the same posting list, giving the
+    // FTS segment real content to compact.
+    Vector::builder(id, vec![0.0; DIMS as usize])
+        .attribute(
+            "body",
+            AttributeValue::String("the quick brown fox jumps".to_string()),
+        )
+        .build()
+}
+
+/// Snapshot of the FTS segment's compacted sorted runs as seen in the latest
+/// manifest: each entry is `(sorted_run_id, sst_view_ids)`, in manifest order.
+/// Empty if the manifest or the FTS segment isn't present yet, or while all FTS
+/// data still sits in L0 before the first compaction has produced a sorted run.
+async fn fts_compacted_runs(admin: &Admin, fts_prefix: &[u8]) -> Vec<(u32, Vec<String>)> {
+    match admin.read_manifest(None).await {
+        Ok(Some(manifest)) => manifest
+            .segment(fts_prefix)
+            .map(|segment| {
+                segment
+                    .compacted()
+                    .iter()
+                    .map(|run| {
+                        let ssts = run.sst_views.iter().map(|v| v.id.to_string()).collect();
+                        (run.id, ssts)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+/// The flat set of SST view ids backing the FTS segment's sorted runs.
+fn sst_view_ids(runs: &[(u32, Vec<String>)]) -> std::collections::HashSet<String> {
+    runs.iter()
+        .flat_map(|(_, ssts)| ssts.iter().cloned())
+        .collect()
+}
+
+/// Polls the FTS segment's compacted sorted runs until `predicate` holds or the
+/// budget expires. Returns the final observed snapshot.
+async fn poll_fts_compacted_runs(
+    admin: &Admin,
+    fts_prefix: &[u8],
+    budget: Duration,
+    predicate: impl Fn(&[(u32, Vec<String>)]) -> bool,
+) -> Vec<(u32, Vec<String>)> {
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        let runs = fts_compacted_runs(admin, fts_prefix).await;
+        if predicate(&runs) || std::time::Instant::now() >= deadline {
+            return runs;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn should_force_full_fts_compaction_when_deletes_exceed_threshold() {
+    // given - a real SlateDB-backed db with aggressive compaction settings and a
+    // text field.
+    let tmp = tempfile::tempdir().unwrap();
+    let settings_path = tmp.path().join("slatedb.toml");
+    std::fs::write(&settings_path, slatedb_settings_toml()).unwrap();
+    let config = make_config(tmp.path(), &settings_path);
+
+    let object_store = create_object_store(match &config.storage {
+        StorageConfig::SlateDb(c) => &c.object_store,
+        _ => unreachable!(),
+    })
+    .unwrap();
+
+    let db = VectorDb::open(config).await.unwrap();
+
+    // A read-only Admin pointed at the same path/object store to observe the
+    // manifest. SlateDB allows read-only manifest reads alongside the open
+    // writer.
+    let admin = Admin::builder(DB_PATH, Arc::clone(&object_store)).build();
+    let fts_prefix = fts_segment_prefix();
+
+    // when - write 50 docs in batches, flushing after each so the FTS segment
+    // accumulates several L0 SSTs (and, via size-tiered, sorted runs).
+    let total = 50usize;
+    for batch_start in (0..total).step_by(10) {
+        let batch: Vec<Vector> = (batch_start..batch_start + 10)
+            .map(|i| doc(&format!("doc-{i}")))
+            .collect();
+        db.write(batch).await.unwrap();
+        db.flush().await.unwrap();
+    }
+
+    // Let size-tiered build at least one FTS sorted run so a full-segment
+    // compaction has something to merge, then baseline the segment's compacted
+    // sorted runs and the SST views backing them. The forced compaction will
+    // rewrite those SSTs.
+    let baseline = poll_fts_compacted_runs(&admin, &fts_prefix, Duration::from_secs(30), |runs| {
+        !runs.is_empty()
+    })
+    .await;
+    let baseline_ssts = sst_view_ids(&baseline);
+
+    // Sanity: queries return matching docs before deletes.
+    let before = db
+        .search(&Query::bm25("body", "fox").with_limit(total))
+        .await
+        .unwrap();
+    assert_eq!(before.len(), total, "all docs should match before deletes");
+
+    // when - delete 30% of the docs (> 20% threshold) and flush so the flusher
+    // refreshes the delete tracker and the scheduler sees the crossing.
+    let to_delete: Vec<String> = (0..15).map(|i| format!("doc-{i}")).collect();
+    db.delete(to_delete.clone()).await.unwrap();
+    db.flush().await.unwrap();
+
+    // then - the forced full FTS-segment compaction merges every sorted run into
+    // the segment's lowest-id run, rewriting its postings (deleted ids pruned) as
+    // entirely new SSTs. Poll the manifest until none of the baseline SST views
+    // survive in the segment's sorted runs — proof the compacted FTS data was
+    // rewritten. Since no documents are written after the baseline, that rewrite
+    // can only be the cleanup compaction VectorCompactionPolicy forced once the
+    // deletes crossed the threshold.
+    let after = poll_fts_compacted_runs(&admin, &fts_prefix, Duration::from_secs(30), |runs| {
+        let current = sst_view_ids(runs);
+        !current.is_empty() && current.is_disjoint(&baseline_ssts)
+    })
+    .await;
+    let after_ssts = sst_view_ids(&after);
+    assert!(
+        !after_ssts.is_empty() && after_ssts.is_disjoint(&baseline_ssts),
+        "expected the forced compaction to rewrite the FTS segment's sorted-run SSTs \
+         (baseline runs {baseline:?}, observed {after:?})"
+    );
+    // The full compaction collapses every sorted run into the lowest-id run.
+    assert_eq!(
+        after.len(),
+        1,
+        "expected the forced full compaction to collapse the FTS segment to a single \
+         sorted run (baseline runs {baseline:?}, observed {after:?})"
+    );
+
+    // and - queries remain correct after the forced compaction: the deleted docs
+    // are gone, the survivors remain.
+    let results = db
+        .search(&Query::bm25("body", "fox").with_limit(total))
+        .await
+        .unwrap();
+    assert_eq!(
+        results.len(),
+        total - to_delete.len(),
+        "survivors should remain queryable after forced compaction"
+    );
+    for r in &results {
+        assert!(
+            !to_delete.contains(&r.vector.id),
+            "deleted doc {} should not appear in results",
+            r.vector.id
+        );
+    }
+}


### PR DESCRIPTION
## Summary

This patch implements the custom compaction policy and filter for
the fts segment:
- Adds the FieldStats entry to the db which tracks stats about each
text field like number of writes and number of deletes
- Adds a DeleteSentinel key/value. This value is written on every flush
and is used by the filter to error out on resumed compactions. The
filter has no way to reconstruct its internal state when a compaction
is resumed, so we just disallow it for now.
- Adds VectorCompactionPolicy, which implements slatedb::CompactionScheduler.
For non-fts segments, the policy defers to the slatedb size-tiered scheduler.
For fts segments, the policy defers to the slatedb size-tiered scheduler most
of the time. The policy spawns a poller that periodically reads FieldStats
from the db and pushes them into FtsDeleteTracker. The policy inspects
FtsDeleteTracker and schedules a major compaction when the deletes cross the
fts deletes threshold. The poller and the policy synchronize using the manifest
version. When the policy detects that there is no fts compaction in-flight, it
update the tracker with the manifest id. The poller pushes stats along with the
db's manifest id. The tracker only updates stats if the associated manifest id
is advanced enough.
- Adds VectorCompationFilter which applies deletes from the deletions bitmap to
the data in the fts segment as per rfc-0006.

## Test Plan

- e2e test that asserts compaction ran

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
