### PR TITLE
[vector] simd term scoring + msmarco benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ target
 
 # Vector test datasets
 vector/tests/data/sift100k/*vecs
+vector/bench/data/
 
 # misc AI tooling
 .claude/

--- a/vector/bench/README.md
+++ b/vector/bench/README.md
@@ -55,6 +55,25 @@ end cold reader phase
     cold_p99_latency_us  9.51K
 ```
 
+## Full-Text Search Benchmarks
+
+The `fts` benchmark supports two corpus modes:
+
+- `dataset = "synthetic"` (default): deterministic Zipf-distributed generated text.
+- `dataset = "msmarco-passage"`: MS MARCO passage-ranking `collection.tsv` with query text from `queries.dev.small.tsv`.
+
+For MS MARCO, download and extract the official archive under `vector/bench/data/msmarco/`:
+
+```bash
+curl -L -o /tmp/msmarco-passage.tar.gz \
+  https://msmarco.z22.web.core.windows.net/msmarcoranking/collectionandqueries.tar.gz
+mkdir -p vector/bench/data/msmarco
+tar xzf /tmp/msmarco-passage.tar.gz -C vector/bench/data/msmarco
+cargo run -p vector-bench --release -- --config vector/bench/fts-msmarco-passage.toml --benchmark fts
+```
+
+`num_docs` caps how many passages are ingested, so the same config can run quick subsets or the full 8.8M-passage corpus.
+
 ## Measurements 
 
 - **recall@10** — fraction of true top-10 neighbours returned (uses precomputed exact

--- a/vector/bench/src/fts.rs
+++ b/vector/bench/src/fts.rs
@@ -1,7 +1,7 @@
 //! Full-text-search (BM25) latency benchmark for the vector database.
 //!
-//! Ingests a deterministic synthetic corpus (Zipf-distributed vocabulary,
-//! log-normal-ish document lengths) and measures sequential BM25 query
+//! Ingests either a deterministic synthetic corpus (Zipf-distributed vocabulary,
+//! log-normal-ish document lengths) or an MS MARCO passage corpus, then measures sequential BM25 query
 //! latency for each configured scorer (`block_max`, `exhaustive`),
 //! cross-checking that the scorers return identical result lists.
 //!
@@ -31,6 +31,7 @@ const DEFAULT_AVG_DOC_LEN: f64 = 100.0;
 const DEFAULT_DIMENSIONS: u16 = 8;
 const DEFAULT_NUM_QUERIES: usize = 200;
 const DEFAULT_LIMIT: usize = 10;
+const DEFAULT_DATASET: FtsDataset = FtsDataset::Synthetic;
 
 /// Default phase list when the params don't specify otherwise.
 const DEFAULT_PHASES: &[Phase] = &[Phase::Ingest, Phase::Warm];
@@ -101,15 +102,36 @@ fn param_to_scorers(s: &str) -> Vec<Bm25Scorer> {
         .collect()
 }
 
+// -- Corpus datasets -----------------------------------------------------------
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum FtsDataset {
+    /// Deterministic Zipf-distributed synthetic corpus.
+    Synthetic,
+    /// MS MARCO passage ranking corpus (`collection.tsv`) and query TSV.
+    MsMarcoPassage,
+}
+
+fn parse_dataset(s: &str) -> FtsDataset {
+    match s {
+        "synthetic" => FtsDataset::Synthetic,
+        "msmarco" | "msmarco-passage" | "msmarco_passage" => FtsDataset::MsMarcoPassage,
+        _ => panic!("unknown fts dataset: {}", s),
+    }
+}
+
 // -- Spec ---------------------------------------------------------------------
 
 /// FTS benchmark spec, parsed from `[[params.fts]]`. All values are strings
 /// in the bencher config and fall back to the defaults above when unset.
 #[derive(Clone, Debug)]
 pub(crate) struct FtsSpec {
-    /// Seed for the deterministic corpus and query generators.
+    /// Corpus/query source for the FTS benchmark.
+    pub dataset: FtsDataset,
+    /// Seed for deterministic synthetic generation and filler embeddings.
     pub seed: u64,
-    /// Number of synthetic documents to ingest.
+    /// Number of documents to ingest. For file-backed datasets this caps the
+    /// document stream; set it to the corpus size to ingest the full dataset.
     pub num_docs: usize,
     /// Vocabulary size (term ranks `t0..t<vocab_size-1>`).
     pub vocab_size: usize,
@@ -128,6 +150,15 @@ pub(crate) struct FtsSpec {
     /// benchmark: `None` = phase default, negative = disabled, `n >= 0` =
     /// exactly `n` bytes.
     pub block_cache_bytes: Option<i64>,
+    /// Directory containing file-backed FTS datasets. Defaults to
+    /// `vector/bench/data`.
+    pub data_dir: Option<String>,
+    /// Corpus file path relative to `data_dir`, or absolute. Used by
+    /// `msmarco-passage`; defaults to `msmarco/collection.tsv`.
+    pub corpus_file: Option<String>,
+    /// Query file path relative to `data_dir`, or absolute. Used by
+    /// `msmarco-passage`; defaults to `msmarco/queries.dev.small.tsv`.
+    pub queries_file: Option<String>,
     /// Scorers to measure during the warm phase, in order.
     pub scorers: Vec<Bm25Scorer>,
     /// Phases to run, in order.
@@ -137,6 +168,10 @@ pub(crate) struct FtsSpec {
 impl From<Params> for FtsSpec {
     fn from(p: Params) -> Self {
         FtsSpec {
+            dataset: p
+                .get("dataset")
+                .map(parse_dataset)
+                .unwrap_or(DEFAULT_DATASET),
             seed: p.get_parse("seed").ok().unwrap_or(DEFAULT_SEED),
             num_docs: p.get_parse("num_docs").ok().unwrap_or(DEFAULT_NUM_DOCS),
             vocab_size: p.get_parse("vocab_size").ok().unwrap_or(DEFAULT_VOCAB_SIZE),
@@ -152,6 +187,9 @@ impl From<Params> for FtsSpec {
                 .unwrap_or(DEFAULT_NUM_QUERIES),
             limit: p.get_parse("limit").ok().unwrap_or(DEFAULT_LIMIT),
             block_cache_bytes: p.get_parse::<i64>("block_cache_bytes").ok(),
+            data_dir: p.get("data_dir").map(str::to_string),
+            corpus_file: p.get("corpus_file").map(str::to_string),
+            queries_file: p.get("queries_file").map(str::to_string),
             scorers: p
                 .get("scorers")
                 .map(param_to_scorers)
@@ -161,6 +199,13 @@ impl From<Params> for FtsSpec {
                 .map(param_to_phases)
                 .unwrap_or_else(|| DEFAULT_PHASES.to_vec()),
         }
+    }
+}
+
+fn dataset_summary_id(dataset: FtsDataset) -> f64 {
+    match dataset {
+        FtsDataset::Synthetic => 0.0,
+        FtsDataset::MsMarcoPassage => 1.0,
     }
 }
 
@@ -243,13 +288,14 @@ impl Benchmark for FtsBenchmark {
             ..Default::default()
         };
 
-        // Queries are derived from the seed alone, so WARM-only runs against
+        // Queries are derived from the spec alone, so WARM-only runs against
         // a previously ingested corpus issue the same queries.
-        let queries = corpus::generate_queries(spec.seed, spec.vocab_size, spec.num_queries);
-        println!("  Generated {} queries", queries.len());
+        let queries = corpus::load_queries(&spec)?;
+        println!("  Loaded {} queries", queries.len());
 
         // -- Dispatch each configured phase --------------------------------
         let mut summary = Summary::new()
+            .add("dataset_id", dataset_summary_id(spec.dataset))
             .add("num_docs", spec.num_docs as f64)
             .add("num_queries", spec.num_queries as f64)
             .add("limit", spec.limit as f64);

--- a/vector/bench/src/fts/corpus.rs
+++ b/vector/bench/src/fts/corpus.rs
@@ -1,18 +1,19 @@
-//! Deterministic synthetic corpus and query generation for the FTS
-//! benchmark.
+//! Corpus and query loading for the FTS benchmark.
 //!
-//! Everything here is derived from the spec's `seed` with a hand-rolled
-//! splitmix64 generator (no RNG dependency), so the same spec always
-//! produces the same corpus and queries:
-//!
-//! - **Terms** follow a Zipf distribution over `vocab_size` ranks with
-//!   exponent `zipf_s`; rank `r` renders as the token `t<r>`.
-//! - **Document lengths** are log-normal-ish: a standard normal is
-//!   approximated by summing 12 uniforms (Irwin–Hall) and the length is
-//!   `clamp(round(avg_doc_len * exp(0.5 * n)), 5, 2000)`.
-//! - **Queries** mix three strata of head/torso/tail term ranks.
+//! The benchmark supports the original deterministic synthetic corpus and
+//! MS MARCO passage-ranking files. Synthetic data is generated from the spec's
+//! seed. MS MARCO data is streamed from `collection.tsv`, so large corpora do
+//! not need to be materialized in memory before ingest.
 
-use crate::fts::FtsSpec;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::thread;
+
+use anyhow::Context;
+use tokio::sync::mpsc;
+
+use crate::fts::{FtsDataset, FtsSpec};
 
 /// Salt XOR'd into the seed for the query generator so queries don't reuse
 /// the corpus generator's random stream.
@@ -22,8 +23,11 @@ const QUERY_SEED_SALT: u64 = 0x9E3779B97F4A7C15;
 const MIN_DOC_LEN: usize = 5;
 const MAX_DOC_LEN: usize = 2000;
 
-/// A generated document: external id `d<i>`, a filler embedding, and the
-/// space-joined term body.
+const DEFAULT_MSMARCO_CORPUS_FILE: &str = "msmarco/collection.tsv";
+const DEFAULT_MSMARCO_QUERIES_FILE: &str = "msmarco/queries.dev.small.tsv";
+
+/// A generated or loaded document: external id, a filler embedding, and the
+/// text body.
 pub(crate) struct Doc {
     pub id: String,
     pub embedding: Vec<f32>,
@@ -102,10 +106,33 @@ impl ZipfTable {
 
 // -- Corpus generation ------------------------------------------------------------
 
-/// Streaming generator for the synthetic corpus. Documents are produced
-/// sequentially from a single random stream, so chunking does not affect
-/// the generated corpus — only how much is materialized at once.
-pub(crate) struct CorpusGenerator {
+/// Streaming generator for the configured corpus. Documents are produced
+/// sequentially, so chunking affects only how much is materialized at once.
+enum CorpusGenerator {
+    Synthetic(SyntheticCorpusGenerator),
+    MsMarco(MsMarcoCorpusGenerator),
+}
+
+impl CorpusGenerator {
+    pub fn new(spec: &FtsSpec) -> anyhow::Result<Self> {
+        match spec.dataset {
+            FtsDataset::Synthetic => Ok(Self::Synthetic(SyntheticCorpusGenerator::new(spec))),
+            FtsDataset::MsMarcoPassage => Ok(Self::MsMarco(MsMarcoCorpusGenerator::open(spec)?)),
+        }
+    }
+
+    /// Generate or load the next chunk of up to `max_docs` documents, or
+    /// `None` when the corpus is exhausted.
+    pub fn next_chunk(&mut self, max_docs: usize) -> anyhow::Result<Option<Vec<Doc>>> {
+        match self {
+            Self::Synthetic(generator) => Ok(generator.next_chunk(max_docs)),
+            Self::MsMarco(generator) => generator.next_chunk(max_docs),
+        }
+    }
+}
+
+/// Streaming generator for the synthetic corpus.
+struct SyntheticCorpusGenerator {
     rng: SplitMix64,
     zipf: ZipfTable,
     avg_doc_len: f64,
@@ -114,8 +141,8 @@ pub(crate) struct CorpusGenerator {
     next_doc: usize,
 }
 
-impl CorpusGenerator {
-    pub fn new(spec: &FtsSpec) -> Self {
+impl SyntheticCorpusGenerator {
+    fn new(spec: &FtsSpec) -> Self {
         Self {
             rng: SplitMix64::new(spec.seed),
             zipf: ZipfTable::new(spec.vocab_size, spec.zipf_s),
@@ -126,9 +153,7 @@ impl CorpusGenerator {
         }
     }
 
-    /// Generate the next chunk of up to `max_docs` documents, or `None`
-    /// when the corpus is exhausted.
-    pub fn next_chunk(&mut self, max_docs: usize) -> Option<Vec<Doc>> {
+    fn next_chunk(&mut self, max_docs: usize) -> Option<Vec<Doc>> {
         if self.next_doc >= self.num_docs {
             return None;
         }
@@ -170,6 +195,213 @@ impl CorpusGenerator {
         let len = (self.avg_doc_len * (0.5 * n).exp()).round();
         (len as usize).clamp(MIN_DOC_LEN, MAX_DOC_LEN)
     }
+}
+
+struct MsMarcoCorpusGenerator {
+    reader: BufReader<File>,
+    rng: SplitMix64,
+    dimensions: usize,
+    remaining: usize,
+    line_number: usize,
+}
+
+impl MsMarcoCorpusGenerator {
+    fn open(spec: &FtsSpec) -> anyhow::Result<Self> {
+        let corpus_path = resolve_data_path(
+            spec,
+            spec.corpus_file.as_deref(),
+            DEFAULT_MSMARCO_CORPUS_FILE,
+        );
+        let file = File::open(&corpus_path)
+            .with_context(|| format!("failed to open MS MARCO corpus {}", corpus_path.display()))?;
+        Ok(Self {
+            reader: BufReader::new(file),
+            rng: SplitMix64::new(spec.seed),
+            dimensions: spec.dimensions as usize,
+            remaining: spec.num_docs,
+            line_number: 0,
+        })
+    }
+
+    fn next_chunk(&mut self, max_docs: usize) -> anyhow::Result<Option<Vec<Doc>>> {
+        if self.remaining == 0 {
+            return Ok(None);
+        }
+        let count = max_docs.min(self.remaining);
+        let mut docs = Vec::with_capacity(count);
+        while docs.len() < count {
+            let Some(doc) = self.next_doc()? else {
+                break;
+            };
+            docs.push(doc);
+        }
+        if docs.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(docs))
+        }
+    }
+
+    fn next_doc(&mut self) -> anyhow::Result<Option<Doc>> {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let bytes = self.reader.read_line(&mut line)?;
+            if bytes == 0 {
+                return Ok(None);
+            }
+            self.line_number += 1;
+            let line = line.trim_end_matches(&['\r', '\n'][..]);
+            if line.is_empty() {
+                continue;
+            }
+            let mut parts = line.splitn(2, '\t');
+            let id = parts.next().unwrap_or_default();
+            let Some(body) = parts.next() else {
+                anyhow::bail!(
+                    "invalid MS MARCO collection row {}: expected '<pid>\t<passage>'",
+                    self.line_number
+                );
+            };
+            self.remaining -= 1;
+            let embedding: Vec<f32> = (0..self.dimensions).map(|_| self.rng.next_f32()).collect();
+            return Ok(Some(Doc {
+                id: id.to_string(),
+                embedding,
+                body: body.to_string(),
+            }));
+        }
+    }
+}
+
+/// Spawn a thread that streams corpus chunks through a bounded channel, so
+/// generation/file I/O overlaps with writes without materializing the whole
+/// corpus.
+pub(crate) fn spawn_doc_stream(
+    spec: FtsSpec,
+    chunk_size: usize,
+) -> (
+    mpsc::Receiver<anyhow::Result<Vec<Doc>>>,
+    thread::JoinHandle<()>,
+) {
+    let (tx, rx) = mpsc::channel(1);
+    let handle = thread::spawn(move || {
+        let mut generator = match CorpusGenerator::new(&spec) {
+            Ok(generator) => generator,
+            Err(err) => {
+                let _ = tx.blocking_send(Err(err));
+                return;
+            }
+        };
+        loop {
+            match generator.next_chunk(chunk_size) {
+                Ok(Some(chunk)) => {
+                    if tx.blocking_send(Ok(chunk)).is_err() {
+                        return;
+                    }
+                }
+                Ok(None) => return,
+                Err(err) => {
+                    let _ = tx.blocking_send(Err(err));
+                    return;
+                }
+            }
+        }
+    });
+    (rx, handle)
+}
+
+pub(crate) fn corpus_description(spec: &FtsSpec) -> String {
+    match spec.dataset {
+        FtsDataset::Synthetic => format!(
+            "synthetic docs (vocab={}, zipf_s={}, avg_len={}, dim={})",
+            spec.vocab_size, spec.zipf_s, spec.avg_doc_len, spec.dimensions
+        ),
+        FtsDataset::MsMarcoPassage => {
+            let corpus_path = resolve_data_path(
+                spec,
+                spec.corpus_file.as_deref(),
+                DEFAULT_MSMARCO_CORPUS_FILE,
+            );
+            format!(
+                "MS MARCO passage docs from {} (dim={})",
+                corpus_path.display(),
+                spec.dimensions
+            )
+        }
+    }
+}
+
+pub(crate) fn load_queries(spec: &FtsSpec) -> anyhow::Result<Vec<String>> {
+    match spec.dataset {
+        FtsDataset::Synthetic => Ok(generate_queries(
+            spec.seed,
+            spec.vocab_size,
+            spec.num_queries,
+        )),
+        FtsDataset::MsMarcoPassage => load_msmarco_queries(spec),
+    }
+}
+
+fn load_msmarco_queries(spec: &FtsSpec) -> anyhow::Result<Vec<String>> {
+    let path = resolve_data_path(
+        spec,
+        spec.queries_file.as_deref(),
+        DEFAULT_MSMARCO_QUERIES_FILE,
+    );
+    let file = File::open(&path)
+        .with_context(|| format!("failed to open MS MARCO queries {}", path.display()))?;
+    let reader = BufReader::new(file);
+    let mut queries = Vec::with_capacity(spec.num_queries);
+    for (line_idx, line) in reader.lines().enumerate() {
+        if queries.len() == spec.num_queries {
+            break;
+        }
+        let line = line?;
+        let line = line.trim_end_matches(&['\r', '\n'][..]);
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(2, '\t');
+        let _qid = parts.next();
+        let Some(query) = parts.next() else {
+            anyhow::bail!(
+                "invalid MS MARCO query row {}: expected '<qid>\t<query>'",
+                line_idx + 1
+            );
+        };
+        if !query.trim().is_empty() {
+            queries.push(query.to_string());
+        }
+    }
+    if queries.is_empty() {
+        anyhow::bail!("MS MARCO query file {} produced no queries", path.display());
+    }
+    if queries.len() < spec.num_queries {
+        println!(
+            "  Query file {} has {} usable queries; requested {}",
+            path.display(),
+            queries.len(),
+            spec.num_queries
+        );
+    }
+    Ok(queries)
+}
+
+fn resolve_data_path(spec: &FtsSpec, configured: Option<&str>, default_relative: &str) -> PathBuf {
+    let path = PathBuf::from(configured.unwrap_or(default_relative));
+    if path.is_absolute() {
+        path
+    } else {
+        data_dir(spec).join(path)
+    }
+}
+
+fn data_dir(spec: &FtsSpec) -> PathBuf {
+    spec.data_dir
+        .as_ref()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| Path::new(env!("CARGO_MANIFEST_DIR")).join("data"))
 }
 
 // -- Query generation -------------------------------------------------------------
@@ -222,6 +454,7 @@ mod tests {
 
     fn test_spec() -> FtsSpec {
         FtsSpec {
+            dataset: FtsDataset::Synthetic,
             seed: 42,
             num_docs: 100,
             vocab_size: 20_000,
@@ -231,6 +464,9 @@ mod tests {
             num_queries: 50,
             limit: 10,
             block_cache_bytes: None,
+            data_dir: None,
+            corpus_file: None,
+            queries_file: None,
             scorers: Vec::new(),
             phases: Vec::new(),
         }
@@ -240,13 +476,17 @@ mod tests {
     fn corpus_should_be_deterministic_and_chunking_invariant() {
         let spec = test_spec();
         let mut all: Vec<Doc> = Vec::new();
-        let mut generator = CorpusGenerator::new(&spec);
-        while let Some(chunk) = generator.next_chunk(7) {
+        let mut generator = CorpusGenerator::new(&spec).unwrap();
+        while let Some(chunk) = generator.next_chunk(7).unwrap() {
             all.extend(chunk);
         }
         assert_eq!(all.len(), spec.num_docs);
 
-        let again = CorpusGenerator::new(&spec).next_chunk(1000).unwrap();
+        let again = CorpusGenerator::new(&spec)
+            .unwrap()
+            .next_chunk(1000)
+            .unwrap()
+            .unwrap();
         assert_eq!(again.len(), spec.num_docs);
         for (a, b) in all.iter().zip(again.iter()) {
             assert_eq!(a.id, b.id);
@@ -258,8 +498,8 @@ mod tests {
     #[test]
     fn doc_lengths_should_be_clamped() {
         let spec = test_spec();
-        let mut generator = CorpusGenerator::new(&spec);
-        for doc in generator.next_chunk(100).unwrap() {
+        let mut generator = CorpusGenerator::new(&spec).unwrap();
+        for doc in generator.next_chunk(100).unwrap().unwrap() {
             let len = doc.body.split(' ').count();
             assert!((MIN_DOC_LEN..=MAX_DOC_LEN).contains(&len));
         }
@@ -276,5 +516,43 @@ mod tests {
                 assert!(rank < 20_000);
             }
         }
+    }
+
+    #[test]
+    fn msmarco_should_load_queries_and_docs() {
+        // given
+        let root =
+            std::env::temp_dir().join(format!("opendata-msmarco-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("msmarco")).unwrap();
+        std::fs::write(
+            root.join("msmarco/collection.tsv"),
+            "10\tfirst passage text\n11\tsecond passage text\n",
+        )
+        .unwrap();
+        std::fs::write(
+            root.join("msmarco/queries.dev.small.tsv"),
+            "1\twhat is first\n2\twhat is second\n",
+        )
+        .unwrap();
+        let mut spec = test_spec();
+        spec.dataset = FtsDataset::MsMarcoPassage;
+        spec.data_dir = Some(root.to_string_lossy().to_string());
+        spec.num_docs = 2;
+        spec.num_queries = 2;
+
+        // when
+        let queries = load_queries(&spec).unwrap();
+        let mut generator = CorpusGenerator::new(&spec).unwrap();
+        let docs = generator.next_chunk(10).unwrap().unwrap();
+
+        // then
+        assert_eq!(queries, vec!["what is first", "what is second"]);
+        assert_eq!(docs.len(), 2);
+        assert_eq!(docs[0].id, "10");
+        assert_eq!(docs[0].body, "first passage text");
+        assert_eq!(docs[0].embedding.len(), spec.dimensions as usize);
+        assert_eq!(docs[1].id, "11");
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/vector/bench/src/fts/ingest.rs
+++ b/vector/bench/src/fts/ingest.rs
@@ -1,4 +1,4 @@
-//! INGEST phase: stream the synthetic corpus into a fresh `VectorDb`.
+//! INGEST phase: stream the configured FTS corpus into a fresh `VectorDb`.
 //!
 //! Opens a fresh `VectorDb` at phase start, generates documents on a
 //! background thread in fixed-size chunks, writes them in small batches,
@@ -7,14 +7,13 @@
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::thread;
 use std::time::{Duration, Instant};
 
 use chrono::Local;
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::oneshot;
 use vector::{Vector, VectorDb};
 
-use crate::fts::corpus::{CorpusGenerator, Doc};
+use crate::fts::corpus;
 use crate::fts::{BODY_FIELD, FtsSpec, open_db};
 use crate::recall::ingest_default_memory_bytes;
 
@@ -37,10 +36,12 @@ pub async fn run(spec: &FtsSpec, config: &vector::Config) -> anyhow::Result<Inge
 async fn ingest(spec: &FtsSpec, db: &VectorDb) -> anyhow::Result<IngestSummary> {
     let num_docs = spec.num_docs as u64;
     println!(
-        "  Streaming {} synthetic docs (vocab={}, zipf_s={}, avg_len={}, dim={}) in chunks of {}",
-        num_docs, spec.vocab_size, spec.zipf_s, spec.avg_doc_len, spec.dimensions, DOC_CHUNK_SIZE
+        "  Streaming up to {} {} in chunks of {}",
+        num_docs,
+        corpus::corpus_description(spec),
+        DOC_CHUNK_SIZE
     );
-    let (mut stream, gen_thread) = spawn_doc_stream(spec, DOC_CHUNK_SIZE);
+    let (mut stream, gen_thread) = corpus::spawn_doc_stream(spec.clone(), DOC_CHUNK_SIZE);
 
     let ingest_start = Instant::now();
     let ingested_counter = Arc::new(AtomicU64::new(0));
@@ -52,6 +53,7 @@ async fn ingest(spec: &FtsSpec, db: &VectorDb) -> anyhow::Result<IngestSummary> 
     let mut batch_idx = 0usize;
     let mut docs_written = 0usize;
     while let Some(chunk) = stream.recv().await {
+        let chunk = chunk?;
         docs_written += chunk.len();
         println!(
             "  Generated chunk: {} docs ({} / {})",
@@ -89,7 +91,10 @@ async fn ingest(spec: &FtsSpec, db: &VectorDb) -> anyhow::Result<IngestSummary> 
         .join()
         .map_err(|_| anyhow::anyhow!("doc generation thread panicked"))?;
     if docs_written != spec.num_docs {
-        anyhow::bail!("generated {} docs but expected {}", docs_written, num_docs);
+        println!(
+            "  Corpus ended after {} docs (requested {})",
+            docs_written, num_docs
+        );
     }
     db.flush().await?;
     let ingest_secs = ingest_start.elapsed().as_secs_f64();
@@ -99,38 +104,18 @@ async fn ingest(spec: &FtsSpec, db: &VectorDb) -> anyhow::Result<IngestSummary> 
         .await
         .map_err(|e| anyhow::anyhow!("ingest throughput monitor panicked: {e}"))?;
 
+    let written_docs = docs_written as u64;
     println!(
         "  Ingested {} docs in {:.1}s ({:.0} docs/s)",
-        num_docs,
+        written_docs,
         ingest_secs,
-        num_docs as f64 / ingest_secs,
+        written_docs as f64 / ingest_secs,
     );
 
     Ok(IngestSummary {
-        num_docs,
+        num_docs: written_docs,
         ingest_secs,
     })
-}
-
-/// Spawn a thread that generates corpus chunks and streams them through a
-/// bounded channel, so generation overlaps with writes without ever
-/// materializing the whole corpus.
-fn spawn_doc_stream(
-    spec: &FtsSpec,
-    chunk_size: usize,
-) -> (mpsc::Receiver<Vec<Doc>>, thread::JoinHandle<()>) {
-    let mut generator = CorpusGenerator::new(spec);
-    let (tx, rx) = mpsc::channel(1);
-
-    let handle = thread::spawn(move || {
-        while let Some(chunk) = generator.next_chunk(chunk_size) {
-            if tx.blocking_send(chunk).is_err() {
-                return;
-            }
-        }
-    });
-
-    (rx, handle)
 }
 
 /// Spawn a task that samples the ingest counter once per minute and logs

--- a/vector/src/math/bm25.rs
+++ b/vector/src/math/bm25.rs
@@ -4,6 +4,13 @@
 //! the FTS query path. Kept in `math` alongside the vector distance functions
 //! so all scoring helpers live in one place.
 
+#[cfg(target_arch = "x86_64")]
+use std::arch::x86_64::{
+    __m256i, _mm256_add_ps, _mm256_cvtepi32_ps, _mm256_div_ps, _mm256_i32gather_ps,
+    _mm256_loadu_si256, _mm256_mul_ps, _mm256_set1_ps, _mm256_setr_epi32, _mm256_storeu_ps,
+    _mm256_sub_ps,
+};
+
 use super::norm;
 
 /// Term-frequency saturation parameter (`k1`).
@@ -140,6 +147,38 @@ impl ScoreContext {
         hit_score(idf, freq, self.norm_cache[norm as usize])
     }
 
+    /// BM25 contributions for one term's posting run.
+    ///
+    /// Computes the same per-hit values as [`score_hit`](Self::score_hit),
+    /// but batches the independent `(freq, norm)` pairs so x86_64 hosts with
+    /// AVX2 can evaluate eight postings per vector instruction group. The
+    /// fallback is scalar and preserves the exact hit arithmetic.
+    pub(crate) fn score_hits(&self, idf: f32, freqs: &[u32], norms: &[u8], out: &mut [f32]) {
+        assert_eq!(freqs.len(), norms.len());
+        assert_eq!(freqs.len(), out.len());
+
+        #[cfg(target_arch = "x86_64")]
+        {
+            if freqs.len() >= 8 && std::is_x86_feature_detected!("avx2") {
+                // SAFETY: AVX2 support is checked at runtime. Slice length
+                // equality is asserted above, and the AVX2 helper handles
+                // chunks and tails within bounds.
+                unsafe {
+                    score_hits_avx2(&self.norm_cache, idf, freqs, norms, out);
+                }
+                return;
+            }
+        }
+
+        self.score_hits_scalar(idf, freqs, norms, out);
+    }
+
+    fn score_hits_scalar(&self, idf: f32, freqs: &[u32], norms: &[u8], out: &mut [f32]) {
+        for ((slot, &freq), &norm) in out.iter_mut().zip(freqs).zip(norms) {
+            *slot = self.score_hit(idf, freq, norm);
+        }
+    }
+
     /// Upper bound on any hit's contribution for a term, regardless of
     /// frequency or document length.
     ///
@@ -149,6 +188,61 @@ impl ScoreContext {
     #[inline]
     pub(crate) fn global_bound(&self, idf: f32) -> f32 {
         idf * (K1 + 1.0)
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[target_feature(enable = "avx2")]
+unsafe fn score_hits_avx2(
+    norm_cache: &[f32; 256],
+    idf: f32,
+    freqs: &[u32],
+    norms: &[u8],
+    out: &mut [f32],
+) {
+    debug_assert_eq!(freqs.len(), norms.len());
+    debug_assert_eq!(freqs.len(), out.len());
+
+    let mut idx = 0usize;
+    let len = freqs.len();
+    let one = _mm256_set1_ps(1.0);
+    let w_scalar = idf * (K1 + 1.0);
+    let w = _mm256_set1_ps(w_scalar);
+
+    while idx + 8 <= len {
+        let freq_chunk = &freqs[idx..idx + 8];
+        if freq_chunk.iter().all(|&freq| freq <= i32::MAX as u32) {
+            // SAFETY: `idx + 8 <= len` guarantees the load and store cover
+            // eight initialized `u32` inputs and eight writable `f32` outputs.
+            let freq_i32 = unsafe { _mm256_loadu_si256(freqs.as_ptr().add(idx).cast::<__m256i>()) };
+            let freq = _mm256_cvtepi32_ps(freq_i32);
+            let norm_idx = _mm256_setr_epi32(
+                norms[idx] as i32,
+                norms[idx + 1] as i32,
+                norms[idx + 2] as i32,
+                norms[idx + 3] as i32,
+                norms[idx + 4] as i32,
+                norms[idx + 5] as i32,
+                norms[idx + 6] as i32,
+                norms[idx + 7] as i32,
+            );
+            // SAFETY: all gathered norm indices are bytes in 0..=255, and
+            // scale 4 addresses `f32` elements in `norm_cache`.
+            let inv = unsafe { _mm256_i32gather_ps(norm_cache.as_ptr(), norm_idx, 4) };
+            let denom = _mm256_add_ps(one, _mm256_mul_ps(freq, inv));
+            let score = _mm256_sub_ps(w, _mm256_div_ps(w, denom));
+            // SAFETY: `idx + 8 <= len` guarantees eight writable `f32`s.
+            unsafe { _mm256_storeu_ps(out.as_mut_ptr().add(idx), score) };
+        } else {
+            for lane in idx..idx + 8 {
+                out[lane] = hit_score(idf, freqs[lane], norm_cache[norms[lane] as usize]);
+            }
+        }
+        idx += 8;
+    }
+
+    for lane in idx..len {
+        out[lane] = hit_score(idf, freqs[lane], norm_cache[norms[lane] as usize]);
     }
 }
 
@@ -249,6 +343,53 @@ mod tests {
             combined,
             single
         );
+    }
+
+    #[test]
+    fn score_hits_matches_scalar_score_hit() {
+        // given
+        let ctx = ScoreContext::new(37.0);
+        let idf = 1.7;
+        let freqs = vec![
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            u32::MAX,
+            17,
+            18,
+            19,
+        ];
+        let norms = vec![
+            0, 1, 3, 7, 15, 31, 63, 127, 255, 200, 150, 100, 50, 25, 12, 6, 4, 2, 1,
+        ];
+        let mut actual = vec![0.0; freqs.len()];
+
+        // when
+        ctx.score_hits(idf, &freqs, &norms, &mut actual);
+
+        // then
+        for i in 0..freqs.len() {
+            let expected = ctx.score_hit(idf, freqs[i], norms[i]);
+            assert_eq!(
+                actual[i].to_bits(),
+                expected.to_bits(),
+                "hit {i}: actual={} expected={}",
+                actual[i],
+                expected
+            );
+        }
     }
 
     #[test]

--- a/vector/src/query_engine/bm25/essential.rs
+++ b/vector/src/query_engine/bm25/essential.rs
@@ -265,11 +265,12 @@ impl EssentialScorer for DenseWindowScorer {
                 .iter_mut()
                 .min_by_key(|ws| ws.scorer.doc())
                 .expect("score_window requires an essential scorer");
-            while ws.scorer.doc() < up_to && candidates.len() < SINGLE_CLAUSE_BATCH {
-                let hit = ws.scorer.current_hit(ctx);
-                candidates.push(ws.scorer.doc(), hit as f64);
-                ws.scorer.next()?;
-            }
+            ws.scorer.collect_candidates_limited_into(
+                up_to,
+                SINGLE_CLAUSE_BATCH,
+                ctx,
+                candidates,
+            )?;
             return Ok(());
         }
 

--- a/vector/src/query_engine/bm25/term_scorer.rs
+++ b/vector/src/query_engine/bm25/term_scorer.rs
@@ -7,7 +7,7 @@
 
 use crate::error::Result;
 use crate::math::bm25::ScoreContext;
-use crate::query_engine::bm25::essential::{HitList, ScoreWindow};
+use crate::query_engine::bm25::essential::{Candidates, HitList, ScoreWindow};
 use crate::serde::term_postings::{DecodedPostingsBlock, TermPostingsView};
 
 /// Sentinel: no documents at or beyond this id (data-vector ids use the low
@@ -32,6 +32,8 @@ pub(super) struct TermScorer {
     pos: usize,
     /// Memoized per-block max score contribution.
     block_max_scores: Vec<Option<f32>>,
+    /// Reusable per-block hit buffer for batched scoring.
+    score_buf: Vec<f32>,
 }
 
 impl TermScorer {
@@ -47,6 +49,7 @@ impl TermScorer {
             decoded: DecodedPostingsBlock::default(),
             pos: 0,
             block_max_scores,
+            score_buf: Vec::new(),
         };
         scorer.load_block(0)?;
         Ok(scorer)
@@ -89,7 +92,7 @@ impl TermScorer {
     }
 
     /// Advance the cursor to the next posting.
-    #[inline]
+    #[cfg(test)]
     pub(super) fn next(&mut self) -> Result<()> {
         self.pos += 1;
         if self.pos < self.decoded.ids.len() {
@@ -226,9 +229,9 @@ impl TermScorer {
     /// accumulator, leaving the cursor at the first posting `>= up_to`.
     /// Slot `i` of the window corresponds to doc id `window_min + i`.
     ///
-    /// This is the term-at-a-time batch loop: for each decoded block it runs
-    /// a tight scalar loop over the block's parallel arrays. Vectorization
-    /// (RFC-0006 future work) will replace the loop body, not the structure.
+    /// This is the term-at-a-time batch loop: for each decoded block it
+    /// scores the block's parallel `(freq, norm)` columns as a batch, then
+    /// scatters the resulting hits into the dense doc-id window.
     pub(super) fn score_window_into(
         &mut self,
         window_min: u64,
@@ -240,13 +243,52 @@ impl TermScorer {
         while self.doc < up_to {
             let ids = &self.decoded.ids;
             let end = self.pos + ids[self.pos..].partition_point(|&id| id < up_to);
-            let run = ids[self.pos..end]
-                .iter()
-                .zip(&self.decoded.freqs[self.pos..end])
-                .zip(&self.decoded.norms[self.pos..end]);
-            for ((&id, &freq), &norm) in run {
+            let len = end - self.pos;
+            self.score_buf.resize(len, 0.0);
+            ctx.score_hits(
+                self.idf,
+                &self.decoded.freqs[self.pos..end],
+                &self.decoded.norms[self.pos..end],
+                &mut self.score_buf,
+            );
+            for (&id, &hit) in ids[self.pos..end].iter().zip(&self.score_buf) {
                 let slot = (id - window_min) as usize;
-                window.add(slot, ctx.score_hit(self.idf, freq, norm));
+                window.add(slot, hit);
+            }
+            if end < ids.len() {
+                self.pos = end;
+                self.set_current();
+                return Ok(());
+            }
+            self.load_block(self.block_idx + 1)?;
+        }
+        Ok(())
+    }
+
+    /// Append up to `limit` postings in `[self.doc, up_to)` directly to
+    /// the candidate buffer for a single essential clause.
+    pub(super) fn collect_candidates_limited_into(
+        &mut self,
+        up_to: u64,
+        limit: usize,
+        ctx: &ScoreContext,
+        candidates: &mut Candidates,
+    ) -> Result<()> {
+        while self.doc < up_to && candidates.len() < limit {
+            let ids = &self.decoded.ids;
+            let block_end = self.pos + ids[self.pos..].partition_point(|&id| id < up_to);
+            let remaining = limit - candidates.len();
+            let end = block_end.min(self.pos + remaining);
+            let len = end - self.pos;
+            self.score_buf.resize(len, 0.0);
+            ctx.score_hits(
+                self.idf,
+                &self.decoded.freqs[self.pos..end],
+                &self.decoded.norms[self.pos..end],
+                &mut self.score_buf,
+            );
+            for (&doc, &hit) in ids[self.pos..end].iter().zip(&self.score_buf) {
+                candidates.push(doc, hit as f64);
             }
             if end < ids.len() {
                 self.pos = end;
@@ -264,7 +306,7 @@ impl TermScorer {
     ///
     /// The merge strategy's counterpart to
     /// [`score_window_into`](Self::score_window_into): the same
-    /// term-at-a-time batch loop over the block's decoded arrays, but
+    /// term-at-a-time batch scoring over the block's decoded arrays, but
     /// appending sequentially instead of scattering into id-indexed slots.
     pub(super) fn collect_hits_into(
         &mut self,
@@ -276,12 +318,14 @@ impl TermScorer {
             let ids = &self.decoded.ids;
             let end = self.pos + ids[self.pos..].partition_point(|&id| id < up_to);
             out.docs.extend_from_slice(&ids[self.pos..end]);
-            let run = self.decoded.freqs[self.pos..end]
-                .iter()
-                .zip(&self.decoded.norms[self.pos..end]);
-            for (&freq, &norm) in run {
-                out.hits.push(ctx.score_hit(self.idf, freq, norm));
-            }
+            let old_len = out.hits.len();
+            out.hits.resize(old_len + end - self.pos, 0.0);
+            ctx.score_hits(
+                self.idf,
+                &self.decoded.freqs[self.pos..end],
+                &self.decoded.norms[self.pos..end],
+                &mut out.hits[old_len..],
+            );
             if end < ids.len() {
                 self.pos = end;
                 self.set_current();


### PR DESCRIPTION
## Summary

- Use SIMD instructions if available to score each term's entries
- Add MSMARCO dataset to fts benchmark

## Test Plan

Benchmark MSMARCO dataset (8M documents, 50 ~5-term queries, limit 10), c6id.4xlarge (16vcpu, 32GB RAM)
- query latency mean/p50/p90/p99: 12ms/10ms/22ms/43ms
- ingest 5.37K docs/second

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [x] Documentation updated (if applicable)
