### PR TITLE
[vector]: ascending term postings + unified in-mem representation

### DIFF
--- a/vector/rfcs/0006-text-search.md
+++ b/vector/rfcs/0006-text-search.md
@@ -460,7 +460,7 @@ reflect deletes after compacting the relevant postings.
 │  Postings                                                      │
 │  ┌──────────────────────────────────────────────────────────┐  │
 |  |  count:           u32 (entries actually used, <= 256)    |  |
-|  |  base_id:         u64 (highest doc id in the block)      |  |
+|  |  base_id:         u64 (lowest doc id in the block)       |  |
 |  |  docs_encoding:   u8  (0 = bitpacked gaps, 1 = varint)   |  |
 |  |  docs:            Bitpacked | Varint                     |  |
 |  |  freqs:           Bitpacked                              |  |
@@ -477,35 +477,37 @@ reflect deletes after compacting the relevant postings.
 
 ** Structure **
 
-The postings stores a sequence of postings for the term in order of descending vector id 
-(highest first), alongside block-level scoring stats and skip data for efficient traversal.
+The postings stores a sequence of postings for the term in order of ascending vector id 
+(lowest first), alongside block-level scoring stats and skip data for efficient traversal.
 Each postings value is a sequence of typed blocks with the type discriminated using a 
 discriminator field (`type`). The type is either `Postings` or `Skip`. Blocks appear in 
-reverse-document ID order. So each `Posting` block holds ids strictly lower than the preceding 
+document ID order, so each `Posting` block holds ids strictly higher than the preceding 
 `Posting` block. We'll target 256 postings per block.
 
 `Postings` stores:
 - `count`: Number of entries actually populated in the block (1..=256). Recorded explicitly
   because the encoded `docs` and `freqs` sections are always sized for a full 256-element
   bitpacked block.
-- `base_id`: The highest doc id in the block (i.e. `doc_ids[0]`). The remaining doc ids are
-  reconstructed by subtracting successive gaps from `base_id`.
-- `docs_encoding`: Discriminator for the layout of `docs`. The encoder first materialises the
-  gap array `gap[0] = 0`, `gap[i] = doc_ids[i-1] - doc_ids[i]` and chooses the encoding from
-  the maximum gap:
-  - `0x00`: gaps fit in `u32`. Stored as a bitpacked 256-element block via the bitpacking
-    crate (https://github.com/quickwit-oss/bitpacking) using `BitPacker8x`. A `num_bits` byte
-    is followed by `num_bits * 32` packed bytes; the tail (entries beyond `count`) is padded
-    with zero so it never widens `num_bits`.
-  - `0x01`: at least one gap exceeds `u32::MAX`. Each gap is written as an unsigned LEB128
-    `u64` varint, in order, for `count` entries total.
+- `base_id`: The lowest doc id in the block (i.e. `doc_ids[0]`). The remaining doc ids are
+  reconstructed by adding the encoded offsets/gaps to `base_id`.
+- `docs_encoding`: Discriminator for the layout of `docs`, chosen from the block's largest
+  gap:
+  - `0x00`: every gap fits in `u32`. The ascending gaps `doc_ids[i] - doc_ids[i-1]` for
+    `i >= 1` are stored as a plain bitpacked 256-element block via the bitpacking crate
+    (https://github.com/quickwit-oss/bitpacking) using `BitPacker8x`. A `num_bits` byte is
+    followed by `num_bits * 32` packed bytes; the tail (entries beyond `count`) is padded
+    with zeros so it never widens `num_bits`. (Plain gap packing is chosen over the crate's
+    strictly-sorted delta codec, whose decode measured ~50x slower for a one-bit-per-id
+    saving.)
+  - `0x01`: at least one gap exceeds `u32::MAX`. The ascending gaps are written as unsigned
+    LEB128 `u64` varints, in order, for `count - 1` entries total.
 - `freqs`: Per-document term frequencies, bitpacked as `u32` using the same `BitPacker8x`
   block layout (tail padded with zero).
 - `norms`: The size norm of each document, stored as a `count`-byte array.
 
 `Skips` stores skip data that can be used to efficiently find postings for a document in the list.
 It also contains max score stats for the skipped range.
-- `last_id`: The id of the last document in the range (subsequent block).
+- `last_id`: The id of the last (highest) document in the range (subsequent block).
 - `impacts`: An array of (freq, norm) pairs where freq is the frequency of the term in a doc and
   norm is the size norm of the associated document. These represent the set of dominating size
   norms where either the freq is larger or the norm is lower than another vector in the range.
@@ -518,7 +520,9 @@ For the initial version of this feature we will only encode a skip for every blo
 iterations, we will additionally encode skips for longer ranges to support more efficient 
 traversal of the posting list.
 
-The postings are written as a SlateDB `Merge`. Merges are simple buffer concatenations.
+The postings are written as a SlateDB `Merge`. Merges are simple buffer concatenations in
+operand delivery (oldest-to-newest) order: ids are allocated monotonically, so appending
+newer operands preserves the global ascending order.
 
 ### Term Statistics 
 
@@ -636,7 +640,7 @@ For each write, the Indexer:
    specifies the vector ID, the frequency, and the document's length norm. It can collect these 
    into simple `Vec<(VectorId, u32, u8)>`, and then when flushing pack these into a `Merge` 
    whose value contains the encoded posting blocks. The posting will store the documents in 
-   descending ID order.
+   ascending ID order.
 2. Update `TermStatsValue` for every term in each of its `Text` attribute.
 3. Put the `VectorFieldStatsValue` with lengths for each `Text` attribute.
 4. Update the `FieldStatsValue` for every `Text` attribute.

--- a/vector/src/query_engine/bm25/block_max.rs
+++ b/vector/src/query_engine/bm25/block_max.rs
@@ -58,7 +58,7 @@ use crate::query_engine::filter::PreparedFilter;
 use crate::query_engine::operator::Operator;
 use crate::query_engine::types::{Score, ScoredVectorId};
 use crate::serde::key::TermPostingsKey;
-use crate::serde::term_postings::PostingListView;
+use crate::serde::term_postings::TermPostingsView;
 use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_id::VectorId;
 
@@ -114,7 +114,7 @@ impl BlockMaxBM25Operator {
             let Some(record) = self.storage.get(key).await? else {
                 return Ok(None);
             };
-            let view = PostingListView::parse(record.value)?;
+            let view = TermPostingsView::parse(record.value)?;
             if view.blocks().is_empty() {
                 return Ok(None);
             }
@@ -836,7 +836,7 @@ mod tests {
     /// must surface as a recoverable error from the scorer, not a panic.
     #[test]
     fn corrupt_block_surfaces_as_error_not_panic() {
-        use crate::serde::term_postings::{PostingEntry, TermPostingsValue};
+        use crate::serde::term_postings::{PostingEntry, TermPostingsEncoder};
         let postings = vec![
             PostingEntry {
                 id: VectorId::from_raw(8),
@@ -849,7 +849,7 @@ mod tests {
                 norm: 20,
             },
         ];
-        let encoded = TermPostingsValue::from_postings(postings).encode_to_bytes();
+        let encoded = TermPostingsEncoder::from_postings(postings).encode_to_bytes();
         // Corrupt the ids_encoding byte (payload offset 12) of the first
         // postings block (tag 0x00); parse() never reads it.
         let mut bytes = encoded.to_vec();
@@ -869,7 +869,7 @@ mod tests {
             }
             offset = payload_start + len;
         }
-        let view = PostingListView::parse(bytes::Bytes::from(bytes))
+        let view = TermPostingsView::parse(bytes::Bytes::from(bytes))
             .expect("parse() accepts the corrupt payload");
         assert!(TermScorer::new(view, 1.0).is_err());
     }
@@ -1046,5 +1046,54 @@ mod tests {
             let sparse = run_block_max_sparse(&db, query, None, 10).await;
             assert_same_results(&sparse, &ex, &format!("sparse operands q=[{}]", query));
         }
+    }
+
+    /// Traversal over the mixed layout the compaction filter produces:
+    /// verbatim 256-entry pairs interleaved with a re-packed survivor pair
+    /// of odd count. Seeks and window planning must cross the boundary
+    /// between copied and rewritten pairs cleanly.
+    #[test]
+    fn term_scorer_traverses_filter_rewritten_layout() {
+        use crate::serde::term_postings::{PostingEntry, TermPostingsEncoder, TermPostingsView};
+        use bytes::BytesMut;
+
+        let posting = |id: u64| PostingEntry {
+            id: VectorId::from_raw(id),
+            freq: 1,
+            norm: 1,
+        };
+        // Original: 4 blocks [256, 256, 256, 32]; "delete" ids 300 and 400
+        // from the second block by emulating the filter's rewrite: copy the
+        // clean pairs verbatim and re-encode the survivors of block 1.
+        let original: Vec<_> = (0..800u64).map(posting).collect();
+        let encoded = TermPostingsEncoder::from_postings(original).encode_to_bytes();
+        let view = TermPostingsView::parse(encoded).unwrap();
+        assert_eq!(view.blocks().len(), 4);
+
+        let mut rewritten = BytesMut::new();
+        rewritten.extend_from_slice(view.pair_bytes(0));
+        let survivors: Vec<_> = (256..512u64)
+            .filter(|&id| id != 300 && id != 400)
+            .map(posting)
+            .collect();
+        rewritten
+            .extend_from_slice(&TermPostingsEncoder::from_postings(survivors).encode_to_bytes());
+        rewritten.extend_from_slice(view.pair_bytes(2));
+        rewritten.extend_from_slice(view.pair_bytes(3));
+
+        let mixed = TermPostingsView::parse(rewritten.freeze()).unwrap();
+        assert_eq!(mixed.blocks().len(), 4);
+        assert_eq!(mixed.blocks()[1].count, 254);
+
+        // Seeks across the verbatim/rewritten boundaries.
+        let mut scorer = TermScorer::new(mixed, 1.0).unwrap();
+        assert_eq!(scorer.seek(255).unwrap(), 255);
+        assert_eq!(scorer.seek(300).unwrap(), 301);
+        assert_eq!(scorer.seek(400).unwrap(), 401);
+        assert_eq!(scorer.seek(511).unwrap(), 511);
+        assert_eq!(scorer.seek(512).unwrap(), 512);
+        assert_eq!(scorer.seek(799).unwrap(), 799);
+        scorer.next().unwrap();
+        assert_eq!(scorer.doc(), NO_MORE_DOCS);
     }
 }

--- a/vector/src/query_engine/bm25/exhaustive.rs
+++ b/vector/src/query_engine/bm25/exhaustive.rs
@@ -21,7 +21,7 @@ use crate::query_engine::filter::PreparedFilter;
 use crate::query_engine::operator::Operator;
 use crate::query_engine::types::ScoredVectorId;
 use crate::serde::key::TermPostingsKey;
-use crate::serde::term_postings::{PostingEntry, TermPostingsValue};
+use crate::serde::term_postings::{PostingEntry, TermPostingsView};
 use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_id::VectorId;
 
@@ -69,24 +69,23 @@ impl BM25Operator {
             if n_t == 0 {
                 return Ok::<Option<TermScorer>, crate::error::Error>(None);
             }
-            let postings = self.load_term_postings(field, term).await?;
-            // Block iteration order is already descending by doc id.
-            let entries: Vec<PostingEntry> = postings.iter_entries().copied().collect();
+            let key = TermPostingsKey::new(field, term).encode();
+            let Some(record) = self.storage.get(key).await? else {
+                return Ok(None);
+            };
+            let view = TermPostingsView::parse(record.value)?;
+            // Postings are stored ascending; this scorer's union heap
+            // consumes entries highest-id first, so collect and flip.
+            let mut entries: Vec<PostingEntry> =
+                view.iter_entries().collect::<std::result::Result<_, _>>()?;
             if entries.is_empty() {
                 return Ok(None);
             }
+            entries.reverse();
             Ok(Some(TermScorer::new(entries, bm25::idf(n_docs, n_t))))
         });
         let scorers: Vec<Option<TermScorer>> = futures::future::try_join_all(loads).await?;
         Ok(scorers.into_iter().flatten().collect())
-    }
-
-    async fn load_term_postings(&self, field: &str, term: &str) -> Result<TermPostingsValue> {
-        let key = TermPostingsKey::new(field, term).encode();
-        match self.storage.get(key).await? {
-            Some(record) => Ok(TermPostingsValue::decode_from_bytes(&record.value)?),
-            None => Ok(TermPostingsValue::default()),
-        }
     }
 }
 
@@ -179,8 +178,9 @@ impl Operator<Vec<ScoredVectorId<BM25Score>>> for BM25Operator {
 
 /// A term's postings paired with the term's precomputed IDF.
 ///
-/// Yields entries in descending `doc_id` order — the same order the underlying
-/// `TermPostingsValue` blocks are stored in (RFC-0006).
+/// Yields entries in descending `doc_id` order — reversed by the loader from
+/// the ascending storage order of the posting list (RFC-0006), because the
+/// union heap consumes per-scorer streams highest-id first.
 struct TermScorer {
     /// All entries in descending `doc_id` order.
     entries: Vec<PostingEntry>,

--- a/vector/src/query_engine/bm25/term_scorer.rs
+++ b/vector/src/query_engine/bm25/term_scorer.rs
@@ -8,7 +8,7 @@
 use crate::error::Result;
 use crate::math::bm25::ScoreContext;
 use crate::query_engine::bm25::essential::{HitList, ScoreWindow};
-use crate::serde::term_postings::{DecodedPostingsBlock, PostingListView};
+use crate::serde::term_postings::{DecodedPostingsBlock, TermPostingsView};
 
 /// Sentinel: no documents at or beyond this id (data-vector ids use the low
 /// 56 bits only, so `u64::MAX` is unreachable).
@@ -16,7 +16,7 @@ pub(super) const NO_MORE_DOCS: u64 = u64::MAX;
 
 /// One query term's posting list, iterated lazily in ascending doc id order.
 pub(super) struct TermScorer {
-    view: PostingListView,
+    view: TermPostingsView,
     /// IDF for this term in the current corpus.
     idf: f32,
     /// Current doc id; [`NO_MORE_DOCS`] when exhausted.
@@ -35,7 +35,7 @@ pub(super) struct TermScorer {
 }
 
 impl TermScorer {
-    pub(super) fn new(view: PostingListView, idf: f32) -> Result<Self> {
+    pub(super) fn new(view: TermPostingsView, idf: f32) -> Result<Self> {
         let block_max_scores = vec![None; view.blocks().len()];
         let mut scorer = Self {
             view,
@@ -191,7 +191,7 @@ impl TermScorer {
         }
         let impacts = self.view.impacts(idx);
         let score = if impacts.is_empty() {
-            // Written before impacts landed: fall back to the global bound.
+            // Empty impacts means unknown: fall back to the global bound.
             ctx.global_bound(self.idf)
         } else {
             impacts

--- a/vector/src/serde/term_postings.rs
+++ b/vector/src/serde/term_postings.rs
@@ -3,19 +3,23 @@
 //! A term's posting list is a sequence of typed blocks written one after
 //! another to the end of the value buffer. Each `Postings` block holds up to
 //! [`TARGET_POSTINGS_PER_BLOCK`] `(id, freq, norm)` triples in strictly
-//! descending `id` order. Each `Postings` block is preceded by a `Skip`
-//! block that summarises the postings block's last id and serialized byte
-//! length, so a future query path can iterate without parsing the full
-//! payload. Multiple `(Skip, Postings)` pairs may appear in a single value;
-//! they too are stored in descending id order (each pair's ids are strictly
-//! lower than all ids in the preceding pair).
+//! ascending `id` order. Each `Postings` block is preceded by a `Skip`
+//! block that summarises the postings block's last (highest) id, impacts,
+//! and serialized byte length, so readers can index and skip blocks without
+//! decoding their payloads. Multiple `(Skip, Postings)` pairs may appear in
+//! a single value, also in ascending id order (each pair's ids are strictly
+//! higher than all ids in the preceding pair).
 //!
 //! Each skip block carries the `impacts` of its postings block: the dominating
 //! `(freq, norm)` pairs of the contained documents (RFC-0006). The query path
 //! uses them to compute a tight upper bound on the BM25 contribution of any
-//! document in the block without decoding the block (BlockMaxScore). Values
-//! written before impacts landed decode with an empty impact list, which
-//! readers must treat as "unknown" (fall back to the term's global bound).
+//! document in the block without decoding the block (BlockMaxScore).
+//!
+//! The canonical decoded representation is columnar: [`TermPostingsView`]
+//! parses block headers into a directory and decodes payloads on demand into
+//! ascending parallel arrays ([`DecodedPostingsBlock`]). Row-oriented readers
+//! use [`TermPostingsView::iter_entries`]; [`TermPostingsEncoder`] is the
+//! encode-side builder only.
 //!
 //! ## Value Layout (little-endian unless noted)
 //!
@@ -28,28 +32,27 @@
 //! Postings (type = 0x00) payload
 //! ┌──────────────────────────────────────────────────────────────────┐
 //! │  count:        u32   (1..=256 entries actually used)             │
-//! │  base_id:      u64   (highest id in block)                       │
-//! │  ids_encoding: u8   (0 = bitpacked gaps, 1 = u64 varint gaps)    │
+//! │  base_id:      u64   (lowest id in block, == ids[0])             │
+//! │  ids_encoding: u8   (0 = bitpacked gaps, 1 = varint gaps)       │
 //! │  -- if ids_encoding == 0:                                        │
 //! │     ids_bits:    u8                                              │
-//! │     ids_packed:  ids_bits * 32 bytes (BitPacker8x of 256 gaps)   │
+//! │     ids_packed:  ids_bits * 32 bytes (BitPacker8x of 256 gaps)  │
 //! │  -- if ids_encoding == 1:                                        │
-//! │     ids_varint:  count u64 LEB128 unsigned varints               │
+//! │     ids_varint:  count - 1 u64 LEB128 unsigned varints           │
 //! │  freqs_bits:   u8                                                │
 //! │  freqs_packed: freqs_bits * 32 bytes (BitPacker8x of 256 freqs)  │
 //! │  norms:        count bytes                                       │
 //! └──────────────────────────────────────────────────────────────────┘
 //!
-//! `ids_*` carries gaps between consecutive ids in descending order:
-//! `gap[0] = 0` (the delta from the first id to itself) and
-//! `gap[i] = ids[i-1] - ids[i]` for `i > 0`. The encoder builds the
-//! gap array first, then picks bitpacked when every gap fits in `u32` and
-//! falls back to per-gap LEB128 unsigned varints (`ids_encoding = 1`)
-//! otherwise.
+//! `ids_*` carries the ascending gaps `ids[i] - ids[i-1]` for `i >= 1`
+//! (`base_id` itself is stored explicitly). When every gap fits in `u32`
+//! they are stored as a plain bitpacked 256-element [`BitPacker8x`] block
+//! (tail padded with zeros so it never widens `ids_bits`); otherwise each
+//! gap is written as an unsigned LEB128 `u64` varint (`ids_encoding = 1`).
 //!
 //! Skip (type = 0x01) payload
 //! ┌──────────────────────────────────────────────────────────────────┐
-//! │  last_id:        u64                                              │
+//! │  last_id:        u64   (highest id in block, == ids[count - 1])   │
 //! │  impacts_count:  u16                                              │
 //! │  impacts:        impacts_count * { freq: u32, norm: u8 }          │
 //! │  length:         u64   (byte length of associated Postings block) │
@@ -62,14 +65,9 @@
 //! produces a single `(Skip, Postings)` pair containing only the newly
 //! inserted ids. Vector ids are monotonically allocated, so a newer batch's
 //! ids are strictly higher than any previous batch's ids and the merge
-//! operator can simply concatenate newer operands' bytes before the existing
-//! value's bytes — preserving the global descending-id ordering.
-//!
-//! TODO(rfc-0006 milestone 1+): once the FTS compaction filter lands, it
-//! will rewrite postings into uniform 256-entry `Postings` blocks (each
-//! preceded by a refreshed `Skip`) and prune any stale ids removed via the
-//! deletions bitmap. The variable-size last block today is a Milestone 0
-//! artifact of merge-by-concat with batches of arbitrary size.
+//! operator can simply concatenate operands' bytes after the existing
+//! value's bytes, in delivery (oldest-to-newest) order — preserving the
+//! global ascending-id ordering.
 
 use super::EncodingError;
 use crate::serde::vector_id::VectorId;
@@ -85,14 +83,19 @@ pub(crate) const TARGET_POSTINGS_PER_BLOCK: usize = BLOCK_LEN;
 const BLOCK_TYPE_POSTINGS: u8 = 0x00;
 const BLOCK_TYPE_SKIP: u8 = 0x01;
 
-/// id `gaps` packed via [`BitPacker8x`]. Used when every gap fits in `u32`.
+/// Ascending id gaps packed via [`BitPacker8x`]. Used when every gap fits
+/// in `u32`. This format encodes deltas between consecutive ids. One alternative
+/// is to encode deltas between each id and the first id in the block. These are
+/// strictly sorted and could use [`BitPacker8x#compress_strictly_sorted`]. This
+/// was measured to be much slower (1.9us vs 36ns per block)
 const IDS_ENCODING_BITPACKED: u8 = 0;
 
-/// id `gaps` written one-by-one as unsigned LEB128 `u64` varints. Used
-/// when at least one gap exceeds [`u32::MAX`].
+/// Ascending id gaps written one-by-one as unsigned LEB128 `u64` varints.
+/// Used when at least one gap exceeds `u32::MAX`.
 const IDS_ENCODING_VARINT: u8 = 1;
 
-/// A single posting entry within a `Postings` block.
+/// A single posting entry within a `Postings` block. Used for construction
+/// and row-oriented/aos iteration
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) struct PostingEntry {
     pub(crate) id: VectorId,
@@ -106,7 +109,7 @@ pub(crate) struct PostingEntry {
 /// Impacts have a partial order: a pair with higher `freq` *and* lower `norm`
 /// than another is guaranteed to score at least as high under BM25 (the score
 /// is non-decreasing in frequency and non-increasing in document length). A
-/// skip block stores the *dominating* pairs — those not dominated by any other
+/// skip block stores the *dominating* pairs — those not lower than any other
 /// pair in the block — so the max score over the block is the max score over
 /// its impacts.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,6 +128,7 @@ fn compute_dominating_impacts(entries: &[PostingEntry]) -> Vec<Impact> {
     let mut max_freq_by_norm = [0u32; 256];
     for entry in entries {
         let slot = &mut max_freq_by_norm[entry.norm as usize];
+        // this assumes entry.freq is non-zero, so entry.freq.max(1) _should_ be a no-op
         *slot = (*slot).max(entry.freq.max(1));
     }
     // Sweep norms ascending; a pair survives only when its freq strictly
@@ -143,28 +147,35 @@ fn compute_dominating_impacts(entries: &[PostingEntry]) -> Vec<Impact> {
     impacts
 }
 
-/// A `Postings` block: a run of `PostingEntry` in descending `id` order.
+/// A `Postings` block: a run of `PostingEntry` in ascending `id` order.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub(crate) struct PostingsBlock {
-    /// Entries, sorted by descending `id`.
+    /// Entries, sorted by ascending `id`.
     pub(crate) entries: Vec<PostingEntry>,
 }
 
 impl PostingsBlock {
-    pub(crate) fn from_descending(entries: Vec<PostingEntry>) -> Self {
+    pub(crate) fn from_ascending(entries: Vec<PostingEntry>) -> Self {
         debug_assert!(
-            entries.windows(2).all(|w| w[0].id > w[1].id),
-            "PostingsBlock entries must be strictly descending"
+            entries.windows(2).all(|w| w[0].id < w[1].id),
+            "PostingsBlock entries must be strictly ascending"
         );
         debug_assert!(entries.len() <= BLOCK_LEN);
         Self { entries }
     }
 
+    /// Id of the last (highest) entry in the block.
     pub(crate) fn last_id(&self) -> VectorId {
         self.entries
             .last()
             .map(|e| e.id)
-            .unwrap_or(VectorId::data_vector_id(0))
+            .expect("invalid empty posting block")
+    }
+
+    fn encoded_len(&self) -> usize {
+        let mut payload = BytesMut::new();
+        self.encode_payload(&mut payload);
+        payload.len()
     }
 
     /// Encode just the payload (no type tag or length prefix).
@@ -179,40 +190,34 @@ impl PostingsBlock {
         let base_id = self.entries[0].id.id();
         buf.put_u64_le(base_id);
 
-        // Build the gap array first so we can choose the id encoding
-        // based on the max gap. `gap[0]` is always 0 (the first id is
-        // its own delta); subsequent gaps are positive because the block is
-        // strictly descending.
-        let mut gaps = Vec::with_capacity(count);
-        gaps.push(0u64);
+        let bitpacker = BitPacker8x::new();
+
+        // Gaps between consecutive ids for entries 1.. (the first entry is
+        // base_id itself, so only `count - 1` gaps are real).
         let mut max_gap = 0u64;
         for window in self.entries.windows(2) {
-            let g = window[0].id.id() - window[1].id.id();
-            max_gap = max_gap.max(g);
-            gaps.push(g);
+            max_gap = max_gap.max(window[1].id.id() - window[0].id.id());
         }
-
-        let bitpacker = BitPacker8x::new();
 
         if max_gap <= u32::MAX as u64 {
             buf.put_u8(IDS_ENCODING_BITPACKED);
-            // Pad the tail with zeros — zero is `<= max_gap`, so this never
-            // widens num_bits beyond what the real data requires.
-            let mut ids = [0u32; BLOCK_LEN];
-            for (i, &g) in gaps.iter().enumerate() {
-                ids[i] = g as u32;
+            // Pad the tail with zeros — zero is `<= max_gap`, so padding
+            // never widens ids_bits beyond what the real data requires.
+            let mut gaps = [0u32; BLOCK_LEN];
+            for (i, window) in self.entries.windows(2).enumerate() {
+                gaps[i] = (window[1].id.id() - window[0].id.id()) as u32;
             }
-            let ids_bits = bitpacker.num_bits(&ids);
+            let ids_bits = bitpacker.num_bits(&gaps);
             buf.put_u8(ids_bits);
             let ids_bytes = ids_bits as usize * (BLOCK_LEN / 8);
             let mut packed = vec![0u8; ids_bytes];
-            let written = bitpacker.compress(&ids, &mut packed, ids_bits);
+            let written = bitpacker.compress(&gaps, &mut packed, ids_bits);
             debug_assert_eq!(written, ids_bytes);
             buf.extend_from_slice(&packed);
         } else {
             buf.put_u8(IDS_ENCODING_VARINT);
-            for &g in &gaps {
-                write_u64_varint(buf, g);
+            for window in self.entries.windows(2) {
+                write_u64_varint(buf, window[1].id.id() - window[0].id.id());
             }
         }
 
@@ -235,29 +240,12 @@ impl PostingsBlock {
             buf.put_u8(entry.norm);
         }
     }
-
-    fn decode_payload(buf: &[u8]) -> Result<Self, EncodingError> {
-        let mut ids = [0u64; BLOCK_LEN];
-        let mut freqs = [0u32; BLOCK_LEN];
-        let (count, norms) = decode_postings_raw(buf, &mut ids, &mut freqs)?;
-        let mut entries = Vec::with_capacity(count);
-        for i in 0..count {
-            entries.push(PostingEntry {
-                id: VectorId::from_raw(ids[i]),
-                freq: freqs[i],
-                norm: norms[i],
-            });
-        }
-        Ok(Self { entries })
-    }
 }
 
 /// Decode a `Postings` block payload into caller-provided stack arrays in
-/// stored (descending id) order. Returns the entry count and the borrowed
-/// norms slice. Shared by the eager [`PostingsBlock`] decode and the lazy
-/// [`PostingListView`] block decode; allocation-free so both hot paths can
-/// reuse buffers.
-fn decode_postings_raw<'a>(
+/// ascending id order. Returns the entry count and the borrowed norms
+/// slice. Allocation-free so the hot decode path can reuse buffers.
+fn decode_postings_block_raw<'a>(
     buf: &'a [u8],
     ids: &mut [u64; BLOCK_LEN],
     freqs: &mut [u32; BLOCK_LEN],
@@ -303,8 +291,9 @@ fn decode_postings_raw<'a>(
     let ids_encoding = cursor[0];
     cursor = &cursor[1..];
 
-    // Decode gaps into `ids` (as the gap values), then reconstruct the
-    // descending ids in place below. `gap[0]` is 0 so ids[0] == base_id.
+    // The first id is base_id itself; the remaining `count - 1` come from
+    // the encoded section.
+    ids[0] = base_id;
     match ids_encoding {
         IDS_ENCODING_BITPACKED => {
             if cursor.is_empty() {
@@ -314,6 +303,13 @@ fn decode_postings_raw<'a>(
             }
             let ids_bits = cursor[0];
             cursor = &cursor[1..];
+            // BitPacker8x asserts (panics) on widths above 32; corrupt data
+            // must surface as a recoverable error instead.
+            if ids_bits > 32 {
+                return Err(EncodingError {
+                    message: format!("postings ids_bits {} exceeds 32", ids_bits),
+                });
+            }
             let ids_bytes = ids_bits as usize * (BLOCK_LEN / 8);
             if cursor.len() < ids_bytes {
                 return Err(EncodingError {
@@ -328,15 +324,25 @@ fn decode_postings_raw<'a>(
             let consumed = bitpacker.decompress(&cursor[..ids_bytes], &mut gaps, ids_bits);
             debug_assert_eq!(consumed, ids_bytes);
             cursor = &cursor[ids_bytes..];
-            for i in 0..count {
-                ids[i] = gaps[i] as u64;
+            let mut current = base_id;
+            for i in 1..count {
+                current = current
+                    .checked_add(gaps[i - 1] as u64)
+                    .ok_or_else(|| EncodingError {
+                        message: format!("gap {} overflows running id {}", gaps[i - 1], current),
+                    })?;
+                ids[i] = current;
             }
         }
         IDS_ENCODING_VARINT => {
-            for slot in ids.iter_mut().take(count) {
+            let mut current = base_id;
+            for slot in ids.iter_mut().take(count).skip(1) {
                 let (g, used) = read_u64_varint(cursor)?;
                 cursor = &cursor[used..];
-                *slot = g;
+                current = current.checked_add(g).ok_or_else(|| EncodingError {
+                    message: format!("gap {} overflows running id {}", g, current),
+                })?;
+                *slot = current;
             }
         }
         other => {
@@ -344,17 +350,6 @@ fn decode_postings_raw<'a>(
                 message: format!("unknown postings ids_encoding: 0x{:02x}", other),
             });
         }
-    }
-
-    let mut current = base_id;
-    for (i, slot) in ids.iter_mut().enumerate().take(count) {
-        let g = *slot;
-        if i > 0 {
-            current = current.checked_sub(g).ok_or_else(|| EncodingError {
-                message: format!("gap {} underflows running id {}", g, current),
-            })?;
-        }
-        *slot = current;
     }
 
     // freqs
@@ -365,6 +360,11 @@ fn decode_postings_raw<'a>(
     }
     let freqs_bits = cursor[0];
     cursor = &cursor[1..];
+    if freqs_bits > 32 {
+        return Err(EncodingError {
+            message: format!("postings freqs_bits {} exceeds 32", freqs_bits),
+        });
+    }
     let freqs_bytes = freqs_bits as usize * (BLOCK_LEN / 8);
     if cursor.len() < freqs_bytes {
         return Err(EncodingError {
@@ -429,8 +429,8 @@ fn read_u64_varint(buf: &[u8]) -> Result<(u64, usize), EncodingError> {
 /// A `Skip` block summarising the immediately following `Postings` block.
 ///
 /// `impacts` holds the dominating `(freq, norm)` pairs of the postings block
-/// (see [`Impact`]). Values written before impacts landed (RFC-0006 M0-M2)
-/// decode with an empty list, which readers treat as "unknown".
+/// (see [`Impact`]). An empty list is valid on the wire and means "unknown" —
+/// readers must fall back to the term's global score bound.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SkipBlock {
     pub(crate) last_id: VectorId,
@@ -449,91 +449,47 @@ impl SkipBlock {
         }
         buf.put_u64_le(self.length);
     }
-
-    fn decode_payload(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < 8 + 2 + 8 {
-            return Err(EncodingError {
-                message: format!(
-                    "skip block payload too short: need {} bytes, have {}",
-                    8 + 2 + 8,
-                    buf.len()
-                ),
-            });
-        }
-        let last_id = VectorId::from_raw(u64::from_le_bytes([
-            buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
-        ]));
-        let impacts_count = u16::from_le_bytes([buf[8], buf[9]]);
-        let mut cursor = &buf[10..];
-        let mut impacts = Vec::with_capacity(impacts_count as usize);
-        for _ in 0..impacts_count {
-            if cursor.len() < 5 {
-                return Err(EncodingError {
-                    message: "skip block payload truncated within impacts".to_string(),
-                });
-            }
-            impacts.push(Impact {
-                freq: u32::from_le_bytes([cursor[0], cursor[1], cursor[2], cursor[3]]),
-                norm: cursor[4],
-            });
-            cursor = &cursor[5..];
-        }
-        if cursor.len() < 8 {
-            return Err(EncodingError {
-                message: "skip block payload too short for length".to_string(),
-            });
-        }
-        let length = u64::from_le_bytes([
-            cursor[0], cursor[1], cursor[2], cursor[3], cursor[4], cursor[5], cursor[6], cursor[7],
-        ]);
-        Ok(Self {
-            last_id,
-            impacts,
-            length,
-        })
-    }
 }
 
-/// Decoded block within a `TermPostingsValue`.
+/// Block within a `TermPostingsValue` builder.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TermPostingsBlock {
     Skip(SkipBlock),
     Postings(PostingsBlock),
 }
 
-/// Decoded view of a term's posting list.
+/// Encode-side builder for a term's posting list. The decoded/canonical
+/// representation is [`TermPostingsView`].
 ///
-/// Blocks appear in descending `id` order: each `Skip` is immediately
+/// Blocks appear in ascending `id` order: each `Skip` is immediately
 /// followed by the `Postings` block it describes, and successive pairs cover
-/// strictly lower id ranges.
+/// strictly higher id ranges.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub(crate) struct TermPostingsValue {
+pub(crate) struct TermPostingsEncoder {
     pub(crate) blocks: Vec<TermPostingsBlock>,
 }
 
-impl TermPostingsValue {
+impl TermPostingsEncoder {
     /// Build a value from a flat list of postings in arbitrary order.
     ///
-    /// Postings are sorted descending and chunked into
+    /// Postings are sorted ascending and chunked into
     /// [`TARGET_POSTINGS_PER_BLOCK`]-sized `Postings` blocks; each block is
     /// preceded by its `Skip` summary.
     pub(crate) fn from_postings(mut postings: Vec<PostingEntry>) -> Self {
         if postings.is_empty() {
             return Self::default();
         }
-        postings.sort_unstable_by_key(|p| std::cmp::Reverse(p.id));
+        postings.sort_unstable_by_key(|p| p.id);
         // De-dup defensively; a single id should appear at most once per term per batch.
         postings.dedup_by_key(|e| e.id);
 
         let mut blocks = Vec::new();
         for chunk in postings.chunks(TARGET_POSTINGS_PER_BLOCK) {
-            let postings_block = PostingsBlock::from_descending(chunk.to_vec());
-            let mut payload = BytesMut::new();
-            postings_block.encode_payload(&mut payload);
+            let postings_block = PostingsBlock::from_ascending(chunk.to_vec());
             let skip = SkipBlock {
                 last_id: postings_block.last_id(),
                 impacts: compute_dominating_impacts(&postings_block.entries),
-                length: payload.len() as u64,
+                length: postings_block.encoded_len() as u64,
             };
             blocks.push(TermPostingsBlock::Skip(skip));
             blocks.push(TermPostingsBlock::Postings(postings_block));
@@ -541,101 +497,57 @@ impl TermPostingsValue {
         Self { blocks }
     }
 
-    /// Iterate all decoded posting entries in descending `id` order across blocks.
-    pub(crate) fn iter_entries(&self) -> impl Iterator<Item = &PostingEntry> {
-        self.blocks.iter().flat_map(|block| match block {
-            TermPostingsBlock::Postings(p) => p.entries.iter(),
-            TermPostingsBlock::Skip(_) => [].iter(),
-        })
-    }
-
     pub(crate) fn encode_to_bytes(&self) -> Bytes {
         let mut buf = BytesMut::new();
         for block in &self.blocks {
-            encode_block(block, &mut buf);
+            Self::encode_block(block, &mut buf);
         }
         buf.freeze()
     }
 
-    pub(crate) fn decode_from_bytes(buf: &[u8]) -> Result<Self, EncodingError> {
-        let mut cursor = buf;
-        let mut blocks = Vec::new();
-        while !cursor.is_empty() {
-            if cursor.len() < 5 {
-                return Err(EncodingError {
-                    message: "term postings value truncated at block header".to_string(),
-                });
+    fn encode_block(block: &TermPostingsBlock, buf: &mut BytesMut) {
+        let mut payload = BytesMut::new();
+        let (tag, payload_buf) = match block {
+            TermPostingsBlock::Skip(s) => {
+                s.encode_payload(&mut payload);
+                (BLOCK_TYPE_SKIP, &payload)
             }
-            let block_type = cursor[0];
-            let len = u32::from_le_bytes([cursor[1], cursor[2], cursor[3], cursor[4]]) as usize;
-            cursor = &cursor[5..];
-            if cursor.len() < len {
-                return Err(EncodingError {
-                    message: format!(
-                        "term postings value truncated within block: need {}, have {}",
-                        len,
-                        cursor.len()
-                    ),
-                });
+            TermPostingsBlock::Postings(p) => {
+                p.encode_payload(&mut payload);
+                (BLOCK_TYPE_POSTINGS, &payload)
             }
-            let payload = &cursor[..len];
-            cursor = &cursor[len..];
-            let block = match block_type {
-                BLOCK_TYPE_SKIP => TermPostingsBlock::Skip(SkipBlock::decode_payload(payload)?),
-                BLOCK_TYPE_POSTINGS => {
-                    TermPostingsBlock::Postings(PostingsBlock::decode_payload(payload)?)
-                }
-                other => {
-                    return Err(EncodingError {
-                        message: format!("unknown term postings block type: 0x{:02x}", other),
-                    });
-                }
-            };
-            blocks.push(block);
-        }
-        Ok(Self { blocks })
+        };
+        buf.put_u8(tag);
+        buf.put_u32_le(payload_buf.len() as u32);
+        buf.extend_from_slice(payload_buf);
     }
 }
 
-fn encode_block(block: &TermPostingsBlock, buf: &mut BytesMut) {
-    let mut payload = BytesMut::new();
-    let (tag, payload_buf) = match block {
-        TermPostingsBlock::Skip(s) => {
-            s.encode_payload(&mut payload);
-            (BLOCK_TYPE_SKIP, &payload)
-        }
-        TermPostingsBlock::Postings(p) => {
-            p.encode_payload(&mut payload);
-            (BLOCK_TYPE_POSTINGS, &payload)
-        }
-    };
-    buf.put_u8(tag);
-    buf.put_u32_le(payload_buf.len() as u32);
-    buf.extend_from_slice(payload_buf);
-}
-
 /// Directory entry for one `(Skip, Postings)` pair within an encoded
-/// `TermPostings` value, recorded by [`PostingListView::parse`].
+/// `TermPostings` value, recorded by [`TermPostingsView::parse`].
 #[derive(Debug, Clone)]
 pub(crate) struct PostingBlockMeta {
-    /// Lowest doc id in the block (the skip block's `last_id`).
+    /// Lowest doc id in the block (the postings payload's `base_id`).
     pub(crate) min_id: u64,
-    /// Highest doc id in the block (the postings payload's `base_id`).
+    /// Highest doc id in the block (the skip block's `last_id`).
     pub(crate) max_id: u64,
     /// Number of postings in the block.
     pub(crate) count: u32,
     /// Range of this block's impacts within the view's impact arena.
     impacts_start: u32,
     impacts_len: u16,
+    /// Byte offset of the skip+postings pair's skip-block header within the raw value;
+    /// with `payload_start + payload_len` this delimits the whole
+    /// `(Skip, Postings)` pair for verbatim copying.
+    pair_start: usize,
     /// Byte range of the postings payload within the raw value.
     payload_start: usize,
     payload_len: usize,
 }
 
-/// A `Postings` block decoded into parallel arrays in **ascending** doc id
-/// order — the iteration order of the BlockMaxScore query path. (Blocks are
-/// stored descending; [`PostingListView::decode_block_into`] reverses on
-/// decode.)
+/// A `Postings` block decoded into parallel arrays in ascending doc id
+/// order — the storage order, and the iteration order of the BlockMaxScore
+/// query path.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DecodedPostingsBlock {
     pub(crate) ids: Vec<u64>,
@@ -643,7 +555,7 @@ pub(crate) struct DecodedPostingsBlock {
     pub(crate) norms: Vec<u8>,
 }
 
-/// A lazily-decoded view over an encoded `TermPostings` value.
+/// A lazily-decoded view over an encoded term postings value.
 ///
 /// [`parse`](Self::parse) scans only the block headers and skip payloads —
 /// it never touches the bitpacked postings payloads — and records where each
@@ -651,27 +563,27 @@ pub(crate) struct DecodedPostingsBlock {
 /// blocks on demand. This is what lets BlockMaxScore skip whole blocks
 /// without paying their decode cost.
 ///
-/// `blocks` is ordered by **ascending** doc id range (the reverse of storage
-/// order): `blocks[0]` holds the lowest ids. Ranges of distinct blocks never
+/// `blocks` is ordered by ascending doc id range (the storage order):
+/// `blocks[0]` holds the lowest ids. Ranges of distinct blocks never
 /// overlap (merge operands partition the id space). All blocks' impacts live
 /// in one arena (`impacts`) rather than per-block `Vec`s so a query on a
 /// common term with thousands of blocks doesn't pay one allocation per block.
 #[derive(Debug, Clone, Default)]
-pub(crate) struct PostingListView {
+pub(crate) struct TermPostingsView {
     raw: Bytes,
     blocks: Vec<PostingBlockMeta>,
     impacts: Vec<Impact>,
 }
 
-impl PostingListView {
-    /// Scan the value's block headers into a directory. Cost is proportional
-    /// to the number of blocks, not the number of postings.
+impl TermPostingsView {
+    /// Scan the value's block headers into a directory.
     pub(crate) fn parse(raw: Bytes) -> Result<Self, EncodingError> {
         let mut blocks = Vec::new();
         let mut impacts: Vec<Impact> = Vec::new();
         let mut offset = 0usize;
-        // (min_id, impacts range) decoded from the pending skip block.
-        let mut pending_skip: Option<(u64, u32, u16)> = None;
+        // (max_id, impacts range, pair start) decoded from the pending skip
+        // block.
+        let mut pending_skip: Option<(u64, u32, u16, usize)> = None;
         while offset < raw.len() {
             if raw.len() - offset < 5 {
                 return Err(EncodingError {
@@ -715,7 +627,7 @@ impl PostingListView {
                             ),
                         });
                     }
-                    let min_id = u64::from_le_bytes([
+                    let max_id = u64::from_le_bytes([
                         payload[0], payload[1], payload[2], payload[3], payload[4], payload[5],
                         payload[6], payload[7],
                     ]);
@@ -733,10 +645,17 @@ impl PostingListView {
                             norm: chunk[4],
                         });
                     }
-                    pending_skip = Some((min_id, impacts_start, impacts_count as u16));
+                    pending_skip = Some((
+                        max_id,
+                        impacts_start,
+                        impacts_count as u16,
+                        payload_start - 5,
+                    ));
                 }
                 BLOCK_TYPE_POSTINGS => {
-                    let Some((min_id, impacts_start, impacts_len)) = pending_skip.take() else {
+                    let Some((max_id, impacts_start, impacts_len, pair_start)) =
+                        pending_skip.take()
+                    else {
                         return Err(EncodingError {
                             message: "postings block without preceding skip block".to_string(),
                         });
@@ -760,7 +679,7 @@ impl PostingListView {
                             message: "postings block payload too short for base id".to_string(),
                         });
                     }
-                    let max_id = u64::from_le_bytes([
+                    let min_id = u64::from_le_bytes([
                         payload[4],
                         payload[5],
                         payload[6],
@@ -770,12 +689,35 @@ impl PostingListView {
                         payload[10],
                         payload[11],
                     ]);
+                    // The directory invariants every consumer relies on
+                    // (block ranges are well-formed, ascending, and
+                    // disjoint) come from persisted bytes, so check them
+                    // here rather than trusting the writer.
+                    if min_id > max_id {
+                        return Err(EncodingError {
+                            message: format!(
+                                "postings block base_id {} exceeds skip block last_id {}",
+                                min_id, max_id
+                            ),
+                        });
+                    }
+                    if let Some(prev) = blocks.last().map(|b: &PostingBlockMeta| b.max_id)
+                        && min_id <= prev
+                    {
+                        return Err(EncodingError {
+                            message: format!(
+                                "postings block base_id {} does not ascend past previous block's last id {}",
+                                min_id, prev
+                            ),
+                        });
+                    }
                     blocks.push(PostingBlockMeta {
                         min_id,
                         max_id,
                         count,
                         impacts_start,
                         impacts_len,
+                        pair_start,
                         payload_start,
                         payload_len: len,
                     });
@@ -792,9 +734,6 @@ impl PostingListView {
                 message: "trailing skip block without postings block".to_string(),
             });
         }
-        // Storage order is descending; flip so blocks[0] holds the lowest ids.
-        // Arena ranges are positional and unaffected by directory order.
-        blocks.reverse();
         Ok(Self {
             raw,
             blocks,
@@ -807,9 +746,8 @@ impl PostingListView {
         &self.blocks
     }
 
-    /// Impacts of block `idx`. Empty when the block was written before
-    /// impacts landed — callers must treat that as "unknown" and fall back to
-    /// the term's global score bound.
+    /// Impacts of block `idx`. May be empty ("unknown") — callers must fall
+    /// back to the term's global score bound.
     pub(crate) fn impacts(&self, idx: usize) -> &[Impact] {
         let meta = &self.blocks[idx];
         &self.impacts[meta.impacts_start as usize..][..meta.impacts_len as usize]
@@ -827,13 +765,13 @@ impl PostingListView {
         let payload = &self.raw[meta.payload_start..meta.payload_start + meta.payload_len];
         let mut ids = [0u64; BLOCK_LEN];
         let mut freqs = [0u32; BLOCK_LEN];
-        let (count, norms) = decode_postings_raw(payload, &mut ids, &mut freqs)?;
+        let (count, norms) = decode_postings_block_raw(payload, &mut ids, &mut freqs)?;
         out.ids.clear();
-        out.ids.extend(ids[..count].iter().rev());
+        out.ids.extend_from_slice(&ids[..count]);
         out.freqs.clear();
-        out.freqs.extend(freqs[..count].iter().rev());
+        out.freqs.extend_from_slice(&freqs[..count]);
         out.norms.clear();
-        out.norms.extend(norms.iter().rev());
+        out.norms.extend_from_slice(norms);
         Ok(())
     }
 
@@ -844,15 +782,86 @@ impl PostingListView {
         self.decode_block_into(idx, &mut out)?;
         Ok(out)
     }
+
+    /// The raw bytes of block `idx`'s whole `(Skip, Postings)` pair —
+    /// headers included — for copying into a rewritten value verbatim.
+    pub(crate) fn pair_bytes(&self, idx: usize) -> &[u8] {
+        &self.raw[self.pair_range(idx)]
+    }
+
+    /// Byte range of block `idx`'s whole `(Skip, Postings)` pair within the
+    /// raw value.
+    pub(crate) fn pair_range(&self, idx: usize) -> std::ops::Range<usize> {
+        let meta = &self.blocks[idx];
+        meta.pair_start..meta.payload_start + meta.payload_len
+    }
+
+    /// Iterate every posting in ascending doc id order, decoding blocks
+    /// lazily into a reused buffer (memory stays O(one block)). The
+    /// row-oriented adapter over the columnar representation: yields an
+    /// `Err` once and ends if a block payload fails to decode.
+    pub(crate) fn iter_entries(&self) -> PostingEntriesIter<'_> {
+        PostingEntriesIter {
+            view: self,
+            block_idx: 0,
+            decoded: DecodedPostingsBlock::default(),
+            pos: 0,
+            failed: false,
+        }
+    }
+}
+
+/// Row-oriented iterator over a [`TermPostingsView`] that returns `PostingEntry`s; see
+/// [`TermPostingsView::iter_entries`].
+pub(crate) struct PostingEntriesIter<'a> {
+    view: &'a TermPostingsView,
+    /// Index of the next block to decode.
+    block_idx: usize,
+    /// Decoded arrays for the block currently being yielded.
+    decoded: DecodedPostingsBlock,
+    /// Cursor within `decoded`.
+    pos: usize,
+    failed: bool,
+}
+
+impl Iterator for PostingEntriesIter<'_> {
+    type Item = Result<PostingEntry, EncodingError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.failed {
+            return None;
+        }
+        while self.pos >= self.decoded.ids.len() {
+            if self.block_idx >= self.view.blocks().len() {
+                return None;
+            }
+            if let Err(err) = self
+                .view
+                .decode_block_into(self.block_idx, &mut self.decoded)
+            {
+                self.failed = true;
+                return Some(Err(err));
+            }
+            self.block_idx += 1;
+            self.pos = 0;
+        }
+        let i = self.pos;
+        self.pos += 1;
+        Some(Ok(PostingEntry {
+            id: VectorId::from_raw(self.decoded.ids[i]),
+            freq: self.decoded.freqs[i],
+            norm: self.decoded.norms[i],
+        }))
+    }
 }
 
 /// Merge multiple `TermPostings` values via byte concatenation.
 ///
 /// SlateDB delivers operands oldest-to-newest. Newer batches insert strictly
-/// higher vector ids (ids are monotonically allocated and Milestone 0 is
-/// insert-only), so reversing the operand list and prepending it to the
-/// existing value preserves the global descending-id invariant. No parsing
-/// or re-encoding required.
+/// higher vector ids (ids are monotonically allocated; deletes never reuse
+/// ids), so appending operands after the existing value, in delivery order,
+/// preserves the global ascending-id invariant. No parsing or re-encoding
+/// required.
 pub(crate) fn merge_batch_term_postings(existing: Option<Bytes>, operands: &[Bytes]) -> Bytes {
     if operands.is_empty() {
         return existing.unwrap_or_default();
@@ -863,11 +872,11 @@ pub(crate) fn merge_batch_term_postings(existing: Option<Bytes>, operands: &[Byt
     let total: usize = existing.as_ref().map(|b| b.len()).unwrap_or(0)
         + operands.iter().map(|b| b.len()).sum::<usize>();
     let mut out = BytesMut::with_capacity(total);
-    for operand in operands.iter().rev() {
-        out.extend_from_slice(operand);
-    }
     if let Some(ex) = existing {
         out.extend_from_slice(&ex);
+    }
+    for operand in operands {
+        out.extend_from_slice(operand);
     }
     out.freeze()
 }
@@ -884,11 +893,21 @@ mod tests {
         }
     }
 
-    /// Corrupt bytes at the given payload offsets within the first
+    /// Decode every posting through the view's row iterator.
+    fn all_entries(encoded: Bytes) -> Vec<PostingEntry> {
+        TermPostingsView::parse(encoded)
+            .unwrap()
+            .iter_entries()
+            .collect::<Result<_, _>>()
+            .unwrap()
+    }
+
+    /// Corrupt bytes at the given payload offsets within the `nth`
     /// postings-block payload of an encoded value.
-    fn corrupt_postings_payload(encoded: &Bytes, edits: &[(usize, u8)]) -> Bytes {
+    fn corrupt_nth_postings_payload(encoded: &Bytes, nth: usize, edits: &[(usize, u8)]) -> Bytes {
         let mut bytes = encoded.to_vec();
         let mut offset = 0usize;
+        let mut seen = 0usize;
         loop {
             let tag = bytes[offset];
             let len = u32::from_le_bytes([
@@ -899,13 +918,21 @@ mod tests {
             ]) as usize;
             let payload_start = offset + 5;
             if tag == BLOCK_TYPE_POSTINGS {
-                for &(off, val) in edits {
-                    bytes[payload_start + off] = val;
+                if seen == nth {
+                    for &(off, val) in edits {
+                        bytes[payload_start + off] = val;
+                    }
+                    return Bytes::from(bytes);
                 }
-                return Bytes::from(bytes);
+                seen += 1;
             }
             offset = payload_start + len;
         }
+    }
+
+    /// Corrupt bytes within the first postings-block payload.
+    fn corrupt_postings_payload(encoded: &Bytes, edits: &[(usize, u8)]) -> Bytes {
+        corrupt_nth_postings_payload(encoded, 0, edits)
     }
 
     /// parse() only validates framing; a payload corrupted past the header
@@ -913,32 +940,36 @@ mod tests {
     #[test]
     fn corrupt_payload_decodes_to_error_not_panic() {
         let postings = vec![entry(8, 2, 30), entry(2, 3, 20), entry(5, 1, 10)];
-        let encoded = TermPostingsValue::from_postings(postings).encode_to_bytes();
+        let encoded = TermPostingsEncoder::from_postings(postings).encode_to_bytes();
 
         // ids_encoding byte is at payload offset 12 (count:4 + base_id:8).
         let bad_encoding = corrupt_postings_payload(&encoded, &[(12, 0xEE)]);
-        let view = PostingListView::parse(bad_encoding).expect("framing is intact");
+        let view = TermPostingsView::parse(bad_encoding).expect("framing is intact");
         let err = view.decode_block(0).unwrap_err();
         assert!(
             err.message.contains("unknown postings ids_encoding"),
             "{}",
             err.message
         );
+        // The row iterator surfaces the same error once, then ends.
+        let items: Vec<_> = view.iter_entries().collect();
+        assert_eq!(items.len(), 1);
+        assert!(items[0].is_err());
 
         // count is payload bytes 0..4; 300 (0x012C) > BLOCK_LEN (256).
         let bad_count = corrupt_postings_payload(&encoded, &[(0, 0x2C), (1, 0x01)]);
-        let view = PostingListView::parse(bad_count).expect("framing is intact");
+        let view = TermPostingsView::parse(bad_count).expect("framing is intact");
         let err = view.decode_block(0).unwrap_err();
         assert!(err.message.contains("exceeds BLOCK_LEN"), "{}", err.message);
     }
 
-    /// A degenerate count==0 postings block is tolerated by the eager decoder
-    /// and must be skipped (not turned into an error) by the lazy view.
+    /// A degenerate count==0 postings block must be skipped by the view,
+    /// not turned into an error.
     #[test]
     fn view_should_skip_zero_count_blocks() {
         // given - a valid pair followed by an empty (skip, postings) pair
         let mut buf = BytesMut::new();
-        let real = TermPostingsValue::from_postings(vec![entry(7, 1, 1), entry(3, 2, 2)]);
+        let real = TermPostingsEncoder::from_postings(vec![entry(7, 1, 1), entry(3, 2, 2)]);
         buf.extend_from_slice(&real.encode_to_bytes());
         // skip block for the empty pair
         let mut skip_payload = BytesMut::new();
@@ -954,51 +985,45 @@ mod tests {
         buf.put_u32_le(0);
         let encoded = buf.freeze();
 
-        // when - both decoders read the value
-        let eager = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
-        let view = PostingListView::parse(encoded).unwrap();
+        // when
+        let view = TermPostingsView::parse(encoded).unwrap();
 
         // then - the view skips the empty pair and indexes only the real one
         assert_eq!(view.blocks().len(), 1);
         assert_eq!(view.decode_block(0).unwrap().ids, vec![3, 7]);
-        assert_eq!(eager.iter_entries().count(), 2);
     }
 
     #[test]
     fn should_roundtrip_empty_value() {
         // given
-        let value = TermPostingsValue::default();
+        let value = TermPostingsEncoder::default();
 
         // when
         let encoded = value.encode_to_bytes();
-        let decoded = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
+        let view = TermPostingsView::parse(encoded).unwrap();
 
         // then
-        assert_eq!(decoded, value);
+        assert!(view.blocks().is_empty());
     }
 
     #[test]
     fn should_roundtrip_single_block() {
         // given
-        let value = TermPostingsValue::from_postings(vec![
+        let value = TermPostingsEncoder::from_postings(vec![
             entry(5, 1, 10),
             entry(2, 3, 20),
             entry(8, 2, 30),
         ]);
 
-        // when
-        let encoded = value.encode_to_bytes();
-        let decoded = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
-
-        // then - two blocks: Skip + Postings
-        assert_eq!(decoded.blocks.len(), 2);
-        assert!(matches!(decoded.blocks[0], TermPostingsBlock::Skip(_)));
-        assert!(matches!(decoded.blocks[1], TermPostingsBlock::Postings(_)));
-        // Entries descending by id with original freq/norm preserved.
-        let entries: Vec<_> = decoded.iter_entries().copied().collect();
+        // then - one (Skip, Postings) pair in the builder
+        assert_eq!(value.blocks.len(), 2);
+        assert!(matches!(value.blocks[0], TermPostingsBlock::Skip(_)));
+        assert!(matches!(value.blocks[1], TermPostingsBlock::Postings(_)));
+        // Entries ascending by id with original freq/norm preserved.
+        let entries = all_entries(value.encode_to_bytes());
         assert_eq!(
             entries,
-            vec![entry(8, 2, 30), entry(5, 1, 10), entry(2, 3, 20),]
+            vec![entry(2, 3, 20), entry(5, 1, 10), entry(8, 2, 30)]
         );
     }
 
@@ -1009,19 +1034,17 @@ mod tests {
         let postings: Vec<_> = (0..n as u64)
             .map(|i| entry(i, (i % 7) as u32 + 1, ((i % 11) as u8) + 1))
             .collect();
-        let value = TermPostingsValue::from_postings(postings);
+        let value = TermPostingsEncoder::from_postings(postings);
 
         // when
-        let encoded = value.encode_to_bytes();
-        let decoded = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
+        let entries = all_entries(value.encode_to_bytes());
 
         // then - 3 pairs of (Skip, Postings)
-        assert_eq!(decoded.blocks.len(), 6);
-        let entries: Vec<_> = decoded.iter_entries().copied().collect();
+        assert_eq!(value.blocks.len(), 6);
         assert_eq!(entries.len(), n);
-        // Strictly descending
+        // Strictly ascending
         for w in entries.windows(2) {
-            assert!(w[0].id > w[1].id);
+            assert!(w[0].id < w[1].id);
         }
     }
 
@@ -1030,7 +1053,7 @@ mod tests {
         // given - enough postings for 2 blocks
         let n = TARGET_POSTINGS_PER_BLOCK + 5;
         let postings: Vec<_> = (0..n as u64).map(|i| entry(i, 1, 1)).collect();
-        let value = TermPostingsValue::from_postings(postings);
+        let value = TermPostingsEncoder::from_postings(postings);
 
         // when
         let kinds: Vec<&str> = value
@@ -1047,45 +1070,43 @@ mod tests {
     }
 
     #[test]
-    fn should_merge_concatenating_newer_blocks_first() {
+    fn should_merge_appending_newer_blocks_after_older() {
         // given - older operand has lower ids, newer operand has higher ids
-        let older = TermPostingsValue::from_postings(vec![entry(1, 1, 1), entry(2, 1, 1)])
+        let older = TermPostingsEncoder::from_postings(vec![entry(1, 1, 1), entry(2, 1, 1)])
             .encode_to_bytes();
-        let newer = TermPostingsValue::from_postings(vec![entry(10, 1, 1), entry(11, 1, 1)])
+        let newer = TermPostingsEncoder::from_postings(vec![entry(10, 1, 1), entry(11, 1, 1)])
             .encode_to_bytes();
 
         // when - operands ordered oldest -> newest
         let merged = merge_batch_term_postings(None, &[older, newer]);
-        let decoded = TermPostingsValue::decode_from_bytes(&merged).unwrap();
 
-        // then - ids are globally descending
-        let ids: Vec<u64> = decoded.iter_entries().map(|e| e.id.id()).collect();
-        assert_eq!(ids, vec![11, 10, 2, 1]);
+        // then - ids are globally ascending
+        let ids: Vec<u64> = all_entries(merged).iter().map(|e| e.id.id()).collect();
+        assert_eq!(ids, vec![1, 2, 10, 11]);
     }
 
     #[test]
     fn should_merge_with_existing_value() {
         // given
-        let existing = TermPostingsValue::from_postings(vec![entry(1, 1, 1)]).encode_to_bytes();
-        let op = TermPostingsValue::from_postings(vec![entry(5, 1, 1)]).encode_to_bytes();
+        let existing = TermPostingsEncoder::from_postings(vec![entry(1, 1, 1)]).encode_to_bytes();
+        let op = TermPostingsEncoder::from_postings(vec![entry(5, 1, 1)]).encode_to_bytes();
 
         // when
         let merged = merge_batch_term_postings(Some(existing), &[op]);
-        let decoded = TermPostingsValue::decode_from_bytes(&merged).unwrap();
 
-        // then - ids globally descending
-        let ids: Vec<u64> = decoded.iter_entries().map(|e| e.id.id()).collect();
-        assert_eq!(ids, vec![5, 1]);
+        // then - ids globally ascending
+        let ids: Vec<u64> = all_entries(merged).iter().map(|e| e.id.id()).collect();
+        assert_eq!(ids, vec![1, 5]);
     }
 
     #[test]
     fn merge_is_pure_byte_concatenation() {
         // given - the encoded forms of two operands
-        let older = TermPostingsValue::from_postings(vec![entry(1, 1, 1)]).encode_to_bytes();
-        let newer = TermPostingsValue::from_postings(vec![entry(10, 1, 1)]).encode_to_bytes();
+        let older = TermPostingsEncoder::from_postings(vec![entry(1, 1, 1)]).encode_to_bytes();
+        let newer = TermPostingsEncoder::from_postings(vec![entry(10, 1, 1)]).encode_to_bytes();
         let mut expected = Vec::with_capacity(older.len() + newer.len());
-        expected.extend_from_slice(&newer); // newer first
-        expected.extend_from_slice(&older);
+        expected.extend_from_slice(&older); // delivery order: oldest first
+        expected.extend_from_slice(&newer);
 
         // when
         let merged = merge_batch_term_postings(None, &[older, newer]);
@@ -1097,7 +1118,7 @@ mod tests {
     #[test]
     fn should_preserve_skip_last_id_and_length() {
         // given
-        let value = TermPostingsValue::from_postings(vec![
+        let value = TermPostingsEncoder::from_postings(vec![
             entry(10, 1, 1),
             entry(20, 1, 1),
             entry(30, 1, 1),
@@ -1113,8 +1134,9 @@ mod tests {
             })
             .unwrap();
 
-        // then - last_id is the lowest id in the following postings block; length matches
-        assert_eq!(skip.last_id.id(), 10);
+        // then - last_id is the highest id in the following postings block;
+        // length matches
+        assert_eq!(skip.last_id.id(), 30);
         let postings_payload_len = {
             let postings = value
                 .blocks
@@ -1132,9 +1154,9 @@ mod tests {
     }
 
     #[test]
-    fn should_use_bitpacked_id_encoding_when_gaps_fit_in_u32() {
+    fn should_use_bitpacked_id_encoding_when_range_fits_u32() {
         // given
-        let value = TermPostingsValue::from_postings(vec![
+        let value = TermPostingsEncoder::from_postings(vec![
             entry(100, 1, 1),
             entry(50, 1, 1),
             entry(1, 1, 1),
@@ -1152,18 +1174,19 @@ mod tests {
         // then
         assert_eq!(ids_encoding, IDS_ENCODING_BITPACKED);
 
-        // and - encode/decode round-trips identical entries
-        let encoded = value.encode_to_bytes();
-        let decoded = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
-        let ids: Vec<u64> = decoded.iter_entries().map(|e| e.id.id()).collect();
-        assert_eq!(ids, vec![100, 50, 1]);
+        // and - encode/decode round-trips identical ids, ascending
+        let ids: Vec<u64> = all_entries(value.encode_to_bytes())
+            .iter()
+            .map(|e| e.id.id())
+            .collect();
+        assert_eq!(ids, vec![1, 50, 100]);
     }
 
     #[test]
-    fn should_switch_to_varint_id_encoding_when_gap_exceeds_u32() {
-        // given - gap between two consecutive entries exceeds u32::MAX
-        let huge = (u32::MAX as u64) + 2; // gap will be 1 too big for u32
-        let value = TermPostingsValue::from_postings(vec![entry(huge, 1, 5), entry(0, 2, 7)]);
+    fn should_switch_to_varint_id_encoding_when_range_exceeds_u32() {
+        // given - the block's id range exceeds what bitpacked offsets hold
+        let huge = (u32::MAX as u64) + 2;
+        let value = TermPostingsEncoder::from_postings(vec![entry(huge, 1, 5), entry(0, 2, 7)]);
 
         // when - inspect ids_encoding byte
         let TermPostingsBlock::Postings(p) = &value.blocks[1] else {
@@ -1177,10 +1200,61 @@ mod tests {
         assert_eq!(ids_encoding, IDS_ENCODING_VARINT);
 
         // and - encode/decode preserves the original entries (huge id and all)
-        let encoded = value.encode_to_bytes();
-        let decoded = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
-        let entries: Vec<_> = decoded.iter_entries().copied().collect();
-        assert_eq!(entries, vec![entry(huge, 1, 5), entry(0, 2, 7)]);
+        let entries = all_entries(value.encode_to_bytes());
+        assert_eq!(entries, vec![entry(0, 2, 7), entry(huge, 1, 5)]);
+    }
+
+    /// The bitpacked condition is per-gap: the block's total id range can
+    /// exceed `u32::MAX` as long as every individual gap fits (the prefix
+    /// sum accumulates in u64).
+    #[test]
+    fn should_stay_bitpacked_when_gaps_fit_but_range_does_not() {
+        let step = 3_000_000_000u64; // < u32::MAX, but two steps exceed it
+        let value = TermPostingsEncoder::from_postings(vec![
+            entry(0, 1, 1),
+            entry(step, 1, 1),
+            entry(2 * step, 1, 1),
+        ]);
+
+        let TermPostingsBlock::Postings(p) = &value.blocks[1] else {
+            panic!("expected postings block")
+        };
+        let mut payload = BytesMut::new();
+        p.encode_payload(&mut payload);
+        assert_eq!(payload[12], IDS_ENCODING_BITPACKED);
+
+        let ids: Vec<u64> = all_entries(value.encode_to_bytes())
+            .iter()
+            .map(|e| e.id.id())
+            .collect();
+        assert_eq!(ids, vec![0, step, 2 * step]);
+    }
+
+    /// Single-entry blocks exercise the all-padding path of the
+    /// strictly-sorted codec.
+    #[test]
+    fn should_roundtrip_single_entry_block() {
+        let value = TermPostingsEncoder::from_postings(vec![entry(12345, 7, 3)]);
+        let entries = all_entries(value.encode_to_bytes());
+        assert_eq!(entries, vec![entry(12345, 7, 3)]);
+    }
+
+    /// Dense consecutive ids pack to one-bit gaps.
+    #[test]
+    fn consecutive_ids_pack_to_one_bit() {
+        let postings: Vec<_> = (1000..1256u64).map(|i| entry(i, 1, 1)).collect();
+        let value = TermPostingsEncoder::from_postings(postings.clone());
+
+        let TermPostingsBlock::Postings(p) = &value.blocks[1] else {
+            panic!("expected postings block")
+        };
+        let mut payload = BytesMut::new();
+        p.encode_payload(&mut payload);
+        // count(4) + base_id(8) + encoding(1), then ids_bits.
+        assert_eq!(payload[12], IDS_ENCODING_BITPACKED);
+        assert_eq!(payload[13], 1, "gaps of 1 need 1 bit");
+
+        assert_eq!(all_entries(value.encode_to_bytes()), postings);
     }
 
     #[test]
@@ -1270,23 +1344,19 @@ mod tests {
     #[test]
     fn should_roundtrip_skip_impacts() {
         // given
-        let value = TermPostingsValue::from_postings(vec![
+        let value = TermPostingsEncoder::from_postings(vec![
             entry(10, 3, 7),
             entry(20, 1, 2),
             entry(30, 5, 9),
         ]);
 
         // when
-        let encoded = value.encode_to_bytes();
-        let decoded = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
+        let view = TermPostingsView::parse(value.encode_to_bytes()).unwrap();
 
         // then - skip block impacts survive the round trip
-        let TermPostingsBlock::Skip(skip) = &decoded.blocks[0] else {
-            panic!("expected skip block");
-        };
         assert_eq!(
-            skip.impacts,
-            vec![
+            view.impacts(0),
+            &[
                 Impact { freq: 1, norm: 2 },
                 Impact { freq: 3, norm: 7 },
                 Impact { freq: 5, norm: 9 }
@@ -1294,26 +1364,33 @@ mod tests {
         );
     }
 
+    /// A pair whose skip block carries no impacts parses with an empty
+    /// impact list (the "unknown — use the global bound" signal).
     #[test]
-    fn should_decode_legacy_skip_block_without_impacts() {
-        // given - a skip payload hand-encoded the way M0 wrote it (impacts_count = 0)
-        let mut buf = BytesMut::new();
-        buf.put_u8(BLOCK_TYPE_SKIP);
-        buf.put_u32_le(8 + 2 + 8);
-        buf.put_u64_le(42); // last_id
-        buf.put_u16_le(0); // impacts_count
-        buf.put_u64_le(99); // length
+    fn should_parse_skip_block_without_impacts() {
+        // given - a hand-built pair with impacts stripped from the skip
+        let postings = PostingsBlock::from_ascending(vec![entry(7, 1, 1), entry(42, 2, 2)]);
+        let mut payload = BytesMut::new();
+        postings.encode_payload(&mut payload);
+        let value = TermPostingsEncoder {
+            blocks: vec![
+                TermPostingsBlock::Skip(SkipBlock {
+                    last_id: postings.last_id(),
+                    impacts: Vec::new(),
+                    length: payload.len() as u64,
+                }),
+                TermPostingsBlock::Postings(postings),
+            ],
+        };
 
         // when
-        let decoded = TermPostingsValue::decode_from_bytes(&buf).unwrap();
+        let view = TermPostingsView::parse(value.encode_to_bytes()).unwrap();
 
-        // then - decodes with an empty impact list
-        let TermPostingsBlock::Skip(skip) = &decoded.blocks[0] else {
-            panic!("expected skip block");
-        };
-        assert_eq!(skip.last_id.id(), 42);
-        assert_eq!(skip.length, 99);
-        assert!(skip.impacts.is_empty());
+        // then
+        assert_eq!(view.blocks().len(), 1);
+        assert_eq!(view.blocks()[0].min_id, 7);
+        assert_eq!(view.blocks()[0].max_id, 42);
+        assert!(view.impacts(0).is_empty());
     }
 
     #[test]
@@ -1322,19 +1399,13 @@ mod tests {
         let postings: Vec<_> = (0..TARGET_POSTINGS_PER_BLOCK as u64)
             .map(|i| entry(i, (i as u32 % 5) + 1, ((i % 200) as u8) + 1))
             .collect();
-        let value = TermPostingsValue::from_postings(postings.clone());
+        let value = TermPostingsEncoder::from_postings(postings.clone());
 
         // when
-        let encoded = value.encode_to_bytes();
-        let decoded = TermPostingsValue::decode_from_bytes(&encoded).unwrap();
+        let entries = all_entries(value.encode_to_bytes());
 
-        // then
-        let entries: Vec<_> = decoded.iter_entries().copied().collect();
-        assert_eq!(entries.len(), postings.len());
-        // Original postings sorted descending should match decoded order.
-        let mut expected = postings;
-        expected.sort_unstable_by_key(|e| std::cmp::Reverse(e.id));
-        assert_eq!(entries, expected);
+        // then - decoded order is the ascending input order
+        assert_eq!(entries, postings);
     }
 
     #[test]
@@ -1344,10 +1415,10 @@ mod tests {
         let postings: Vec<_> = (0..n as u64)
             .map(|i| entry(i, (i % 7) as u32 + 1, ((i % 11) as u8) + 1))
             .collect();
-        let encoded = TermPostingsValue::from_postings(postings).encode_to_bytes();
+        let encoded = TermPostingsEncoder::from_postings(postings).encode_to_bytes();
 
         // when
-        let view = PostingListView::parse(encoded).unwrap();
+        let view = TermPostingsView::parse(encoded).unwrap();
 
         // then - three blocks, ascending and non-overlapping, counts sum to n
         assert_eq!(view.blocks().len(), 3);
@@ -1368,10 +1439,10 @@ mod tests {
     fn view_decode_block_should_return_ascending_arrays() {
         // given
         let postings = vec![entry(8, 2, 30), entry(2, 3, 20), entry(5, 1, 10)];
-        let encoded = TermPostingsValue::from_postings(postings).encode_to_bytes();
+        let encoded = TermPostingsEncoder::from_postings(postings).encode_to_bytes();
 
         // when
-        let view = PostingListView::parse(encoded).unwrap();
+        let view = TermPostingsView::parse(encoded).unwrap();
         let decoded = view.decode_block(0).unwrap();
 
         // then
@@ -1383,18 +1454,18 @@ mod tests {
     #[test]
     fn view_should_parse_merged_operands() {
         // given - two merge operands (older = lower ids)
-        let older = TermPostingsValue::from_postings(
+        let older = TermPostingsEncoder::from_postings(
             (0..300u64).map(|i| entry(i, 1, 1)).collect::<Vec<_>>(),
         )
         .encode_to_bytes();
-        let newer = TermPostingsValue::from_postings(
+        let newer = TermPostingsEncoder::from_postings(
             (1000..1100u64).map(|i| entry(i, 2, 2)).collect::<Vec<_>>(),
         )
         .encode_to_bytes();
         let merged = merge_batch_term_postings(None, &[older, newer]);
 
         // when
-        let view = PostingListView::parse(merged).unwrap();
+        let view = TermPostingsView::parse(merged).unwrap();
 
         // then - blocks ascending across operand boundaries
         let mut prev_max = None;
@@ -1415,7 +1486,171 @@ mod tests {
 
     #[test]
     fn view_of_empty_value_has_no_blocks() {
-        let view = PostingListView::parse(Bytes::new()).unwrap();
+        let view = TermPostingsView::parse(Bytes::new()).unwrap();
         assert!(view.blocks().is_empty());
+    }
+
+    /// `iter_entries` walks every block lazily and yields the ascending row
+    /// stream the compaction filter and exhaustive scorer consume.
+    #[test]
+    fn iter_entries_yields_all_postings_ascending() {
+        let n = TARGET_POSTINGS_PER_BLOCK + 17;
+        let postings: Vec<_> = (0..n as u64)
+            .map(|i| entry(i * 3, (i % 9) as u32 + 1, (i % 50) as u8 + 1))
+            .collect();
+        let encoded = TermPostingsEncoder::from_postings(postings.clone()).encode_to_bytes();
+
+        let entries = all_entries(encoded);
+
+        assert_eq!(entries, postings);
+    }
+
+    /// The pair byte ranges recorded by parse() tile the raw value exactly,
+    /// so verbatim pair copies reconstruct it byte-for-byte.
+    #[test]
+    fn pair_bytes_tile_the_encoded_value() {
+        let n = TARGET_POSTINGS_PER_BLOCK * 2 + 9;
+        let postings: Vec<_> = (0..n as u64).map(|i| entry(i, 1, 1)).collect();
+        let encoded = TermPostingsEncoder::from_postings(postings).encode_to_bytes();
+
+        let view = TermPostingsView::parse(encoded.clone()).unwrap();
+        let mut rebuilt = BytesMut::new();
+        for idx in 0..view.blocks().len() {
+            rebuilt.extend_from_slice(view.pair_bytes(idx));
+        }
+
+        assert_eq!(rebuilt.freeze(), encoded);
+    }
+
+    /// Corrupt bit-width bytes must error, not panic inside the bitpacker
+    /// (its `num_bits <= 32` assert is active in release builds, and a panic
+    /// here would crash-loop the compactor on the same corrupt SST).
+    #[test]
+    fn corrupt_bit_widths_decode_to_error_not_panic() {
+        // A full block with wide freqs gives the corrupted ids_bytes claim
+        // room to pass the payload-length check.
+        let postings: Vec<_> = (0..BLOCK_LEN as u64)
+            .map(|i| entry(1000 + i, u32::MAX, 1))
+            .collect();
+        let encoded = TermPostingsEncoder::from_postings(postings).encode_to_bytes();
+
+        // ids_bits is at payload offset 13 (count:4 + base_id:8 + encoding:1).
+        let bad_ids_bits = corrupt_postings_payload(&encoded, &[(13, 33)]);
+        let view = TermPostingsView::parse(bad_ids_bits).expect("framing is intact");
+        let err = view.decode_block(0).unwrap_err();
+        assert!(err.message.contains("ids_bits"), "{}", err.message);
+
+        // freqs_bits sits after the packed ids section, whose width depends
+        // on the encoded ids_bits — read it back rather than hardcoding.
+        let ids_bits = {
+            // Skip block first: its header is 5 bytes + payload.
+            let skip_len =
+                u32::from_le_bytes([encoded[1], encoded[2], encoded[3], encoded[4]]) as usize;
+            let payload_start = 5 + skip_len + 5;
+            encoded[payload_start + 13] as usize
+        };
+        let freqs_bits_offset = 14 + ids_bits * (BLOCK_LEN / 8);
+        let bad_freqs_bits = corrupt_postings_payload(&encoded, &[(freqs_bits_offset, 40)]);
+        let view = TermPostingsView::parse(bad_freqs_bits).expect("framing is intact");
+        let err = view.decode_block(0).unwrap_err();
+        assert!(err.message.contains("freqs_bits"), "{}", err.message);
+    }
+
+    /// Inconsistent directory metadata (inverted or non-ascending pairs) is
+    /// rejected at parse time rather than trusted by consumers — the
+    /// compaction filter's verbatim-copy probe would otherwise silently
+    /// resurrect deleted postings.
+    #[test]
+    fn parse_rejects_inconsistent_pair_metadata() {
+        // Inverted: corrupt the skip's last_id below the postings base_id.
+        let encoded = TermPostingsEncoder::from_postings(vec![
+            entry(10, 1, 1),
+            entry(42, 1, 1),
+            entry(100, 1, 1),
+        ])
+        .encode_to_bytes();
+        let mut bytes = encoded.to_vec();
+        // Skip block payload starts at offset 5; last_id is its first 8 bytes.
+        bytes[5..13].copy_from_slice(&5u64.to_le_bytes());
+        let err = TermPostingsView::parse(Bytes::from(bytes)).unwrap_err();
+        assert!(
+            err.message.contains("exceeds skip block"),
+            "{}",
+            err.message
+        );
+
+        // Non-ascending: two pairs whose ranges do not ascend.
+        let pair_a = TermPostingsEncoder::from_postings(vec![entry(50, 1, 1)]).encode_to_bytes();
+        let pair_b = TermPostingsEncoder::from_postings(vec![entry(20, 1, 1)]).encode_to_bytes();
+        let mut merged = BytesMut::new();
+        merged.extend_from_slice(&pair_a);
+        merged.extend_from_slice(&pair_b);
+        let err = TermPostingsView::parse(merged.freeze()).unwrap_err();
+        assert!(err.message.contains("does not ascend"), "{}", err.message);
+    }
+
+    /// Both sides of the codec-selection seam: the boundary is the largest
+    /// single gap, `u32::MAX`.
+    #[test]
+    fn codec_selection_boundary() {
+        let ids_encoding = |value: &TermPostingsEncoder| {
+            let TermPostingsBlock::Postings(p) = &value.blocks[1] else {
+                panic!("expected postings block")
+            };
+            let mut payload = BytesMut::new();
+            p.encode_payload(&mut payload);
+            payload[12]
+        };
+
+        // gap == u32::MAX: bitpacked, round-trips.
+        let at =
+            TermPostingsEncoder::from_postings(vec![entry(0, 1, 1), entry(u32::MAX as u64, 1, 1)]);
+        assert_eq!(ids_encoding(&at), IDS_ENCODING_BITPACKED);
+        let ids: Vec<u64> = all_entries(at.encode_to_bytes())
+            .iter()
+            .map(|e| e.id.id())
+            .collect();
+        assert_eq!(ids, vec![0, u32::MAX as u64]);
+
+        // gap == u32::MAX + 1: varint, round-trips.
+        let past = TermPostingsEncoder::from_postings(vec![
+            entry(0, 1, 1),
+            entry(u32::MAX as u64 + 1, 1, 1),
+        ]);
+        assert_eq!(ids_encoding(&past), IDS_ENCODING_VARINT);
+        let ids: Vec<u64> = all_entries(past.encode_to_bytes())
+            .iter()
+            .map(|e| e.id.id())
+            .collect();
+        assert_eq!(ids, vec![0, u32::MAX as u64 + 1]);
+
+        // Full block with one boundary gap: zero padding never widens bits.
+        let mut postings: Vec<_> = (0..(BLOCK_LEN as u64 - 1))
+            .map(|i| entry(i, 1, 1))
+            .collect();
+        postings.push(entry(BLOCK_LEN as u64 - 2 + u32::MAX as u64, 1, 1));
+        let full = TermPostingsEncoder::from_postings(postings.clone());
+        assert_eq!(ids_encoding(&full), IDS_ENCODING_BITPACKED);
+        assert_eq!(all_entries(full.encode_to_bytes()), postings);
+    }
+
+    /// Mid-stream corruption: the iterator yields every entry of the good
+    /// blocks, then exactly one Err, then ends.
+    #[test]
+    fn iter_entries_yields_good_blocks_then_one_error() {
+        let n = TARGET_POSTINGS_PER_BLOCK + 5;
+        let postings: Vec<_> = (0..n as u64).map(|i| entry(i, 1, 1)).collect();
+        let encoded = TermPostingsEncoder::from_postings(postings.clone()).encode_to_bytes();
+        // Corrupt the SECOND postings payload's ids_encoding byte.
+        let corrupted = corrupt_nth_postings_payload(&encoded, 1, &[(12, 0xEE)]);
+
+        let view = TermPostingsView::parse(corrupted).expect("framing is intact");
+        let mut iter = view.iter_entries();
+        for expected in postings.iter().take(TARGET_POSTINGS_PER_BLOCK) {
+            assert_eq!(iter.next().unwrap().unwrap(), *expected);
+        }
+        assert!(iter.next().unwrap().is_err());
+        assert!(iter.next().is_none());
+        assert!(iter.next().is_none());
     }
 }

--- a/vector/src/serde/vector_bitmap.rs
+++ b/vector/src/serde/vector_bitmap.rs
@@ -61,6 +61,17 @@ impl VectorBitmap {
         self.vector_ids.contains(vector_id)
     }
 
+    /// Check if any vector ID in `min..=max` is in the bitmap.
+    pub fn contains_in_range(&self, min: u64, max: u64) -> bool {
+        debug_assert!(min <= max);
+        // Seek-based probe: `advance_to` is an O(log containers) seek,
+        // whereas `rank` sums container lengths linearly and would make a
+        // per-block scan O(blocks x containers).
+        let mut iter = self.vector_ids.iter();
+        iter.advance_to(min);
+        iter.next().is_some_and(|v| v <= max)
+    }
+
     /// Returns the number of vector IDs in the bitmap.
     pub fn len(&self) -> u64 {
         self.vector_ids.len()
@@ -249,5 +260,36 @@ mod tests {
 
         // then
         assert_eq!(ids, vec![1, 2, 3]); // Sorted order
+    }
+
+    /// Table-driven edges for the range probe: it gates whether the
+    /// compaction filter skips a postings block entirely, so an off-by-one
+    /// here silently resurrects deleted documents.
+    #[test]
+    fn contains_in_range_edges() {
+        let empty = VectorBitmap::new();
+        assert!(!empty.contains_in_range(0, u64::MAX));
+
+        let mut bitmap = VectorBitmap::new();
+        for id in [0u64, 10, 100, u64::MAX] {
+            bitmap.insert(id);
+        }
+        // min == 0 with id 0 present.
+        assert!(bitmap.contains_in_range(0, 0));
+        assert!(bitmap.contains_in_range(0, 5));
+        // Single-id ranges.
+        assert!(bitmap.contains_in_range(10, 10));
+        assert!(!bitmap.contains_in_range(9, 9));
+        assert!(!bitmap.contains_in_range(11, 11));
+        // Sole hit exactly at the lower inclusive bound.
+        assert!(bitmap.contains_in_range(10, 99));
+        // Sole hit exactly at the upper inclusive bound.
+        assert!(bitmap.contains_in_range(11, 100));
+        // Empty interior ranges.
+        assert!(!bitmap.contains_in_range(11, 99));
+        assert!(!bitmap.contains_in_range(1, 9));
+        // u64::MAX edges.
+        assert!(bitmap.contains_in_range(u64::MAX, u64::MAX));
+        assert!(!bitmap.contains_in_range(101, u64::MAX - 1));
     }
 }

--- a/vector/src/storage/compaction_filter.rs
+++ b/vector/src/storage/compaction_filter.rs
@@ -31,10 +31,11 @@
 //!    compaction. The `Deletions` entries are dropped — every posting they
 //!    reference is in this compaction and has been pruned, so the ids can never
 //!    resurface.
-//! 2. **Prunes term postings.** Deleted ids are removed from each
-//!    [`TermPostingsValue`] and the survivors are re-packed into uniform blocks
-//!    via [`TermPostingsValue::from_postings`]. The number of removed documents
-//!    is recorded for the sibling `TermStats` key.
+//! 2. **Prunes term postings.** Each posting value is streamed block by
+//!    block ([`TermPostingsView`]): blocks whose id range holds no deleted id
+//!    are copied verbatim, the rest are decoded, pruned, and re-encoded with
+//!    fresh impacts. The number of removed documents is recorded for the
+//!    sibling `TermStats` key.
 //! 3. **Applies the term document-frequency delta** to the immediately
 //!    following [`TermStatsValue`] (the `TermStats` key for a `(field, term)`
 //!    sorts right after its `TermPostings` key — discriminator `0x01` > `0x00`).
@@ -61,7 +62,7 @@
 //! merged value. The design tolerates this because every FTS merge is structured
 //! so that pruning-then-merging equals merging-then-pruning:
 //!
-//! - **Postings** merge by byte concatenation in descending-id order. Each
+//! - **Postings** merge by byte concatenation in ascending-id order. Each
 //!   operand is a self-contained, independently decodable `TermPostingsValue`,
 //!   so pruning deleted ids from each operand in turn yields the same result as
 //!   pruning the concatenation. The document-frequency decrement is accumulated
@@ -82,15 +83,18 @@
 //!   written together, so this holds in practice; if a stats entry is somehow
 //!   absent the delta is dropped and the statistic is left slightly stale (BM25
 //!   tolerates document-frequency drift — see the RFC).
-//! - Block re-alignment uses the fixed 256-entry block size baked into the
-//!   posting encoder; the configurable `target_posting_block_size` from the RFC
-//!   is not yet wired.
+//! - Rewritten blocks re-pack to the fixed 256-entry block size baked into
+//!   the posting encoder (the configurable `target_posting_block_size` from
+//!   the RFC is not yet wired). Re-packing coalesces survivors only within a
+//!   run of consecutive touched blocks — a verbatim-copied clean pair between
+//!   two runs is a hard boundary, since ids must stay ascending across pairs —
+//!   so each rewritten run ends with one block below the target size.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
 use slatedb::{
     CompactionFilter, CompactionFilterDecision, CompactionFilterError, CompactionFilterSupplier,
     CompactionJobContext, RowEntry, ValueDeletable,
@@ -102,10 +106,13 @@ use crate::serde::key::{
     DELETIONS_DISCRIMINATOR, DELETIONS_SENTINEL_DISCRIMINATOR, FieldStatsKey,
     TERM_POSTINGS_DISCRIMINATOR, TERM_STATS_DISCRIMINATOR, VectorFieldStatsKey,
 };
-use crate::serde::term_postings::TermPostingsValue;
+use crate::serde::term_postings::{
+    DecodedPostingsBlock, PostingEntry, TermPostingsEncoder, TermPostingsView,
+};
 use crate::serde::term_stats::TermStatsValue;
 use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_field_stats::VectorFieldStatsValue;
+use crate::serde::vector_id::VectorId;
 use crate::serde::{EncodingError, RecordType, Segment, parse_record_tag};
 
 #[derive(Debug, PartialEq, Eq)]
@@ -212,6 +219,16 @@ impl VectorCompactionFilter {
 
     /// Removes deleted ids from a term's postings and records the
     /// document-frequency decrement for the sibling `TermStats` key.
+    ///
+    /// Streams the value block by block: a block whose `[min_id, max_id]`
+    /// range holds no deleted id is copied into the rewritten value
+    /// **verbatim** — no decode, no re-encode, impacts preserved — so a
+    /// sparse delete set only pays for the blocks it actually touches.
+    /// Touched blocks are decoded and pruned; the survivors of each run of
+    /// consecutive touched blocks are re-encoded together as fresh
+    /// `(Skip, Postings)` pairs with recomputed impacts, re-packed into full
+    /// blocks. (Runs cannot coalesce across a clean block: its verbatim pair
+    /// sits between them in id order.)
     fn handle_postings(
         &mut self,
         entry: &RowEntry,
@@ -233,34 +250,82 @@ impl VectorCompactionFilter {
                 "unexpected empty postings val".into(),
             ));
         };
-        let value = TermPostingsValue::decode_from_bytes(&bytes).map_err(filter_err)?;
+        let view = TermPostingsView::parse(bytes.clone()).map_err(filter_err)?;
 
-        let mut retained = Vec::new();
+        // `out` is created lazily at the first touched block; while it is
+        // `None` every block so far was clean and the original value can be
+        // kept as-is. Survivors accumulate across each *run* of consecutive
+        // touched blocks and are re-encoded together when the run ends, so
+        // they re-pack into full blocks instead of one undersized pair per
+        // touched block (which would fragment a little further on every
+        // delete/compaction cycle).
+        let mut out: Option<BytesMut> = None;
         let mut removed: i64 = 0;
-        for posting in value.iter_entries() {
-            if self.deletions.contains(posting.id.id()) {
-                removed += 1;
-            } else {
-                retained.push(*posting);
+        let mut scratch = DecodedPostingsBlock::default();
+        let mut run_survivors: Vec<PostingEntry> = Vec::new();
+        for idx in 0..view.blocks().len() {
+            let meta = &view.blocks()[idx];
+            if !self.deletions.contains_in_range(meta.min_id, meta.max_id) {
+                if let Some(out) = &mut out {
+                    // A clean pair ends the current dirty run: its verbatim
+                    // bytes follow the run's survivors in id order, so the
+                    // run must be encoded before the pair is copied.
+                    flush_survivor_run(out, &mut run_survivors);
+                    out.extend_from_slice(view.pair_bytes(idx));
+                }
+                continue;
             }
+            view.decode_block_into(idx, &mut scratch)
+                .map_err(filter_err)?;
+            for i in 0..scratch.ids.len() {
+                if self.deletions.contains(scratch.ids[i]) {
+                    removed += 1;
+                } else {
+                    run_survivors.push(PostingEntry {
+                        id: VectorId::from_raw(scratch.ids[i]),
+                        freq: scratch.freqs[i],
+                        norm: scratch.norms[i],
+                    });
+                }
+            }
+            out.get_or_insert_with(|| {
+                // First touched block: start the rewrite with every earlier
+                // (clean) pair. Copy pair by pair rather than slicing the raw
+                // prefix so degenerate zero-count pairs (tolerated by parse
+                // but absent from the directory) are dropped uniformly —
+                // otherwise an all-deleted value with a leading dead pair
+                // would be kept alive by its dead bytes instead of dropped.
+                let mut buf = BytesMut::with_capacity(bytes.len());
+                for clean_idx in 0..idx {
+                    buf.extend_from_slice(view.pair_bytes(clean_idx));
+                }
+                buf
+            });
         }
+        if let Some(out) = &mut out {
+            flush_survivor_run(out, &mut run_survivors);
+        }
+
         if removed == 0 {
+            // Either no block's id range intersected the deletions bitmap, or
+            // the intersecting ids fell in gaps between this term's postings;
+            // the value is unchanged either way.
             return Ok(CompactionFilterDecision::Keep);
         }
+        let out = out.expect("a removed posting implies a touched block");
 
         *self
             .pending_term_deltas
             .entry(term_map_key(&entry.key))
             .or_insert(0) += removed;
 
-        if retained.is_empty() {
+        if out.is_empty() {
             // No documents left for this term in this run; drop the operand.
             // The sibling TermStats decrement is still applied when its key is
             // reached.
             return Ok(CompactionFilterDecision::Drop);
         }
-        let rewritten = TermPostingsValue::from_postings(retained).encode_to_bytes();
-        Ok(replace_value(&entry.value, rewritten))
+        Ok(replace_value(&entry.value, out.freeze()))
     }
 
     /// Applies the pending document-frequency decrement recorded by
@@ -488,6 +553,21 @@ impl CompactionFilter for NoOpCompactionFilter {
     }
 }
 
+/// Re-encodes the survivors of one run of consecutive touched blocks as
+/// fresh `(Skip, Postings)` pairs appended to `out`, leaving `survivors`
+/// empty. Encoding the run as a whole re-packs the survivors into full
+/// blocks ([`TermPostingsEncoder::from_postings`] chunks them at the target
+/// block size); encoding per touched block instead would emit one undersized
+/// pair each, fragmenting the list further on every delete/compaction cycle.
+fn flush_survivor_run(out: &mut BytesMut, survivors: &mut Vec<PostingEntry>) {
+    if survivors.is_empty() {
+        return;
+    }
+    out.extend_from_slice(
+        &TermPostingsEncoder::from_postings(std::mem::take(survivors)).encode_to_bytes(),
+    );
+}
+
 /// Strips the trailing discriminator byte from an `FtsTerm` key so a
 /// `TermPostings` key (`0x00`) and its sibling `TermStats` key (`0x01`) map to
 /// the same entry.
@@ -650,7 +730,7 @@ mod tests {
         filter.filter(&sentinel_entry()).await.unwrap();
         filter.filter(&deletions_entry(&[1, 2])).await.unwrap();
 
-        let postings = TermPostingsValue::from_postings(vec![
+        let postings = TermPostingsEncoder::from_postings(vec![
             posting(1, 2, 10),
             posting(2, 1, 20),
             posting(3, 3, 30),
@@ -668,14 +748,58 @@ mod tests {
         let stats_decision = filter.filter(&stats_entry).await.unwrap();
 
         // then - only doc 3 survives in the postings
-        let pruned =
-            TermPostingsValue::decode_from_bytes(&modified_bytes(&postings_decision)).unwrap();
-        let ids: Vec<u64> = pruned.iter_entries().map(|e| e.id.id()).collect();
+        let pruned = TermPostingsView::parse(modified_bytes(&postings_decision)).unwrap();
+        let ids: Vec<u64> = pruned
+            .iter_entries()
+            .map(|e| e.map(|e| e.id.id()))
+            .collect::<Result<_, _>>()
+            .unwrap();
         assert_eq!(ids, vec![3]);
 
         // and the document frequency dropped by the 2 removed docs (3 -> 1)
         let stats = TermStatsValue::decode_from_bytes(&modified_bytes(&stats_decision)).unwrap();
         assert_eq!(stats.freq, 1);
+    }
+
+    /// Blocks whose id range holds no deleted id must be copied into the
+    /// rewritten value byte-for-byte — impacts, alignment, and all — with
+    /// only the touched block re-encoded.
+    #[tokio::test]
+    async fn should_copy_untouched_blocks_verbatim() {
+        // given - three full blocks (0..768); deletions hit only the middle
+        let mut filter = VectorCompactionFilter::new(None);
+        filter.filter(&sentinel_entry()).await.unwrap();
+        filter.filter(&deletions_entry(&[300, 400])).await.unwrap();
+
+        let postings: Vec<_> = (0..768)
+            .map(|i| posting(i, (i % 7) as u32 + 1, 1))
+            .collect();
+        let encoded = TermPostingsEncoder::from_postings(postings).encode_to_bytes();
+        let view = TermPostingsView::parse(encoded.clone()).unwrap();
+        assert_eq!(view.blocks().len(), 3);
+        let first_pair = view.pair_bytes(0).to_vec();
+        let last_pair = view.pair_bytes(2).to_vec();
+
+        // when
+        let postings_entry = merge_entry(TermPostingsKey::new("body", "fox").encode(), encoded);
+        let decision = filter.filter(&postings_entry).await.unwrap();
+
+        // then - the clean pairs are byte-identical verbatim copies
+        let rewritten = TermPostingsView::parse(modified_bytes(&decision)).unwrap();
+        assert_eq!(rewritten.blocks().len(), 3);
+        assert_eq!(rewritten.pair_bytes(0), first_pair.as_slice());
+        assert_eq!(rewritten.pair_bytes(2), last_pair.as_slice());
+        assert_eq!(rewritten.impacts(0), view.impacts(0));
+
+        // and - the touched block lost exactly the deleted ids
+        let ids: Vec<u64> = rewritten
+            .iter_entries()
+            .map(|e| e.map(|e| e.id.id()))
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(ids.len(), 766);
+        assert!(!ids.contains(&300) && !ids.contains(&400));
+        assert!(ids.windows(2).all(|w| w[0] < w[1]));
     }
 
     #[tokio::test]
@@ -685,7 +809,7 @@ mod tests {
         filter.filter(&sentinel_entry()).await.unwrap();
         filter.filter(&deletions_entry(&[1, 2])).await.unwrap();
 
-        let postings = TermPostingsValue::from_postings(vec![posting(1, 1, 1), posting(2, 1, 1)])
+        let postings = TermPostingsEncoder::from_postings(vec![posting(1, 1, 1), posting(2, 1, 1)])
             .encode_to_bytes();
         let postings_entry = merge_entry(TermPostingsKey::new("body", "fox").encode(), postings);
         let stats_entry = merge_entry(
@@ -807,7 +931,7 @@ mod tests {
         // term postings -> CollectPostings
         let postings = merge_entry(
             TermPostingsKey::new("body", "fox").encode(),
-            TermPostingsValue::from_postings(vec![posting(5, 1, 1)]).encode_to_bytes(),
+            TermPostingsEncoder::from_postings(vec![posting(5, 1, 1)]).encode_to_bytes(),
         );
         filter.filter(&postings).await.unwrap();
         assert!(matches!(filter.phase, FilterPhase::CollectPostings(_)));
@@ -845,7 +969,7 @@ mod tests {
         filter.filter(&sentinel_entry()).await.unwrap();
         let postings = merge_entry(
             TermPostingsKey::new("body", "fox").encode(),
-            TermPostingsValue::from_postings(vec![posting(1, 1, 1)]).encode_to_bytes(),
+            TermPostingsEncoder::from_postings(vec![posting(1, 1, 1)]).encode_to_bytes(),
         );
         filter.filter(&postings).await.unwrap();
 
@@ -868,7 +992,7 @@ mod tests {
         filter.filter(&sentinel_entry()).await.unwrap();
         let postings = merge_entry(
             TermPostingsKey::new("body", "fox").encode(),
-            TermPostingsValue::from_postings(vec![posting(1, 1, 1)]).encode_to_bytes(),
+            TermPostingsEncoder::from_postings(vec![posting(1, 1, 1)]).encode_to_bytes(),
         );
         filter.filter(&postings).await.unwrap();
         let stats = merge_entry(
@@ -888,5 +1012,173 @@ mod tests {
         // unchanged, and the phase advances to CollectFieldStats
         assert_eq!(decision, CompactionFilterDecision::Keep);
         assert_eq!(filter.phase, FilterPhase::CollectFieldStats);
+    }
+
+    /// A deleted id can fall inside a block's `[min_id, max_id]` without
+    /// matching any of this term's postings (it matched other terms). The
+    /// block decodes, nothing is removed, and the value must be Kept with no
+    /// document-frequency decrement — not spuriously rewritten.
+    #[tokio::test]
+    async fn should_keep_postings_when_deleted_id_falls_in_gap_between_postings() {
+        // given - postings on even ids; deleted id 3 is inside the block's
+        // range but not one of this term's postings
+        let mut filter = VectorCompactionFilter::new(None);
+        filter.filter(&sentinel_entry()).await.unwrap();
+        filter.filter(&deletions_entry(&[3])).await.unwrap();
+
+        let encoded = TermPostingsEncoder::from_postings(vec![
+            posting(0, 1, 1),
+            posting(2, 1, 1),
+            posting(4, 1, 1),
+        ])
+        .encode_to_bytes();
+        // sanity: the deletion intersects the block's range, so the decode
+        // path (not the verbatim-copy probe) is exercised
+        let view = TermPostingsView::parse(encoded.clone()).unwrap();
+        assert!(
+            filter
+                .deletions
+                .contains_in_range(view.blocks()[0].min_id, view.blocks()[0].max_id)
+        );
+
+        // when
+        let entry = merge_entry(TermPostingsKey::new("body", "fox").encode(), encoded);
+        let decision = filter.filter(&entry).await.unwrap();
+
+        // then - Keep, and no pending document-frequency decrement
+        assert_eq!(decision, CompactionFilterDecision::Keep);
+        assert!(filter.pending_term_deltas.is_empty());
+    }
+
+    /// Degenerate zero-count pairs occupy bytes but are absent from the
+    /// directory; when every real posting is deleted, the rewrite must not
+    /// keep the value alive on dead bytes alone — it must Drop.
+    #[tokio::test]
+    async fn should_drop_value_with_leading_zero_count_pair_when_all_docs_deleted() {
+        use bytes::BufMut;
+        let mut filter = VectorCompactionFilter::new(None);
+        filter.filter(&sentinel_entry()).await.unwrap();
+        filter.filter(&deletions_entry(&[3, 7])).await.unwrap();
+
+        // value = zero-count pair ++ real pair {3, 7}
+        let mut buf = BytesMut::new();
+        let mut skip_payload = BytesMut::new();
+        skip_payload.put_u64_le(0); // last_id
+        skip_payload.put_u16_le(0); // impacts_count
+        skip_payload.put_u64_le(4); // length of the empty postings payload
+        buf.put_u8(0x01); // BLOCK_TYPE_SKIP
+        buf.put_u32_le(skip_payload.len() as u32);
+        buf.extend_from_slice(&skip_payload);
+        buf.put_u8(0x00); // BLOCK_TYPE_POSTINGS
+        buf.put_u32_le(4);
+        buf.put_u32_le(0); // count == 0
+        buf.extend_from_slice(
+            &TermPostingsEncoder::from_postings(vec![posting(3, 1, 1), posting(7, 1, 1)])
+                .encode_to_bytes(),
+        );
+
+        let entry = merge_entry(TermPostingsKey::new("body", "fox").encode(), buf.freeze());
+        let decision = filter.filter(&entry).await.unwrap();
+
+        assert_eq!(decision, CompactionFilterDecision::Drop);
+    }
+
+    /// The verbatim-copy prefix logic differs by dirty-block position; pin
+    /// first-dirty (empty prefix), middle-dirty, and last-dirty (whole-value
+    /// prefix, no trailing pairs).
+    #[tokio::test]
+    async fn should_copy_untouched_blocks_verbatim_at_every_position() {
+        for (deleted, dirty_idx) in [
+            (vec![10u64, 200], 0usize),
+            (vec![300, 400], 1),
+            (vec![600, 767], 2),
+        ] {
+            let mut filter = VectorCompactionFilter::new(None);
+            filter.filter(&sentinel_entry()).await.unwrap();
+            filter.filter(&deletions_entry(&deleted)).await.unwrap();
+
+            let postings: Vec<_> = (0..768)
+                .map(|i| posting(i, (i % 7) as u32 + 1, 1))
+                .collect();
+            let encoded = TermPostingsEncoder::from_postings(postings).encode_to_bytes();
+            let view = TermPostingsView::parse(encoded.clone()).unwrap();
+            assert_eq!(view.blocks().len(), 3);
+
+            let entry = merge_entry(
+                TermPostingsKey::new("body", "fox").encode(),
+                encoded.clone(),
+            );
+            let decision = filter.filter(&entry).await.unwrap();
+            let rewritten = TermPostingsView::parse(modified_bytes(&decision)).unwrap();
+
+            // Clean pairs are byte-identical; the dirty one is not.
+            assert_eq!(rewritten.blocks().len(), 3, "dirty_idx {}", dirty_idx);
+            for idx in 0..3 {
+                if idx == dirty_idx {
+                    assert_ne!(rewritten.pair_bytes(idx), view.pair_bytes(idx));
+                } else {
+                    assert_eq!(
+                        rewritten.pair_bytes(idx),
+                        view.pair_bytes(idx),
+                        "clean pair {} (dirty_idx {})",
+                        idx,
+                        dirty_idx
+                    );
+                }
+            }
+
+            // Exactly the deleted ids are gone; order stays ascending.
+            let ids: Vec<u64> = rewritten
+                .iter_entries()
+                .map(|e| e.map(|e| e.id.id()))
+                .collect::<Result<_, _>>()
+                .unwrap();
+            assert_eq!(ids.len(), 766);
+            for id in &deleted {
+                assert!(!ids.contains(id));
+            }
+            assert!(ids.windows(2).all(|w| w[0] < w[1]));
+        }
+    }
+
+    /// Survivors of *consecutive* touched blocks must re-pack into full
+    /// 256-entry blocks (one combined encode per dirty run), not one
+    /// undersized pair per touched block — per-block encoding would shrink
+    /// the blocks a little further on every delete/compaction cycle.
+    #[tokio::test]
+    async fn should_repack_consecutive_dirty_blocks_into_full_blocks() {
+        // given - three full blocks (0..768); deletions hit blocks 0 and 1,
+        // so they form one dirty run with 510 survivors; block 2 stays clean
+        let mut filter = VectorCompactionFilter::new(None);
+        filter.filter(&sentinel_entry()).await.unwrap();
+        filter.filter(&deletions_entry(&[10, 300])).await.unwrap();
+
+        let postings: Vec<_> = (0..768)
+            .map(|i| posting(i, (i % 7) as u32 + 1, 1))
+            .collect();
+        let encoded = TermPostingsEncoder::from_postings(postings).encode_to_bytes();
+        let view = TermPostingsView::parse(encoded.clone()).unwrap();
+        assert_eq!(view.blocks().len(), 3);
+
+        // when
+        let entry = merge_entry(TermPostingsKey::new("body", "fox").encode(), encoded);
+        let decision = filter.filter(&entry).await.unwrap();
+        let rewritten = TermPostingsView::parse(modified_bytes(&decision)).unwrap();
+
+        // then - the run re-packed as [256, 254], not [255, 255]; the clean
+        // pair follows verbatim
+        let counts: Vec<u32> = rewritten.blocks().iter().map(|b| b.count).collect();
+        assert_eq!(counts, vec![256, 254, 256]);
+        assert_eq!(rewritten.pair_bytes(2), view.pair_bytes(2));
+
+        // and - exactly the deleted ids are gone; order stays ascending
+        let ids: Vec<u64> = rewritten
+            .iter_entries()
+            .map(|e| e.map(|e| e.id.id()))
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(ids.len(), 766);
+        assert!(!ids.contains(&10) && !ids.contains(&300));
+        assert!(ids.windows(2).all(|w| w[0] < w[1]));
     }
 }

--- a/vector/src/write/indexer/tree/state.rs
+++ b/vector/src/write/indexer/tree/state.rs
@@ -13,7 +13,7 @@ use crate::serde::key::{
 };
 use crate::serde::metadata_index::MetadataIndexValue;
 use crate::serde::posting_list::{PostingListValue, PostingUpdate};
-use crate::serde::term_postings::{PostingEntry, TermPostingsValue};
+use crate::serde::term_postings::{PostingEntry, TermPostingsEncoder};
 use crate::serde::term_stats::TermStatsValue;
 use crate::serde::vector_bitmap::VectorBitmap;
 use crate::serde::vector_data::{Field, VectorDataValue};
@@ -728,7 +728,7 @@ impl FtsIndexDelta {
         ));
 
         for ((field, term), entries) in term_postings {
-            let value = TermPostingsValue::from_postings(entries);
+            let value = TermPostingsEncoder::from_postings(entries);
             let key = TermPostingsKey::new(&field, &term).encode();
             output_ops.push(RecordOp::Merge(
                 Record::new(key, value.encode_to_bytes()).into(),


### PR DESCRIPTION
## Summary

Switch the stored term postings to use ascending doc id order, and use a single in-memory representation (lazy-decode columnar) when reading term postings
- Postings, blocks, and merge operands now ascend: base_id is the lowest id, the skip block's last_id the highest, and the merge operator appends operands in delivery order (plain concatenation, no reversal). The scoring logic was already processing in ascending order as its more intuitive, so this just changes the storage format to do the same. There's no added cost on the storage side - the merge operator just concatenates postings in the opposite order from before.
- PostingListView is the canonical decoded representation: the old aos decode path (TermPostingsValue::decode_from_bytes/iter_entries, PostingsBlock/SkipBlock decode) is removed.
- TermPostingsValue is renamed to TermPostingsEncoder and is used to encode new postings from the indexer.
- The compaction filter streams postings block by block and copies blocks whose id range holds no deleted id verbatim — no decode, no re-encode, impacts preserved — so sparse deletes only pay for the blocks they touch.
- RFC-0006 Term Postings section updated to match.

## Test Plan

- e2e tests + benchmark run

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
