### PR TITLE
Logdb: Size-based segment seal

### DIFF
--- a/log/c/src/ffi.rs
+++ b/log/c/src/ffi.rs
@@ -355,7 +355,10 @@ pub(crate) unsafe fn build_config(
     };
     Ok(Config {
         storage,
-        segmentation: SegmentConfig { seal_interval },
+        segmentation: SegmentConfig {
+            seal_interval,
+            ..Default::default()
+        },
         read_visibility: match config.read_visibility {
             OPENDATA_LOG_READ_VISIBILITY_REMOTE => ReadVisibility::Remote,
             OPENDATA_LOG_READ_VISIBILITY_MEMORY => ReadVisibility::Memory,

--- a/log/src/config.rs
+++ b/log/src/config.rs
@@ -187,11 +187,33 @@ pub struct SegmentConfig {
     /// // Create a new segment every hour
     /// let config = SegmentConfig {
     ///     seal_interval: Some(Duration::from_secs(3600)),
+    ///     ..Default::default()
     /// };
     /// ```
     #[serde_as(as = "Option<DurationMilliSeconds<u64>>")]
     #[serde(default)]
     pub seal_interval: Option<Duration>,
+
+    /// Maximum accumulated storage bytes in the active segment before it is
+    /// sealed.
+    ///
+    /// "Storage bytes" counts the serialized key plus value of each log entry
+    /// written to the segment (bookkeeping records such as listings and
+    /// segment metadata are not counted). When the active segment reaches this
+    /// many bytes, the next append rolls a new segment. Combines with
+    /// [`seal_interval`](Self::seal_interval): whichever threshold is reached
+    /// first triggers a seal.
+    ///
+    /// This is a soft target. The check uses bytes committed *before* the
+    /// current batch, so a segment may exceed the limit by up to one batch.
+    /// The running total is in-memory and resets to zero on restart, so the
+    /// active segment at startup may grow by up to one additional limit before
+    /// sealing. Both overshoots are bounded and acceptable for size-based
+    /// partitioning.
+    ///
+    /// When `None` (the default), size-based sealing is disabled.
+    #[serde(default)]
+    pub seal_byte_limit: Option<u64>,
 }
 
 /// Retention policy configuration.
@@ -414,7 +436,10 @@ mod tests {
 
     fn config_with(retention: Option<Duration>, seal_interval: Option<Duration>) -> Config {
         Config {
-            segmentation: SegmentConfig { seal_interval },
+            segmentation: SegmentConfig {
+                seal_interval,
+                ..Default::default()
+            },
             retention: RetentionConfig {
                 retention,
                 ..RetentionConfig::default()

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -2098,6 +2098,7 @@ mod tests {
             storage: StorageConfig::InMemory,
             segmentation: SegmentConfig {
                 seal_interval: Some(seal_interval),
+                ..Default::default()
             },
             retention: RetentionConfig {
                 retention: Some(retention),
@@ -2361,6 +2362,7 @@ mod tests {
             storage: StorageConfig::InMemory,
             segmentation: SegmentConfig {
                 seal_interval: Some(Duration::from_nanos(1)),
+                ..Default::default()
             },
             ..Default::default()
         };
@@ -2427,6 +2429,7 @@ mod tests {
             storage.clone(),
             SegmentConfig {
                 seal_interval: Some(Duration::from_nanos(1)),
+                ..Default::default()
             },
             RetentionConfig::default(),
             ReadVisibility::Memory,

--- a/log/src/segment.rs
+++ b/log/src/segment.rs
@@ -79,6 +79,13 @@ pub(crate) struct SegmentCache {
     segments: BTreeMap<u64, LogSegment>,
     /// Configuration for segment management.
     config: SegmentConfig,
+    /// Accumulated storage bytes (serialized key + value of log entries)
+    /// written to the active (latest) segment. Drives size-based sealing.
+    ///
+    /// In-memory only: reset to zero when a new segment is created and on
+    /// startup. See [`SegmentConfig::seal_byte_limit`] for the soft-target
+    /// semantics this implies.
+    active_bytes: u64,
 }
 
 impl SegmentCache {
@@ -93,7 +100,11 @@ impl SegmentCache {
             segments.insert(segment.meta.start_seq, segment);
         }
 
-        Ok(Self { segments, config })
+        Ok(Self {
+            segments,
+            config,
+            active_bytes: 0,
+        })
     }
 
     /// Creates an empty cache for testing.
@@ -102,6 +113,7 @@ impl SegmentCache {
         Self {
             segments: BTreeMap::new(),
             config: SegmentConfig::default(),
+            active_bytes: 0,
         }
     }
 
@@ -234,7 +246,13 @@ impl SegmentCache {
     ) -> SegmentAssignment {
         let latest = self.latest();
         let needs_new_segment = force_seal
-            || Self::should_roll(self.config.seal_interval, current_time_ms, latest.as_ref());
+            || Self::should_roll(
+                self.config.seal_interval,
+                self.config.seal_byte_limit,
+                current_time_ms,
+                self.active_bytes,
+                latest.as_ref(),
+            );
 
         if needs_new_segment {
             let segment_id = latest.map(|s| s.id + 1).unwrap_or(FIRST_USER_SEGMENT_ID);
@@ -248,6 +266,9 @@ impl SegmentCache {
 
             let segment = LogSegment::new(segment_id, meta);
             self.insert(segment.clone());
+            // The new segment starts empty; the bytes for this batch are added
+            // after the write commits (see `record_active_bytes`).
+            self.active_bytes = 0;
             SegmentAssignment {
                 segment,
                 is_new: true,
@@ -261,10 +282,17 @@ impl SegmentCache {
         }
     }
 
-    /// Checks if a new segment should be created based on seal interval.
+    /// Checks if a new segment should be created.
+    ///
+    /// Rolls when either threshold is reached: the active segment's age has
+    /// met `seal_interval`, or its accumulated `active_bytes` has met
+    /// `seal_byte_limit`. With no thresholds set, only the absence of any
+    /// segment forces a roll.
     fn should_roll(
         seal_interval: Option<Duration>,
+        seal_byte_limit: Option<u64>,
         current_time_ms: i64,
+        active_bytes: u64,
         latest: Option<&LogSegment>,
     ) -> bool {
         // No latest segment means we need to create the first one
@@ -272,14 +300,29 @@ impl SegmentCache {
             return true;
         };
 
-        // No seal interval means we never roll (use existing segment)
-        let Some(seal_interval) = seal_interval else {
-            return false;
-        };
+        // Time-based trigger.
+        if let Some(seal_interval) = seal_interval {
+            let seal_interval_ms = seal_interval.as_millis() as i64;
+            let segment_age_ms = current_time_ms - latest.meta().start_time_ms;
+            if segment_age_ms >= seal_interval_ms {
+                return true;
+            }
+        }
 
-        let seal_interval_ms = seal_interval.as_millis() as i64;
-        let segment_age_ms = current_time_ms - latest.meta().start_time_ms;
-        segment_age_ms >= seal_interval_ms
+        // Size-based trigger.
+        if seal_byte_limit.is_some_and(|limit| active_bytes >= limit) {
+            return true;
+        }
+
+        false
+    }
+
+    /// Records `bytes` of committed log-entry data against the active segment.
+    ///
+    /// Called after a write commits so the running total reflects only durable
+    /// data. Drives the size-based seal check in [`should_roll`].
+    pub(crate) fn record_active_bytes(&mut self, bytes: u64) {
+        self.active_bytes = self.active_bytes.saturating_add(bytes);
     }
 }
 
@@ -574,7 +617,7 @@ mod tests {
     #[tokio::test]
     async fn should_roll_returns_false_when_no_seal_interval() {
         // given: no seal interval, no latest segment
-        let should_roll = SegmentCache::should_roll(None, 1000, None);
+        let should_roll = SegmentCache::should_roll(None, None, 1000, 0, None);
 
         // then: should roll (no segment exists)
         assert!(should_roll);
@@ -586,7 +629,7 @@ mod tests {
         let seal_interval = Some(Duration::from_secs(3600));
 
         // when
-        let should_roll = SegmentCache::should_roll(seal_interval, 1000, None);
+        let should_roll = SegmentCache::should_roll(seal_interval, None, 1000, 0, None);
 
         // then: should roll to create first segment
         assert!(should_roll);
@@ -600,7 +643,8 @@ mod tests {
 
         // when: current time is 1000 + 30 minutes
         let current_time_ms = 1000 + 30 * 60 * 1000;
-        let should_roll = SegmentCache::should_roll(seal_interval, current_time_ms, Some(&segment));
+        let should_roll =
+            SegmentCache::should_roll(seal_interval, None, current_time_ms, 0, Some(&segment));
 
         // then
         assert!(!should_roll);
@@ -614,7 +658,8 @@ mod tests {
 
         // when: current time is 1000 + 2 hours
         let current_time_ms = 1000 + 2 * 60 * 60 * 1000;
-        let should_roll = SegmentCache::should_roll(seal_interval, current_time_ms, Some(&segment));
+        let should_roll =
+            SegmentCache::should_roll(seal_interval, None, current_time_ms, 0, Some(&segment));
 
         // then
         assert!(should_roll);
@@ -628,7 +673,8 @@ mod tests {
 
         // when: current time is exactly at the interval boundary
         let current_time_ms = 1000 + 60 * 60 * 1000;
-        let should_roll = SegmentCache::should_roll(seal_interval, current_time_ms, Some(&segment));
+        let should_roll =
+            SegmentCache::should_roll(seal_interval, None, current_time_ms, 0, Some(&segment));
 
         // then: at boundary should roll
         assert!(should_roll);
@@ -640,10 +686,59 @@ mod tests {
         let segment = LogSegment::new(FIRST_USER_SEGMENT_ID, SegmentMeta::new(0, 1000));
 
         // when
-        let should_roll = SegmentCache::should_roll(None, 999999999, Some(&segment));
+        let should_roll = SegmentCache::should_roll(None, None, 999999999, 0, Some(&segment));
 
         // then: never rolls without seal_interval when segment exists
         assert!(!should_roll);
+    }
+
+    #[tokio::test]
+    async fn should_roll_returns_false_when_under_byte_limit() {
+        // given: byte limit of 1000, segment with 500 accumulated bytes
+        let seal_byte_limit = Some(1000);
+        let segment = LogSegment::new(FIRST_USER_SEGMENT_ID, SegmentMeta::new(0, 1000));
+
+        // when: well within both time and size
+        let should_roll =
+            SegmentCache::should_roll(None, seal_byte_limit, 1000, 500, Some(&segment));
+
+        // then
+        assert!(!should_roll);
+    }
+
+    #[tokio::test]
+    async fn should_roll_returns_true_when_byte_limit_reached() {
+        // given: byte limit of 1000, segment exactly at the limit
+        let seal_byte_limit = Some(1000);
+        let segment = LogSegment::new(FIRST_USER_SEGMENT_ID, SegmentMeta::new(0, 1000));
+
+        // when: at the boundary, no time trigger
+        let should_roll =
+            SegmentCache::should_roll(None, seal_byte_limit, 1000, 1000, Some(&segment));
+
+        // then: at boundary should roll
+        assert!(should_roll);
+    }
+
+    #[tokio::test]
+    async fn should_roll_rolls_on_size_before_time_when_both_set() {
+        // given: both triggers configured, size exceeded but time not
+        let seal_interval = Some(Duration::from_secs(3600));
+        let seal_byte_limit = Some(1000);
+        let segment = LogSegment::new(FIRST_USER_SEGMENT_ID, SegmentMeta::new(0, 1000));
+
+        // when: 1 minute later (within interval) but over the byte limit
+        let current_time_ms = 1000 + 60 * 1000;
+        let should_roll = SegmentCache::should_roll(
+            seal_interval,
+            seal_byte_limit,
+            current_time_ms,
+            2000,
+            Some(&segment),
+        );
+
+        // then: size trigger fires even though the interval has not elapsed
+        assert!(should_roll);
     }
 
     #[storage_test]
@@ -674,6 +769,7 @@ mod tests {
         // given: segment exists, within seal interval
         let config = SegmentConfig {
             seal_interval: Some(Duration::from_secs(3600)),
+            ..Default::default()
         };
         let mut cache = SegmentCache::open(storage.as_ref(), config).await.unwrap();
         write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
@@ -696,6 +792,7 @@ mod tests {
         // given: segment at time 1000, seal interval 1 hour
         let config = SegmentConfig {
             seal_interval: Some(Duration::from_secs(3600)),
+            ..Default::default()
         };
         let mut cache = SegmentCache::open(storage.as_ref(), config).await.unwrap();
         write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
@@ -718,6 +815,7 @@ mod tests {
         // given: segment exists, within seal interval
         let config = SegmentConfig {
             seal_interval: Some(Duration::from_secs(3600)),
+            ..Default::default()
         };
         let mut cache = SegmentCache::open(storage.as_ref(), config).await.unwrap();
         write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
@@ -731,6 +829,36 @@ mod tests {
         assert!(assignment.is_new);
         assert_eq!(assignment.segment.id(), FIRST_USER_SEGMENT_ID + 1);
         assert_eq!(cache.all().len(), 2);
+    }
+
+    #[storage_test]
+    async fn assign_segment_rolls_and_resets_on_byte_limit(storage: Arc<dyn Storage>) {
+        // given: a byte limit of 1000 and an active segment that has
+        // accumulated 1500 bytes (over the limit). No seal_interval, so only
+        // size can trigger a roll.
+        let config = SegmentConfig {
+            seal_byte_limit: Some(1000),
+            ..Default::default()
+        };
+        let mut cache = SegmentCache::open(storage.as_ref(), config).await.unwrap();
+        write_segment(storage.as_ref(), &mut cache, SegmentMeta::new(0, 1000)).await;
+        cache.record_active_bytes(1500);
+        let mut records = Vec::new();
+
+        // when: a new batch arrives
+        let assignment = cache.assign_segment(2000, 100, &mut records, false);
+
+        // then: a new segment is created and the byte counter is reset
+        assert!(assignment.is_new);
+        assert_eq!(assignment.segment.id(), FIRST_USER_SEGMENT_ID + 1);
+        assert_eq!(cache.active_bytes, 0);
+
+        // and: a subsequent batch under the limit stays in the same segment
+        cache.record_active_bytes(500);
+        let mut records2 = Vec::new();
+        let assignment2 = cache.assign_segment(3000, 200, &mut records2, false);
+        assert!(!assignment2.is_new);
+        assert_eq!(assignment2.segment.id(), FIRST_USER_SEGMENT_ID + 1);
     }
 
     #[storage_test]

--- a/log/src/segment_extractor.rs
+++ b/log/src/segment_extractor.rs
@@ -441,6 +441,7 @@ mod integration_tests {
             storage: storage.clone(),
             segmentation: SegmentConfig {
                 seal_interval: Some(Duration::from_secs(1)),
+                ..Default::default()
             },
             ..Default::default()
         })

--- a/log/src/writer.rs
+++ b/log/src/writer.rs
@@ -341,11 +341,15 @@ impl LogWriter {
             .assign_new_keys(assignment.segment.id(), &keys, &mut puts);
 
         // 4. Build log entry records
-        self.add_entries(&assignment.segment, base_seq, &write.records, &mut puts);
+        let entry_bytes =
+            self.add_entries(&assignment.segment, base_seq, &write.records, &mut puts);
 
         // 5. Write to storage and broadcast
         let ops: Vec<RecordOp> = puts.into_iter().map(RecordOp::Put).collect();
         self.apply_and_broadcast(ops, Some(&assignment)).await?;
+
+        // 6. Account committed bytes against the active segment (size-based seal).
+        self.segment_cache.record_active_bytes(entry_bytes);
 
         Ok(Some(AppendOutput {
             start_sequence: base_seq,
@@ -507,14 +511,18 @@ impl LogWriter {
     }
 
     /// Builds log entry storage records from user records and appends them.
+    ///
+    /// Returns the total storage bytes (serialized key + value) of the entries
+    /// appended, used to drive size-based segment sealing.
     fn add_entries(
         &self,
         segment: &LogSegment,
         base_sequence: u64,
         user_records: &[UserRecord],
         records: &mut Vec<PutRecordOp>,
-    ) {
+    ) -> u64 {
         let segment_start_seq = segment.meta().start_seq;
+        let mut entry_bytes: u64 = 0;
         for (i, user_record) in user_records.iter().enumerate() {
             let sequence = base_sequence + i as u64;
             let entry_key = LogEntryKey::new(segment.id(), user_record.key.clone(), sequence);
@@ -522,11 +530,13 @@ impl LogWriter {
                 entry_key.serialize(segment_start_seq),
                 user_record.value.clone(),
             );
+            entry_bytes += (storage_record.key.len() + storage_record.value.len()) as u64;
             records.push(PutRecordOp::new_with_options(
                 storage_record,
                 PutOptions { ttl: NoExpiry },
             ));
         }
+        entry_bytes
     }
 }
 

--- a/log/tests/http_server.rs
+++ b/log/tests/http_server.rs
@@ -280,6 +280,7 @@ async fn setup_test_log_with_segment_interval(interval: Duration) -> Arc<LogDb> 
         storage: StorageConfig::InMemory,
         segmentation: SegmentConfig {
             seal_interval: Some(interval),
+            ..Default::default()
         },
         ..Default::default()
     };

--- a/log/tests/reader_writer.rs
+++ b/log/tests/reader_writer.rs
@@ -179,6 +179,7 @@ async fn reader_drops_expired_segments_after_retention_deletes_metadata() {
         storage: storage.clone(),
         segmentation: SegmentConfig {
             seal_interval: Some(Duration::from_millis(100)),
+            ..Default::default()
         },
         retention: RetentionConfig {
             retention: Some(Duration::from_millis(100)),
@@ -296,6 +297,7 @@ async fn reader_idle_key_resumes_at_sealed_frontier() {
         storage: storage.clone(),
         segmentation: SegmentConfig {
             seal_interval: Some(Duration::from_millis(50)),
+            ..Default::default()
         },
         ..Default::default()
     })

--- a/log/tests/retention_config.rs
+++ b/log/tests/retention_config.rs
@@ -9,7 +9,10 @@ use log::{Config, Error, LogCompactionOptions, LogDb, RetentionConfig, SegmentCo
 fn in_memory_with(retention: Option<Duration>, seal_interval: Option<Duration>) -> Config {
     Config {
         storage: StorageConfig::InMemory,
-        segmentation: SegmentConfig { seal_interval },
+        segmentation: SegmentConfig {
+            seal_interval,
+            ..Default::default()
+        },
         retention: RetentionConfig {
             retention,
             ..RetentionConfig::default()

--- a/log/tests/retention_slatedb_smoke.rs
+++ b/log/tests/retention_slatedb_smoke.rs
@@ -29,6 +29,7 @@ async fn slatedb_open_with_retention_and_compaction_options() {
         storage: local_storage_config(&temp_dir),
         segmentation: SegmentConfig {
             seal_interval: Some(Duration::from_secs(3600)),
+            ..Default::default()
         },
         retention: RetentionConfig {
             retention: Some(Duration::from_secs(86400)),


### PR DESCRIPTION
This is a minor addition which I had in one of my benchmark branches. We currently only support time-based segment sealing, but this policy can lead to large differences between segment sizes, which ultimately affects both compaction and query performance. Size-base sealing is a nice alternative which gives more predictable behavior.
