### PR TITLE
LogDb: read-only http gateway

### DIFF
--- a/log/src/main.rs
+++ b/log/src/main.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
-use log::LogDb;
-use log::server::{CliArgs, LogServer, LogServerConfig};
+use log::server::{CliArgs, LogBackend, LogServer, LogServerConfig};
+use log::{LogDb, LogDbReader};
 
 #[tokio::main]
 async fn main() {
@@ -24,22 +24,30 @@ async fn main() {
     // Parse CLI arguments
     let args = CliArgs::parse();
 
-    // Create log configuration
-    let log_config = args.to_log_config();
     let server_config = LogServerConfig::from(&args);
 
     // Install the metrics-rs recorder early so that slatedb metrics registered
-    // during LogDb::open() are captured by the prometheus exporter.
+    // during open are captured by the prometheus exporter.
     let recorder = metrics_exporter_prometheus::PrometheusBuilder::new().build_recorder();
     let metrics_handle = recorder.handle();
     let _ = metrics::set_global_recorder(recorder);
 
-    tracing::info!("Opening log with config: {:?}", log_config);
-
-    // Open the log
-    let log = LogDb::open(log_config).await.expect("Failed to open log");
+    // Open a read-only reader or a full read-write log depending on the flag.
+    let backend = if args.read_only {
+        let reader_config = args.to_reader_config();
+        tracing::info!("Opening log reader with config: {:?}", reader_config);
+        let reader = LogDbReader::open(reader_config)
+            .await
+            .expect("Failed to open log reader");
+        LogBackend::ReadOnly(Arc::new(reader))
+    } else {
+        let log_config = args.to_log_config();
+        tracing::info!("Opening log with config: {:?}", log_config);
+        let log = LogDb::open(log_config).await.expect("Failed to open log");
+        LogBackend::ReadWrite(Arc::new(log))
+    };
 
     // Create and run the server
-    let server = LogServer::new(Arc::new(log), server_config, metrics_handle);
+    let server = LogServer::new(backend, server_config, metrics_handle);
     server.run().await;
 }

--- a/log/src/main.rs
+++ b/log/src/main.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use clap::Parser;
 use tracing_subscriber::EnvFilter;
 
-use log::server::{CliArgs, LogBackend, LogServer, LogServerConfig};
+use log::server::{CliArgs, LogServer, LogServerConfig};
 use log::{LogDb, LogDbReader};
 
 #[tokio::main]
@@ -32,22 +32,20 @@ async fn main() {
     let metrics_handle = recorder.handle();
     let _ = metrics::set_global_recorder(recorder);
 
-    // Open a read-only reader or a full read-write log depending on the flag.
-    let backend = if args.read_only {
+    // Open a read-only gateway or a full read-write server depending on the flag.
+    let server = if args.read_only {
         let reader_config = args.to_reader_config();
         tracing::info!("Opening log reader with config: {:?}", reader_config);
         let reader = LogDbReader::open(reader_config)
             .await
             .expect("Failed to open log reader");
-        LogBackend::ReadOnly(Arc::new(reader))
+        LogServer::new_read_only(Arc::new(reader), server_config, metrics_handle)
     } else {
         let log_config = args.to_log_config();
         tracing::info!("Opening log with config: {:?}", log_config);
         let log = LogDb::open(log_config).await.expect("Failed to open log");
-        LogBackend::ReadWrite(Arc::new(log))
+        LogServer::new(Arc::new(log), server_config, metrics_handle)
     };
 
-    // Create and run the server
-    let server = LogServer::new(backend, server_config, metrics_handle);
     server.run().await;
 }

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -825,6 +825,20 @@ impl LogDbReader {
         })
     }
 
+    /// Verifies the storage backend is reachable with a single key lookup.
+    ///
+    /// Mirrors [`LogDb::check_storage`](crate::LogDb::check_storage) for the
+    /// read-only path: it reads the sequence block key, which confirms storage
+    /// is responding without scanning or listing data. Used by the HTTP
+    /// server's readiness probe when running as a read-only gateway.
+    #[cfg(feature = "http-server")]
+    pub(crate) async fn check_storage(&self) -> Result<()> {
+        let seq_key = Bytes::from_static(&crate::serde::SEQ_BLOCK_KEY);
+        let view = self.read_view.read().await;
+        let _ = view.storage.get(seq_key).await?;
+        Ok(())
+    }
+
     /// Closes the reader, stopping the background refresh task.
     ///
     /// This method consumes `self` and gracefully shuts down the background

--- a/log/src/server/config.rs
+++ b/log/src/server/config.rs
@@ -6,7 +6,7 @@ use common::storage::config::{
     AwsObjectStoreConfig, LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig,
 };
 
-use crate::Config;
+use crate::{Config, ReaderConfig};
 
 /// CLI arguments for the log server.
 #[derive(Debug, Parser)]
@@ -32,12 +32,20 @@ pub struct CliArgs {
     /// AWS region for S3 storage.
     #[arg(long, default_value = "us-east-1")]
     pub s3_region: String,
+
+    /// Run as a read-only gateway backed by a `LogDbReader`.
+    ///
+    /// In this mode the server serves only read routes (scan, keys, segments,
+    /// count) and the append route is not registered.
+    #[arg(long, default_value = "false")]
+    pub read_only: bool,
 }
 
 impl CliArgs {
-    /// Convert CLI args to log configuration.
-    pub fn to_log_config(&self) -> Config {
-        let storage = if self.in_memory {
+    /// Build the storage configuration shared by the read-write and read-only
+    /// paths from the CLI flags.
+    fn build_storage_config(&self) -> StorageConfig {
+        if self.in_memory {
             StorageConfig::InMemory
         } else if let Some(bucket) = &self.s3_bucket {
             // S3 storage
@@ -62,10 +70,21 @@ impl CliArgs {
                 block_cache: None,
                 meta_cache: None,
             })
-        };
+        }
+    }
 
+    /// Convert CLI args to log configuration (read-write mode).
+    pub fn to_log_config(&self) -> Config {
         Config {
-            storage,
+            storage: self.build_storage_config(),
+            ..Default::default()
+        }
+    }
+
+    /// Convert CLI args to reader configuration (read-only mode).
+    pub fn to_reader_config(&self) -> ReaderConfig {
+        ReaderConfig {
+            storage: self.build_storage_config(),
             ..Default::default()
         }
     }
@@ -103,6 +122,7 @@ mod tests {
             in_memory: true,
             s3_bucket: None,
             s3_region: "us-east-1".to_string(),
+            read_only: false,
         };
 
         // when
@@ -121,6 +141,7 @@ mod tests {
             in_memory: false,
             s3_bucket: None,
             s3_region: "us-east-1".to_string(),
+            read_only: false,
         };
 
         // when
@@ -147,6 +168,7 @@ mod tests {
             in_memory: false,
             s3_bucket: Some("my-bucket".to_string()),
             s3_region: "us-west-2".to_string(),
+            read_only: false,
         };
 
         // when
@@ -174,6 +196,7 @@ mod tests {
             in_memory: true,
             s3_bucket: None,
             s3_region: "us-east-1".to_string(),
+            read_only: false,
         };
 
         // when

--- a/log/src/server/handlers.rs
+++ b/log/src/server/handlers.rs
@@ -36,7 +36,7 @@ use crate::{
 /// [`LogRead`] implementation shared by both variants; write methods are only
 /// meaningful on the read-write variant.
 #[derive(Clone)]
-pub enum LogBackend {
+pub(crate) enum LogBackend {
     /// Full read-write log.
     ReadWrite(Arc<LogDb>),
     /// Read-only view that periodically discovers data written elsewhere.
@@ -121,7 +121,7 @@ impl LogBackend {
 
 /// Shared application state.
 #[derive(Clone)]
-pub struct AppState {
+pub(crate) struct AppState {
     pub log: LogBackend,
     pub metrics: Arc<Metrics>,
 }
@@ -130,7 +130,7 @@ pub struct AppState {
 ///
 /// Supports both `Content-Type: application/protobuf` and `Content-Type: application/protobuf+json`.
 /// Returns response in format matching the `Accept` header.
-pub async fn handle_append(
+pub(crate) async fn handle_append(
     State(state): State<AppState>,
     headers: HeaderMap,
     body: Bytes,
@@ -167,7 +167,7 @@ pub async fn handle_append(
 ///
 /// Returns response in format matching the `Accept` header.
 /// Supports long-polling via `follow=true` and `timeout_ms` parameters.
-pub async fn handle_scan(
+pub(crate) async fn handle_scan(
     State(state): State<AppState>,
     headers: HeaderMap,
     Query(params): Query<ScanParams>,
@@ -269,7 +269,7 @@ async fn scan_entries(
 /// Handle GET /api/v1/log/keys
 ///
 /// Returns response in format matching the `Accept` header.
-pub async fn handle_list_keys(
+pub(crate) async fn handle_list_keys(
     State(state): State<AppState>,
     headers: HeaderMap,
     Query(params): Query<ListKeysParams>,
@@ -295,7 +295,7 @@ pub async fn handle_list_keys(
 /// Handle GET /api/v1/log/segments
 ///
 /// Returns response in format matching the `Accept` header.
-pub async fn handle_list_segments(
+pub(crate) async fn handle_list_segments(
     State(state): State<AppState>,
     headers: HeaderMap,
     Query(params): Query<ListSegmentsParams>,
@@ -320,7 +320,7 @@ pub async fn handle_list_segments(
 /// Handle GET /api/v1/log/count
 ///
 /// Returns response in format matching the `Accept` header.
-pub async fn handle_count(
+pub(crate) async fn handle_count(
     State(state): State<AppState>,
     headers: HeaderMap,
     Query(params): Query<CountParams>,
@@ -336,14 +336,14 @@ pub async fn handle_count(
 }
 
 /// Handle GET /metrics
-pub async fn handle_metrics(State(state): State<AppState>) -> String {
+pub(crate) async fn handle_metrics(State(state): State<AppState>) -> String {
     state.metrics.encode()
 }
 
 /// Handle GET /-/healthy
 ///
 /// Returns 200 OK if the service is running.
-pub async fn handle_healthy() -> (axum::http::StatusCode, &'static str) {
+pub(crate) async fn handle_healthy() -> (axum::http::StatusCode, &'static str) {
     (axum::http::StatusCode::OK, "OK")
 }
 
@@ -351,7 +351,9 @@ pub async fn handle_healthy() -> (axum::http::StatusCode, &'static str) {
 ///
 /// Returns 200 OK if the service is ready to serve requests.
 /// Performs a lightweight storage check to verify the log backend is accessible.
-pub async fn handle_ready(State(state): State<AppState>) -> (axum::http::StatusCode, &'static str) {
+pub(crate) async fn handle_ready(
+    State(state): State<AppState>,
+) -> (axum::http::StatusCode, &'static str) {
     // Verify storage is accessible with a lightweight read operation.
     // This reads the sequence block key, which verifies the storage backend
     // is responding without scanning or listing data.

--- a/log/src/server/handlers.rs
+++ b/log/src/server/handlers.rs
@@ -3,6 +3,7 @@
 //! Per RFC 0004, handlers support both binary protobuf (`application/protobuf`)
 //! and ProtoJSON (`application/protobuf+json`) formats.
 
+use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -15,17 +16,113 @@ use axum::http::HeaderMap;
 use super::error::ApiError;
 use super::metrics::Metrics;
 use super::proto::{
-    AppendResponse, CountResponse, KeysResponse, ScanResponse, Segment, SegmentsResponse, Value,
+    AppendResponse, CountResponse, KeysResponse, ScanResponse, Segment as ProtoSegment,
+    SegmentsResponse, Value,
 };
 use super::request::{AppendRequest, CountParams, ListKeysParams, ListSegmentsParams, ScanParams};
 use super::response::{ApiResponse, ResponseFormat, to_api_response};
-use crate::LogDb;
+use crate::error::AppendError;
 use crate::reader::LogRead;
+use crate::{
+    AppendOutput, AppendResult, LogDb, LogDbReader, LogIterator, LogKeyIterator, Record, Segment,
+    SegmentId, Sequence,
+};
+
+/// Storage backend behind the HTTP server.
+///
+/// A full read-write [`LogDb`] exposes every route; a [`LogDbReader`] backs a
+/// read-only gateway where the append route is not registered (see
+/// [`LogServer`](super::http::LogServer)). Read methods delegate to the
+/// [`LogRead`] implementation shared by both variants; write methods are only
+/// meaningful on the read-write variant.
+#[derive(Clone)]
+pub enum LogBackend {
+    /// Full read-write log.
+    ReadWrite(Arc<LogDb>),
+    /// Read-only view that periodically discovers data written elsewhere.
+    ReadOnly(Arc<LogDbReader>),
+}
+
+impl LogBackend {
+    /// Appends records to the log.
+    ///
+    /// Errors on a read-only backend. The append route is not registered in
+    /// read-only mode, so this arm is a defensive guard rather than a reachable
+    /// code path.
+    pub async fn try_append(&self, records: Vec<Record>) -> AppendResult<AppendOutput> {
+        match self {
+            Self::ReadWrite(log) => log.try_append(records).await,
+            Self::ReadOnly(_) => Err(AppendError::Storage("log gateway is read-only".to_string())),
+        }
+    }
+
+    /// Flushes pending writes. A no-op on a read-only backend.
+    pub async fn flush(&self) -> crate::Result<()> {
+        match self {
+            Self::ReadWrite(log) => log.flush().await,
+            Self::ReadOnly(_) => Ok(()),
+        }
+    }
+
+    /// Verifies the storage backend is reachable (readiness probe).
+    pub async fn check_storage(&self) -> crate::Result<()> {
+        match self {
+            Self::ReadWrite(log) => log.check_storage().await,
+            Self::ReadOnly(reader) => reader.check_storage().await,
+        }
+    }
+
+    /// Scans entries for a key within a sequence range.
+    pub async fn scan(
+        &self,
+        key: Bytes,
+        seq_range: impl RangeBounds<Sequence> + Send,
+    ) -> crate::Result<LogIterator> {
+        match self {
+            Self::ReadWrite(log) => log.scan(key, seq_range).await,
+            Self::ReadOnly(reader) => reader.scan(key, seq_range).await,
+        }
+    }
+
+    /// Counts entries for a key within a sequence range.
+    pub async fn count(
+        &self,
+        key: Bytes,
+        seq_range: impl RangeBounds<Sequence> + Send,
+    ) -> crate::Result<u64> {
+        match self {
+            Self::ReadWrite(log) => log.count(key, seq_range).await,
+            Self::ReadOnly(reader) => reader.count(key, seq_range).await,
+        }
+    }
+
+    /// Lists distinct keys within a segment range.
+    pub async fn list_keys(
+        &self,
+        segment_range: impl RangeBounds<SegmentId> + Send,
+    ) -> crate::Result<LogKeyIterator> {
+        match self {
+            Self::ReadWrite(log) => log.list_keys(segment_range).await,
+            Self::ReadOnly(reader) => reader.list_keys(segment_range).await,
+        }
+    }
+
+    /// Lists segments overlapping a sequence range.
+    pub async fn list_segments(
+        &self,
+        seq_range: impl RangeBounds<Sequence> + Send,
+    ) -> crate::Result<Vec<Segment>> {
+        match self {
+            Self::ReadWrite(log) => log.list_segments(seq_range).await,
+            Self::ReadOnly(reader) => reader.list_segments(seq_range).await,
+        }
+    }
+}
 
 /// Shared application state.
 #[derive(Clone)]
 pub struct AppState {
-    pub log: Arc<LogDb>,
+    pub log: LogBackend,
     pub metrics: Arc<Metrics>,
 }
 
@@ -207,9 +304,9 @@ pub async fn handle_list_segments(
     let seq_range = params.seq_range();
 
     let segments = state.log.list_segments(seq_range).await?;
-    let segment_entries: Vec<Segment> = segments
+    let segment_entries: Vec<ProtoSegment> = segments
         .into_iter()
-        .map(|s| Segment {
+        .map(|s| ProtoSegment {
             id: s.id,
             start_seq: s.start_seq,
             start_time_ms: s.start_time_ms,
@@ -293,7 +390,10 @@ mod tests {
         // given
         let log = Arc::new(LogDb::open(test_config()).await.unwrap());
         let metrics = Arc::new(Metrics::new());
-        let state = AppState { log, metrics };
+        let state = AppState {
+            log: LogBackend::ReadWrite(log),
+            metrics,
+        };
 
         // when
         let (status, body) = handle_ready(State(state)).await;
@@ -418,7 +518,10 @@ mod tests {
         let storage = Arc::new(ToggleFailStorage::new());
         let log = Arc::new(LogDb::new(storage.clone()).await.unwrap());
         let metrics = Arc::new(Metrics::new());
-        let state = AppState { log, metrics };
+        let state = AppState {
+            log: LogBackend::ReadWrite(log),
+            metrics,
+        };
 
         // Configure storage to fail after initialization
         storage.set_failing(true);

--- a/log/src/server/http.rs
+++ b/log/src/server/http.rs
@@ -9,29 +9,32 @@ use tokio::signal;
 
 use super::config::LogServerConfig;
 use super::handlers::{
-    AppState, handle_append, handle_count, handle_healthy, handle_list_keys, handle_list_segments,
-    handle_metrics, handle_ready, handle_scan,
+    AppState, LogBackend, handle_append, handle_count, handle_healthy, handle_list_keys,
+    handle_list_segments, handle_metrics, handle_ready, handle_scan,
 };
 use super::metrics::Metrics;
 use super::middleware::{MetricsLayer, TracingLayer};
-use crate::LogDb;
 
 /// HTTP server for the log service.
 pub struct LogServer {
-    log: Arc<LogDb>,
+    backend: LogBackend,
     config: LogServerConfig,
     metrics_handle: metrics_exporter_prometheus::PrometheusHandle,
 }
 
 impl LogServer {
     /// Create a new log server.
+    ///
+    /// Pass a [`LogBackend::ReadWrite`] for a full log service, or a
+    /// [`LogBackend::ReadOnly`] for a read-only gateway. In read-only mode the
+    /// append route is not registered.
     pub fn new(
-        log: Arc<LogDb>,
+        backend: LogBackend,
         config: LogServerConfig,
         metrics_handle: metrics_exporter_prometheus::PrometheusHandle,
     ) -> Self {
         Self {
-            log,
+            backend,
             config,
             metrics_handle,
         }
@@ -41,28 +44,37 @@ impl LogServer {
     pub async fn run(self) {
         let metrics = Arc::new(Metrics::with_metrics_rs_handle(Some(self.metrics_handle)));
 
+        let read_only = matches!(self.backend, LogBackend::ReadOnly(_));
+
         // Create app state
         let state = AppState {
-            log: self.log,
+            log: self.backend,
             metrics: metrics.clone(),
         };
 
-        // Build router with routes and middleware
-        let app = Router::new()
-            .route("/api/v1/log/append", post(handle_append))
+        // Build router with read routes shared by both modes.
+        let mut app = Router::new()
             .route("/api/v1/log/scan", get(handle_scan))
             .route("/api/v1/log/keys", get(handle_list_keys))
             .route("/api/v1/log/segments", get(handle_list_segments))
             .route("/api/v1/log/count", get(handle_count))
             .route("/metrics", get(handle_metrics))
             .route("/-/healthy", get(handle_healthy))
-            .route("/-/ready", get(handle_ready))
+            .route("/-/ready", get(handle_ready));
+
+        // The append route exists only when the server fronts a writable log.
+        if !read_only {
+            app = app.route("/api/v1/log/append", post(handle_append));
+        }
+
+        let app = app
             .layer(TracingLayer::new())
             .layer(MetricsLayer::new(metrics))
             .with_state(state);
 
         let addr = SocketAddr::from(([0, 0, 0, 0], self.config.port));
-        tracing::info!("Starting Log HTTP server on {}", addr);
+        let mode = if read_only { "read-only" } else { "read-write" };
+        tracing::info!("Starting Log HTTP server on {} ({} mode)", addr, mode);
 
         let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
         axum::serve(listener, app)

--- a/log/src/server/http.rs
+++ b/log/src/server/http.rs
@@ -14,6 +14,7 @@ use super::handlers::{
 };
 use super::metrics::Metrics;
 use super::middleware::{MetricsLayer, TracingLayer};
+use crate::{LogDb, LogDbReader};
 
 /// HTTP server for the log service.
 pub struct LogServer {
@@ -23,58 +24,56 @@ pub struct LogServer {
 }
 
 impl LogServer {
-    /// Create a new log server.
+    /// Create a read-write log server fronting a full [`LogDb`].
     ///
-    /// Pass a [`LogBackend::ReadWrite`] for a full log service, or a
-    /// [`LogBackend::ReadOnly`] for a read-only gateway. In read-only mode the
-    /// append route is not registered.
+    /// Every route is served, including `POST /api/v1/log/append`.
     pub fn new(
-        backend: LogBackend,
+        log: Arc<LogDb>,
         config: LogServerConfig,
         metrics_handle: metrics_exporter_prometheus::PrometheusHandle,
     ) -> Self {
         Self {
-            backend,
+            backend: LogBackend::ReadWrite(log),
             config,
             metrics_handle,
         }
     }
 
+    /// Create a read-only gateway fronting a [`LogDbReader`].
+    ///
+    /// Only the read routes (scan, keys, segments, count), `/metrics`, and the
+    /// health probes are served; the append route is not registered, so writes
+    /// receive a 404.
+    pub fn new_read_only(
+        reader: Arc<LogDbReader>,
+        config: LogServerConfig,
+        metrics_handle: metrics_exporter_prometheus::PrometheusHandle,
+    ) -> Self {
+        Self {
+            backend: LogBackend::ReadOnly(reader),
+            config,
+            metrics_handle,
+        }
+    }
+
+    /// Consumes the server and builds its axum [`Router`] without binding a
+    /// socket.
+    ///
+    /// [`run`](Self::run) uses this internally; it is also the seam for tests
+    /// and embedders that want to drive or mount the routes directly.
+    pub fn into_router(self) -> Router {
+        let metrics = Arc::new(Metrics::with_metrics_rs_handle(Some(self.metrics_handle)));
+        build_router(self.backend, metrics)
+    }
+
     /// Run the HTTP server.
     pub async fn run(self) {
-        let metrics = Arc::new(Metrics::with_metrics_rs_handle(Some(self.metrics_handle)));
-
-        let read_only = matches!(self.backend, LogBackend::ReadOnly(_));
-
-        // Create app state
-        let state = AppState {
-            log: self.backend,
-            metrics: metrics.clone(),
-        };
-
-        // Build router with read routes shared by both modes.
-        let mut app = Router::new()
-            .route("/api/v1/log/scan", get(handle_scan))
-            .route("/api/v1/log/keys", get(handle_list_keys))
-            .route("/api/v1/log/segments", get(handle_list_segments))
-            .route("/api/v1/log/count", get(handle_count))
-            .route("/metrics", get(handle_metrics))
-            .route("/-/healthy", get(handle_healthy))
-            .route("/-/ready", get(handle_ready));
-
-        // The append route exists only when the server fronts a writable log.
-        if !read_only {
-            app = app.route("/api/v1/log/append", post(handle_append));
-        }
-
-        let app = app
-            .layer(TracingLayer::new())
-            .layer(MetricsLayer::new(metrics))
-            .with_state(state);
-
         let addr = SocketAddr::from(([0, 0, 0, 0], self.config.port));
+        let read_only = matches!(self.backend, LogBackend::ReadOnly(_));
         let mode = if read_only { "read-only" } else { "read-write" };
         tracing::info!("Starting Log HTTP server on {} ({} mode)", addr, mode);
+
+        let app = self.into_router();
 
         let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
         axum::serve(listener, app)
@@ -84,6 +83,40 @@ impl LogServer {
 
         tracing::info!("Server shut down gracefully");
     }
+}
+
+/// Builds the axum router for the given backend and metrics.
+///
+/// The read routes (scan, keys, segments, count), `/metrics`, and the health
+/// probes are always registered. The append route is registered only for a
+/// [`LogBackend::ReadWrite`] backend, so a read-only gateway responds with 404
+/// to writes.
+fn build_router(backend: LogBackend, metrics: Arc<Metrics>) -> Router {
+    let read_only = matches!(backend, LogBackend::ReadOnly(_));
+
+    let state = AppState {
+        log: backend,
+        metrics: metrics.clone(),
+    };
+
+    // Read routes shared by both modes.
+    let mut app = Router::new()
+        .route("/api/v1/log/scan", get(handle_scan))
+        .route("/api/v1/log/keys", get(handle_list_keys))
+        .route("/api/v1/log/segments", get(handle_list_segments))
+        .route("/api/v1/log/count", get(handle_count))
+        .route("/metrics", get(handle_metrics))
+        .route("/-/healthy", get(handle_healthy))
+        .route("/-/ready", get(handle_ready));
+
+    // The append route exists only when the server fronts a writable log.
+    if !read_only {
+        app = app.route("/api/v1/log/append", post(handle_append));
+    }
+
+    app.layer(TracingLayer::new())
+        .layer(MetricsLayer::new(metrics))
+        .with_state(state)
 }
 
 /// Listen for SIGTERM (K8s pod termination) and SIGINT (Ctrl+C).

--- a/log/src/server/mod.rs
+++ b/log/src/server/mod.rs
@@ -5,7 +5,7 @@
 
 mod config;
 mod error;
-pub mod handlers;
+pub(crate) mod handlers;
 mod http;
 pub mod metrics;
 mod middleware;
@@ -14,5 +14,4 @@ mod request;
 mod response;
 
 pub use config::{CliArgs, LogServerConfig};
-pub use handlers::LogBackend;
 pub use http::LogServer;

--- a/log/src/server/mod.rs
+++ b/log/src/server/mod.rs
@@ -14,4 +14,5 @@ mod request;
 mod response;
 
 pub use config::{CliArgs, LogServerConfig};
+pub use handlers::LogBackend;
 pub use http::LogServer;

--- a/log/tests/http_api_formats.rs
+++ b/log/tests/http_api_formats.rs
@@ -15,7 +15,8 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 use bytes::Bytes;
 use common::StorageConfig;
 use log::server::handlers::{
-    AppState, handle_append, handle_list_keys, handle_list_segments, handle_metrics, handle_scan,
+    AppState, LogBackend, handle_append, handle_list_keys, handle_list_segments, handle_metrics,
+    handle_scan,
 };
 use log::server::metrics::Metrics;
 use log::server::proto;
@@ -32,7 +33,7 @@ async fn setup_test_app() -> (Router, Arc<LogDb>) {
     let metrics = Arc::new(Metrics::new());
 
     let state = AppState {
-        log: log.clone(),
+        log: LogBackend::ReadWrite(log.clone()),
         metrics,
     };
 
@@ -872,7 +873,7 @@ async fn setup_slatedb_test_app() -> Router {
     let metrics = Arc::new(Metrics::with_metrics_rs_handle(Some(handle)));
 
     let state = AppState {
-        log: log.clone(),
+        log: LogBackend::ReadWrite(log.clone()),
         metrics,
     };
 

--- a/log/tests/http_api_formats.rs
+++ b/log/tests/http_api_formats.rs
@@ -10,17 +10,13 @@ use std::time::Duration;
 use axum::Router;
 use axum::body::Body;
 use axum::http::{Request, StatusCode, header};
-use axum::routing::{get, post};
 use base64::{Engine, engine::general_purpose::STANDARD};
 use bytes::Bytes;
 use common::StorageConfig;
-use log::server::handlers::{
-    AppState, LogBackend, handle_append, handle_list_keys, handle_list_segments, handle_metrics,
-    handle_scan,
-};
-use log::server::metrics::Metrics;
 use log::server::proto;
+use log::server::{LogServer, LogServerConfig};
 use log::{Config, LogDb, Record};
+use metrics_exporter_prometheus::PrometheusBuilder;
 use prost::Message;
 use tower::ServiceExt;
 
@@ -30,19 +26,11 @@ async fn setup_test_app() -> (Router, Arc<LogDb>) {
         ..Default::default()
     };
     let log = Arc::new(LogDb::open(config).await.expect("Failed to open log"));
-    let metrics = Arc::new(Metrics::new());
 
-    let state = AppState {
-        log: LogBackend::ReadWrite(log.clone()),
-        metrics,
-    };
-
-    let app = Router::new()
-        .route("/api/v1/log/append", post(handle_append))
-        .route("/api/v1/log/scan", get(handle_scan))
-        .route("/api/v1/log/keys", get(handle_list_keys))
-        .route("/api/v1/log/segments", get(handle_list_segments))
-        .with_state(state);
+    // Drive the real server router rather than a hand-built route table, so
+    // these tests track the routes the server actually serves.
+    let metrics_handle = PrometheusBuilder::new().build_recorder().handle();
+    let app = LogServer::new(log.clone(), LogServerConfig::default(), metrics_handle).into_router();
 
     (app, log)
 }
@@ -870,18 +858,8 @@ async fn setup_slatedb_test_app() -> Router {
 
     let handle = global_prometheus_handle();
     let log = Arc::new(LogDb::open(config).await.expect("Failed to open log"));
-    let metrics = Arc::new(Metrics::with_metrics_rs_handle(Some(handle)));
 
-    let state = AppState {
-        log: LogBackend::ReadWrite(log.clone()),
-        metrics,
-    };
-
-    Router::new()
-        .route("/api/v1/log/append", post(handle_append))
-        .route("/api/v1/log/scan", get(handle_scan))
-        .route("/metrics", get(handle_metrics))
-        .with_state(state)
+    LogServer::new(log, LogServerConfig::default(), handle).into_router()
 }
 
 #[tokio::test]

--- a/log/tests/http_readonly_gateway.rs
+++ b/log/tests/http_readonly_gateway.rs
@@ -1,0 +1,244 @@
+#![cfg(feature = "http-server")]
+//! Integration tests for the read-only HTTP gateway.
+//!
+//! These drive the real router built by [`log::server::LogServer::into_router`]
+//! (the same one the server serves) so the read-only wiring is exercised end to
+//! end: a reader-backed gateway serves reads, the append route is absent (404),
+//! and readiness flows through `LogDbReader`. A read-write counterpart pins the
+//! append route from the other side.
+
+use std::future::Future;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use bytes::Bytes;
+use common::StorageConfig;
+use common::storage::config::{LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig};
+use log::server::{LogServer, LogServerConfig};
+use log::{Config, LogDb, LogDbReader, LogRead, ReaderConfig, Record};
+use metrics_exporter_prometheus::{PrometheusBuilder, PrometheusHandle};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+/// A throwaway Prometheus handle for building a server in tests; the recorder
+/// is not installed globally, so metric increments are no-ops.
+fn test_metrics_handle() -> PrometheusHandle {
+    PrometheusBuilder::new().build_recorder().handle()
+}
+
+fn local_storage_config(dir: &TempDir) -> StorageConfig {
+    StorageConfig::SlateDb(SlateDbStorageConfig {
+        path: "log-data".to_string(),
+        object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
+            path: dir.path().to_string_lossy().to_string(),
+        }),
+        settings_path: None,
+        block_cache: None,
+        meta_cache: None,
+    })
+}
+
+async fn wait_until<F, Fut>(timeout: Duration, interval: Duration, mut predicate: F)
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let deadline = Instant::now() + timeout;
+    loop {
+        if predicate().await {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "condition was not satisfied within {:?}",
+            timeout
+        );
+        tokio::time::sleep(interval).await;
+    }
+}
+
+/// Persists two records to "events" with a writer, then returns a read-only
+/// gateway router backed by a `LogDbReader` that has discovered them. The
+/// `TempDir` and writer are returned so the caller keeps the backing storage
+/// alive for the duration of the test.
+async fn setup_readonly_gateway() -> (Router, TempDir, Arc<LogDb>) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let storage = local_storage_config(&temp_dir);
+
+    let writer = LogDb::open(Config {
+        storage: storage.clone(),
+        ..Default::default()
+    })
+    .await
+    .expect("Failed to open writer");
+    writer
+        .try_append(vec![
+            Record {
+                key: Bytes::from("events"),
+                value: Bytes::from("event-1"),
+            },
+            Record {
+                key: Bytes::from("events"),
+                value: Bytes::from("event-2"),
+            },
+        ])
+        .await
+        .expect("Failed to append");
+    writer.flush().await.expect("Failed to flush");
+    let writer = Arc::new(writer);
+
+    let reader = LogDbReader::open(ReaderConfig {
+        storage,
+        refresh_interval: Duration::from_millis(50),
+    })
+    .await
+    .expect("Failed to open reader");
+
+    // Wait for the reader's background refresh to discover the flushed data
+    // before fronting it with the gateway.
+    wait_until(
+        Duration::from_secs(5),
+        Duration::from_millis(50),
+        || async { reader.count(Bytes::from("events"), ..).await.unwrap_or(0) == 2 },
+    )
+    .await;
+
+    let app = LogServer::new_read_only(
+        Arc::new(reader),
+        LogServerConfig::default(),
+        test_metrics_handle(),
+    )
+    .into_router();
+    (app, temp_dir, writer)
+}
+
+#[tokio::test]
+async fn read_only_gateway_serves_scans() {
+    let (app, _temp_dir, _writer) = setup_readonly_gateway().await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/v1/log/scan?key=events")
+        .header(header::ACCEPT, "application/protobuf+json")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["status"], "success");
+    let values = json["values"].as_array().unwrap();
+    assert_eq!(values.len(), 2);
+
+    let value0 = STANDARD
+        .decode(values[0]["value"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(value0, b"event-1");
+    let value1 = STANDARD
+        .decode(values[1]["value"].as_str().unwrap())
+        .unwrap();
+    assert_eq!(value1, b"event-2");
+}
+
+#[tokio::test]
+async fn read_only_gateway_serves_count() {
+    let (app, _temp_dir, _writer) = setup_readonly_gateway().await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/api/v1/log/count?key=events")
+        .header(header::ACCEPT, "application/protobuf+json")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["count"], 2);
+}
+
+#[tokio::test]
+async fn read_only_gateway_rejects_append_with_404() {
+    let (app, _temp_dir, _writer) = setup_readonly_gateway().await;
+
+    let key_b64 = STANDARD.encode("events");
+    let value_b64 = STANDARD.encode("should-not-write");
+    let body = format!(
+        r#"{{"records": [{{"key": "{}", "value": "{}"}}], "awaitDurable": false}}"#,
+        key_b64, value_b64
+    );
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/log/append")
+        .header(header::CONTENT_TYPE, "application/protobuf+json")
+        .body(Body::from(body))
+        .unwrap();
+
+    // The append route is not registered in read-only mode, so axum has no
+    // match and returns 404 rather than reaching the handler.
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn read_only_gateway_reports_ready() {
+    let (app, _temp_dir, _writer) = setup_readonly_gateway().await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/-/ready")
+        .body(Body::empty())
+        .unwrap();
+
+    // Readiness flows through LogDbReader::check_storage.
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn read_write_gateway_accepts_append() {
+    // Counterpart to the read-only 404 test: the same router builder registers
+    // the append route for a read-write backend, so the write succeeds.
+    let log = Arc::new(
+        LogDb::open(Config {
+            storage: StorageConfig::InMemory,
+            ..Default::default()
+        })
+        .await
+        .expect("Failed to open log"),
+    );
+    let app = LogServer::new(log, LogServerConfig::default(), test_metrics_handle()).into_router();
+
+    let key_b64 = STANDARD.encode("events");
+    let value_b64 = STANDARD.encode("event-1");
+    let body = format!(
+        r#"{{"records": [{{"key": "{}", "value": "{}"}}], "awaitDurable": false}}"#,
+        key_b64, value_b64
+    );
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/log/append")
+        .header(header::CONTENT_TYPE, "application/protobuf+json")
+        .body(Body::from(body))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}


### PR DESCRIPTION
We have an HTTP service today, but it only uses the embedded reader/writer. Easy win to give it a read-only option. No cross-az charges when the writer is not in the same zone. Also did some minor api visibility fixes: `LogService` remains public, but `AppState` is now crate-visible.