### PR TITLE
[vector]: blockmaxscore for bm25 queries

### DIFF
--- a/vector/bench/fts-1m-s3.toml
+++ b/vector/bench/fts-1m-s3.toml
@@ -1,0 +1,15 @@
+# 1M-document FTS (BM25) benchmark against SlateDB backed by S3.
+#
+#   cargo run -p vector-bench --release -- --config vector/bench/fts-1m-s3.toml --benchmark fts
+
+[data.storage]
+type = "SlateDb"
+path = "fts-bench-m3"
+
+[data.storage.object_store]
+type = "Aws"
+region = "us-west-2"
+bucket = "opendata-vector-bench"
+
+[[params.fts]]
+num_docs = "1000000"

--- a/vector/bench/fts-smoke.toml
+++ b/vector/bench/fts-smoke.toml
@@ -1,0 +1,16 @@
+# Small local smoke test for the FTS (BM25) benchmark.
+#
+#   cargo run -p vector-bench --release -- --config vector/bench/fts-smoke.toml --benchmark fts
+
+[data.storage]
+type = "SlateDb"
+path = "fts-smoke"
+
+[data.storage.object_store]
+type = "Local"
+path = "/tmp/fts-bench-smoke"
+
+[[params.fts]]
+num_docs = "20000"
+vocab_size = "20000"
+num_queries = "100"

--- a/vector/bench/src/fts.rs
+++ b/vector/bench/src/fts.rs
@@ -1,0 +1,284 @@
+//! Full-text-search (BM25) latency benchmark for the vector database.
+//!
+//! Ingests a deterministic synthetic corpus (Zipf-distributed vocabulary,
+//! log-normal-ish document lengths) and measures sequential BM25 query
+//! latency for each configured scorer (`block_max`, `exhaustive`),
+//! cross-checking that the scorers return identical result lists.
+//!
+//! Splits work into two phases — `INGEST` and `WARM` — configured via the
+//! `phases` param. Each phase opens its own fresh `VectorDb` and closes it
+//! before the next phase starts, mirroring the recall benchmark.
+
+mod corpus;
+mod ingest;
+mod warm;
+
+use std::sync::Arc;
+
+use bencher::{Bench, Benchmark, Params, Summary};
+use common::StorageBuilder;
+use common::storage::factory::{DbCache, FoyerCache, FoyerCacheOptions};
+use vector::{Bm25Scorer, Config, DistanceMetric, FieldType, MetadataFieldSpec, VectorDb};
+
+/// Name of the text metadata field that holds each document's body.
+pub(crate) const BODY_FIELD: &str = "body";
+
+const DEFAULT_SEED: u64 = 42;
+const DEFAULT_NUM_DOCS: usize = 100_000;
+const DEFAULT_VOCAB_SIZE: usize = 200_000;
+const DEFAULT_ZIPF_S: f64 = 1.07;
+const DEFAULT_AVG_DOC_LEN: f64 = 100.0;
+const DEFAULT_DIMENSIONS: u16 = 8;
+const DEFAULT_NUM_QUERIES: usize = 200;
+const DEFAULT_LIMIT: usize = 10;
+
+/// Default phase list when the params don't specify otherwise.
+const DEFAULT_PHASES: &[Phase] = &[Phase::Ingest, Phase::Warm];
+
+/// Default scorer list when the params don't specify otherwise.
+const DEFAULT_SCORERS: &[Bm25Scorer] = &[Bm25Scorer::BlockMax, Bm25Scorer::Exhaustive];
+
+// -- Phases -------------------------------------------------------------------
+
+/// A single phase of the FTS benchmark.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Phase {
+    /// Ingest the synthetic corpus into a fresh `VectorDb`.
+    Ingest,
+    /// Run the per-scorer warmup + measured query passes.
+    Warm,
+}
+
+impl Phase {
+    fn as_str(self) -> &'static str {
+        match self {
+            Phase::Ingest => "INGEST",
+            Phase::Warm => "WARM",
+        }
+    }
+
+    fn parse(s: &str) -> Self {
+        match s {
+            "INGEST" => Phase::Ingest,
+            "WARM" => Phase::Warm,
+            _ => panic!("unknown phase: {}", s),
+        }
+    }
+}
+
+fn param_to_phases(s: &str) -> Vec<Phase> {
+    s.split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(Phase::parse)
+        .collect()
+}
+
+// -- Scorers ------------------------------------------------------------------
+
+pub(crate) fn scorer_name(scorer: Bm25Scorer) -> &'static str {
+    match scorer {
+        Bm25Scorer::BlockMax => "block_max",
+        Bm25Scorer::BlockMaxSparse => "block_max_sparse",
+        Bm25Scorer::Exhaustive => "exhaustive",
+    }
+}
+
+fn parse_scorer(s: &str) -> Bm25Scorer {
+    match s {
+        "block_max" => Bm25Scorer::BlockMax,
+        "block_max_sparse" => Bm25Scorer::BlockMaxSparse,
+        "exhaustive" => Bm25Scorer::Exhaustive,
+        _ => panic!("unknown scorer: {}", s),
+    }
+}
+
+fn param_to_scorers(s: &str) -> Vec<Bm25Scorer> {
+    s.split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(parse_scorer)
+        .collect()
+}
+
+// -- Spec ---------------------------------------------------------------------
+
+/// FTS benchmark spec, parsed from `[[params.fts]]`. All values are strings
+/// in the bencher config and fall back to the defaults above when unset.
+#[derive(Clone, Debug)]
+pub(crate) struct FtsSpec {
+    /// Seed for the deterministic corpus and query generators.
+    pub seed: u64,
+    /// Number of synthetic documents to ingest.
+    pub num_docs: usize,
+    /// Vocabulary size (term ranks `t0..t<vocab_size-1>`).
+    pub vocab_size: usize,
+    /// Zipf exponent for the term-frequency distribution.
+    pub zipf_s: f64,
+    /// Target mean document length in terms.
+    pub avg_doc_len: f64,
+    /// Embedding dimensionality (the embeddings are filler; BM25 queries
+    /// don't use them, but every vector must carry one).
+    pub dimensions: u16,
+    /// Number of BM25 queries per scorer pass.
+    pub num_queries: usize,
+    /// Result limit (top-k) for each query.
+    pub limit: usize,
+    /// In-memory block-cache size in bytes. Same semantics as the recall
+    /// benchmark: `None` = phase default, negative = disabled, `n >= 0` =
+    /// exactly `n` bytes.
+    pub block_cache_bytes: Option<i64>,
+    /// Scorers to measure during the warm phase, in order.
+    pub scorers: Vec<Bm25Scorer>,
+    /// Phases to run, in order.
+    pub phases: Vec<Phase>,
+}
+
+impl From<Params> for FtsSpec {
+    fn from(p: Params) -> Self {
+        FtsSpec {
+            seed: p.get_parse("seed").ok().unwrap_or(DEFAULT_SEED),
+            num_docs: p.get_parse("num_docs").ok().unwrap_or(DEFAULT_NUM_DOCS),
+            vocab_size: p.get_parse("vocab_size").ok().unwrap_or(DEFAULT_VOCAB_SIZE),
+            zipf_s: p.get_parse("zipf_s").ok().unwrap_or(DEFAULT_ZIPF_S),
+            avg_doc_len: p
+                .get_parse("avg_doc_len")
+                .ok()
+                .unwrap_or(DEFAULT_AVG_DOC_LEN),
+            dimensions: p.get_parse("dimensions").ok().unwrap_or(DEFAULT_DIMENSIONS),
+            num_queries: p
+                .get_parse("num_queries")
+                .ok()
+                .unwrap_or(DEFAULT_NUM_QUERIES),
+            limit: p.get_parse("limit").ok().unwrap_or(DEFAULT_LIMIT),
+            block_cache_bytes: p.get_parse::<i64>("block_cache_bytes").ok(),
+            scorers: p
+                .get("scorers")
+                .map(param_to_scorers)
+                .unwrap_or_else(|| DEFAULT_SCORERS.to_vec()),
+            phases: p
+                .get("phases")
+                .map(param_to_phases)
+                .unwrap_or_else(|| DEFAULT_PHASES.to_vec()),
+        }
+    }
+}
+
+// -- Storage helpers ------------------------------------------------------------
+
+/// Resolve the effective memory-tier byte count for the block cache, with
+/// the same semantics as the recall benchmark: `None` → use
+/// `default_memory_bytes`, negative → disabled, `n >= 0` → exactly `n`.
+fn resolve_block_cache_memory(configured: Option<i64>, default_memory_bytes: u64) -> Option<u64> {
+    match configured {
+        None => Some(default_memory_bytes),
+        Some(n) if n < 0 => None,
+        Some(n) => Some(n as u64),
+    }
+}
+
+/// Open a fresh `VectorDb` for the given `Config`, layering in a memory-only
+/// foyer block cache sized by the spec's `block_cache_bytes` (or
+/// `default_memory_bytes` when unset — see the recall benchmark's
+/// `ingest_default_memory_bytes` / `warm_default_memory_bytes`).
+pub(crate) async fn open_db(
+    config: &Config,
+    spec: &FtsSpec,
+    default_memory_bytes: u64,
+) -> anyhow::Result<VectorDb> {
+    let mut sb = StorageBuilder::new(&config.storage).await?;
+    match resolve_block_cache_memory(spec.block_cache_bytes, default_memory_bytes) {
+        Some(memory_bytes) if memory_bytes > 0 => {
+            println!("  Block cache: memory-only, {} bytes", memory_bytes);
+            let cache = FoyerCache::new_with_opts(FoyerCacheOptions {
+                max_capacity: memory_bytes,
+                ..Default::default()
+            });
+            let cache = Arc::new(cache) as Arc<dyn DbCache>;
+            sb = sb.map_slatedb(move |db| db.with_db_cache(cache));
+        }
+        _ => println!("  Block cache: disabled"),
+    }
+    Ok(VectorDb::open_with_storage(config.clone(), sb).await?)
+}
+
+// -- Benchmark ----------------------------------------------------------------
+
+pub struct FtsBenchmark;
+
+impl FtsBenchmark {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for FtsBenchmark {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl Benchmark for FtsBenchmark {
+    fn name(&self) -> &str {
+        "fts"
+    }
+
+    fn default_params(&self) -> Vec<Params> {
+        // All spec fields have defaults, so an empty param set is a valid run.
+        vec![Params::new()]
+    }
+
+    async fn run(&self, bench: Bench) -> anyhow::Result<()> {
+        let spec: FtsSpec = bench.spec().params().clone().into();
+        println!("  Spec: {:?}", spec);
+
+        // BM25 queries run against the `body` text field; the field is not
+        // indexed for metadata filtering.
+        let config = Config {
+            storage: bench.spec().data().storage.clone(),
+            dimensions: spec.dimensions,
+            distance_metric: DistanceMetric::L2,
+            metadata_fields: vec![MetadataFieldSpec::new(BODY_FIELD, FieldType::Text, false)],
+            ..Default::default()
+        };
+
+        // Queries are derived from the seed alone, so WARM-only runs against
+        // a previously ingested corpus issue the same queries.
+        let queries = corpus::generate_queries(spec.seed, spec.vocab_size, spec.num_queries);
+        println!("  Generated {} queries", queries.len());
+
+        // -- Dispatch each configured phase --------------------------------
+        let mut summary = Summary::new()
+            .add("num_docs", spec.num_docs as f64)
+            .add("num_queries", spec.num_queries as f64)
+            .add("limit", spec.limit as f64);
+        for phase in spec.phases.iter().copied() {
+            println!("\n=== phase: {} ===", phase.as_str());
+            match phase {
+                Phase::Ingest => {
+                    let s = ingest::run(&spec, &config).await?;
+                    summary = summary
+                        .add("ingest_secs", s.ingest_secs)
+                        .add("ingest_docs_per_sec", s.num_docs as f64 / s.ingest_secs);
+                }
+                Phase::Warm => {
+                    let s = warm::run(&spec, &config, &queries, &bench).await?;
+                    for (name, sc) in &s.scorers {
+                        summary = summary
+                            .add(format!("{}_p50_latency_us", name), sc.p50)
+                            .add(format!("{}_p90_latency_us", name), sc.p90)
+                            .add(format!("{}_p99_latency_us", name), sc.p99)
+                            .add(format!("{}_mean_latency_us", name), sc.mean)
+                            .add(format!("{}_qps", name), sc.qps);
+                    }
+                    summary = summary.add("result_mismatches", s.result_mismatches as f64);
+                }
+            }
+        }
+
+        bench.summarize(summary).await?;
+        bench.close().await?;
+        Ok(())
+    }
+}

--- a/vector/bench/src/fts/corpus.rs
+++ b/vector/bench/src/fts/corpus.rs
@@ -1,0 +1,280 @@
+//! Deterministic synthetic corpus and query generation for the FTS
+//! benchmark.
+//!
+//! Everything here is derived from the spec's `seed` with a hand-rolled
+//! splitmix64 generator (no RNG dependency), so the same spec always
+//! produces the same corpus and queries:
+//!
+//! - **Terms** follow a Zipf distribution over `vocab_size` ranks with
+//!   exponent `zipf_s`; rank `r` renders as the token `t<r>`.
+//! - **Document lengths** are log-normal-ish: a standard normal is
+//!   approximated by summing 12 uniforms (Irwin–Hall) and the length is
+//!   `clamp(round(avg_doc_len * exp(0.5 * n)), 5, 2000)`.
+//! - **Queries** mix three strata of head/torso/tail term ranks.
+
+use crate::fts::FtsSpec;
+
+/// Salt XOR'd into the seed for the query generator so queries don't reuse
+/// the corpus generator's random stream.
+const QUERY_SEED_SALT: u64 = 0x9E3779B97F4A7C15;
+
+/// Minimum / maximum document length in terms.
+const MIN_DOC_LEN: usize = 5;
+const MAX_DOC_LEN: usize = 2000;
+
+/// A generated document: external id `d<i>`, a filler embedding, and the
+/// space-joined term body.
+pub(crate) struct Doc {
+    pub id: String,
+    pub embedding: Vec<f32>,
+    pub body: String,
+}
+
+// -- RNG ----------------------------------------------------------------------
+
+/// splitmix64 (Vigna). Tiny, fast, and good enough for synthetic data.
+pub(crate) struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    pub fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E3779B97F4A7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform f64 in [0, 1) with 53 bits of precision.
+    pub fn next_f64(&mut self) -> f64 {
+        (self.next_u64() >> 11) as f64 / (1u64 << 53) as f64
+    }
+
+    /// Uniform f32 in [0, 1) with 24 bits of precision.
+    pub fn next_f32(&mut self) -> f32 {
+        (self.next_u64() >> 40) as f32 / (1u32 << 24) as f32
+    }
+
+    /// Uniform usize in [lo, hi). Modulo bias is negligible at benchmark
+    /// range sizes.
+    pub fn next_range(&mut self, lo: usize, hi: usize) -> usize {
+        debug_assert!(lo < hi);
+        lo + (self.next_u64() % (hi - lo) as u64) as usize
+    }
+}
+
+// -- Zipf sampling --------------------------------------------------------------
+
+/// Precomputed normalized cumulative Zipf distribution over term ranks.
+/// Sampling is a binary search on a uniform f64.
+pub(crate) struct ZipfTable {
+    cdf: Vec<f64>,
+}
+
+impl ZipfTable {
+    pub fn new(vocab_size: usize, s: f64) -> Self {
+        assert!(vocab_size > 0, "vocab_size must be positive");
+        let mut cdf = Vec::with_capacity(vocab_size);
+        let mut acc = 0.0;
+        for rank in 0..vocab_size {
+            acc += 1.0 / ((rank + 1) as f64).powf(s);
+            cdf.push(acc);
+        }
+        let total = acc;
+        for v in &mut cdf {
+            *v /= total;
+        }
+        Self { cdf }
+    }
+
+    /// Sample a term rank.
+    pub fn sample(&self, rng: &mut SplitMix64) -> usize {
+        let u = rng.next_f64();
+        // First rank whose cumulative probability covers `u`.
+        self.cdf.partition_point(|&c| c < u).min(self.cdf.len() - 1)
+    }
+}
+
+// -- Corpus generation ------------------------------------------------------------
+
+/// Streaming generator for the synthetic corpus. Documents are produced
+/// sequentially from a single random stream, so chunking does not affect
+/// the generated corpus — only how much is materialized at once.
+pub(crate) struct CorpusGenerator {
+    rng: SplitMix64,
+    zipf: ZipfTable,
+    avg_doc_len: f64,
+    dimensions: usize,
+    num_docs: usize,
+    next_doc: usize,
+}
+
+impl CorpusGenerator {
+    pub fn new(spec: &FtsSpec) -> Self {
+        Self {
+            rng: SplitMix64::new(spec.seed),
+            zipf: ZipfTable::new(spec.vocab_size, spec.zipf_s),
+            avg_doc_len: spec.avg_doc_len,
+            dimensions: spec.dimensions as usize,
+            num_docs: spec.num_docs,
+            next_doc: 0,
+        }
+    }
+
+    /// Generate the next chunk of up to `max_docs` documents, or `None`
+    /// when the corpus is exhausted.
+    pub fn next_chunk(&mut self, max_docs: usize) -> Option<Vec<Doc>> {
+        if self.next_doc >= self.num_docs {
+            return None;
+        }
+        let count = max_docs.min(self.num_docs - self.next_doc);
+        let mut docs = Vec::with_capacity(count);
+        for _ in 0..count {
+            docs.push(self.next_doc());
+        }
+        Some(docs)
+    }
+
+    fn next_doc(&mut self) -> Doc {
+        let id = format!("d{}", self.next_doc);
+        self.next_doc += 1;
+
+        let embedding: Vec<f32> = (0..self.dimensions).map(|_| self.rng.next_f32()).collect();
+
+        use std::fmt::Write;
+        let len = self.doc_len();
+        let mut body = String::with_capacity(len * 7);
+        for i in 0..len {
+            if i > 0 {
+                body.push(' ');
+            }
+            let _ = write!(body, "t{}", self.zipf.sample(&mut self.rng));
+        }
+
+        Doc {
+            id,
+            embedding,
+            body,
+        }
+    }
+
+    /// Log-normal-ish document length: `n` approximates a standard normal
+    /// via the sum of 12 uniforms minus 6 (Irwin–Hall).
+    fn doc_len(&mut self) -> usize {
+        let n: f64 = (0..12).map(|_| self.rng.next_f64()).sum::<f64>() - 6.0;
+        let len = (self.avg_doc_len * (0.5 * n).exp()).round();
+        (len as usize).clamp(MIN_DOC_LEN, MAX_DOC_LEN)
+    }
+}
+
+// -- Query generation -------------------------------------------------------------
+
+/// Generate the benchmark's BM25 query strings. Queries are assigned to
+/// strata round-robin by index so any prefix keeps roughly the configured
+/// 40/30/30 mix:
+///
+/// - 40%: 2 terms — one head rank [0, 100), one torso rank [1000, 10000)
+/// - 30%: 3 terms — head + torso + tail rank [10000, vocab)
+/// - 30%: 2 terms — both mid ranks [1000, 50000)
+///
+/// All stratum bounds are clamped to the vocabulary.
+pub(crate) fn generate_queries(seed: u64, vocab_size: usize, num_queries: usize) -> Vec<String> {
+    let mut rng = SplitMix64::new(seed ^ QUERY_SEED_SALT);
+    (0..num_queries)
+        .map(|i| {
+            let ranks = match i % 10 {
+                0..=3 => vec![
+                    rank_in(&mut rng, 0, 100, vocab_size),
+                    rank_in(&mut rng, 1000, 10_000, vocab_size),
+                ],
+                4..=6 => vec![
+                    rank_in(&mut rng, 0, 100, vocab_size),
+                    rank_in(&mut rng, 1000, 10_000, vocab_size),
+                    rank_in(&mut rng, 10_000, vocab_size, vocab_size),
+                ],
+                _ => vec![
+                    rank_in(&mut rng, 1000, 50_000, vocab_size),
+                    rank_in(&mut rng, 1000, 50_000, vocab_size),
+                ],
+            };
+            let terms: Vec<String> = ranks.iter().map(|r| format!("t{}", r)).collect();
+            terms.join(" ")
+        })
+        .collect()
+}
+
+/// Uniform term rank in [lo, hi), with the stratum clamped to the
+/// vocabulary while keeping at least one valid rank.
+fn rank_in(rng: &mut SplitMix64, lo: usize, hi: usize, vocab_size: usize) -> usize {
+    let hi = hi.min(vocab_size).max(1);
+    let lo = lo.min(hi - 1);
+    rng.next_range(lo, hi)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_spec() -> FtsSpec {
+        FtsSpec {
+            seed: 42,
+            num_docs: 100,
+            vocab_size: 20_000,
+            zipf_s: 1.07,
+            avg_doc_len: 100.0,
+            dimensions: 8,
+            num_queries: 50,
+            limit: 10,
+            block_cache_bytes: None,
+            scorers: Vec::new(),
+            phases: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn corpus_should_be_deterministic_and_chunking_invariant() {
+        let spec = test_spec();
+        let mut all: Vec<Doc> = Vec::new();
+        let mut generator = CorpusGenerator::new(&spec);
+        while let Some(chunk) = generator.next_chunk(7) {
+            all.extend(chunk);
+        }
+        assert_eq!(all.len(), spec.num_docs);
+
+        let again = CorpusGenerator::new(&spec).next_chunk(1000).unwrap();
+        assert_eq!(again.len(), spec.num_docs);
+        for (a, b) in all.iter().zip(again.iter()) {
+            assert_eq!(a.id, b.id);
+            assert_eq!(a.embedding, b.embedding);
+            assert_eq!(a.body, b.body);
+        }
+    }
+
+    #[test]
+    fn doc_lengths_should_be_clamped() {
+        let spec = test_spec();
+        let mut generator = CorpusGenerator::new(&spec);
+        for doc in generator.next_chunk(100).unwrap() {
+            let len = doc.body.split(' ').count();
+            assert!((MIN_DOC_LEN..=MAX_DOC_LEN).contains(&len));
+        }
+    }
+
+    #[test]
+    fn queries_should_be_deterministic_and_in_vocab() {
+        let a = generate_queries(42, 20_000, 100);
+        let b = generate_queries(42, 20_000, 100);
+        assert_eq!(a, b);
+        for q in &a {
+            for term in q.split(' ') {
+                let rank: usize = term.strip_prefix('t').unwrap().parse().unwrap();
+                assert!(rank < 20_000);
+            }
+        }
+    }
+}

--- a/vector/bench/src/fts/ingest.rs
+++ b/vector/bench/src/fts/ingest.rs
@@ -1,0 +1,177 @@
+//! INGEST phase: stream the synthetic corpus into a fresh `VectorDb`.
+//!
+//! Opens a fresh `VectorDb` at phase start, generates documents on a
+//! background thread in fixed-size chunks, writes them in small batches,
+//! then flushes and closes the db. Mirrors the recall benchmark's ingest
+//! phase, including a once-per-minute throughput log line.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use chrono::Local;
+use tokio::sync::{mpsc, oneshot};
+use vector::{Vector, VectorDb};
+
+use crate::fts::corpus::{CorpusGenerator, Doc};
+use crate::fts::{BODY_FIELD, FtsSpec, open_db};
+use crate::recall::ingest_default_memory_bytes;
+
+const DOC_CHUNK_SIZE: usize = 10_000;
+const INGEST_WRITE_BATCH_SIZE: usize = 10;
+
+/// Metrics produced by the ingest phase.
+pub struct IngestSummary {
+    pub num_docs: u64,
+    pub ingest_secs: f64,
+}
+
+pub async fn run(spec: &FtsSpec, config: &vector::Config) -> anyhow::Result<IngestSummary> {
+    let db = open_db(config, spec, ingest_default_memory_bytes()).await?;
+    let summary = ingest(spec, &db).await?;
+    db.close().await?;
+    Ok(summary)
+}
+
+async fn ingest(spec: &FtsSpec, db: &VectorDb) -> anyhow::Result<IngestSummary> {
+    let num_docs = spec.num_docs as u64;
+    println!(
+        "  Streaming {} synthetic docs (vocab={}, zipf_s={}, avg_len={}, dim={}) in chunks of {}",
+        num_docs, spec.vocab_size, spec.zipf_s, spec.avg_doc_len, spec.dimensions, DOC_CHUNK_SIZE
+    );
+    let (mut stream, gen_thread) = spawn_doc_stream(spec, DOC_CHUNK_SIZE);
+
+    let ingest_start = Instant::now();
+    let ingested_counter = Arc::new(AtomicU64::new(0));
+    let (stop_tx, stop_rx) = oneshot::channel::<()>();
+    let monitor_handle =
+        spawn_ingest_throughput_monitor(ingested_counter.clone(), ingest_start, stop_rx);
+
+    let num_batches = spec.num_docs.div_ceil(INGEST_WRITE_BATCH_SIZE);
+    let mut batch_idx = 0usize;
+    let mut docs_written = 0usize;
+    while let Some(chunk) = stream.recv().await {
+        docs_written += chunk.len();
+        println!(
+            "  Generated chunk: {} docs ({} / {})",
+            chunk.len(),
+            docs_written,
+            num_docs
+        );
+        let mut batch: Vec<Vector> = Vec::with_capacity(INGEST_WRITE_BATCH_SIZE);
+        for doc in chunk {
+            batch.push(
+                Vector::builder(doc.id, doc.embedding)
+                    .attribute(BODY_FIELD, doc.body)
+                    .build(),
+            );
+            if batch.len() == INGEST_WRITE_BATCH_SIZE {
+                let written = batch.len() as u64;
+                db.write(std::mem::take(&mut batch)).await?;
+                ingested_counter.fetch_add(written, Ordering::Relaxed);
+                batch_idx += 1;
+                if batch_idx.is_multiple_of(10_000) {
+                    println!("  Written batch {}/{}", batch_idx, num_batches);
+                }
+            }
+        }
+        // Final partial batch of the corpus (chunks are multiples of the
+        // batch size except possibly the last).
+        if !batch.is_empty() {
+            let written = batch.len() as u64;
+            db.write(batch).await?;
+            ingested_counter.fetch_add(written, Ordering::Relaxed);
+            batch_idx += 1;
+        }
+    }
+    gen_thread
+        .join()
+        .map_err(|_| anyhow::anyhow!("doc generation thread panicked"))?;
+    if docs_written != spec.num_docs {
+        anyhow::bail!("generated {} docs but expected {}", docs_written, num_docs);
+    }
+    db.flush().await?;
+    let ingest_secs = ingest_start.elapsed().as_secs_f64();
+
+    let _ = stop_tx.send(());
+    monitor_handle
+        .await
+        .map_err(|e| anyhow::anyhow!("ingest throughput monitor panicked: {e}"))?;
+
+    println!(
+        "  Ingested {} docs in {:.1}s ({:.0} docs/s)",
+        num_docs,
+        ingest_secs,
+        num_docs as f64 / ingest_secs,
+    );
+
+    Ok(IngestSummary {
+        num_docs,
+        ingest_secs,
+    })
+}
+
+/// Spawn a thread that generates corpus chunks and streams them through a
+/// bounded channel, so generation overlaps with writes without ever
+/// materializing the whole corpus.
+fn spawn_doc_stream(
+    spec: &FtsSpec,
+    chunk_size: usize,
+) -> (mpsc::Receiver<Vec<Doc>>, thread::JoinHandle<()>) {
+    let mut generator = CorpusGenerator::new(spec);
+    let (tx, rx) = mpsc::channel(1);
+
+    let handle = thread::spawn(move || {
+        while let Some(chunk) = generator.next_chunk(chunk_size) {
+            if tx.blocking_send(chunk).is_err() {
+                return;
+            }
+        }
+    });
+
+    (rx, handle)
+}
+
+/// Spawn a task that samples the ingest counter once per minute and logs
+/// the throughput since the previous sample.
+fn spawn_ingest_throughput_monitor(
+    counter: Arc<AtomicU64>,
+    ingest_start: Instant,
+    mut stop_rx: oneshot::Receiver<()>,
+) -> tokio::task::JoinHandle<()> {
+    const SAMPLE_PERIOD: Duration = Duration::from_secs(60);
+
+    tokio::spawn(async move {
+        let mut last = (ingest_start, 0u64);
+        let mut interval =
+            tokio::time::interval_at(tokio::time::Instant::now() + SAMPLE_PERIOD, SAMPLE_PERIOD);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    let now = Instant::now();
+                    let count = counter.load(Ordering::Relaxed);
+                    let window_secs = now.duration_since(last.0).as_secs_f64();
+                    let delta = count.saturating_sub(last.1);
+                    let docs_per_sec = if window_secs > 0.0 {
+                        delta as f64 / window_secs
+                    } else {
+                        0.0
+                    };
+                    println!(
+                        "  [ingest throughput] {} | {:>10.1} docs/s (preceding {:.0}s, {} docs, {} total)",
+                        Local::now().format("%Y-%m-%d %H:%M:%S"),
+                        docs_per_sec,
+                        window_secs,
+                        delta,
+                        count,
+                    );
+                    last = (now, count);
+                }
+                _ = &mut stop_rx => break,
+            }
+        }
+    })
+}

--- a/vector/bench/src/fts/warm.rs
+++ b/vector/bench/src/fts/warm.rs
@@ -1,0 +1,186 @@
+//! WARM phase: open a fresh `VectorDb` and, for each configured scorer, run
+//! an unmeasured warmup pass over all queries followed by a measured
+//! sequential pass (concurrency 1, unthrottled) that produces the per-scorer
+//! latency metrics. The first few queries' result lists are cross-checked
+//! between scorers to catch BlockMax/Exhaustive divergence.
+
+use std::time::Instant;
+
+use bencher::Bench;
+use vector::{Bm25Scorer, Config, Query, SearchOptions, VectorDb, VectorDbRead};
+
+use crate::fts::{BODY_FIELD, FtsSpec, open_db, scorer_name};
+use crate::recall::{percentile, warm_default_memory_bytes};
+
+/// Number of leading queries whose result lists are compared across scorers.
+const CONSISTENCY_CHECK_QUERIES: usize = 20;
+
+/// Latency metrics for one scorer's measured pass.
+pub struct ScorerSummary {
+    pub p50: f64,
+    pub p90: f64,
+    pub p99: f64,
+    pub mean: f64,
+    pub qps: f64,
+}
+
+/// Metrics produced by the warm phase.
+pub struct WarmSummary {
+    /// Per-scorer latency summaries, in the spec's scorer order.
+    pub scorers: Vec<(&'static str, ScorerSummary)>,
+    /// Number of (query, scorer-pair) result-list divergences observed.
+    pub result_mismatches: u64,
+}
+
+pub async fn run(
+    spec: &FtsSpec,
+    config: &Config,
+    queries: &[String],
+    bench: &Bench,
+) -> anyhow::Result<WarmSummary> {
+    let db = open_db(config, spec, warm_default_memory_bytes()).await?;
+    let summary = warm(spec, &db, queries, bench).await?;
+    db.close().await?;
+    Ok(summary)
+}
+
+async fn warm(
+    spec: &FtsSpec,
+    db: &VectorDb,
+    queries: &[String],
+    bench: &Bench,
+) -> anyhow::Result<WarmSummary> {
+    let check_n = queries.len().min(CONSISTENCY_CHECK_QUERIES);
+    // Result-id lists for the first `check_n` queries, per scorer, used for
+    // the cross-scorer consistency check.
+    let mut check_results: Vec<(&'static str, Vec<Vec<String>>)> =
+        Vec::with_capacity(spec.scorers.len());
+    let mut summaries = Vec::with_capacity(spec.scorers.len());
+
+    for scorer in spec.scorers.iter().copied() {
+        let name = scorer_name(scorer);
+
+        // -- Warmup (unmeasured) -------------------------------------------
+        println!("  [{}] start warmup", name);
+        for query in queries {
+            let _ = search(db, spec, query, scorer).await?;
+        }
+        println!("  [{}] end warmup", name);
+
+        // -- Measured sequential pass --------------------------------------
+        let latency_hist = bench.histogram(latency_metric(scorer));
+        let mut latencies_us = Vec::with_capacity(queries.len());
+        let mut ids: Vec<Vec<String>> = Vec::with_capacity(check_n);
+        let pass_start = Instant::now();
+        for (i, query) in queries.iter().enumerate() {
+            let t = Instant::now();
+            let results = search(db, spec, query, scorer).await?;
+            let elapsed_us = t.elapsed().as_secs_f64() * 1_000_000.0;
+            latency_hist.record(elapsed_us);
+            latencies_us.push(elapsed_us);
+            if i < check_n {
+                ids.push(results);
+            }
+        }
+        let pass_secs = pass_start.elapsed().as_secs_f64();
+        let qps = queries.len() as f64 / pass_secs;
+        let mean = latencies_us.iter().sum::<f64>() / latencies_us.len().max(1) as f64;
+
+        latencies_us.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        let p50 = percentile(&latencies_us, 50.0);
+        let p90 = percentile(&latencies_us, 90.0);
+        let p99 = percentile(&latencies_us, 99.0);
+
+        println!(
+            "  [{}] QPS = {:.1}, mean = {:.2} ms, p50 = {:.2} ms, p90 = {:.2} ms, p99 = {:.2} ms",
+            name,
+            qps,
+            mean / 1000.0,
+            p50 / 1000.0,
+            p90 / 1000.0,
+            p99 / 1000.0,
+        );
+
+        check_results.push((name, ids));
+        summaries.push((
+            name,
+            ScorerSummary {
+                p50,
+                p90,
+                p99,
+                mean,
+                qps,
+            },
+        ));
+    }
+
+    let result_mismatches = count_result_mismatches(queries, &check_results, check_n);
+
+    Ok(WarmSummary {
+        scorers: summaries,
+        result_mismatches,
+    })
+}
+
+/// Run one BM25 query against the `body` field, returning the result doc
+/// ids in rank order.
+async fn search(
+    db: &VectorDb,
+    spec: &FtsSpec,
+    query: &str,
+    scorer: Bm25Scorer,
+) -> anyhow::Result<Vec<String>> {
+    let q = Query::bm25(BODY_FIELD, query).with_limit(spec.limit);
+    let results = db
+        .search_with_options(
+            &q,
+            SearchOptions {
+                nprobe: None,
+                bm25_scorer: Some(scorer),
+            },
+        )
+        .await?;
+    Ok(results.into_iter().map(|r| r.vector.id).collect())
+}
+
+/// Per-scorer histogram name (must be `&'static str` for the bench recorder).
+fn latency_metric(scorer: Bm25Scorer) -> &'static str {
+    match scorer {
+        Bm25Scorer::BlockMax => "block_max_query_latency_us",
+        Bm25Scorer::BlockMaxSparse => "block_max_sparse_query_latency_us",
+        Bm25Scorer::Exhaustive => "exhaustive_query_latency_us",
+    }
+}
+
+/// Order-sensitive comparison of the first `check_n` queries' result-id
+/// lists between the first scorer and every other scorer. Mismatches are
+/// logged (not fatal) and counted.
+fn count_result_mismatches(
+    queries: &[String],
+    check_results: &[(&'static str, Vec<Vec<String>>)],
+    check_n: usize,
+) -> u64 {
+    let Some((base_name, base)) = check_results.first() else {
+        return 0;
+    };
+    let mut mismatches = 0u64;
+    for (name, ids) in &check_results[1..] {
+        for i in 0..check_n {
+            if ids[i] != base[i] {
+                mismatches += 1;
+                eprintln!(
+                    "  result mismatch on query {:?}: {}={:?} vs {}={:?}",
+                    queries[i], base_name, base[i], name, ids[i],
+                );
+            }
+        }
+    }
+    if mismatches == 0 && check_results.len() > 1 {
+        println!(
+            "  consistency check: {} queries identical across {} scorers",
+            check_n,
+            check_results.len(),
+        );
+    }
+    mismatches
+}

--- a/vector/bench/src/lib.rs
+++ b/vector/bench/src/lib.rs
@@ -4,4 +4,5 @@
 //! shared between the `vector-bench` runner (`main.rs`) and auxiliary tools
 //! such as the `gen_groundtruth` binary.
 
+pub mod fts;
 pub mod recall;

--- a/vector/bench/src/main.rs
+++ b/vector/bench/src/main.rs
@@ -6,10 +6,14 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 use bencher::Benchmark;
 use tracing_subscriber::EnvFilter;
+use vector_bench::fts::FtsBenchmark;
 use vector_bench::recall::RecallBenchmark;
 
 fn benchmarks() -> Vec<Box<dyn Benchmark>> {
-    vec![Box::new(RecallBenchmark::new())]
+    vec![
+        Box::new(RecallBenchmark::new()),
+        Box::new(FtsBenchmark::new()),
+    ]
 }
 
 #[tokio::main]

--- a/vector/bench/src/recall/cold.rs
+++ b/vector/bench/src/recall/cold.rs
@@ -84,6 +84,7 @@ pub async fn run(
                     &q,
                     SearchOptions {
                         nprobe: Some(dataset.nprobe),
+                        ..Default::default()
                     },
                 )
                 .await?;

--- a/vector/bench/src/recall/warm.rs
+++ b/vector/bench/src/recall/warm.rs
@@ -59,6 +59,7 @@ async fn warm(
                 &q,
                 SearchOptions {
                     nprobe: Some(dataset.nprobe),
+                    ..Default::default()
                 },
             )
             .await?;
@@ -133,6 +134,7 @@ async fn warm(
                             &q,
                             SearchOptions {
                                 nprobe: Some(nprobe),
+                                ..Default::default()
                             },
                         )
                         .await?;

--- a/vector/src/lib.rs
+++ b/vector/src/lib.rs
@@ -57,8 +57,8 @@ pub use admin::VectorDbAdmin;
 pub use db::{VectorDb, VectorDbRead};
 pub use error::{Error, Result};
 pub use model::{
-    Attribute, AttributeValue, Bm25Query, Config, DistanceMetric, FieldSelection, FieldType,
-    Filter, MetadataFieldSpec, Query, ReaderConfig, ScoreBy, SearchOptions, SearchResult, Vector,
-    VectorBuilder,
+    Attribute, AttributeValue, Bm25Query, Bm25Scorer, Config, DistanceMetric, FieldSelection,
+    FieldType, Filter, MetadataFieldSpec, Query, ReaderConfig, ScoreBy, SearchOptions,
+    SearchResult, Vector, VectorBuilder,
 };
 pub use reader::VectorDbReader;

--- a/vector/src/math/bm25.rs
+++ b/vector/src/math/bm25.rs
@@ -38,19 +38,137 @@ pub(crate) fn idf(n_docs: u64, n_t: u64) -> f32 {
     (((n_docs - n_t + 0.5) / (n_t + 0.5)) + 1.0).ln()
 }
 
+/// The reciprocal of the BM25 denominator's document-length component:
+/// `1 / c` with `c = K1 * (1 - B + B * dl/avgdl)`.
+///
+/// Cached inverted (rather than as `c` itself) so [`hit_score`] can use the
+/// rounding-monotone `w - w / (1 + f * inv)` form; see [`hit_score`].
+#[inline]
+fn norm_inverse(norm: u8, avgdl: f32) -> f32 {
+    let dl = norm::decode_norm(norm) as f32;
+    1.0 / (K1 * (1.0 - B + B * (dl / avgdl)))
+}
+
+/// BM25 contribution of a single (term, document) hit, computed as
+/// `w - w / (1 + f * inv)` where `w = idf * (K1 + 1)`, `f` is the term
+/// frequency, and `inv` comes from [`norm_inverse`] — the same rewrite
+/// Lucene's `BM25Similarity` uses.
+///
+/// This is the textbook BM25 hit `idf * f*(K1+1) / (f + c)` rewritten in
+/// terms of `inv = 1/c`:
+///
+/// ```text
+/// w - w/(1 + f/c) = w - w*c/(c + f)        multiply num and denom by c
+///                 = w * (1 - c/(f + c))
+///                 = w * f/(f + c)
+///                 = idf * f*(K1+1) / (f + c)
+/// ```
+///
+/// The two forms are equal in real arithmetic but differ under f32 rounding,
+/// and only the rewritten form is *monotone* there. It evaluates as a chain
+/// of single correctly-rounded operations,
+///
+/// ```text
+/// x = f * inv    increasing in f (and in inv)
+/// y = 1 + x      increasing in x
+/// z = w / y      decreasing in y
+/// w - z          increasing as z decreases
+/// ```
+///
+/// and rounding-to-nearest preserves ordering per operation, so the computed
+/// score never decreases when `f` rises or `dl` falls. The textbook form
+/// rounds `f`'s appearance in the numerator and the denominator
+/// independently and can drop by an ulp as `f` increases. That matters
+/// because BlockMaxScore bounds a block by its dominating `(freq, norm)`
+/// impact pairs: dominance only implies a bound if higher freq / lower norm
+/// can never score lower *as computed*, otherwise a dominated posting can
+/// exceed the block "maximum" and a document near the top-k floor can be
+/// wrongly pruned.
+///
+/// Every scoring path (the exhaustive scorer, BlockMaxScore accumulation,
+/// and impact-based bounds) must use this exact arithmetic so that scores and
+/// bounds stay bit-consistent with each other.
+#[inline(always)]
+fn hit_score(idf: f32, freq: u32, inv: f32) -> f32 {
+    let w = idf * (K1 + 1.0);
+    w - w / (1.0 + freq as f32 * inv)
+}
+
 /// BM25 score for a single document given all its term hits and the corpus
 /// average document length. Uses the [`K1`] and [`B`] module constants and
 /// decodes the per-entry [`Bm25TermEntry::norm`] back to a document length
 /// via [`norm::decode_norm`].
+///
+/// Each hit is computed in f32 ([`hit_score`]) and the hits are accumulated
+/// in f64 with one final rounding. An f64 sum of a query's worth of f32 hits
+/// is exact, so the result is independent of accumulation order — which is
+/// what lets the BlockMaxScore path (which sums the same hits in window
+/// order) return bit-identical scores.
 pub(crate) fn score(entries: &[Bm25TermEntry], avgdl: f32) -> f32 {
-    let mut sum = 0.0f32;
+    let mut sum = 0.0f64;
     for entry in entries {
-        let f = entry.freq as f32;
-        let dl = norm::decode_norm(entry.norm) as f32;
-        let denom = f + K1 * (1.0 - B + B * (dl / avgdl));
-        sum += entry.idf * (f * (K1 + 1.0) / denom);
+        let inv = norm_inverse(entry.norm, avgdl);
+        sum += hit_score(entry.idf, entry.freq, inv) as f64;
     }
-    sum
+    sum as f32
+}
+
+/// Per-query scoring context for the BlockMaxScore path.
+///
+/// Caches [`norm_inverse`] for all 256 norm bytes (the same trick as Lucene's
+/// `BM25Similarity` norm cache), so a per-hit score is one lookup and four
+/// arithmetic ops — a shape that batches/vectorizes cleanly.
+#[derive(Debug, Clone)]
+pub(crate) struct ScoreContext {
+    /// [`norm_inverse`] for every norm byte.
+    norm_cache: [f32; 256],
+}
+
+impl ScoreContext {
+    pub(crate) fn new(avgdl: f32) -> Self {
+        let mut norm_cache = [0f32; 256];
+        for (b, slot) in norm_cache.iter_mut().enumerate() {
+            *slot = norm_inverse(b as u8, avgdl);
+        }
+        Self { norm_cache }
+    }
+
+    /// BM25 contribution of one (term, document) hit; bit-identical to the
+    /// corresponding term of the exhaustive [`score`] sum.
+    #[inline(always)]
+    pub(crate) fn score_hit(&self, idf: f32, freq: u32, norm: u8) -> f32 {
+        hit_score(idf, freq, self.norm_cache[norm as usize])
+    }
+
+    /// Upper bound on any hit's contribution for a term, regardless of
+    /// frequency or document length.
+    ///
+    /// [`hit_score`] is `w - w / (1 + f * inv)` and the subtracted quotient
+    /// is non-negative, so the rounded result never exceeds
+    /// `w = idf * (K1 + 1)`. Used for blocks written before impacts landed.
+    #[inline]
+    pub(crate) fn global_bound(&self, idf: f32) -> f32 {
+        idf * (K1 + 1.0)
+    }
+}
+
+/// Upper bound of the sum of `num_values` non-negative `f32`-valued terms
+/// accumulated in `f64`, mirroring Lucene's `MathUtil.sumUpperBound`.
+///
+/// Summation order affects the rounded result, so bound comparisons against a
+/// threshold must allow for the worst-case accumulation error (Higham, "The
+/// accuracy of floating point summation", bound 3.5) or documents could be
+/// pruned that an exhaustive scorer would have kept.
+#[inline]
+pub(crate) fn sum_upper_bound(sum: f64, num_values: usize) -> f64 {
+    if num_values <= 2 {
+        // A sum of two values is the same regardless of order.
+        return sum;
+    }
+    // Relative error bound `b = (n - 1) * u` with unit roundoff `u = 2^-52`
+    // (`f64::EPSILON`); two differently-ordered sums are within `2b`.
+    let b = (num_values - 1) as f64 * f64::EPSILON;
+    sum * (1.0 + 2.0 * b)
 }
 
 #[cfg(test)]

--- a/vector/src/model.rs
+++ b/vector/src/model.rs
@@ -351,6 +351,30 @@ fn default_buffer_gc_grace_period() -> Duration {
 pub struct SearchOptions {
     /// Number of centroids to probe during search.
     pub nprobe: Option<usize>,
+    /// BM25 scoring algorithm override (default: [`Bm25Scorer::BlockMax`]).
+    pub bm25_scorer: Option<Bm25Scorer>,
+}
+
+/// Which scoring algorithm the BM25 query path uses.
+///
+/// `BlockMax` (the default) prunes non-competitive documents with
+/// BlockMaxScore (RFC-0006 Milestone 3). `Exhaustive` scores every document
+/// in the union of the query terms' posting lists; it exists as a reference
+/// implementation and for benchmarking the pruned path against it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Bm25Scorer {
+    /// Score every candidate document (RFC-0006 Milestone 0 path).
+    Exhaustive,
+    /// Skip non-competitive documents using BlockMaxScore, accumulating
+    /// essential clauses in a dense doc-id-indexed window buffer. Fastest
+    /// when doc ids are dense.
+    #[default]
+    BlockMax,
+    /// BlockMaxScore with posting-count-sized windows and sort-merge
+    /// accumulation. Holds up when the doc id space is sparse (heavy
+    /// delete/update churn leaves permanent id gaps), where `BlockMax`'s
+    /// dense window buffer degrades.
+    BlockMaxSparse,
 }
 
 /// Configuration for a read-only vector database client.

--- a/vector/src/query_engine/bm25/block_max.rs
+++ b/vector/src/query_engine/bm25/block_max.rs
@@ -3,7 +3,7 @@
 //! Scores a BM25 query without visiting every document in the union of the
 //! query terms' posting lists. The structure is a Rust port of Lucene's
 //! `MaxScoreBulkScorer`
-//! (https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java):
+//! (<https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java>):
 //!
 //! - Documents are scored in ascending id order, in **outer windows** aligned
 //!   to posting-block boundaries so per-block impacts give tight score bounds.

--- a/vector/src/query_engine/bm25/block_max.rs
+++ b/vector/src/query_engine/bm25/block_max.rs
@@ -1,0 +1,1050 @@
+//! BlockMaxScore BM25 operator (RFC-0006 Milestone 3).
+//!
+//! Scores a BM25 query without visiting every document in the union of the
+//! query terms' posting lists. The structure is a Rust port of Lucene's
+//! `MaxScoreBulkScorer`
+//! (https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/search/MaxScoreBulkScorer.java):
+//!
+//! - Documents are scored in ascending id order, in **outer windows** aligned
+//!   to posting-block boundaries so per-block impacts give tight score bounds.
+//! - Within each outer window, scorers are partitioned into *essential* and
+//!   *non-essential* sets: the non-essential set is the largest
+//!   lowest-bounded group whose summed maximum contribution cannot lift a
+//!   document into the current top-k. Only essential posting lists generate
+//!   candidates; non-essential lists are probed per candidate.
+//! - Essential clauses are scored **term-by-term** through a pluggable
+//!   [`EssentialScorer`] strategy (see [`super::essential`]): the strategy
+//!   plans each outer window's end and turns the essential postings within
+//!   it into a doc-ascending candidate list with partial scores. Window
+//!   planning and accumulation are the two pieces that depend on doc-id
+//!   density, so they live behind the trait; everything else is shared.
+//! - Candidates are filtered against the metadata filter and the FTS
+//!   deletions bitmap, then non-essential clauses are applied highest-impact
+//!   first with progressive pruning of candidates whose partial score plus
+//!   the remaining maximum cannot reach the top-k floor.
+//!
+//! Individual hits are computed in `f32` with exactly the arithmetic of the
+//! exhaustive scorer ([`bm25::score`]), so the two scorers return idential
+//! documents and scores.
+//!
+//! Known future work:
+//! - Partitioning sorts by each clause's window bound; It may be worth factoring
+//!   in posting sizes (e.g. `bound`/`posting size`), which can split better when
+//!   bounds and posting-list lengths are uncorrelated (see [`MaxScoreScorer::partition`]).
+//! - Outer windows have no minimum size. This can result in window-sizing/partitioning
+//!   dominating scoring. Lucene stretches degenerate windows by tracking window size stats
+//!   and probing larger window sizes when they are too small.
+//! - Essential accumulation is not filter-aware: with a selective metadata
+//!   filter (or heavy un-compacted deletes), essential clauses still score
+//!   every posting in the window and candidates are filtered at flush.
+//! - Lucene's `firstRequiredScorer` refinement (treating top non-essential
+//!   clauses as required when a single essential clause cannot reach the
+//!   floor alone) is not implemented.
+
+use std::sync::Arc;
+
+use common::storage::StorageRead;
+
+use super::essential::{
+    Candidates, DenseWindowScorer, EssentialScorer, EssentialStrategy, MergeScorer, WindowScorer,
+};
+use super::term_scorer::{NO_MORE_DOCS, TermScorer};
+use super::{BM25Score, dedupe_query_terms, load_field_stats, load_term_stats};
+use crate::error::Result;
+use crate::math::bm25::{self, ScoreContext};
+use crate::model::Bm25Query;
+use crate::query_engine::collectors::{Collector, TopK};
+use crate::query_engine::filter::PreparedFilter;
+use crate::query_engine::operator::Operator;
+use crate::query_engine::types::{Score, ScoredVectorId};
+use crate::serde::key::TermPostingsKey;
+use crate::serde::term_postings::PostingListView;
+use crate::serde::vector_bitmap::VectorBitmap;
+use crate::serde::vector_id::VectorId;
+
+/// Scores a BM25 query with BlockMaxScore pruning and produces the ranked
+/// `ScoredVectorId`s. Drop-in alternative to the exhaustive
+/// [`BM25Operator`](super::BM25Operator). The `strategy` picks how essential
+/// clauses are accumulated (see [`super::essential`]).
+pub(crate) struct BlockMaxBM25Operator {
+    storage: Arc<dyn StorageRead>,
+    query: Bm25Query,
+    filter: PreparedFilter,
+    deletions: Arc<VectorBitmap>,
+    limit: usize,
+    strategy: EssentialStrategy,
+}
+
+impl BlockMaxBM25Operator {
+    pub(crate) fn new(
+        storage: Arc<dyn StorageRead>,
+        query: Bm25Query,
+        filter: PreparedFilter,
+        deletions: Arc<VectorBitmap>,
+        limit: usize,
+        strategy: EssentialStrategy,
+    ) -> Self {
+        Self {
+            storage,
+            query,
+            filter,
+            deletions,
+            limit,
+            strategy,
+        }
+    }
+
+    /// Load postings + term stats for each query term as lazily-decoded
+    /// [`TermScorer`]s, fetching all terms concurrently (a cold N-term query
+    /// would otherwise pay 2N serialized storage round trips). Terms with no
+    /// documents are omitted.
+    async fn open_term_scorers(
+        &self,
+        field: &str,
+        terms: &[String],
+        n_docs: u64,
+    ) -> Result<Vec<TermScorer>> {
+        let loads = terms.iter().map(|term| async move {
+            let stats = load_term_stats(self.storage.as_ref(), field, term).await?;
+            let n_t = stats.freq.max(0) as u64;
+            if n_t == 0 {
+                return Ok::<Option<TermScorer>, crate::error::Error>(None);
+            }
+            let key = TermPostingsKey::new(field, term).encode();
+            let Some(record) = self.storage.get(key).await? else {
+                return Ok(None);
+            };
+            let view = PostingListView::parse(record.value)?;
+            if view.blocks().is_empty() {
+                return Ok(None);
+            }
+            Ok(Some(TermScorer::new(view, bm25::idf(n_docs, n_t))?))
+        });
+        let scorers: Vec<Option<TermScorer>> = futures::future::try_join_all(loads).await?;
+        Ok(scorers.into_iter().flatten().collect())
+    }
+}
+
+#[async_trait::async_trait]
+impl Operator<Vec<ScoredVectorId<BM25Score>>> for BlockMaxBM25Operator {
+    async fn execute(&self) -> Result<Vec<ScoredVectorId<BM25Score>>> {
+        let collector: TopK<BM25Score> = TopK::new(self.limit);
+
+        let terms = dedupe_query_terms(&self.query.query);
+        if terms.is_empty() {
+            return Ok(collector.finish());
+        }
+
+        let field_stats = load_field_stats(self.storage.as_ref(), &self.query.field).await?;
+        let n_docs = field_stats.count.max(0) as u64;
+        if n_docs == 0 || field_stats.total_length <= 0 {
+            return Ok(collector.finish());
+        }
+        let avgdl = field_stats.total_length as f32 / n_docs as f32;
+
+        let scorers = self
+            .open_term_scorers(&self.query.field, &terms, n_docs)
+            .await?;
+        if scorers.is_empty() {
+            return Ok(collector.finish());
+        }
+        let ctx = ScoreContext::new(avgdl);
+
+        match self.strategy {
+            EssentialStrategy::DenseWindow => {
+                self.run(scorers, ctx, DenseWindowScorer::new(), collector)
+            }
+            EssentialStrategy::SortMerge => self.run(scorers, ctx, MergeScorer::new(), collector),
+        }
+    }
+}
+
+impl BlockMaxBM25Operator {
+    fn run<S: EssentialScorer>(
+        &self,
+        scorers: Vec<TermScorer>,
+        ctx: ScoreContext,
+        strategy: S,
+        collector: TopK<BM25Score>,
+    ) -> Result<Vec<ScoredVectorId<BM25Score>>> {
+        let mut scorer = MaxScoreScorer::new(
+            scorers,
+            ctx,
+            &self.filter,
+            &self.deletions,
+            collector,
+            strategy,
+        );
+        scorer.score_all()?;
+        let MaxScoreScorer { collector, .. } = scorer;
+        Ok(collector.finish())
+    }
+}
+
+/// The BlockMaxScore driver: owns the scorers, the essential/non-essential
+/// partition, the candidate buffer, and the collector; delegates window
+/// planning and essential accumulation to the [`EssentialScorer`] strategy.
+struct MaxScoreScorer<'a, S: EssentialScorer> {
+    /// Scorers, physically partitioned per window (as Lucene's
+    /// `partitionScorers` rewrites `allScorers`): `scorers[..first_essential]`
+    /// holds the non-essential scorers (ascending window bound),
+    /// `scorers[first_essential..]` the essential ones. Rebuilt by
+    /// [`partition`](Self::partition).
+    scorers: Vec<WindowScorer>,
+    first_essential: usize,
+    /// `max_score_sums[i]` = upper bound of the summed contribution of
+    /// non-essential scorers `scorers[0..=i]` for the current window.
+    max_score_sums: Vec<f64>,
+    /// Threshold at which the current partition goes stale and the outer
+    /// window is re-planned.
+    next_min_competitive: f32,
+    ctx: ScoreContext,
+    filter: &'a PreparedFilter,
+    deletions: &'a VectorBitmap,
+    collector: TopK<BM25Score>,
+    strategy: S,
+    candidates: Candidates,
+}
+
+impl<'a, S: EssentialScorer> MaxScoreScorer<'a, S> {
+    fn new(
+        scorers: Vec<TermScorer>,
+        ctx: ScoreContext,
+        filter: &'a PreparedFilter,
+        deletions: &'a VectorBitmap,
+        collector: TopK<BM25Score>,
+        strategy: S,
+    ) -> Self {
+        let n = scorers.len();
+        let scorers = scorers
+            .into_iter()
+            .map(|scorer| WindowScorer {
+                scorer,
+                max_window_score: 0.0,
+            })
+            .collect();
+        Self {
+            scorers,
+            first_essential: 0,
+            max_score_sums: vec![0.0; n],
+            next_min_competitive: 0.0,
+            ctx,
+            filter,
+            deletions,
+            collector,
+            strategy,
+            candidates: Candidates::default(),
+        }
+    }
+
+    /// Current top-k floor as a raw f32, or 0 while the collector is not full
+    /// (any score is competitive; BM25 scores are non-negative).
+    fn min_competitive(&self) -> f32 {
+        self.collector
+            .min_competitive_score()
+            .map(|s| s.score())
+            .unwrap_or(0.0)
+    }
+
+    /// Main loop: iterate outer windows over the whole doc id space.
+    fn score_all(&mut self) -> Result<()> {
+        let mut window_min = self
+            .scorers
+            .iter()
+            .map(|ws| ws.scorer.doc())
+            .min()
+            .unwrap_or(NO_MORE_DOCS);
+
+        while window_min < NO_MORE_DOCS {
+            let mut window_max = self.plan_window(window_min);
+            // Window/partition fixpoint: the window depends on which scorers
+            // are essential, and essentialness depends on per-window max
+            // scores. Usually settles in one iteration.
+            let mut competitive = true;
+            loop {
+                self.update_max_window_scores(window_min, window_max);
+                if !self.partition(self.min_competitive()) {
+                    // Even matching every term cannot reach the top-k floor
+                    // anywhere in this window: skip it entirely.
+                    competitive = false;
+                    break;
+                }
+                let new_max = self.plan_window(window_min);
+                if new_max >= window_max {
+                    break;
+                }
+                window_max = new_max;
+            }
+            if !competitive {
+                window_min = window_max;
+                continue;
+            }
+
+            // Bring essential scorers up to the window start.
+            for ws in &mut self.scorers[self.first_essential..] {
+                if ws.scorer.doc() < window_min {
+                    ws.scorer.seek(window_min)?;
+                }
+            }
+
+            let mut top = self.essential_top();
+            while top < window_max {
+                self.score_window_chunk(window_max)?;
+                top = self.essential_top();
+                if self.min_competitive() >= self.next_min_competitive {
+                    // The floor rose enough to demote another scorer to
+                    // non-essential: re-plan the rest of this window.
+                    break;
+                }
+            }
+            // We need to consider both top and window_max here:
+            // - if the loop above breaks early because the min competitive score rose, then
+            //   top may not be past window_max
+            // - otherwise, top may be advanced past non-essential scorers whose items need to
+            //   still be scored
+            window_min = top.min(window_max);
+        }
+        Ok(())
+    }
+
+    /// Smallest current doc among essential scorers.
+    fn essential_top(&self) -> u64 {
+        self.scorers[self.first_essential..]
+            .iter()
+            .map(|ws| ws.scorer.doc())
+            .min()
+            .unwrap_or(NO_MORE_DOCS)
+    }
+
+    /// Pick the outer window end (exclusive) via the strategy.
+    fn plan_window(&self, window_min: u64) -> u64 {
+        // Window leads are the essential scorers (from the previous
+        // partition), so a non-essential clause's boundaries don't shrink
+        // every window. `first_essential == scorers.len()` is reachable
+        // here — when a window's partition demotes every scorer, score_all
+        // skips the window and re-plans from this function — so fall back to
+        // the last (highest-bounded) scorer as the lead rather than
+        // producing an unbounded window.
+        let first_lead = self.first_essential.min(self.scorers.len() - 1);
+        self.strategy
+            .plan_window(&self.scorers[first_lead..], window_min)
+    }
+
+    /// Refresh every scorer's max possible contribution for
+    /// `[window_min, window_max)`.
+    fn update_max_window_scores(&mut self, window_min: u64, window_max: u64) {
+        for ws in &mut self.scorers {
+            ws.max_window_score = if ws.scorer.doc() < window_max {
+                let from = ws.scorer.doc().max(window_min);
+                ws.scorer
+                    .max_score_in_range(from, window_max - 1, &self.ctx)
+            } else {
+                0.0
+            };
+        }
+    }
+
+    /// Split scorers into non-essential/essential for the current window.
+    ///
+    /// Returns `false` when every scorer is non-essential — no document in
+    /// the window can be competitive. Scorers are sorted by ascending window
+    /// bound and the non-essential prefix grows while its error-adjusted
+    /// bound sum stays below the top-k floor.
+    ///
+    /// Demotions stop at the first scorer that fails the test: with the
+    /// sort keyed on the bound itself, every later scorer has an
+    /// equal-or-larger bound against the same accumulated sum (and
+    /// [`bm25::sum_upper_bound`] is monotone in both arguments), so it would
+    /// fail too. NOTE: Lucene instead sorts by `bound / cost`, which can
+    /// produce a better split when bounds and posting-list lengths are
+    /// uncorrelated — but then demotions are no longer a prefix of the sort
+    /// order and the demoted scorers must be individually compacted into the
+    /// prefix as `partitionScorers` does. If cost-aware ordering is
+    /// reintroduced, the `partition_*` regression tests cover the corpora
+    /// where the orderings disagree.
+    fn partition(&mut self, min_competitive: f32) -> bool {
+        // Physically reorder so the regions are contiguous slices (the
+        // essential suffix is handed to the strategy as `&mut [WindowScorer]`).
+        self.scorers
+            .sort_by(|a, b| a.max_window_score.total_cmp(&b.max_window_score));
+
+        let n = self.scorers.len();
+        self.first_essential = n;
+        self.next_min_competitive = f32::INFINITY;
+        let mut max_score_sum = 0.0f64;
+        for i in 0..n {
+            let w = self.scorers[i].max_window_score as f64;
+            let new_sum = max_score_sum + w;
+            let upper_bound = bm25::sum_upper_bound(new_sum, i + 1) as f32;
+            if upper_bound < min_competitive {
+                // Matching all non-essential clauses so far still cannot be
+                // competitive.
+                max_score_sum = new_sum;
+                self.max_score_sums[i] = max_score_sum;
+            } else {
+                self.first_essential = i;
+                self.next_min_competitive = upper_bound;
+                break;
+            }
+        }
+        self.first_essential < n
+    }
+
+    /// Score one chunk of the current window: the strategy populates the
+    /// candidate buffer from the essential scorers, then the driver drops
+    /// filtered/deleted docs, probes non-essential clauses, and collects.
+    fn score_window_chunk(&mut self, window_max: u64) -> Result<()> {
+        let Self {
+            scorers,
+            first_essential,
+            strategy,
+            ctx,
+            candidates,
+            filter,
+            deletions,
+            ..
+        } = self;
+        candidates.clear();
+        strategy.score_window(
+            &mut scorers[*first_essential..],
+            window_max,
+            ctx,
+            candidates,
+        )?;
+        candidates.retain_docs(|doc| filter.matches(doc) && !deletions.contains(doc));
+
+        self.score_non_essential_and_collect()
+    }
+
+    /// Apply non-essential clauses to the candidate buffer — highest
+    /// max-score first, pruning candidates that can no longer reach the
+    /// top-k floor — then offer the survivors to the collector.
+    fn score_non_essential_and_collect(&mut self) -> Result<()> {
+        let n = self.scorers.len();
+        for i in (0..self.first_essential).rev() {
+            if self.candidates.is_empty() {
+                break;
+            }
+            let min_competitive = self.min_competitive();
+            if min_competitive > 0.0 {
+                let max_remaining = self.max_score_sums[i];
+                let min_required = min_required_score(min_competitive, max_remaining, n);
+                if min_required > 0.0 {
+                    self.candidates.retain_at_least(min_required);
+                }
+            }
+            // Leapfrog this clause over the (doc-ascending) candidates.
+            let ws = &mut self.scorers[i];
+            for c in 0..self.candidates.len() {
+                let doc = self.candidates.docs[c];
+                if ws.scorer.doc() < doc {
+                    ws.scorer.seek(doc)?;
+                }
+                if ws.scorer.doc() == doc {
+                    let hit = ws.scorer.current_hit(&self.ctx);
+                    self.candidates.scores[c] += hit as f64;
+                }
+            }
+        }
+
+        for c in 0..self.candidates.len() {
+            self.collector.collect(ScoredVectorId {
+                val: VectorId::from_raw(self.candidates.docs[c]),
+                score: BM25Score(self.candidates.scores[c] as f32),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Lowest partial score a candidate needs for `partial + max_remaining` to
+/// possibly reach `min_competitive`, conservatively widened for summation
+/// rounding (Lucene's ulp-backoff in `MaxScoreBulkScorer#scoreNonEssential`).
+fn min_required_score(min_competitive: f32, max_remaining: f64, num_scorers: usize) -> f64 {
+    let mut min_required = min_competitive as f64 - max_remaining;
+    let ulp = ulp_f32(min_competitive) as f64;
+    while min_required > 0.0
+        && bm25::sum_upper_bound(min_required + max_remaining, num_scorers) as f32
+            >= min_competitive
+    {
+        min_required -= ulp;
+    }
+    min_required
+}
+
+/// Unit in the last place of a positive finite f32.
+#[inline]
+fn ulp_f32(x: f32) -> f32 {
+    debug_assert!(x.is_finite() && x > 0.0);
+    f32::from_bits(x.to_bits() + 1) - x
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::VectorDb;
+    use crate::model::{Config, Filter, MetadataFieldSpec, Vector};
+    use crate::query_engine::bm25::BM25Operator;
+    use crate::serde::FieldType;
+    use crate::serde::collection_meta::DistanceMetric;
+    use common::StorageConfig;
+
+    fn text_config() -> Config {
+        Config {
+            storage: StorageConfig::InMemory,
+            dimensions: 3,
+            distance_metric: DistanceMetric::L2,
+            metadata_fields: vec![
+                MetadataFieldSpec::new("body", FieldType::Text, false),
+                MetadataFieldSpec::new("category", FieldType::String, true),
+            ],
+            ..Default::default()
+        }
+    }
+
+    fn doc(id: &str, body: &str, category: &str) -> Vector {
+        Vector::builder(id, vec![0.0; 3])
+            .attribute("body", body)
+            .attribute("category", category)
+            .build()
+    }
+
+    async fn seeded_db(docs: Vec<Vector>) -> VectorDb {
+        let db = VectorDb::open(text_config()).await.unwrap();
+        db.write(docs).await.unwrap();
+        db.flush().await.unwrap();
+        db
+    }
+
+    /// Run the BlockMax operator with the given essential-scoring strategy
+    /// against the db's current snapshot.
+    async fn run_block_max_with(
+        strategy: EssentialStrategy,
+        db: &VectorDb,
+        query: &str,
+        filter: Option<&Filter>,
+        limit: usize,
+    ) -> Vec<ScoredVectorId<BM25Score>> {
+        let engine = db.query_engine();
+        let filter = PreparedFilter::build(filter, engine.storage.as_ref())
+            .await
+            .unwrap();
+        BlockMaxBM25Operator::new(
+            engine.storage.clone(),
+            Bm25Query {
+                field: "body".to_string(),
+                query: query.to_string(),
+            },
+            filter,
+            engine.deletions.clone(),
+            limit,
+            strategy,
+        )
+        .execute()
+        .await
+        .unwrap()
+    }
+
+    /// Run the BlockMax operator (dense-window strategy).
+    async fn run_block_max(
+        db: &VectorDb,
+        query: &str,
+        filter: Option<&Filter>,
+        limit: usize,
+    ) -> Vec<ScoredVectorId<BM25Score>> {
+        run_block_max_with(EssentialStrategy::DenseWindow, db, query, filter, limit).await
+    }
+
+    /// Run the BlockMax operator (sort-merge strategy).
+    async fn run_block_max_sparse(
+        db: &VectorDb,
+        query: &str,
+        filter: Option<&Filter>,
+        limit: usize,
+    ) -> Vec<ScoredVectorId<BM25Score>> {
+        run_block_max_with(EssentialStrategy::SortMerge, db, query, filter, limit).await
+    }
+
+    /// Run the exhaustive reference operator against the same snapshot.
+    async fn run_exhaustive(
+        db: &VectorDb,
+        query: &str,
+        filter: Option<&Filter>,
+        limit: usize,
+    ) -> Vec<ScoredVectorId<BM25Score>> {
+        let engine = db.query_engine();
+        let filter = PreparedFilter::build(filter, engine.storage.as_ref())
+            .await
+            .unwrap();
+        BM25Operator::new(
+            engine.storage.clone(),
+            Bm25Query {
+                field: "body".to_string(),
+                query: query.to_string(),
+            },
+            filter,
+            engine.deletions.clone(),
+            limit,
+        )
+        .execute()
+        .await
+        .unwrap()
+    }
+
+    /// Assert both scorers return the same ranked documents.
+    ///
+    /// Doc ids must match exactly in order; scores may differ in the last few
+    /// ulps because the block-max path accumulates per-window sums in `f64`.
+    fn assert_same_results(
+        block_max: &[ScoredVectorId<BM25Score>],
+        exhaustive: &[ScoredVectorId<BM25Score>],
+        context: &str,
+    ) {
+        let bm_ids: Vec<u64> = block_max.iter().map(|r| r.val.id()).collect();
+        let ex_ids: Vec<u64> = exhaustive.iter().map(|r| r.val.id()).collect();
+        assert_eq!(
+            bm_ids, ex_ids,
+            "{}: block-max docs {:?} != exhaustive docs {:?}",
+            context, bm_ids, ex_ids
+        );
+        for (bm, ex) in block_max.iter().zip(exhaustive) {
+            let (b, e) = (bm.score.score(), ex.score.score());
+            assert!(
+                (b - e).abs() <= 1e-4 * e.abs().max(1.0),
+                "{}: score mismatch for doc {}: {} vs {}",
+                context,
+                bm.val.id(),
+                b,
+                e
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn should_rank_documents_by_bm25() {
+        let db = seeded_db(vec![
+            doc("d1", "quick brown fox", "a"),
+            doc("d2", "fox fox", "a"),
+            doc("d3", "slow green turtle", "b"),
+        ])
+        .await;
+
+        let results = run_block_max(&db, "fox", None, 10).await;
+        let exhaustive = run_exhaustive(&db, "fox", None, 10).await;
+
+        assert_eq!(results.len(), 2);
+        assert_same_results(&results, &exhaustive, "single term");
+    }
+
+    #[tokio::test]
+    async fn should_respect_limit_and_prune() {
+        let db = seeded_db(vec![
+            doc("d1", "quick brown fox", "a"),
+            doc("d2", "fox fox", "a"),
+            doc("d3", "another fox here", "a"),
+        ])
+        .await;
+
+        let results = run_block_max(&db, "fox", None, 1).await;
+        let exhaustive = run_exhaustive(&db, "fox", None, 1).await;
+
+        assert_eq!(results.len(), 1);
+        assert_same_results(&results, &exhaustive, "limit 1");
+    }
+
+    #[tokio::test]
+    async fn should_exclude_deleted_documents() {
+        let db = seeded_db(vec![
+            doc("d1", "quick brown fox", "a"),
+            doc("d2", "fox fox", "a"),
+        ])
+        .await;
+        db.delete(vec!["d2"]).await.unwrap();
+        db.flush().await.unwrap();
+
+        let results = run_block_max(&db, "fox", None, 10).await;
+        let exhaustive = run_exhaustive(&db, "fox", None, 10).await;
+
+        assert_eq!(results.len(), 1);
+        assert_same_results(&results, &exhaustive, "after delete");
+    }
+
+    #[tokio::test]
+    async fn should_apply_metadata_filter() {
+        let db = seeded_db(vec![
+            doc("d1", "quick fox", "a"),
+            doc("d2", "fox fox", "b"),
+            doc("d3", "lazy fox", "a"),
+        ])
+        .await;
+
+        let filter = Filter::eq("category", "a");
+        let results = run_block_max(&db, "fox", Some(&filter), 10).await;
+        let exhaustive = run_exhaustive(&db, "fox", Some(&filter), 10).await;
+
+        assert_eq!(results.len(), 2);
+        assert_same_results(&results, &exhaustive, "filtered");
+    }
+
+    #[tokio::test]
+    async fn should_return_empty_when_no_term_matches() {
+        let db = seeded_db(vec![doc("d1", "quick brown fox", "a")]).await;
+        let results = run_block_max(&db, "zebra", None, 10).await;
+        assert!(results.is_empty());
+    }
+
+    /// Tiny deterministic PRNG so the differential corpus needs no deps.
+    struct Lcg(u64);
+
+    impl Lcg {
+        fn next(&mut self) -> u64 {
+            self.0 = self
+                .0
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
+            self.0 >> 33
+        }
+
+        fn below(&mut self, n: u64) -> u64 {
+            self.next() % n
+        }
+    }
+
+    /// Build a corpus with a skewed (Zipf-ish) term distribution: term `t<j>`
+    /// appears in a document with probability ~1/(j+1), so low-index terms
+    /// are stop-word-like and high-index terms are rare. Documents vary in
+    /// length so norms vary too.
+    fn build_corpus(num_docs: usize, vocab: usize, seed: u64) -> Vec<Vector> {
+        let mut rng = Lcg(seed);
+        let mut docs = Vec::with_capacity(num_docs);
+        for i in 0..num_docs {
+            let mut body = String::new();
+            for j in 0..vocab {
+                // Frequency within the doc also varies.
+                if rng.below((j + 2) as u64) == 0 {
+                    let occurrences = 1 + rng.below(4);
+                    for _ in 0..occurrences {
+                        body.push_str(&format!("t{} ", j));
+                    }
+                }
+            }
+            // Padding terms unique to the doc stretch the length distribution.
+            for p in 0..rng.below(30) {
+                body.push_str(&format!("pad{}x{} ", i, p));
+            }
+            let category = if i % 3 == 0 { "a" } else { "b" };
+            docs.push(doc(&format!("d{}", i), body.trim(), category));
+        }
+        docs
+    }
+
+    /// Differential test: BlockMax must return exactly the documents the
+    /// exhaustive scorer returns, across query shapes that exercise
+    /// single/multi-term, common/rare mixes, filters, and small limits
+    /// (small limits raise the pruning floor fastest).
+    #[tokio::test]
+    async fn block_max_matches_exhaustive_on_random_corpus() {
+        // > 4 * 256 docs for the most common terms, so multi-block postings,
+        // window advancement, and block skipping all engage.
+        let db = seeded_db(build_corpus(1500, 40, 42)).await;
+
+        let queries = [
+            "t0",
+            "t1 t30",
+            "t0 t1 t2",
+            "t5 t25 t39",
+            "t0 t39",
+            "t0 t1 t2 t3 t10 t35",
+            "t38 t39",
+            "t0 t0 t1", // duplicate query terms collapse
+            "zebra t7", // one term missing entirely
+        ];
+        for query in queries {
+            for limit in [1, 10, 100] {
+                let bm = run_block_max(&db, query, None, limit).await;
+                let ex = run_exhaustive(&db, query, None, limit).await;
+                assert_same_results(&bm, &ex, &format!("q=[{}] k={}", query, limit));
+                let sparse = run_block_max_sparse(&db, query, None, limit).await;
+                assert_same_results(&sparse, &ex, &format!("sparse q=[{}] k={}", query, limit));
+            }
+            let filter = Filter::eq("category", "a");
+            let bm = run_block_max(&db, query, Some(&filter), 10).await;
+            let ex = run_exhaustive(&db, query, Some(&filter), 10).await;
+            assert_same_results(&bm, &ex, &format!("q=[{}] filtered", query));
+            let sparse = run_block_max_sparse(&db, query, Some(&filter), 10).await;
+            assert_same_results(&sparse, &ex, &format!("sparse q=[{}] filtered", query));
+        }
+    }
+
+    /// Same differential check after deleting a third of the corpus, so the
+    /// deletions bitmap interacts with pruning and block boundaries.
+    #[tokio::test]
+    async fn block_max_matches_exhaustive_after_deletes() {
+        let db = seeded_db(build_corpus(900, 30, 7)).await;
+        let to_delete: Vec<String> = (0..900).step_by(3).map(|i| format!("d{}", i)).collect();
+        db.delete(to_delete.iter().map(|s| s.as_str()))
+            .await
+            .unwrap();
+        db.flush().await.unwrap();
+
+        for query in ["t0", "t0 t1", "t2 t20 t29", "t0 t29"] {
+            for limit in [1, 10] {
+                let ex = run_exhaustive(&db, query, None, limit).await;
+                let bm = run_block_max(&db, query, None, limit).await;
+                assert_same_results(&bm, &ex, &format!("deleted q=[{}] k={}", query, limit));
+                let sparse = run_block_max_sparse(&db, query, None, limit).await;
+                assert_same_results(
+                    &sparse,
+                    &ex,
+                    &format!("sparse deleted q=[{}] k={}", query, limit),
+                );
+            }
+        }
+    }
+
+    /// Differential check over a heavily sparse id space (~94% of ids
+    /// deleted): the regime the sort-merge strategy exists for. Both
+    /// strategies must still match the exhaustive scorer exactly.
+    #[tokio::test]
+    async fn block_max_matches_exhaustive_on_sparse_id_space() {
+        let db = seeded_db(build_corpus(1600, 30, 11)).await;
+        let to_delete: Vec<String> = (0..1600)
+            .filter(|i| i % 16 != 0)
+            .map(|i| format!("d{}", i))
+            .collect();
+        db.delete(to_delete.iter().map(|s| s.as_str()))
+            .await
+            .unwrap();
+        db.flush().await.unwrap();
+
+        for query in ["t0", "t0 t1", "t1 t12 t29", "t0 t29"] {
+            for limit in [1, 10] {
+                let ex = run_exhaustive(&db, query, None, limit).await;
+                let bm = run_block_max(&db, query, None, limit).await;
+                assert_same_results(&bm, &ex, &format!("sparse-ids q=[{}] k={}", query, limit));
+                let sparse = run_block_max_sparse(&db, query, None, limit).await;
+                assert_same_results(
+                    &sparse,
+                    &ex,
+                    &format!("sparse-ids merge q=[{}] k={}", query, limit),
+                );
+            }
+        }
+    }
+
+    /// `parse()` validates framing only; a payload corrupted past its header
+    /// must surface as a recoverable error from the scorer, not a panic.
+    #[test]
+    fn corrupt_block_surfaces_as_error_not_panic() {
+        use crate::serde::term_postings::{PostingEntry, TermPostingsValue};
+        let postings = vec![
+            PostingEntry {
+                id: VectorId::from_raw(8),
+                freq: 2,
+                norm: 30,
+            },
+            PostingEntry {
+                id: VectorId::from_raw(2),
+                freq: 3,
+                norm: 20,
+            },
+        ];
+        let encoded = TermPostingsValue::from_postings(postings).encode_to_bytes();
+        // Corrupt the ids_encoding byte (payload offset 12) of the first
+        // postings block (tag 0x00); parse() never reads it.
+        let mut bytes = encoded.to_vec();
+        let mut offset = 0usize;
+        loop {
+            let tag = bytes[offset];
+            let len = u32::from_le_bytes([
+                bytes[offset + 1],
+                bytes[offset + 2],
+                bytes[offset + 3],
+                bytes[offset + 4],
+            ]) as usize;
+            let payload_start = offset + 5;
+            if tag == 0x00 {
+                bytes[payload_start + 12] = 0xEE;
+                break;
+            }
+            offset = payload_start + len;
+        }
+        let view = PostingListView::parse(bytes::Bytes::from(bytes))
+            .expect("parse() accepts the corrupt payload");
+        assert!(TermScorer::new(view, 1.0).is_err());
+    }
+
+    /// Regression for the partition's essential/non-essential split when the
+    /// terms' costs and bounds point in opposite directions: "alpha" is
+    /// common (long posting list) with high-impact blocks pushing its bound
+    /// above the floor; "bravo" is rare (short posting list) but only in very
+    /// long docs, putting its bound below the floor. Under a cost-aware sort
+    /// (Lucene's `bound / cost`, the original implementation here) demotions
+    /// are not a prefix of the sort order, and a partition that doesn't
+    /// physically compact the regions generates candidates from the wrong
+    /// posting list. The current bound-keyed sort makes demotions a prefix by
+    /// construction; this corpus pins that down and guards any future return
+    /// to cost-aware ordering.
+    #[tokio::test]
+    async fn partition_keeps_competitive_docs_when_cost_and_bound_disagree() {
+        let mut docs = Vec::new();
+        let mut filler_id = 0usize;
+        let mut filler = |n: usize| -> String {
+            let mut s = String::new();
+            for _ in 0..n {
+                s.push_str(&format!("w{} ", filler_id));
+                filler_id += 1;
+            }
+            s
+        };
+        for i in 0..300 {
+            docs.push(doc(
+                &format!("d{:04}", i),
+                &format!("alpha alpha {}", filler(8)),
+                "a",
+            ));
+        }
+        for i in 300..500 {
+            docs.push(doc(&format!("d{:04}", i), &filler(10), "a"));
+        }
+        for i in 500..900 {
+            if i == 600 || i == 700 || i == 800 {
+                docs.push(doc(
+                    &format!("d{:04}", i),
+                    &format!("bravo {}", filler(1000)),
+                    "a",
+                ));
+            } else {
+                let mut body = "alpha ".repeat(10);
+                body.push_str(&filler(2));
+                docs.push(doc(&format!("d{:04}", i), &body, "a"));
+            }
+        }
+        let db = seeded_db(docs).await;
+        let bm = run_block_max(&db, "alpha bravo", None, 10).await;
+        let ex = run_exhaustive(&db, "alpha bravo", None, 10).await;
+        eprintln!(
+            "block_max: {:?}",
+            bm.iter()
+                .map(|r| (r.val.id(), r.score.score()))
+                .collect::<Vec<_>>()
+        );
+        eprintln!(
+            "exhaustive: {:?}",
+            ex.iter()
+                .map(|r| (r.val.id(), r.score.score()))
+                .collect::<Vec<_>>()
+        );
+        assert_same_results(&bm, &ex, "partition region swap");
+        let sparse = run_block_max_sparse(&db, "alpha bravo", None, 10).await;
+        assert_same_results(&sparse, &ex, "partition region swap (sparse)");
+    }
+
+    /// Companion regression to
+    /// [`partition_keeps_competitive_docs_when_cost_and_bound_disagree`],
+    /// with the mis-assignable window holding a doc strictly above the
+    /// floor. "common": 600 early freq-1 docs set the top-1 floor; one late
+    /// doc has freq 50 (score well above the floor). "rare": short-posting
+    /// docs with a bound below the floor, interleaved with the hot doc so
+    /// they share the last window. Under cost-aware ordering with a
+    /// non-compacting partition, the freq-50 doc was silently dropped from
+    /// the top-1.
+    #[tokio::test]
+    async fn partition_floor_between_term_bounds_keeps_competitive_docs() {
+        // Batch 1 sets the floor: 600 freq-1 "common" docs + filler.
+        let mut batch1 = Vec::new();
+        let mut i = 0usize;
+        for _ in 0..600 {
+            batch1.push(doc(
+                &format!("d{:04}", i),
+                &format!("common p{}a p{}b", i, i),
+                "a",
+            ));
+            i += 1;
+        }
+        for _ in 0..796 {
+            batch1.push(doc(
+                &format!("d{:04}", i),
+                &format!("f{}a f{}b f{}c", i, i, i),
+                "a",
+            ));
+            i += 1;
+        }
+        // Batch 2 (higher internal ids, one shared block range): 250 freq-1
+        // common docs, ONE hot common doc (freq 50, above the floor), and 30
+        // long rare docs (freq 1, below the floor) interleaved.
+        let mut batch2 = Vec::new();
+        for _ in 0..250 {
+            batch2.push(doc(
+                &format!("d{:04}", i),
+                &format!("common p{}a p{}b", i, i),
+                "a",
+            ));
+            i += 1;
+        }
+        batch2.push(doc(&format!("d{:04}", i), "common ".repeat(50).trim(), "a"));
+        i += 1;
+        for t in 0..30 {
+            let mut b = String::from("rare");
+            for p in 0..200 {
+                b.push_str(&format!(" q{}x{}", t, p));
+            }
+            batch2.push(doc(&format!("d{:04}", i), &b, "a"));
+            i += 1;
+        }
+
+        let db = seeded_db(batch1).await;
+        db.write(batch2).await.unwrap();
+        db.flush().await.unwrap();
+        let bm = run_block_max(&db, "common rare", None, 1).await;
+        let ex = run_exhaustive(&db, "common rare", None, 1).await;
+        eprintln!(
+            "block_max: {:?}",
+            bm.iter()
+                .map(|r| (r.val.id(), r.score.score()))
+                .collect::<Vec<_>>()
+        );
+        eprintln!(
+            "exhaustive: {:?}",
+            ex.iter()
+                .map(|r| (r.val.id(), r.score.score()))
+                .collect::<Vec<_>>()
+        );
+        assert_same_results(&bm, &ex, "non-prefix demotion");
+        let sparse = run_block_max_sparse(&db, "common rare", None, 1).await;
+        assert_same_results(&sparse, &ex, "non-prefix demotion (sparse)");
+    }
+
+    /// Multiple flushes produce multiple merge operands per posting list
+    /// (small tail blocks between operands); the view and windowing must
+    /// handle the fragmented block layout.
+    #[tokio::test]
+    async fn block_max_matches_exhaustive_across_merge_operands() {
+        let db = VectorDb::open(text_config()).await.unwrap();
+        let mut rng = Lcg(99);
+        let mut next_id = 0usize;
+        for _ in 0..5 {
+            let mut batch = Vec::new();
+            for _ in 0..120 {
+                let mut body = String::new();
+                for j in 0..15 {
+                    if rng.below((j + 2) as u64) == 0 {
+                        body.push_str(&format!("t{} t{} ", j, j));
+                    }
+                }
+                batch.push(doc(&format!("d{}", next_id), body.trim(), "a"));
+                next_id += 1;
+            }
+            db.write(batch).await.unwrap();
+            db.flush().await.unwrap();
+        }
+
+        for query in ["t0 t1", "t0 t14", "t3 t7 t11"] {
+            let ex = run_exhaustive(&db, query, None, 10).await;
+            let bm = run_block_max(&db, query, None, 10).await;
+            assert_same_results(&bm, &ex, &format!("operands q=[{}]", query));
+            let sparse = run_block_max_sparse(&db, query, None, 10).await;
+            assert_same_results(&sparse, &ex, &format!("sparse operands q=[{}]", query));
+        }
+    }
+}

--- a/vector/src/query_engine/bm25/essential.rs
+++ b/vector/src/query_engine/bm25/essential.rs
@@ -1,0 +1,404 @@
+//! Essential-clause scoring strategies for the BlockMaxScore driver.
+//!
+//! The driver ([`MaxScoreScorer`](super::block_max::MaxScoreScorer)) owns
+//! partitioning, score bounds, filtering, non-essential probing, and
+//! collection; an [`EssentialScorer`] owns the two pieces that depend on how
+//! candidates are accumulated:
+//!
+//! - **planning** — where the next outer window should end, and
+//! - **scoring** — turning the essential scorers' postings within that
+//!   window into a doc-ascending list of partially-scored candidates.
+//!
+//! Two strategies are provided:
+//!
+//! - [`DenseWindowScorer`]: Lucene's `MaxScoreBulkScorer` shape. Windows end
+//!   at the nearest posting-block boundary; essential postings scatter into
+//!   a dense [`ScoreWindow`] indexed by `doc - window_min`. Best when doc
+//!   ids are dense — slot utilization is high and cross-term combination is
+//!   one array write.
+//! - [`MergeScorer`]: windows sized by posting **count** (the id span ends
+//!   where each lead scorer is ~[`WINDOW_POSTINGS`] entries past its
+//!   cursor); each essential term appends its hits to a per-term list and
+//!   the lists are k-way merged. Work and memory scale with postings, not
+//!   with id span, so this holds up when the id space is sparse (deletes /
+//!   update churn leave permanent holes — ids are never reassigned).
+//!
+//! Both strategies compute hits with the same [`ScoreContext`] arithmetic
+//! and accumulate in `f64`, so they produce bit-identical candidate scores.
+
+use crate::error::Result;
+use crate::math::bm25::ScoreContext;
+
+use super::term_scorer::{NO_MORE_DOCS, TermScorer};
+
+/// Size of the dense inner scoring window, in doc ids. Only meaningful for
+/// [`DenseWindowScorer`]: a window of ids maps to this many accumulator
+/// slots, so utilization degrades as the id space grows sparse.
+const INNER_WINDOW_SIZE: u64 = 4096;
+
+/// Target number of postings per window lead for [`MergeScorer`]'s
+/// count-based planning. The window ends at the block boundary where the
+/// tightest lead is roughly this many entries past its cursor, so per-window
+/// essential work is bounded by postings rather than id span.
+const WINDOW_POSTINGS: usize = 4096;
+
+/// Per-batch candidate cap for the single-essential-clause fast path. Caps
+/// how many candidates accumulate before the driver probes non-essential
+/// clauses and collects — keeping the top-k floor fresh.
+const SINGLE_CLAUSE_BATCH: usize = 256;
+
+/// Which [`EssentialScorer`] the BlockMax operator drives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EssentialStrategy {
+    /// [`DenseWindowScorer`]: block-aligned windows + dense accumulator.
+    DenseWindow,
+    /// [`MergeScorer`]: count-sized windows + sort-merge accumulation.
+    SortMerge,
+}
+
+/// A [`TermScorer`] plus its partitioning state for the current outer window
+/// (Lucene's `DisiWrapper`). The window bound lives here — not on the
+/// iterator — because it belongs to the partitioning pass, which rewrites it
+/// every window.
+pub(super) struct WindowScorer {
+    pub(super) scorer: TermScorer,
+    /// Max possible contribution within the current outer window.
+    pub(super) max_window_score: f32,
+}
+
+/// Candidate documents within a window: doc-ascending parallel arrays of ids
+/// and partial (essential-only, then progressively completed) scores. This is
+/// first populated from the accumulated scores from essential terms, then
+/// updated with scores from non-essential terms.
+#[derive(Default)]
+pub(super) struct Candidates {
+    pub(super) docs: Vec<u64>,
+    pub(super) scores: Vec<f64>,
+}
+
+impl Candidates {
+    pub(super) fn clear(&mut self) {
+        self.docs.clear();
+        self.scores.clear();
+    }
+
+    pub(super) fn push(&mut self, doc: u64, score: f64) {
+        self.docs.push(doc);
+        self.scores.push(score);
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.docs.len()
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.docs.is_empty()
+    }
+
+    /// Drop candidates whose score is below `min_score`, in place.
+    pub(super) fn retain_at_least(&mut self, min_score: f64) {
+        let mut out = 0usize;
+        for i in 0..self.docs.len() {
+            if self.scores[i] >= min_score {
+                self.docs[out] = self.docs[i];
+                self.scores[out] = self.scores[i];
+                out += 1;
+            }
+        }
+        self.docs.truncate(out);
+        self.scores.truncate(out);
+    }
+
+    /// Drop candidates whose doc id fails `keep`, in place.
+    pub(super) fn retain_docs(&mut self, mut keep: impl FnMut(u64) -> bool) {
+        let mut out = 0usize;
+        for i in 0..self.docs.len() {
+            if keep(self.docs[i]) {
+                self.docs[out] = self.docs[i];
+                self.scores[out] = self.scores[i];
+                out += 1;
+            }
+        }
+        self.docs.truncate(out);
+        self.scores.truncate(out);
+    }
+}
+
+/// Strategy for planning outer windows and scoring the essential clauses
+/// within them.
+///
+/// `score_window` may consume only a *chunk* of `[top, window_max)` per call
+/// (e.g. one inner window, or one candidate batch); the driver keeps calling
+/// while the minimum essential doc stays below `window_max`, re-checking the
+/// top-k floor between calls. Contract: each call pushes candidates in
+/// ascending doc order with no duplicates, covering exactly the postings the
+/// essential scorers were advanced past; candidates are *not* filtered — the
+/// driver applies the metadata filter and deletions to the buffer afterwards.
+pub(super) trait EssentialScorer {
+    /// Pick the end (exclusive) of the outer window starting at `window_min`,
+    /// given the window-lead scorers. Must return a bound strictly greater
+    /// than `window_min` unless every lead is exhausted ([`NO_MORE_DOCS`]).
+    fn plan_window(&self, leads: &[WindowScorer], window_min: u64) -> u64;
+
+    /// Score a chunk of the essential scorers' postings in
+    /// `[min essential doc, window_max)` into `candidates`, advancing the
+    /// scorers past everything scored.
+    fn score_window(
+        &mut self,
+        essential: &mut [WindowScorer],
+        window_max: u64,
+        ctx: &ScoreContext,
+        candidates: &mut Candidates,
+    ) -> Result<()>;
+}
+
+/// Smallest and second-smallest current doc among `scorers`.
+fn top2(scorers: &[WindowScorer]) -> (u64, u64) {
+    let mut top = NO_MORE_DOCS;
+    let mut top2 = NO_MORE_DOCS;
+    for ws in scorers {
+        let doc = ws.scorer.doc();
+        if doc < top {
+            top2 = top;
+            top = doc;
+        } else if doc < top2 {
+            top2 = doc;
+        }
+    }
+    (top, top2)
+}
+
+// -- Dense windows (Lucene MaxScoreBulkScorer shape) ----------------------------
+
+/// Dense per-window score accumulator: an `f64` score per slot plus a match
+/// bitset over the slots, populated term-at-a-time by
+/// [`TermScorer::score_window_into`] and emptied with [`drain`](Self::drain).
+pub(super) struct ScoreWindow {
+    scores: Vec<f64>,
+    match_words: Vec<u64>,
+}
+
+impl ScoreWindow {
+    pub(super) fn new(slots: usize) -> Self {
+        let words = slots.div_ceil(64);
+        Self {
+            scores: vec![0.0; words * 64],
+            match_words: vec![0u64; words],
+        }
+    }
+
+    /// Accumulate one hit into `slot`.
+    #[inline]
+    pub(super) fn add(&mut self, slot: usize, hit: f32) {
+        self.scores[slot] += hit as f64;
+        self.match_words[slot >> 6] |= 1u64 << (slot & 63);
+    }
+
+    /// Visit the matched slots in ascending order and reset the window,
+    /// touching only slots that were set (no full clear of the buffers).
+    pub(super) fn drain(&mut self, mut visit: impl FnMut(usize, f64)) {
+        for word_idx in 0..self.match_words.len() {
+            let mut word = self.match_words[word_idx];
+            while word != 0 {
+                let bit = word.trailing_zeros() as usize;
+                // unsets the right-most set bit
+                word &= word - 1;
+                let slot = (word_idx << 6) | bit;
+                let score = self.scores[slot];
+                self.scores[slot] = 0.0;
+                visit(slot, score);
+            }
+            self.match_words[word_idx] = 0;
+        }
+    }
+}
+
+/// Block-aligned windows scored into a dense id-indexed accumulator —
+/// Lucene's `MaxScoreBulkScorer` structure. See the module docs for when
+/// this wins (dense id spaces) and loses (sparse ones).
+pub(super) struct DenseWindowScorer {
+    window: ScoreWindow,
+}
+
+impl DenseWindowScorer {
+    pub(super) fn new() -> Self {
+        Self {
+            window: ScoreWindow::new(INNER_WINDOW_SIZE as usize),
+        }
+    }
+}
+
+impl EssentialScorer for DenseWindowScorer {
+    /// End the window at the nearest posting-block boundary among the leads,
+    /// so block impacts bound the window tightly.
+    fn plan_window(&self, leads: &[WindowScorer], window_min: u64) -> u64 {
+        let mut window_max = NO_MORE_DOCS;
+        for ws in leads {
+            let upper = ws.scorer.probe_block_boundary(window_min);
+            window_max = window_max.min(upper.saturating_add(1));
+        }
+        // TODO(rfc-0006): block-aligned windows can degenerate to a few docs
+        // each when posting lists are poorly aligned, making the scorer spend
+        // more time re-planning windows than scoring documents.
+        // Lucene counteracts this with a minimum window size that doubles
+        // while windows stay unproductive (`MaxScoreBulkScorer`,
+        // `minWindowSize`); revisit if window-planning overhead shows up in
+        // benchmarks.
+        window_max
+    }
+
+    fn score_window(
+        &mut self,
+        essential: &mut [WindowScorer],
+        window_max: u64,
+        ctx: &ScoreContext,
+        candidates: &mut Candidates,
+    ) -> Result<()> {
+        let (top, top2) = top2(essential);
+
+        // Single-clause fast path: when only one essential clause has docs in
+        // the first half-window, stream one candidate batch directly without
+        // the dense accumulator.
+        if top2 >= top.saturating_add(INNER_WINDOW_SIZE / 2) {
+            let up_to = top2.min(window_max);
+            let ws = essential
+                .iter_mut()
+                .min_by_key(|ws| ws.scorer.doc())
+                .expect("score_window requires an essential scorer");
+            while ws.scorer.doc() < up_to && candidates.len() < SINGLE_CLAUSE_BATCH {
+                let hit = ws.scorer.current_hit(ctx);
+                candidates.push(ws.scorer.doc(), hit as f64);
+                ws.scorer.next()?;
+            }
+            return Ok(());
+        }
+
+        let inner_min = top;
+        let inner_max = window_max.min(inner_min.saturating_add(INNER_WINDOW_SIZE));
+
+        // Term-at-a-time: exhaust each essential clause through the whole
+        // inner window before touching the next clause.
+        for ws in essential.iter_mut() {
+            if ws.scorer.doc() < inner_max {
+                ws.scorer
+                    .score_window_into(inner_min, inner_max, ctx, &mut self.window)?;
+            }
+        }
+
+        // Flush the accumulator into the doc-sorted candidate list.
+        self.window.drain(|slot, score| {
+            candidates.push(inner_min + slot as u64, score);
+        });
+        Ok(())
+    }
+}
+
+// -- Count-sized windows + sort-merge accumulation ------------------------------
+
+/// One essential term's hits within the current window, appended in
+/// ascending doc order by [`TermScorer::collect_hits_into`].
+#[derive(Default)]
+pub(super) struct HitList {
+    pub(super) docs: Vec<u64>,
+    pub(super) hits: Vec<f32>,
+}
+
+impl HitList {
+    fn clear(&mut self) {
+        self.docs.clear();
+        self.hits.clear();
+    }
+}
+
+/// Count-sized windows scored by appending each essential term's hits to a
+/// sorted per-term list and k-way merging the lists into the candidate
+/// buffer. Work and memory scale with the postings actually present, never
+/// with the window's id span, so sparsity in the doc id space costs nothing.
+/// The price is a comparison per posting during the merge instead of the
+/// dense path's O(1) slot addressing — cheap while essential clauses are few.
+pub(super) struct MergeScorer {
+    /// Per-essential-term hit buffers, reused across windows.
+    buffers: Vec<HitList>,
+    /// Per-buffer merge cursors, reused across windows.
+    cursors: Vec<usize>,
+}
+
+impl MergeScorer {
+    pub(super) fn new() -> Self {
+        Self {
+            buffers: Vec::new(),
+            cursors: Vec::new(),
+        }
+    }
+}
+
+impl EssentialScorer for MergeScorer {
+    /// End the window where the tightest lead is ~[`WINDOW_POSTINGS`]
+    /// entries past its cursor (rounded out to that entry's block boundary,
+    /// which keeps impact-based window bounds tight).
+    fn plan_window(&self, leads: &[WindowScorer], window_min: u64) -> u64 {
+        let mut window_max = NO_MORE_DOCS;
+        for ws in leads {
+            let upper = ws.scorer.probe_count_boundary(window_min, WINDOW_POSTINGS);
+            window_max = window_max.min(upper.saturating_add(1));
+        }
+        window_max
+    }
+
+    fn score_window(
+        &mut self,
+        essential: &mut [WindowScorer],
+        window_max: u64,
+        ctx: &ScoreContext,
+        candidates: &mut Candidates,
+    ) -> Result<()> {
+        if self.buffers.len() < essential.len() {
+            self.buffers.resize_with(essential.len(), HitList::default);
+        }
+
+        // Term-at-a-time: append each essential clause's window hits to its
+        // own doc-ascending list. Same batch shape as the dense path's
+        // accumulation loop (and the same vectorization target), minus the
+        // scatter.
+        for (ws, buffer) in essential.iter_mut().zip(&mut self.buffers) {
+            buffer.clear();
+            if ws.scorer.doc() < window_max {
+                ws.scorer.collect_hits_into(window_max, ctx, buffer)?;
+            }
+        }
+        let buffers = &self.buffers[..essential.len()];
+
+        // Single-clause fast path: nothing to merge.
+        if let [only] = buffers {
+            for (&doc, &hit) in only.docs.iter().zip(&only.hits) {
+                candidates.push(doc, hit as f64);
+            }
+            return Ok(());
+        }
+
+        // K-way merge: emit each distinct doc once, in ascending order,
+        // summing the hits of every list positioned on it. Linear scan over
+        // the heads instead of a heap — k is the essential clause count.
+        self.cursors.clear();
+        self.cursors.resize(buffers.len(), 0);
+        loop {
+            let mut min_doc = NO_MORE_DOCS;
+            for (cursor, buffer) in self.cursors.iter().zip(buffers) {
+                if let Some(&doc) = buffer.docs.get(*cursor) {
+                    min_doc = min_doc.min(doc);
+                }
+            }
+            if min_doc == NO_MORE_DOCS {
+                return Ok(());
+            }
+            let mut score = 0.0f64;
+            for (cursor, buffer) in self.cursors.iter_mut().zip(buffers) {
+                if buffer.docs.get(*cursor) == Some(&min_doc) {
+                    score += buffer.hits[*cursor] as f64;
+                    *cursor += 1;
+                }
+            }
+            candidates.push(min_doc, score);
+        }
+    }
+}

--- a/vector/src/query_engine/bm25/exhaustive.rs
+++ b/vector/src/query_engine/bm25/exhaustive.rs
@@ -7,61 +7,23 @@
 //! scoring cost. Forward-index lookups are deferred to the lookup operator.
 
 use std::cmp::Ordering;
-use std::collections::{BinaryHeap, HashSet};
+use std::collections::BinaryHeap;
 use std::sync::Arc;
 
 use common::storage::StorageRead;
 
+use super::{BM25Score, dedupe_query_terms, load_field_stats, load_term_stats};
 use crate::error::Result;
 use crate::math::bm25;
 use crate::model::Bm25Query;
 use crate::query_engine::collectors::{Collector, TopK};
 use crate::query_engine::filter::PreparedFilter;
 use crate::query_engine::operator::Operator;
-use crate::query_engine::types::{Score, ScoredVectorId};
-use crate::serde::field_stats::FieldStatsValue;
-use crate::serde::key::{FieldStatsKey, TermPostingsKey, TermStatsKey};
+use crate::query_engine::types::ScoredVectorId;
+use crate::serde::key::TermPostingsKey;
 use crate::serde::term_postings::{PostingEntry, TermPostingsValue};
-use crate::serde::term_stats::TermStatsValue;
 use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_id::VectorId;
-use crate::text;
-
-/// A BM25 relevance score, where a higher raw value is more relevant.
-///
-/// Wraps the raw score so it participates in the generic [`Score`] ordering,
-/// which ranks better scores *first* (`Ordering::Less`). BM25 is "higher is
-/// better", so the natural `f32` order is inverted here; `score` still returns
-/// the raw value for the public `SearchResult.score`.
-#[derive(Clone, Copy, Debug)]
-pub(crate) struct BM25Score(pub(crate) f32);
-
-impl Score for BM25Score {
-    fn score(&self) -> f32 {
-        self.0
-    }
-}
-
-impl PartialEq for BM25Score {
-    fn eq(&self, other: &Self) -> bool {
-        self.cmp(other) == Ordering::Equal
-    }
-}
-
-impl Eq for BM25Score {}
-
-impl PartialOrd for BM25Score {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for BM25Score {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // Higher relevance ranks first, so invert the natural f32 order.
-        other.0.total_cmp(&self.0)
-    }
-}
 
 /// Scores a BM25 query: walks the union of the query terms' posting lists and
 /// produces the ranked `ScoredVectorId`s.
@@ -93,46 +55,30 @@ impl BM25Operator {
     }
 
     /// Load postings + term stats for each query term and wrap them as
-    /// [`TermScorer`]s carrying precomputed IDF. Terms with no documents are
-    /// omitted.
+    /// [`TermScorer`]s carrying precomputed IDF, fetching all terms
+    /// concurrently. Terms with no documents are omitted.
     async fn open_term_scorers(
         &self,
         field: &str,
         terms: &[String],
         n_docs: u64,
     ) -> Result<Vec<TermScorer>> {
-        let mut scorers = Vec::with_capacity(terms.len());
-        for term in terms {
-            let postings = self.load_term_postings(field, term).await?;
-            let stats = self.load_term_stats(field, term).await?;
+        let loads = terms.iter().map(|term| async move {
+            let stats = load_term_stats(self.storage.as_ref(), field, term).await?;
             let n_t = stats.freq.max(0) as u64;
             if n_t == 0 {
-                continue;
+                return Ok::<Option<TermScorer>, crate::error::Error>(None);
             }
+            let postings = self.load_term_postings(field, term).await?;
             // Block iteration order is already descending by doc id.
             let entries: Vec<PostingEntry> = postings.iter_entries().copied().collect();
             if entries.is_empty() {
-                continue;
+                return Ok(None);
             }
-            scorers.push(TermScorer::new(entries, bm25::idf(n_docs, n_t)));
-        }
-        Ok(scorers)
-    }
-
-    async fn load_field_stats(&self, field: &str) -> Result<FieldStatsValue> {
-        let key = FieldStatsKey::new(field).encode();
-        match self.storage.get(key).await? {
-            Some(record) => Ok(FieldStatsValue::decode_from_bytes(&record.value)?),
-            None => Ok(FieldStatsValue::default()),
-        }
-    }
-
-    async fn load_term_stats(&self, field: &str, term: &str) -> Result<TermStatsValue> {
-        let key = TermStatsKey::new(field, term).encode();
-        match self.storage.get(key).await? {
-            Some(record) => Ok(TermStatsValue::decode_from_bytes(&record.value)?),
-            None => Ok(TermStatsValue::default()),
-        }
+            Ok(Some(TermScorer::new(entries, bm25::idf(n_docs, n_t))))
+        });
+        let scorers: Vec<Option<TermScorer>> = futures::future::try_join_all(loads).await?;
+        Ok(scorers.into_iter().flatten().collect())
     }
 
     async fn load_term_postings(&self, field: &str, term: &str) -> Result<TermPostingsValue> {
@@ -155,7 +101,7 @@ impl Operator<Vec<ScoredVectorId<BM25Score>>> for BM25Operator {
         }
 
         // Per-field corpus stats are required to compute IDF / avgdl.
-        let field_stats = self.load_field_stats(&self.query.field).await?;
+        let field_stats = load_field_stats(self.storage.as_ref(), &self.query.field).await?;
         let n_docs = field_stats.count.max(0) as u64;
         if n_docs == 0 || field_stats.total_length <= 0 {
             return Ok(collector.finish());
@@ -295,24 +241,12 @@ impl PartialOrd for ScorerHead {
     }
 }
 
-/// Tokenize a BM25 query string and drop duplicate terms while preserving
-/// first-seen order.
-fn dedupe_query_terms(query: &str) -> Vec<String> {
-    let mut seen: HashSet<String> = HashSet::new();
-    let mut unique = Vec::new();
-    for term in text::tokenize(query) {
-        if seen.insert(term.clone()) {
-            unique.push(term);
-        }
-    }
-    unique
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::db::VectorDb;
     use crate::model::{Config, Filter, MetadataFieldSpec, Vector};
+    use crate::query_engine::types::Score;
     use crate::serde::FieldType;
     use crate::serde::collection_meta::DistanceMetric;
     use crate::storage::VectorDbStorageReadExt;

--- a/vector/src/query_engine/bm25/mod.rs
+++ b/vector/src/query_engine/bm25/mod.rs
@@ -1,0 +1,108 @@
+//! BM25 query operators (RFC-0006).
+//!
+//! Two interchangeable scorers produce the ranked `ScoredVectorId`s for a
+//! [`Bm25Query`](crate::model::Bm25Query):
+//!
+//! - [`block_max`]: the default. Skips non-competitive documents with
+//!   BlockMaxScore (RFC-0006 Milestone 3).
+//! - [`exhaustive`]: scores every document in the union of the query terms'
+//!   posting lists (Milestone 0). Kept as the reference implementation and
+//!   for benchmarking the pruned path against it.
+//!
+//! [`term_scorer`] holds the lazily-decoding posting-list iterator the
+//! block-max scorer drives. This module owns the pieces both scorers share:
+//! the score type, query tokenization, and the term/field statistics loads.
+
+mod block_max;
+mod essential;
+mod exhaustive;
+mod term_scorer;
+
+pub(crate) use block_max::BlockMaxBM25Operator;
+pub(crate) use essential::EssentialStrategy;
+pub(crate) use exhaustive::BM25Operator;
+
+use std::cmp::Ordering;
+use std::collections::HashSet;
+
+use common::storage::StorageRead;
+
+use crate::error::Result;
+use crate::query_engine::types::Score;
+use crate::serde::field_stats::FieldStatsValue;
+use crate::serde::key::{FieldStatsKey, TermStatsKey};
+use crate::serde::term_stats::TermStatsValue;
+use crate::text;
+
+/// A BM25 relevance score, where a higher raw value is more relevant.
+///
+/// Wraps the raw score so it participates in the generic [`Score`] ordering,
+/// which ranks better scores *first* (`Ordering::Less`). BM25 is "higher is
+/// better", so the natural `f32` order is inverted here; `score` still returns
+/// the raw value for the public `SearchResult.score`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct BM25Score(pub(crate) f32);
+
+impl Score for BM25Score {
+    fn score(&self) -> f32 {
+        self.0
+    }
+}
+
+impl PartialEq for BM25Score {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+
+impl Eq for BM25Score {}
+
+impl PartialOrd for BM25Score {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for BM25Score {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Higher relevance ranks first, so invert the natural f32 order.
+        other.0.total_cmp(&self.0)
+    }
+}
+
+/// Tokenize a BM25 query string and drop duplicate terms while preserving
+/// first-seen order.
+fn dedupe_query_terms(query: &str) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut unique = Vec::new();
+    for term in text::tokenize(query) {
+        if seen.insert(term.clone()) {
+            unique.push(term);
+        }
+    }
+    unique
+}
+
+/// Load the per-field corpus statistics (document count / total length) that
+/// IDF and `avgdl` derive from. Missing stats decode as zeroed defaults.
+async fn load_field_stats(storage: &dyn StorageRead, field: &str) -> Result<FieldStatsValue> {
+    let key = FieldStatsKey::new(field).encode();
+    match storage.get(key).await? {
+        Some(record) => Ok(FieldStatsValue::decode_from_bytes(&record.value)?),
+        None => Ok(FieldStatsValue::default()),
+    }
+}
+
+/// Load a term's document-frequency statistics. Missing stats decode as
+/// zeroed defaults (the term matches nothing).
+async fn load_term_stats(
+    storage: &dyn StorageRead,
+    field: &str,
+    term: &str,
+) -> Result<TermStatsValue> {
+    let key = TermStatsKey::new(field, term).encode();
+    match storage.get(key).await? {
+        Some(record) => Ok(TermStatsValue::decode_from_bytes(&record.value)?),
+        None => Ok(TermStatsValue::default()),
+    }
+}

--- a/vector/src/query_engine/bm25/term_scorer.rs
+++ b/vector/src/query_engine/bm25/term_scorer.rs
@@ -1,0 +1,294 @@
+//! Lazily-decoding posting-list iterator for the BlockMaxScore scorer.
+//!
+//! [`TermScorer`] walks one query term's posting list in ascending doc id
+//! order. Blocks are decoded (bit-unpacked) only when the cursor enters
+//! them; blocks the algorithm skips are never decoded. Per-block max scores
+//! derived from skip-block impacts are memoized per query.
+
+use crate::error::Result;
+use crate::math::bm25::ScoreContext;
+use crate::query_engine::bm25::essential::{HitList, ScoreWindow};
+use crate::serde::term_postings::{DecodedPostingsBlock, PostingListView};
+
+/// Sentinel: no documents at or beyond this id (data-vector ids use the low
+/// 56 bits only, so `u64::MAX` is unreachable).
+pub(super) const NO_MORE_DOCS: u64 = u64::MAX;
+
+/// One query term's posting list, iterated lazily in ascending doc id order.
+pub(super) struct TermScorer {
+    view: PostingListView,
+    /// IDF for this term in the current corpus.
+    idf: f32,
+    /// Current doc id; [`NO_MORE_DOCS`] when exhausted.
+    doc: u64,
+    /// Term frequency / norm of the current doc.
+    freq: u32,
+    norm: u8,
+    /// Index of the block holding the cursor.
+    block_idx: usize,
+    /// Decoded arrays for `block_idx` (ascending ids).
+    decoded: DecodedPostingsBlock,
+    /// Cursor position within `decoded`.
+    pos: usize,
+    /// Memoized per-block max score contribution.
+    block_max_scores: Vec<Option<f32>>,
+}
+
+impl TermScorer {
+    pub(super) fn new(view: PostingListView, idf: f32) -> Result<Self> {
+        let block_max_scores = vec![None; view.blocks().len()];
+        let mut scorer = Self {
+            view,
+            idf,
+            doc: 0,
+            freq: 0,
+            norm: 0,
+            block_idx: 0,
+            decoded: DecodedPostingsBlock::default(),
+            pos: 0,
+            block_max_scores,
+        };
+        scorer.load_block(0)?;
+        Ok(scorer)
+    }
+
+    /// Current doc id; [`NO_MORE_DOCS`] when exhausted.
+    #[inline]
+    pub(super) fn doc(&self) -> u64 {
+        self.doc
+    }
+
+    /// BM25 contribution of the current doc's hit on this term.
+    #[inline]
+    pub(super) fn current_hit(&self, ctx: &ScoreContext) -> f32 {
+        ctx.score_hit(self.idf, self.freq, self.norm)
+    }
+
+    /// Decode block `idx` and position the cursor on its first posting.
+    ///
+    /// `parse()` only validates block framing, so a payload corrupted past
+    /// its header is first detected here; the error propagates out of the
+    /// query like any other storage decode failure.
+    fn load_block(&mut self, idx: usize) -> Result<()> {
+        if idx >= self.view.blocks().len() {
+            self.doc = NO_MORE_DOCS;
+            return Ok(());
+        }
+        self.block_idx = idx;
+        self.view.decode_block_into(idx, &mut self.decoded)?;
+        self.pos = 0;
+        self.set_current();
+        Ok(())
+    }
+
+    #[inline]
+    fn set_current(&mut self) {
+        self.doc = self.decoded.ids[self.pos];
+        self.freq = self.decoded.freqs[self.pos];
+        self.norm = self.decoded.norms[self.pos];
+    }
+
+    /// Advance the cursor to the next posting.
+    #[inline]
+    pub(super) fn next(&mut self) -> Result<()> {
+        self.pos += 1;
+        if self.pos < self.decoded.ids.len() {
+            self.set_current();
+            Ok(())
+        } else {
+            self.load_block(self.block_idx + 1)
+        }
+    }
+
+    /// Advance to the first posting with `id >= target`. Targets must be
+    /// non-decreasing across calls (cursor only moves forward).
+    pub(super) fn seek(&mut self, target: u64) -> Result<u64> {
+        if self.doc >= target {
+            return Ok(self.doc);
+        }
+        // Skip whole blocks without decoding them.
+        if self.view.blocks()[self.block_idx].max_id < target {
+            let blocks = self.view.blocks();
+            let mut idx = self.block_idx + 1;
+            // Galloping is overkill: block directories are small and this
+            // walk is monotonic across the whole query.
+            while idx < blocks.len() && blocks[idx].max_id < target {
+                idx += 1;
+            }
+            if idx >= blocks.len() {
+                self.doc = NO_MORE_DOCS;
+                return Ok(self.doc);
+            }
+            self.load_block(idx)?;
+            if self.doc >= target {
+                return Ok(self.doc);
+            }
+        }
+        // Target lies within the current decoded block.
+        let ids = &self.decoded.ids;
+        self.pos += ids[self.pos..].partition_point(|&id| id < target);
+        debug_assert!(self.pos < ids.len());
+        self.set_current();
+        Ok(self.doc)
+    }
+
+    /// Inclusive upper bound (`max_id`) of the block containing the cursor
+    /// or `doc`, whichever is further along; [`NO_MORE_DOCS`] when
+    /// the scorer is exhausted or no block remains. Outer windows align to
+    /// these boundaries so block impacts bound them tightly.
+    pub(super) fn probe_block_boundary(&self, doc: u64) -> u64 {
+        if self.doc == NO_MORE_DOCS {
+            return NO_MORE_DOCS;
+        }
+        let from = self.doc.max(doc);
+        let blocks = self.view.blocks();
+        let idx = blocks.partition_point(|b| b.max_id < from);
+        if idx >= blocks.len() {
+            NO_MORE_DOCS
+        } else {
+            blocks[idx].max_id
+        }
+    }
+
+    /// Inclusive upper bound (`max_id`) of the block holding the posting
+    /// roughly `n` entries past the cursor (or past `doc`, whichever is
+    /// further along); [`NO_MORE_DOCS`] when the scorer is exhausted or the
+    /// list ends first. Used for count-based window sizing: the returned
+    /// boundary covers at least `n` of this scorer's postings (rounded out
+    /// to a block edge, so impact-based window bounds stay tight).
+    ///
+    /// Counting is approximate at the edges — entries of the first block
+    /// that precede `doc` are counted when the cursor lags behind it — which
+    /// only shrinks the window; correctness never depends on window size.
+    pub(super) fn probe_count_boundary(&self, doc: u64, n: usize) -> u64 {
+        if self.doc == NO_MORE_DOCS {
+            return NO_MORE_DOCS;
+        }
+        let from = self.doc.max(doc);
+        let blocks = self.view.blocks();
+        let start = blocks.partition_point(|b| b.max_id < from);
+        let mut remaining = n;
+        for (idx, block) in blocks.iter().enumerate().skip(start) {
+            // Exact within the decoded block the cursor sits in; whole-block
+            // counts elsewhere.
+            let count = if idx == self.block_idx {
+                self.decoded.ids.len() - self.pos
+            } else {
+                block.count as usize
+            };
+            if remaining <= count {
+                return block.max_id;
+            }
+            remaining -= count;
+        }
+        NO_MORE_DOCS
+    }
+
+    /// Memoized max score contribution of block `idx`.
+    fn block_max_score(&mut self, idx: usize, ctx: &ScoreContext) -> f32 {
+        if let Some(cached) = self.block_max_scores[idx] {
+            return cached;
+        }
+        let impacts = self.view.impacts(idx);
+        let score = if impacts.is_empty() {
+            // Written before impacts landed: fall back to the global bound.
+            ctx.global_bound(self.idf)
+        } else {
+            impacts
+                .iter()
+                .map(|imp| ctx.score_hit(self.idf, imp.freq, imp.norm))
+                .fold(0.0f32, f32::max)
+        };
+        self.block_max_scores[idx] = Some(score);
+        score
+    }
+
+    /// Max possible contribution of this term for docs in
+    /// `[from, to_inclusive]`, from block impacts.
+    pub(super) fn max_score_in_range(
+        &mut self,
+        from: u64,
+        to_inclusive: u64,
+        ctx: &ScoreContext,
+    ) -> f32 {
+        let start = self.view.blocks().partition_point(|b| b.max_id < from);
+        let mut max = 0.0f32;
+        for idx in start..self.view.blocks().len() {
+            if self.view.blocks()[idx].min_id > to_inclusive {
+                break;
+            }
+            max = max.max(self.block_max_score(idx, ctx));
+        }
+        max
+    }
+
+    /// Score every posting in `[self.doc, up_to)` into the window
+    /// accumulator, leaving the cursor at the first posting `>= up_to`.
+    /// Slot `i` of the window corresponds to doc id `window_min + i`.
+    ///
+    /// This is the term-at-a-time batch loop: for each decoded block it runs
+    /// a tight scalar loop over the block's parallel arrays. Vectorization
+    /// (RFC-0006 future work) will replace the loop body, not the structure.
+    pub(super) fn score_window_into(
+        &mut self,
+        window_min: u64,
+        up_to: u64,
+        ctx: &ScoreContext,
+        window: &mut ScoreWindow,
+    ) -> Result<()> {
+        debug_assert!(self.doc >= window_min);
+        while self.doc < up_to {
+            let ids = &self.decoded.ids;
+            let end = self.pos + ids[self.pos..].partition_point(|&id| id < up_to);
+            let run = ids[self.pos..end]
+                .iter()
+                .zip(&self.decoded.freqs[self.pos..end])
+                .zip(&self.decoded.norms[self.pos..end]);
+            for ((&id, &freq), &norm) in run {
+                let slot = (id - window_min) as usize;
+                window.add(slot, ctx.score_hit(self.idf, freq, norm));
+            }
+            if end < ids.len() {
+                self.pos = end;
+                self.set_current();
+                return Ok(());
+            }
+            self.load_block(self.block_idx + 1)?;
+        }
+        Ok(())
+    }
+
+    /// Append every posting in `[self.doc, up_to)` to `out` as
+    /// `(doc, hit)` pairs in ascending doc order, leaving the cursor at the
+    /// first posting `>= up_to`.
+    ///
+    /// The merge strategy's counterpart to
+    /// [`score_window_into`](Self::score_window_into): the same
+    /// term-at-a-time batch loop over the block's decoded arrays, but
+    /// appending sequentially instead of scattering into id-indexed slots.
+    pub(super) fn collect_hits_into(
+        &mut self,
+        up_to: u64,
+        ctx: &ScoreContext,
+        out: &mut HitList,
+    ) -> Result<()> {
+        while self.doc < up_to {
+            let ids = &self.decoded.ids;
+            let end = self.pos + ids[self.pos..].partition_point(|&id| id < up_to);
+            out.docs.extend_from_slice(&ids[self.pos..end]);
+            let run = self.decoded.freqs[self.pos..end]
+                .iter()
+                .zip(&self.decoded.norms[self.pos..end]);
+            for (&freq, &norm) in run {
+                out.hits.push(ctx.score_hit(self.idf, freq, norm));
+            }
+            if end < ids.len() {
+                self.pos = end;
+                self.set_current();
+                return Ok(());
+            }
+            self.load_block(self.block_idx + 1)?;
+        }
+        Ok(())
+    }
+}

--- a/vector/src/query_engine/mod.rs
+++ b/vector/src/query_engine/mod.rs
@@ -10,13 +10,14 @@ mod types;
 use crate::Vector;
 use crate::error::{Error, Result};
 use crate::metric_names::QUERY_SEARCH_DURATION_SECONDS;
-use crate::model::{Bm25Query, Query, ScoreBy, SearchOptions, SearchResult};
+use crate::model::{Bm25Query, Bm25Scorer, Query, ScoreBy, SearchOptions, SearchResult};
 use crate::query_engine::ann::{ANNOperator, ExhaustiveNNOperator};
-use crate::query_engine::bm25::BM25Operator;
+use crate::query_engine::bm25::{BM25Operator, BM25Score, BlockMaxBM25Operator, EssentialStrategy};
 use crate::query_engine::filter::PreparedFilter;
 use crate::query_engine::lookup::LookupOperator;
 use crate::query_engine::operator::{BoxedOperator, Operator};
 use crate::query_engine::project::ProjectOperator;
+use crate::query_engine::types::ScoredVectorId;
 use crate::serde::collection_meta::DistanceMetric;
 use crate::serde::vector_bitmap::VectorBitmap;
 use crate::storage::VectorDbStorageReadExt;
@@ -161,7 +162,7 @@ impl QueryEngine {
     ) -> Result<BoxedOperator<Vec<SearchResult>>> {
         match &query.score_by {
             ScoreBy::Ann(vector) => self.plan_ann(vector, query, options).await,
-            ScoreBy::Bm25(bm25) => self.plan_bm25(bm25, query).await,
+            ScoreBy::Bm25(bm25) => self.plan_bm25(bm25, query, options).await,
         }
     }
 
@@ -196,30 +197,52 @@ impl QueryEngine {
         Ok(Box::new(plan))
     }
 
-    /// BM25 search path (RFC-0006 Milestone 0).
+    /// BM25 search path (RFC-0006).
     ///
     /// Assembles the operator chain `bm25 -> lookup -> project` and runs it.
-    /// The BM25 operator scores and ranks ids (metadata filtering and FTS delete
-    /// resolution happen there, before scoring); lookup/project then materialize
-    /// the forward-index data and apply field selection.
+    /// The BM25 source scores and ranks ids (metadata filtering and FTS delete
+    /// resolution happen there, before collection); lookup/project then
+    /// materialize the forward-index data and apply field selection. The
+    /// source defaults to the BlockMaxScore scorer; `options.bm25_scorer`
+    /// selects the exhaustive reference scorer instead (Milestone 0 path).
     async fn plan_bm25(
         &self,
         bm25: &Bm25Query,
         query: &Query,
+        options: SearchOptions,
     ) -> Result<BoxedOperator<Vec<SearchResult>>> {
         // TODO: defer filter resolution to execution time
         let filter = PreparedFilter::build(query.filter.as_ref(), self.storage.as_ref()).await?;
-        let source = BM25Operator::new(
-            self.storage.clone(),
-            bm25.clone(),
-            filter,
-            self.deletions.clone(),
-            query.limit,
-        );
+        let source: BoxedOperator<Vec<ScoredVectorId<BM25Score>>> =
+            match options.bm25_scorer.unwrap_or_default() {
+                Bm25Scorer::Exhaustive => Box::new(BM25Operator::new(
+                    self.storage.clone(),
+                    bm25.clone(),
+                    filter,
+                    self.deletions.clone(),
+                    query.limit,
+                )),
+                Bm25Scorer::BlockMax => Box::new(BlockMaxBM25Operator::new(
+                    self.storage.clone(),
+                    bm25.clone(),
+                    filter,
+                    self.deletions.clone(),
+                    query.limit,
+                    EssentialStrategy::DenseWindow,
+                )),
+                Bm25Scorer::BlockMaxSparse => Box::new(BlockMaxBM25Operator::new(
+                    self.storage.clone(),
+                    bm25.clone(),
+                    filter,
+                    self.deletions.clone(),
+                    query.limit,
+                    EssentialStrategy::SortMerge,
+                )),
+            };
         let lookup = LookupOperator::new(
             self.storage.clone(),
             self.options.dimensions as usize,
-            Box::new(source),
+            source,
         );
         let project = ProjectOperator::new(query.include_fields.clone(), Box::new(lookup));
         let plan = LeafOperator::new(project);

--- a/vector/src/serde/term_postings.rs
+++ b/vector/src/serde/term_postings.rs
@@ -10,8 +10,12 @@
 //! they too are stored in descending id order (each pair's ids are strictly
 //! lower than all ids in the preceding pair).
 //!
-//! Milestone 0 does not encode skip-block `impacts` (used for BlockMaxScore);
-//! the field is reserved per the RFC shape but always empty.
+//! Each skip block carries the `impacts` of its postings block: the dominating
+//! `(freq, norm)` pairs of the contained documents (RFC-0006). The query path
+//! uses them to compute a tight upper bound on the BM25 contribution of any
+//! document in the block without decoding the block (BlockMaxScore). Values
+//! written before impacts landed decode with an empty impact list, which
+//! readers must treat as "unknown" (fall back to the term's global bound).
 //!
 //! ## Value Layout (little-endian unless noted)
 //!
@@ -46,7 +50,8 @@
 //! Skip (type = 0x01) payload
 //! ┌──────────────────────────────────────────────────────────────────┐
 //! │  last_id:        u64                                              │
-//! │  impacts_count:  u16   (always 0 in M0)                           │
+//! │  impacts_count:  u16                                              │
+//! │  impacts:        impacts_count * { freq: u32, norm: u8 }          │
 //! │  length:         u64   (byte length of associated Postings block) │
 //! └──────────────────────────────────────────────────────────────────┘
 //! ```
@@ -93,6 +98,49 @@ pub(crate) struct PostingEntry {
     pub(crate) id: VectorId,
     pub(crate) freq: u32,
     pub(crate) norm: u8,
+}
+
+/// A `(freq, norm)` pair bounding the BM25 contribution of the documents in a
+/// postings block (RFC-0006).
+///
+/// Impacts have a partial order: a pair with higher `freq` *and* lower `norm`
+/// than another is guaranteed to score at least as high under BM25 (the score
+/// is non-decreasing in frequency and non-increasing in document length). A
+/// skip block stores the *dominating* pairs — those not dominated by any other
+/// pair in the block — so the max score over the block is the max score over
+/// its impacts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Impact {
+    pub(crate) freq: u32,
+    pub(crate) norm: u8,
+}
+
+/// Compute the dominating impacts of a postings block.
+///
+/// Returns the pareto frontier of the entries' `(freq, norm)` pairs, sorted by
+/// ascending `norm` (and therefore strictly ascending `freq`). Bounded by 256
+/// entries since norms are one byte; in practice much smaller.
+fn compute_dominating_impacts(entries: &[PostingEntry]) -> Vec<Impact> {
+    // Max freq seen for each norm value.
+    let mut max_freq_by_norm = [0u32; 256];
+    for entry in entries {
+        let slot = &mut max_freq_by_norm[entry.norm as usize];
+        *slot = (*slot).max(entry.freq.max(1));
+    }
+    // Sweep norms ascending; a pair survives only when its freq strictly
+    // exceeds every pair with a lower (better) norm.
+    let mut impacts = Vec::new();
+    let mut running_max = 0u32;
+    for (norm, &freq) in max_freq_by_norm.iter().enumerate() {
+        if freq > running_max {
+            impacts.push(Impact {
+                freq,
+                norm: norm as u8,
+            });
+            running_max = freq;
+        }
+    }
+    impacts
 }
 
 /// A `Postings` block: a run of `PostingEntry` in descending `id` order.
@@ -189,137 +237,9 @@ impl PostingsBlock {
     }
 
     fn decode_payload(buf: &[u8]) -> Result<Self, EncodingError> {
-        let mut cursor = buf;
-        if cursor.len() < 4 {
-            return Err(EncodingError {
-                message: "postings block payload too short for count".to_string(),
-            });
-        }
-        let count = u32::from_le_bytes([cursor[0], cursor[1], cursor[2], cursor[3]]) as usize;
-        cursor = &cursor[4..];
-        if count == 0 {
-            return Ok(Self::default());
-        }
-        if count > BLOCK_LEN {
-            return Err(EncodingError {
-                message: format!(
-                    "postings block count {} exceeds BLOCK_LEN {}",
-                    count, BLOCK_LEN
-                ),
-            });
-        }
-
-        if cursor.len() < 8 {
-            return Err(EncodingError {
-                message: "postings block payload too short for base id".to_string(),
-            });
-        }
-        let base_id = u64::from_le_bytes([
-            cursor[0], cursor[1], cursor[2], cursor[3], cursor[4], cursor[5], cursor[6], cursor[7],
-        ]);
-        cursor = &cursor[8..];
-
-        let bitpacker = BitPacker8x::new();
-
-        // ids_encoding byte
-        if cursor.is_empty() {
-            return Err(EncodingError {
-                message: "postings block payload too short for ids_encoding".to_string(),
-            });
-        }
-        let ids_encoding = cursor[0];
-        cursor = &cursor[1..];
-
-        let gaps: Vec<u64> = match ids_encoding {
-            IDS_ENCODING_BITPACKED => {
-                if cursor.is_empty() {
-                    return Err(EncodingError {
-                        message: "postings block payload too short for ids_bits".to_string(),
-                    });
-                }
-                let ids_bits = cursor[0];
-                cursor = &cursor[1..];
-                let ids_bytes = ids_bits as usize * (BLOCK_LEN / 8);
-                if cursor.len() < ids_bytes {
-                    return Err(EncodingError {
-                        message: format!(
-                            "postings block truncated within ids section: need {}, have {}",
-                            ids_bytes,
-                            cursor.len()
-                        ),
-                    });
-                }
-                let mut ids = [0u32; BLOCK_LEN];
-                let consumed = bitpacker.decompress(&cursor[..ids_bytes], &mut ids, ids_bits);
-                debug_assert_eq!(consumed, ids_bytes);
-                cursor = &cursor[ids_bytes..];
-                ids[..count].iter().map(|&g| g as u64).collect()
-            }
-            IDS_ENCODING_VARINT => {
-                let mut gaps = Vec::with_capacity(count);
-                for _ in 0..count {
-                    let (g, used) = read_u64_varint(cursor)?;
-                    cursor = &cursor[used..];
-                    gaps.push(g);
-                }
-                gaps
-            }
-            other => {
-                return Err(EncodingError {
-                    message: format!("unknown postings ids_encoding: 0x{:02x}", other),
-                });
-            }
-        };
-
-        // Reconstruct ids from gaps. `gap[0]` is 0 so ids[0] == base_id.
-        let mut ids = Vec::with_capacity(count);
-        let mut current = base_id;
-        for (i, &g) in gaps.iter().enumerate() {
-            if i == 0 {
-                ids.push(current);
-                continue;
-            }
-            current = current.checked_sub(g).ok_or_else(|| EncodingError {
-                message: format!("gap {} underflows running id {}", g, current),
-            })?;
-            ids.push(current);
-        }
-
-        // freqs
-        if cursor.is_empty() {
-            return Err(EncodingError {
-                message: "postings block payload too short for freqs_bits".to_string(),
-            });
-        }
-        let freqs_bits = cursor[0];
-        cursor = &cursor[1..];
-        let freqs_bytes = freqs_bits as usize * (BLOCK_LEN / 8);
-        if cursor.len() < freqs_bytes {
-            return Err(EncodingError {
-                message: format!(
-                    "postings block truncated within freqs section: need {}, have {}",
-                    freqs_bytes,
-                    cursor.len()
-                ),
-            });
-        }
+        let mut ids = [0u64; BLOCK_LEN];
         let mut freqs = [0u32; BLOCK_LEN];
-        let consumed = bitpacker.decompress(&cursor[..freqs_bytes], &mut freqs, freqs_bits);
-        debug_assert_eq!(consumed, freqs_bytes);
-        cursor = &cursor[freqs_bytes..];
-
-        // norms
-        if cursor.len() < count {
-            return Err(EncodingError {
-                message: format!(
-                    "postings block too short for norms: need {}, have {}",
-                    count,
-                    cursor.len()
-                ),
-            });
-        }
-        let norms = &cursor[..count];
-
+        let (count, norms) = decode_postings_raw(buf, &mut ids, &mut freqs)?;
         let mut entries = Vec::with_capacity(count);
         for i in 0..count {
             entries.push(PostingEntry {
@@ -330,6 +250,146 @@ impl PostingsBlock {
         }
         Ok(Self { entries })
     }
+}
+
+/// Decode a `Postings` block payload into caller-provided stack arrays in
+/// stored (descending id) order. Returns the entry count and the borrowed
+/// norms slice. Shared by the eager [`PostingsBlock`] decode and the lazy
+/// [`PostingListView`] block decode; allocation-free so both hot paths can
+/// reuse buffers.
+fn decode_postings_raw<'a>(
+    buf: &'a [u8],
+    ids: &mut [u64; BLOCK_LEN],
+    freqs: &mut [u32; BLOCK_LEN],
+) -> Result<(usize, &'a [u8]), EncodingError> {
+    let mut cursor = buf;
+    if cursor.len() < 4 {
+        return Err(EncodingError {
+            message: "postings block payload too short for count".to_string(),
+        });
+    }
+    let count = u32::from_le_bytes([cursor[0], cursor[1], cursor[2], cursor[3]]) as usize;
+    cursor = &cursor[4..];
+    if count == 0 {
+        return Ok((0, &[]));
+    }
+    if count > BLOCK_LEN {
+        return Err(EncodingError {
+            message: format!(
+                "postings block count {} exceeds BLOCK_LEN {}",
+                count, BLOCK_LEN
+            ),
+        });
+    }
+
+    if cursor.len() < 8 {
+        return Err(EncodingError {
+            message: "postings block payload too short for base id".to_string(),
+        });
+    }
+    let base_id = u64::from_le_bytes([
+        cursor[0], cursor[1], cursor[2], cursor[3], cursor[4], cursor[5], cursor[6], cursor[7],
+    ]);
+    cursor = &cursor[8..];
+
+    let bitpacker = BitPacker8x::new();
+
+    // ids_encoding byte
+    if cursor.is_empty() {
+        return Err(EncodingError {
+            message: "postings block payload too short for ids_encoding".to_string(),
+        });
+    }
+    let ids_encoding = cursor[0];
+    cursor = &cursor[1..];
+
+    // Decode gaps into `ids` (as the gap values), then reconstruct the
+    // descending ids in place below. `gap[0]` is 0 so ids[0] == base_id.
+    match ids_encoding {
+        IDS_ENCODING_BITPACKED => {
+            if cursor.is_empty() {
+                return Err(EncodingError {
+                    message: "postings block payload too short for ids_bits".to_string(),
+                });
+            }
+            let ids_bits = cursor[0];
+            cursor = &cursor[1..];
+            let ids_bytes = ids_bits as usize * (BLOCK_LEN / 8);
+            if cursor.len() < ids_bytes {
+                return Err(EncodingError {
+                    message: format!(
+                        "postings block truncated within ids section: need {}, have {}",
+                        ids_bytes,
+                        cursor.len()
+                    ),
+                });
+            }
+            let mut gaps = [0u32; BLOCK_LEN];
+            let consumed = bitpacker.decompress(&cursor[..ids_bytes], &mut gaps, ids_bits);
+            debug_assert_eq!(consumed, ids_bytes);
+            cursor = &cursor[ids_bytes..];
+            for i in 0..count {
+                ids[i] = gaps[i] as u64;
+            }
+        }
+        IDS_ENCODING_VARINT => {
+            for slot in ids.iter_mut().take(count) {
+                let (g, used) = read_u64_varint(cursor)?;
+                cursor = &cursor[used..];
+                *slot = g;
+            }
+        }
+        other => {
+            return Err(EncodingError {
+                message: format!("unknown postings ids_encoding: 0x{:02x}", other),
+            });
+        }
+    }
+
+    let mut current = base_id;
+    for (i, slot) in ids.iter_mut().enumerate().take(count) {
+        let g = *slot;
+        if i > 0 {
+            current = current.checked_sub(g).ok_or_else(|| EncodingError {
+                message: format!("gap {} underflows running id {}", g, current),
+            })?;
+        }
+        *slot = current;
+    }
+
+    // freqs
+    if cursor.is_empty() {
+        return Err(EncodingError {
+            message: "postings block payload too short for freqs_bits".to_string(),
+        });
+    }
+    let freqs_bits = cursor[0];
+    cursor = &cursor[1..];
+    let freqs_bytes = freqs_bits as usize * (BLOCK_LEN / 8);
+    if cursor.len() < freqs_bytes {
+        return Err(EncodingError {
+            message: format!(
+                "postings block truncated within freqs section: need {}, have {}",
+                freqs_bytes,
+                cursor.len()
+            ),
+        });
+    }
+    let consumed = bitpacker.decompress(&cursor[..freqs_bytes], freqs, freqs_bits);
+    debug_assert_eq!(consumed, freqs_bytes);
+    cursor = &cursor[freqs_bytes..];
+
+    // norms
+    if cursor.len() < count {
+        return Err(EncodingError {
+            message: format!(
+                "postings block too short for norms: need {}, have {}",
+                count,
+                cursor.len()
+            ),
+        });
+    }
+    Ok((count, &cursor[..count]))
 }
 
 fn write_u64_varint(buf: &mut BytesMut, mut v: u64) {
@@ -368,17 +428,25 @@ fn read_u64_varint(buf: &[u8]) -> Result<(u64, usize), EncodingError> {
 
 /// A `Skip` block summarising the immediately following `Postings` block.
 ///
-/// For Milestone 0 `impacts` is reserved per the RFC shape but always empty.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// `impacts` holds the dominating `(freq, norm)` pairs of the postings block
+/// (see [`Impact`]). Values written before impacts landed (RFC-0006 M0-M2)
+/// decode with an empty list, which readers treat as "unknown".
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SkipBlock {
     pub(crate) last_id: VectorId,
+    pub(crate) impacts: Vec<Impact>,
     pub(crate) length: u64,
 }
 
 impl SkipBlock {
     fn encode_payload(&self, buf: &mut BytesMut) {
         buf.put_u64_le(self.last_id.id());
-        buf.put_u16_le(0); // impacts_count, always 0 in M0
+        debug_assert!(self.impacts.len() <= u16::MAX as usize);
+        buf.put_u16_le(self.impacts.len() as u16);
+        for impact in &self.impacts {
+            buf.put_u32_le(impact.freq);
+            buf.put_u8(impact.norm);
+        }
         buf.put_u64_le(self.length);
     }
 
@@ -396,14 +464,18 @@ impl SkipBlock {
             buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
         ]));
         let impacts_count = u16::from_le_bytes([buf[8], buf[9]]);
-        // Milestone 0 always writes 0 impacts; tolerate but ignore higher counts.
         let mut cursor = &buf[10..];
+        let mut impacts = Vec::with_capacity(impacts_count as usize);
         for _ in 0..impacts_count {
             if cursor.len() < 5 {
                 return Err(EncodingError {
                     message: "skip block payload truncated within impacts".to_string(),
                 });
             }
+            impacts.push(Impact {
+                freq: u32::from_le_bytes([cursor[0], cursor[1], cursor[2], cursor[3]]),
+                norm: cursor[4],
+            });
             cursor = &cursor[5..];
         }
         if cursor.len() < 8 {
@@ -414,7 +486,11 @@ impl SkipBlock {
         let length = u64::from_le_bytes([
             cursor[0], cursor[1], cursor[2], cursor[3], cursor[4], cursor[5], cursor[6], cursor[7],
         ]);
-        Ok(Self { last_id, length })
+        Ok(Self {
+            last_id,
+            impacts,
+            length,
+        })
     }
 }
 
@@ -456,6 +532,7 @@ impl TermPostingsValue {
             postings_block.encode_payload(&mut payload);
             let skip = SkipBlock {
                 last_id: postings_block.last_id(),
+                impacts: compute_dominating_impacts(&postings_block.entries),
                 length: payload.len() as u64,
             };
             blocks.push(TermPostingsBlock::Skip(skip));
@@ -537,6 +614,238 @@ fn encode_block(block: &TermPostingsBlock, buf: &mut BytesMut) {
     buf.extend_from_slice(payload_buf);
 }
 
+/// Directory entry for one `(Skip, Postings)` pair within an encoded
+/// `TermPostings` value, recorded by [`PostingListView::parse`].
+#[derive(Debug, Clone)]
+pub(crate) struct PostingBlockMeta {
+    /// Lowest doc id in the block (the skip block's `last_id`).
+    pub(crate) min_id: u64,
+    /// Highest doc id in the block (the postings payload's `base_id`).
+    pub(crate) max_id: u64,
+    /// Number of postings in the block.
+    pub(crate) count: u32,
+    /// Range of this block's impacts within the view's impact arena.
+    impacts_start: u32,
+    impacts_len: u16,
+    /// Byte range of the postings payload within the raw value.
+    payload_start: usize,
+    payload_len: usize,
+}
+
+/// A `Postings` block decoded into parallel arrays in **ascending** doc id
+/// order — the iteration order of the BlockMaxScore query path. (Blocks are
+/// stored descending; [`PostingListView::decode_block_into`] reverses on
+/// decode.)
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DecodedPostingsBlock {
+    pub(crate) ids: Vec<u64>,
+    pub(crate) freqs: Vec<u32>,
+    pub(crate) norms: Vec<u8>,
+}
+
+/// A lazily-decoded view over an encoded `TermPostings` value.
+///
+/// [`parse`](Self::parse) scans only the block headers and skip payloads —
+/// it never touches the bitpacked postings payloads — and records where each
+/// payload lives so [`decode_block_into`](Self::decode_block_into) can decode
+/// blocks on demand. This is what lets BlockMaxScore skip whole blocks
+/// without paying their decode cost.
+///
+/// `blocks` is ordered by **ascending** doc id range (the reverse of storage
+/// order): `blocks[0]` holds the lowest ids. Ranges of distinct blocks never
+/// overlap (merge operands partition the id space). All blocks' impacts live
+/// in one arena (`impacts`) rather than per-block `Vec`s so a query on a
+/// common term with thousands of blocks doesn't pay one allocation per block.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct PostingListView {
+    raw: Bytes,
+    blocks: Vec<PostingBlockMeta>,
+    impacts: Vec<Impact>,
+}
+
+impl PostingListView {
+    /// Scan the value's block headers into a directory. Cost is proportional
+    /// to the number of blocks, not the number of postings.
+    pub(crate) fn parse(raw: Bytes) -> Result<Self, EncodingError> {
+        let mut blocks = Vec::new();
+        let mut impacts: Vec<Impact> = Vec::new();
+        let mut offset = 0usize;
+        // (min_id, impacts range) decoded from the pending skip block.
+        let mut pending_skip: Option<(u64, u32, u16)> = None;
+        while offset < raw.len() {
+            if raw.len() - offset < 5 {
+                return Err(EncodingError {
+                    message: "term postings value truncated at block header".to_string(),
+                });
+            }
+            let block_type = raw[offset];
+            let len = u32::from_le_bytes([
+                raw[offset + 1],
+                raw[offset + 2],
+                raw[offset + 3],
+                raw[offset + 4],
+            ]) as usize;
+            let payload_start = offset + 5;
+            if raw.len() - payload_start < len {
+                return Err(EncodingError {
+                    message: format!(
+                        "term postings value truncated within block: need {}, have {}",
+                        len,
+                        raw.len() - payload_start
+                    ),
+                });
+            }
+            let payload = &raw[payload_start..payload_start + len];
+            offset = payload_start + len;
+            match block_type {
+                BLOCK_TYPE_SKIP => {
+                    if pending_skip.is_some() {
+                        return Err(EncodingError {
+                            message: "skip block not followed by postings block".to_string(),
+                        });
+                    }
+                    // Decode the skip payload straight into the arena instead
+                    // of through SkipBlock (which allocates per block).
+                    if payload.len() < 8 + 2 + 8 {
+                        return Err(EncodingError {
+                            message: format!(
+                                "skip block payload too short: need {} bytes, have {}",
+                                8 + 2 + 8,
+                                payload.len()
+                            ),
+                        });
+                    }
+                    let min_id = u64::from_le_bytes([
+                        payload[0], payload[1], payload[2], payload[3], payload[4], payload[5],
+                        payload[6], payload[7],
+                    ]);
+                    let impacts_count = u16::from_le_bytes([payload[8], payload[9]]) as usize;
+                    let impacts_bytes = impacts_count * 5;
+                    if payload.len() < 10 + impacts_bytes + 8 {
+                        return Err(EncodingError {
+                            message: "skip block payload truncated within impacts".to_string(),
+                        });
+                    }
+                    let impacts_start = impacts.len() as u32;
+                    for chunk in payload[10..10 + impacts_bytes].chunks_exact(5) {
+                        impacts.push(Impact {
+                            freq: u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]),
+                            norm: chunk[4],
+                        });
+                    }
+                    pending_skip = Some((min_id, impacts_start, impacts_count as u16));
+                }
+                BLOCK_TYPE_POSTINGS => {
+                    let Some((min_id, impacts_start, impacts_len)) = pending_skip.take() else {
+                        return Err(EncodingError {
+                            message: "postings block without preceding skip block".to_string(),
+                        });
+                    };
+                    // Peek count and base_id from the payload header without
+                    // decompressing the block.
+                    if len < 4 {
+                        return Err(EncodingError {
+                            message: "postings block payload too short for count".to_string(),
+                        });
+                    }
+                    let count =
+                        u32::from_le_bytes([payload[0], payload[1], payload[2], payload[3]]);
+                    if count == 0 {
+                        // Empty block: drop the (skip, postings) pair.
+                        impacts.truncate(impacts_start as usize);
+                        continue;
+                    }
+                    if len < 12 {
+                        return Err(EncodingError {
+                            message: "postings block payload too short for base id".to_string(),
+                        });
+                    }
+                    let max_id = u64::from_le_bytes([
+                        payload[4],
+                        payload[5],
+                        payload[6],
+                        payload[7],
+                        payload[8],
+                        payload[9],
+                        payload[10],
+                        payload[11],
+                    ]);
+                    blocks.push(PostingBlockMeta {
+                        min_id,
+                        max_id,
+                        count,
+                        impacts_start,
+                        impacts_len,
+                        payload_start,
+                        payload_len: len,
+                    });
+                }
+                other => {
+                    return Err(EncodingError {
+                        message: format!("unknown term postings block type: 0x{:02x}", other),
+                    });
+                }
+            }
+        }
+        if pending_skip.is_some() {
+            return Err(EncodingError {
+                message: "trailing skip block without postings block".to_string(),
+            });
+        }
+        // Storage order is descending; flip so blocks[0] holds the lowest ids.
+        // Arena ranges are positional and unaffected by directory order.
+        blocks.reverse();
+        Ok(Self {
+            raw,
+            blocks,
+            impacts,
+        })
+    }
+
+    /// Directory of blocks in ascending doc id order.
+    pub(crate) fn blocks(&self) -> &[PostingBlockMeta] {
+        &self.blocks
+    }
+
+    /// Impacts of block `idx`. Empty when the block was written before
+    /// impacts landed — callers must treat that as "unknown" and fall back to
+    /// the term's global score bound.
+    pub(crate) fn impacts(&self, idx: usize) -> &[Impact] {
+        let meta = &self.blocks[idx];
+        &self.impacts[meta.impacts_start as usize..][..meta.impacts_len as usize]
+    }
+
+    /// Decode block `idx` into `out` as ascending-id parallel arrays,
+    /// reusing `out`'s buffers (capacity stabilizes at one block after the
+    /// first decode).
+    pub(crate) fn decode_block_into(
+        &self,
+        idx: usize,
+        out: &mut DecodedPostingsBlock,
+    ) -> Result<(), EncodingError> {
+        let meta = &self.blocks[idx];
+        let payload = &self.raw[meta.payload_start..meta.payload_start + meta.payload_len];
+        let mut ids = [0u64; BLOCK_LEN];
+        let mut freqs = [0u32; BLOCK_LEN];
+        let (count, norms) = decode_postings_raw(payload, &mut ids, &mut freqs)?;
+        out.ids.clear();
+        out.ids.extend(ids[..count].iter().rev());
+        out.freqs.clear();
+        out.freqs.extend(freqs[..count].iter().rev());
+        out.norms.clear();
+        out.norms.extend(norms.iter().rev());
+        Ok(())
+    }
+
+    /// Decode block `idx` into fresh ascending-id parallel arrays.
+    #[cfg(test)]
+    pub(crate) fn decode_block(&self, idx: usize) -> Result<DecodedPostingsBlock, EncodingError> {
+        let mut out = DecodedPostingsBlock::default();
+        self.decode_block_into(idx, &mut out)?;
+        Ok(out)
+    }
+}
+
 /// Merge multiple `TermPostings` values via byte concatenation.
 ///
 /// SlateDB delivers operands oldest-to-newest. Newer batches insert strictly
@@ -573,6 +882,86 @@ mod tests {
             freq,
             norm,
         }
+    }
+
+    /// Corrupt bytes at the given payload offsets within the first
+    /// postings-block payload of an encoded value.
+    fn corrupt_postings_payload(encoded: &Bytes, edits: &[(usize, u8)]) -> Bytes {
+        let mut bytes = encoded.to_vec();
+        let mut offset = 0usize;
+        loop {
+            let tag = bytes[offset];
+            let len = u32::from_le_bytes([
+                bytes[offset + 1],
+                bytes[offset + 2],
+                bytes[offset + 3],
+                bytes[offset + 4],
+            ]) as usize;
+            let payload_start = offset + 5;
+            if tag == BLOCK_TYPE_POSTINGS {
+                for &(off, val) in edits {
+                    bytes[payload_start + off] = val;
+                }
+                return Bytes::from(bytes);
+            }
+            offset = payload_start + len;
+        }
+    }
+
+    /// parse() only validates framing; a payload corrupted past the header
+    /// must surface from decode as a recoverable error, never a panic.
+    #[test]
+    fn corrupt_payload_decodes_to_error_not_panic() {
+        let postings = vec![entry(8, 2, 30), entry(2, 3, 20), entry(5, 1, 10)];
+        let encoded = TermPostingsValue::from_postings(postings).encode_to_bytes();
+
+        // ids_encoding byte is at payload offset 12 (count:4 + base_id:8).
+        let bad_encoding = corrupt_postings_payload(&encoded, &[(12, 0xEE)]);
+        let view = PostingListView::parse(bad_encoding).expect("framing is intact");
+        let err = view.decode_block(0).unwrap_err();
+        assert!(
+            err.message.contains("unknown postings ids_encoding"),
+            "{}",
+            err.message
+        );
+
+        // count is payload bytes 0..4; 300 (0x012C) > BLOCK_LEN (256).
+        let bad_count = corrupt_postings_payload(&encoded, &[(0, 0x2C), (1, 0x01)]);
+        let view = PostingListView::parse(bad_count).expect("framing is intact");
+        let err = view.decode_block(0).unwrap_err();
+        assert!(err.message.contains("exceeds BLOCK_LEN"), "{}", err.message);
+    }
+
+    /// A degenerate count==0 postings block is tolerated by the eager decoder
+    /// and must be skipped (not turned into an error) by the lazy view.
+    #[test]
+    fn view_should_skip_zero_count_blocks() {
+        // given - a valid pair followed by an empty (skip, postings) pair
+        let mut buf = BytesMut::new();
+        let real = TermPostingsValue::from_postings(vec![entry(7, 1, 1), entry(3, 2, 2)]);
+        buf.extend_from_slice(&real.encode_to_bytes());
+        // skip block for the empty pair
+        let mut skip_payload = BytesMut::new();
+        skip_payload.put_u64_le(0); // last_id
+        skip_payload.put_u16_le(0); // impacts_count
+        skip_payload.put_u64_le(4); // length of the empty postings payload
+        buf.put_u8(BLOCK_TYPE_SKIP);
+        buf.put_u32_le(skip_payload.len() as u32);
+        buf.extend_from_slice(&skip_payload);
+        // empty postings block: count == 0
+        buf.put_u8(BLOCK_TYPE_POSTINGS);
+        buf.put_u32_le(4);
+        buf.put_u32_le(0);
+        let encoded = buf.freeze();
+
+        // when - both decoders read the value
+        let eager = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
+        let view = PostingListView::parse(encoded).unwrap();
+
+        // then - the view skips the empty pair and indexes only the real one
+        assert_eq!(view.blocks().len(), 1);
+        assert_eq!(view.decode_block(0).unwrap().ids, vec![3, 7]);
+        assert_eq!(eager.iter_entries().count(), 2);
     }
 
     #[test]
@@ -719,7 +1108,7 @@ mod tests {
             .blocks
             .iter()
             .find_map(|b| match b {
-                TermPostingsBlock::Skip(s) => Some(*s),
+                TermPostingsBlock::Skip(s) => Some(s.clone()),
                 _ => None,
             })
             .unwrap();
@@ -821,6 +1210,113 @@ mod tests {
     }
 
     #[test]
+    fn should_compute_dominating_impacts_per_rfc_example() {
+        // given - the RFC-0006 example impact set
+        let entries: Vec<PostingEntry> = [(10, 5), (5, 15), (11, 7), (12, 3), (13, 8), (11, 1)]
+            .iter()
+            .enumerate()
+            .map(|(i, &(freq, norm))| entry(i as u64, freq, norm))
+            .collect();
+
+        // when
+        let impacts = compute_dominating_impacts(&entries);
+
+        // then - the dominating pairs from the RFC, sorted by ascending norm
+        assert_eq!(
+            impacts,
+            vec![
+                Impact { freq: 11, norm: 1 },
+                Impact { freq: 12, norm: 3 },
+                Impact { freq: 13, norm: 8 },
+            ]
+        );
+    }
+
+    #[test]
+    fn dominating_impacts_should_bound_every_entry() {
+        // given - a pseudo-random block
+        let entries: Vec<PostingEntry> = (0..256u64)
+            .map(|i| {
+                entry(
+                    i,
+                    ((i * 2654435761) % 37) as u32 + 1,
+                    ((i * 40503) % 251) as u8,
+                )
+            })
+            .collect();
+
+        // when
+        let impacts = compute_dominating_impacts(&entries);
+
+        // then - every entry is dominated by (or equal to) some impact
+        for e in &entries {
+            assert!(
+                impacts
+                    .iter()
+                    .any(|imp| imp.freq >= e.freq && imp.norm <= e.norm),
+                "entry (freq {}, norm {}) not covered by impacts {:?}",
+                e.freq,
+                e.norm,
+                impacts
+            );
+        }
+        // and - the frontier is strictly increasing in both norm and freq
+        for w in impacts.windows(2) {
+            assert!(w[0].norm < w[1].norm);
+            assert!(w[0].freq < w[1].freq);
+        }
+    }
+
+    #[test]
+    fn should_roundtrip_skip_impacts() {
+        // given
+        let value = TermPostingsValue::from_postings(vec![
+            entry(10, 3, 7),
+            entry(20, 1, 2),
+            entry(30, 5, 9),
+        ]);
+
+        // when
+        let encoded = value.encode_to_bytes();
+        let decoded = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
+
+        // then - skip block impacts survive the round trip
+        let TermPostingsBlock::Skip(skip) = &decoded.blocks[0] else {
+            panic!("expected skip block");
+        };
+        assert_eq!(
+            skip.impacts,
+            vec![
+                Impact { freq: 1, norm: 2 },
+                Impact { freq: 3, norm: 7 },
+                Impact { freq: 5, norm: 9 }
+            ]
+        );
+    }
+
+    #[test]
+    fn should_decode_legacy_skip_block_without_impacts() {
+        // given - a skip payload hand-encoded the way M0 wrote it (impacts_count = 0)
+        let mut buf = BytesMut::new();
+        buf.put_u8(BLOCK_TYPE_SKIP);
+        buf.put_u32_le(8 + 2 + 8);
+        buf.put_u64_le(42); // last_id
+        buf.put_u16_le(0); // impacts_count
+        buf.put_u64_le(99); // length
+
+        // when
+        let decoded = TermPostingsValue::decode_from_bytes(&buf).unwrap();
+
+        // then - decodes with an empty impact list
+        let TermPostingsBlock::Skip(skip) = &decoded.blocks[0] else {
+            panic!("expected skip block");
+        };
+        assert_eq!(skip.last_id.id(), 42);
+        assert_eq!(skip.length, 99);
+        assert!(skip.impacts.is_empty());
+    }
+
+    #[test]
     fn should_roundtrip_full_block_of_256_entries() {
         // given - exactly TARGET_POSTINGS_PER_BLOCK postings
         let postings: Vec<_> = (0..TARGET_POSTINGS_PER_BLOCK as u64)
@@ -839,5 +1335,87 @@ mod tests {
         let mut expected = postings;
         expected.sort_unstable_by_key(|e| std::cmp::Reverse(e.id));
         assert_eq!(entries, expected);
+    }
+
+    #[test]
+    fn view_should_index_blocks_in_ascending_order() {
+        // given - 2.5 blocks worth of postings
+        let n = TARGET_POSTINGS_PER_BLOCK * 2 + TARGET_POSTINGS_PER_BLOCK / 2;
+        let postings: Vec<_> = (0..n as u64)
+            .map(|i| entry(i, (i % 7) as u32 + 1, ((i % 11) as u8) + 1))
+            .collect();
+        let encoded = TermPostingsValue::from_postings(postings).encode_to_bytes();
+
+        // when
+        let view = PostingListView::parse(encoded).unwrap();
+
+        // then - three blocks, ascending and non-overlapping, counts sum to n
+        assert_eq!(view.blocks().len(), 3);
+        let total: usize = (0..view.blocks().len())
+            .map(|i| view.decode_block(i).unwrap().ids.len())
+            .sum();
+        assert_eq!(total, n);
+        for w in view.blocks().windows(2) {
+            assert!(w[0].max_id < w[1].min_id);
+        }
+        for (idx, block) in view.blocks().iter().enumerate() {
+            assert!(block.min_id <= block.max_id);
+            assert!(!view.impacts(idx).is_empty());
+        }
+    }
+
+    #[test]
+    fn view_decode_block_should_return_ascending_arrays() {
+        // given
+        let postings = vec![entry(8, 2, 30), entry(2, 3, 20), entry(5, 1, 10)];
+        let encoded = TermPostingsValue::from_postings(postings).encode_to_bytes();
+
+        // when
+        let view = PostingListView::parse(encoded).unwrap();
+        let decoded = view.decode_block(0).unwrap();
+
+        // then
+        assert_eq!(decoded.ids, vec![2, 5, 8]);
+        assert_eq!(decoded.freqs, vec![3, 1, 2]);
+        assert_eq!(decoded.norms, vec![20, 10, 30]);
+    }
+
+    #[test]
+    fn view_should_parse_merged_operands() {
+        // given - two merge operands (older = lower ids)
+        let older = TermPostingsValue::from_postings(
+            (0..300u64).map(|i| entry(i, 1, 1)).collect::<Vec<_>>(),
+        )
+        .encode_to_bytes();
+        let newer = TermPostingsValue::from_postings(
+            (1000..1100u64).map(|i| entry(i, 2, 2)).collect::<Vec<_>>(),
+        )
+        .encode_to_bytes();
+        let merged = merge_batch_term_postings(None, &[older, newer]);
+
+        // when
+        let view = PostingListView::parse(merged).unwrap();
+
+        // then - blocks ascending across operand boundaries
+        let mut prev_max = None;
+        for block in view.blocks() {
+            if let Some(prev) = prev_max {
+                assert!(block.min_id > prev);
+            }
+            prev_max = Some(block.max_id);
+        }
+        // and - every posting is reachable, in ascending order overall
+        let mut all_ids = Vec::new();
+        for idx in 0..view.blocks().len() {
+            all_ids.extend(view.decode_block(idx).unwrap().ids);
+        }
+        let expected: Vec<u64> = (0..300).chain(1000..1100).collect();
+        assert_eq!(all_ids, expected);
+    }
+
+    #[test]
+    fn view_of_empty_value_has_no_blocks() {
+        let view = PostingListView::parse(Bytes::new()).unwrap();
+        assert!(view.blocks().is_empty());
     }
 }

--- a/vector/src/server/request.rs
+++ b/vector/src/server/request.rs
@@ -225,6 +225,7 @@ impl SearchRequest {
             query,
             options: SearchOptions {
                 nprobe: proto_request.nprobe.map(|n| n as usize),
+                ..Default::default()
             },
         })
     }
@@ -278,6 +279,7 @@ impl SearchRequest {
             query,
             options: SearchOptions {
                 nprobe: json_request.nprobe.map(|n| n as usize),
+                ..Default::default()
             },
         })
     }

--- a/vector/src/text.rs
+++ b/vector/src/text.rs
@@ -4,8 +4,15 @@
 //! frequencies for `TextAttributeSummary`) and the query path (when expanding
 //! a BM25 query string into terms) tokenize identically.
 
-use icu_segmenter::WordSegmenter;
 use icu_segmenter::options::WordBreakInvariantOptions;
+use icu_segmenter::{WordSegmenter, WordSegmenterBorrowed};
+
+thread_local! {
+    /// Constructing a `WordSegmenter` sets up segmentation models and is too
+    /// expensive to do per call on the write path; cache one per thread.
+    static SEGMENTER: WordSegmenterBorrowed<'static> =
+        WordSegmenter::new_auto(WordBreakInvariantOptions::default());
+}
 
 /// Tokenize a UTF-8 string into Unicode-aware, lowercase word terms.
 ///
@@ -21,24 +28,25 @@ pub(crate) fn tokenize(input: &str) -> Vec<String> {
     if input.is_empty() {
         return Vec::new();
     }
-    let segmenter = WordSegmenter::new_auto(WordBreakInvariantOptions::default());
-    let mut tokens = Vec::new();
-    let mut iter = segmenter.segment_str(input).iter_with_word_type();
-    // The first emitted boundary is the start of input (always 0); we only
-    // care about segments lying _between_ consecutive boundaries.
-    let Some((mut prev, _)) = iter.next() else {
-        return Vec::new();
-    };
-    for (boundary, word_type) in iter {
-        if word_type.is_word_like() {
-            let segment = &input[prev..boundary];
-            if !segment.is_empty() {
-                tokens.push(segment.to_lowercase());
+    SEGMENTER.with(|segmenter| {
+        let mut tokens = Vec::new();
+        let mut iter = segmenter.segment_str(input).iter_with_word_type();
+        // The first emitted boundary is the start of input (always 0); we only
+        // care about segments lying _between_ consecutive boundaries.
+        let Some((mut prev, _)) = iter.next() else {
+            return Vec::new();
+        };
+        for (boundary, word_type) in iter {
+            if word_type.is_word_like() {
+                let segment = &input[prev..boundary];
+                if !segment.is_empty() {
+                    tokens.push(segment.to_lowercase());
+                }
             }
+            prev = boundary;
         }
-        prev = boundary;
-    }
-    tokens
+        tokens
+    })
 }
 
 #[cfg(test)]

--- a/vector/tests/sift1m.rs
+++ b/vector/tests/sift1m.rs
@@ -146,6 +146,7 @@ async fn sift1m_recall() {
                 &q,
                 SearchOptions {
                     nprobe: Some(nprobe),
+                    ..SearchOptions::default()
                 },
             )
             .await
@@ -257,6 +258,7 @@ async fn sift100k_recall() {
                 &q,
                 SearchOptions {
                     nprobe: Some(nprobe),
+                    ..SearchOptions::default()
                 },
             )
             .await


### PR DESCRIPTION
## Summary

Adds block maxscore bm25 evaluation:
- Skip blocks now carry dominating (freq, norm) impacts, computed in TermPostingsValue::from_postings so both the indexer and the compaction filter rewrite path emit them.
- PostingListView: lazy block directory over an encoded posting list that decodes (bit-unpacks) only the blocks the query actually visits, with an impact arena and reusable per-block decode buffers. This allows for lazy decoding of each block into a columnar format optimized for scoring. This will be consolidated with the posting representation used on the write path in a later pr.
- BlockMaxBM25Operator: BlockMaxScore scoring operator modeled on Lucene's MaxScoreBulkScorer
- text: cache the ICU word segmenter per thread (construction dominated bulk-ingest tokenization).
- vector/bench: new 'fts' benchmark — synthetic Zipf corpus, BM25 search latency per scorer, cross-scorer consistency check.

## Test Plan

- e2e integration tests
- benchmark shows query latency for 1M documents drops from 10ms to .8ms

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
