### PR TITLE
Upgrade to slatedb 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -629,6 +629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +755,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +879,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +997,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1118,15 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1252,8 +1310,18 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1757,9 +1825,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1950,6 +2030,15 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -2293,10 +2382,68 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.17",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2310,11 +2457,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -2394,9 +2542,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.178"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2593,12 +2741,12 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2774,6 +2922,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,28 +3096,33 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
+checksum = "765784b4390c6bcf80316e5a22f4e3661b639c9d8c83246856643c27d8ce9dbe"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "base64 0.22.1",
  "bytes",
  "chrono",
+ "crc-fast",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body-util",
  "humantime",
  "hyper",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "md-5",
+ "nix",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.2",
- "reqwest",
- "ring",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2968,6 +3133,7 @@ dependencies = [
  "walkdir",
  "wasm-bindgen-futures",
  "web-time",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3064,7 +3230,7 @@ dependencies = [
  "prometheus-client",
  "proptest",
  "prost",
- "reqwest",
+ "reqwest 0.12.25",
  "serde",
  "serde_json",
  "serde_with",
@@ -3134,7 +3300,7 @@ dependencies = [
  "prost",
  "regex",
  "regex-syntax",
- "reqwest",
+ "reqwest 0.12.25",
  "roaring 0.7.0",
  "rstest",
  "rust-embed",
@@ -3184,7 +3350,7 @@ dependencies = [
  "prost",
  "rand 0.8.5",
  "rayon",
- "reqwest",
+ "reqwest 0.12.25",
  "roaring 0.10.12",
  "rstest",
  "serde",
@@ -3687,9 +3853,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -3721,6 +3887,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -3766,6 +3933,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radix_trie"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3794,6 +3967,17 @@ checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3833,6 +4017,12 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_xorshift"
@@ -3954,6 +4144,44 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
  "futures-util",
  "h2",
  "http",
@@ -3968,11 +4196,8 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
  "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
+ "rustls-platform-verifier",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3985,7 +4210,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4189,6 +4413,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4454,8 +4705,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -4489,6 +4740,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4514,9 +4775,9 @@ checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slatedb"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "286ec5657d17f3ba70c060becd57a5550ad43973b8480811ad27d3fa4d620a49"
+checksum = "d01d14107ae93175aff71ab4174a09da323cc95c4cddd7ee253ae1649211d3d9"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -4537,19 +4798,17 @@ dependencies = [
  "log",
  "lru",
  "object_store",
- "once_cell",
  "ouroboros",
  "parking_lot",
  "rand 0.9.2",
- "rand_xoshiro",
  "serde",
  "serde_json",
  "siphasher",
  "slatedb-common",
  "slatedb-txn-obj",
+ "smallvec",
  "sysinfo 0.35.2",
  "thiserror 1.0.69",
- "thread_local",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4561,21 +4820,25 @@ dependencies = [
 
 [[package]]
 name = "slatedb-common"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9caca0e37a5bc4c65c61143cdd9674faa6b9f69f76a02e1edc94d8e2a6da414a"
+checksum = "d7696aae130a0a617ec44e7c9e731d6f5408f58d949a91ba5082fcab84a896be"
 dependencies = [
  "chrono",
  "log",
+ "object_store",
+ "rand 0.9.2",
+ "rand_xoshiro",
  "serde",
+ "thread_local",
  "tokio",
 ]
 
 [[package]]
 name = "slatedb-txn-obj"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9bd80ee7b7f7da1fd4ada17fcf6ee564e76af71254e8189e68bf497856557aa"
+checksum = "1a5748b15b53b41beac51663a6b05168ac2af1a7abcada92b7720a483beddd30"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4583,6 +4846,7 @@ dependencies = [
  "futures",
  "log",
  "object_store",
+ "parking_lot",
  "slatedb-common",
  "thiserror 1.0.69",
 ]
@@ -4626,6 +4890,12 @@ dependencies = [
  "serde",
  "vob",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "stable_deref_trait"
@@ -5215,9 +5485,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -5436,9 +5706,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5449,22 +5719,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
 dependencies = [
- "cfg-if",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5472,9 +5739,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5485,18 +5752,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -5507,9 +5774,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5523,6 +5790,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,8 @@ serde_json = "1.0"
 serde_with = { version = "3", features = ["base64"] }
 serde_yaml = "0.9"
 foyer = "0.22"
-slatedb = { version = "0.13.0", features = ["compaction_filters"] }
-slatedb-common = "0.13.0"
+slatedb = { version = "0.14.0", features = ["compaction_filters"] }
+slatedb-common = "0.14.0"
 thiserror = "2.0"
 tokio = { version = "1.0", features = ["full", "test-util"] }
 tokio-util = "0.7"

--- a/buffer/src/consumer.rs
+++ b/buffer/src/consumer.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
-use slatedb::object_store::ObjectStore;
 use slatedb::object_store::path::Path;
+use slatedb::object_store::{ObjectStore, ObjectStoreExt};
 use tokio_util::sync::CancellationToken;
 
 use crate::config::ConsumerConfig;

--- a/buffer/src/gc.rs
+++ b/buffer/src/gc.rs
@@ -93,7 +93,7 @@ impl GarbageCollector {
         let mut failed: u64 = 0;
         if !to_delete.is_empty() {
             tracing::debug!(count = to_delete.len(), "GC deleting orphaned batch files");
-            let locations = stream::iter(to_delete.iter().cloned().map(Ok));
+            let locations = stream::iter(to_delete.into_iter().map(Ok));
             let mut results = self.object_store.delete_stream(locations.boxed());
             while let Some(result) = results.next().await {
                 match result {
@@ -169,8 +169,8 @@ mod tests {
     use crate::queue::QueueProducer;
     use bytes::Bytes;
     use common::ObjectStoreConfig;
-    use slatedb::object_store::PutPayload;
     use slatedb::object_store::memory::InMemory;
+    use slatedb::object_store::{ObjectStoreExt, PutPayload};
     use std::time::Duration;
 
     const TEST_MANIFEST_PATH: &str = "test/manifest";

--- a/buffer/src/producer.rs
+++ b/buffer/src/producer.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, Instant, SystemTime};
 use bytes::Bytes;
 use common::clock::Clock;
 use slatedb::object_store::path::Path;
-use slatedb::object_store::{ObjectStore, PutPayload};
+use slatedb::object_store::{ObjectStore, ObjectStoreExt, PutPayload};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
@@ -421,8 +421,8 @@ mod tests {
     use bytes::Bytes;
     use common::ObjectStoreConfig;
     use common::clock::{MockClock, SystemClock};
-    use slatedb::object_store::ObjectStore;
     use slatedb::object_store::memory::InMemory;
+    use slatedb::object_store::{ObjectStore, ObjectStoreExt};
     use std::time::UNIX_EPOCH;
 
     async fn read_manifest_entries(store: &Arc<dyn ObjectStore>, path: &str) -> Vec<QueueEntry> {

--- a/buffer/src/queue.rs
+++ b/buffer/src/queue.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use bytes::{BufMut, Bytes, BytesMut};
 use slatedb::object_store::path::Path;
 use slatedb::object_store::{
-    Error as ObjectStoreError, ObjectStore, PutMode, PutPayload, UpdateVersion,
+    Error as ObjectStoreError, ObjectStore, ObjectStoreExt, PutMode, PutPayload, UpdateVersion,
 };
 
 use crate::error::{Error, Result};

--- a/common/src/bytes.rs
+++ b/common/src/bytes.rs
@@ -95,6 +95,43 @@ impl BytesRange {
             end: Unbounded,
         }
     }
+
+    /// Builds the absolute key range for a prefix scan narrowed to `subrange`.
+    ///
+    /// `subrange` bounds are key *suffixes* interpreted relative to `prefix`: a
+    /// bound `s` selects the full key `prefix ++ s`. An unbounded subrange end
+    /// falls back to the prefix's natural upper bound (its lexicographic
+    /// successor), so `from_prefix_and_subrange(p, &BytesRange::unbounded())`
+    /// equals [`Self::prefix`].
+    ///
+    /// This mirrors SlateDB's own `scan_prefix` subrange semantics so the
+    /// in-memory fallback in [`StorageRead::scan_prefix_iter`] agrees with the
+    /// SlateDB path byte-for-byte.
+    ///
+    /// [`StorageRead::scan_prefix_iter`]: crate::storage::StorageRead::scan_prefix_iter
+    pub fn from_prefix_and_subrange(prefix: &[u8], subrange: &BytesRange) -> Self {
+        let concat = |suffix: &Bytes| -> Bytes {
+            let mut key = BytesMut::with_capacity(prefix.len() + suffix.len());
+            key.extend_from_slice(prefix);
+            key.extend_from_slice(suffix);
+            key.freeze()
+        };
+        let start = match &subrange.start {
+            Included(s) => Included(concat(s)),
+            Excluded(s) => Excluded(concat(s)),
+            Unbounded if prefix.is_empty() => Unbounded,
+            Unbounded => Included(Bytes::copy_from_slice(prefix)),
+        };
+        let end = match &subrange.end {
+            Included(e) => Included(concat(e)),
+            Excluded(e) => Excluded(concat(e)),
+            Unbounded => match lex_increment(prefix) {
+                Some(successor) => Excluded(successor),
+                None => Unbounded,
+            },
+        };
+        Self { start, end }
+    }
 }
 
 impl RangeBounds<Bytes> for BytesRange {
@@ -103,6 +140,17 @@ impl RangeBounds<Bytes> for BytesRange {
     }
     fn end_bound(&self) -> Bound<&Bytes> {
         self.end.as_ref()
+    }
+}
+
+/// SlateDB 0.14 scans are bounded by its own [`ByteRangeBounds`] trait rather
+/// than `std::ops::RangeBounds`, so we map our bounds onto byte slices.
+impl slatedb::ByteRangeBounds for BytesRange {
+    fn start_bound(&self) -> Bound<&[u8]> {
+        self.start.as_ref().map(Bytes::as_ref)
+    }
+    fn end_bound(&self) -> Bound<&[u8]> {
+        self.end.as_ref().map(Bytes::as_ref)
     }
 }
 

--- a/common/src/bytes.rs
+++ b/common/src/bytes.rs
@@ -143,8 +143,8 @@ impl RangeBounds<Bytes> for BytesRange {
     }
 }
 
-/// SlateDB 0.14 scans are bounded by its own [`ByteRangeBounds`] trait rather
-/// than `std::ops::RangeBounds`, so we map our bounds onto byte slices.
+/// SlateDB 0.14 scans are bounded by its own [`slatedb::ByteRangeBounds`] trait
+/// rather than `std::ops::RangeBounds`, so we map our bounds onto byte slices.
 impl slatedb::ByteRangeBounds for BytesRange {
     fn start_bound(&self) -> Bound<&[u8]> {
         self.start.as_ref().map(Bytes::as_ref)

--- a/common/src/storage/factory.rs
+++ b/common/src/storage/factory.rs
@@ -17,7 +17,7 @@ pub use slatedb::db_cache::foyer_hybrid::FoyerHybridCache;
 pub use slatedb::db_cache::{CachedEntry, CachedKey, SplitCache};
 use slatedb::object_store::{self, ObjectStore};
 pub use slatedb::{CompactorBuilder, DbBuilder};
-use slatedb::{DbReader, FilterPolicy, SstReader};
+use slatedb::{DbReader, FilterPolicy, PrefixExtractor, SstReader};
 use tracing::info;
 use uuid::Uuid;
 
@@ -161,6 +161,9 @@ impl StorageBuilder {
                 if let Some(policies) = self.semantics.filter_policies {
                     db_builder = db_builder.with_filter_policies(policies);
                 }
+                if let Some(extractor) = self.semantics.segment_extractor {
+                    db_builder = db_builder.with_segment_extractor(extractor);
+                }
                 let db = db_builder.build().await.map_err(|e| {
                     StorageError::Storage(format!("Failed to create SlateDB: {}", e))
                 })?;
@@ -250,6 +253,7 @@ impl StorageReaderRuntime {
 pub struct StorageSemantics {
     pub(crate) merge_operator: Option<Arc<dyn MergeOperator>>,
     pub(crate) filter_policies: Option<Vec<Arc<dyn FilterPolicy>>>,
+    pub(crate) segment_extractor: Option<Arc<dyn PrefixExtractor>>,
 }
 
 impl StorageSemantics {
@@ -273,6 +277,17 @@ impl StorageSemantics {
     /// reader paths aligned on SST filter encoding/decoding behavior.
     pub fn with_filter_policies(mut self, policies: Vec<Arc<dyn FilterPolicy>>) -> Self {
         self.filter_policies = Some(policies);
+        self
+    }
+
+    /// Sets the segment extractor (SlateDB RFC-0024) for writers and readers.
+    ///
+    /// SlateDB 0.14 persists the extractor's name in the manifest and refuses
+    /// to open a writer or `DbReader` whose configured extractor doesn't match.
+    /// Routing this through semantics keeps the writer, compactor, and
+    /// standalone reader paths aligned on a single extractor.
+    pub fn with_segment_extractor(mut self, extractor: Arc<dyn PrefixExtractor>) -> Self {
+        self.segment_extractor = Some(extractor);
         self
     }
 }
@@ -402,6 +417,9 @@ pub async fn create_storage_read(
             }
             if let Some(policies) = semantics.filter_policies {
                 builder = builder.with_filter_policies(policies);
+            }
+            if let Some(extractor) = semantics.segment_extractor {
+                builder = builder.with_segment_extractor(extractor);
             }
             if let Some(cache) = cache.clone() {
                 builder = builder.with_db_cache(cache);

--- a/common/src/storage/mod.rs
+++ b/common/src/storage/mod.rs
@@ -243,7 +243,14 @@ pub trait StorageRead: Any + Send + Sync {
         range: BytesRange,
     ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>>;
 
-    /// Returns an iterator over records whose key starts with `prefix`.
+    /// Returns an iterator over records whose key starts with `prefix`,
+    /// restricted to `subrange`.
+    ///
+    /// `subrange` bounds are key *suffixes* interpreted relative to `prefix`: a
+    /// bound `s` selects the full key `prefix ++ s`. Pass
+    /// [`BytesRange::unbounded`] to scan the prefix's entire keyspace. Callers
+    /// with a known sub-key ordering (e.g. the log's trailing sequence bytes)
+    /// use this to bound the scan natively instead of filtering client-side.
     ///
     /// Backends that support prefix-aware SST filters (e.g. SlateDB with a
     /// configured `PrefixExtractor` or custom `FilterPolicy`) consult those
@@ -258,14 +265,17 @@ pub trait StorageRead: Any + Send + Sync {
     /// [`slatedb::FilterContext`].
     ///
     /// The default implementation delegates to [`Self::scan_iter`] with the
-    /// range derived from the prefix, which preserves correctness for any
-    /// backend; backends that can do better should override this.
+    /// absolute range derived from `prefix` and `subrange`, which preserves
+    /// correctness for any backend; backends that can do better should override
+    /// this.
     async fn scan_prefix_iter(
         &self,
         prefix: Bytes,
+        subrange: BytesRange,
         _filter_context: Option<FilterContext>,
     ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>> {
-        self.scan_iter(BytesRange::prefix(prefix)).await
+        self.scan_iter(BytesRange::from_prefix_and_subrange(&prefix, &subrange))
+            .await
     }
 
     /// Collects all records in the range into a Vec.

--- a/common/src/storage/slate.rs
+++ b/common/src/storage/slate.rs
@@ -242,12 +242,13 @@ impl StorageRead for SlateDbStorage {
     async fn scan_prefix_iter(
         &self,
         prefix: Bytes,
+        subrange: BytesRange,
         filter_context: Option<FilterContext>,
     ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>> {
         let options = default_scan_options().with_filter_context(filter_context);
         let iter = self
             .db
-            .scan_prefix_with_options(prefix, &options)
+            .scan_prefix_with_options(prefix, subrange, &options)
             .await
             .map_err(StorageError::from_storage)?;
         Ok(Box::new(SlateDbIterator { iter }))
@@ -326,12 +327,13 @@ impl StorageRead for SlateDbStorageSnapshot {
     async fn scan_prefix_iter(
         &self,
         prefix: Bytes,
+        subrange: BytesRange,
         filter_context: Option<FilterContext>,
     ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>> {
         let options = default_scan_options().with_filter_context(filter_context);
         let iter = self
             .snapshot
-            .scan_prefix_with_options(prefix, &options)
+            .scan_prefix_with_options(prefix, subrange, &options)
             .await
             .map_err(StorageError::from_storage)?;
         Ok(Box::new(SlateDbIterator { iter }))
@@ -549,12 +551,13 @@ impl StorageRead for SlateDbStorageReader {
     async fn scan_prefix_iter(
         &self,
         prefix: Bytes,
+        subrange: BytesRange,
         filter_context: Option<FilterContext>,
     ) -> StorageResult<Box<dyn StorageIterator + Send + 'static>> {
         let options = default_scan_options().with_filter_context(filter_context);
         let iter = self
             .reader
-            .scan_prefix_with_options(prefix, &options)
+            .scan_prefix_with_options(prefix, subrange, &options)
             .await
             .map_err(StorageError::from_storage)?;
         Ok(Box::new(SlateDbIterator { iter }))

--- a/common/src/storage/util.rs
+++ b/common/src/storage/util.rs
@@ -4,7 +4,7 @@
 //! such as deleting data from object stores after benchmarks or tests.
 
 use futures::StreamExt;
-use slatedb::object_store::{ObjectStore, path::Path};
+use slatedb::object_store::{ObjectStore, ObjectStoreExt, path::Path};
 
 use super::config::{SlateDbStorageConfig, StorageConfig};
 use super::factory::create_object_store;

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -567,28 +567,33 @@ impl LogDbBuilder {
     pub async fn build(self) -> Result<LogDb> {
         self.config.validate_retention()?;
         self.config.validate_compaction()?;
-        let sb = StorageBuilder::new(&self.config.storage)
-            .await
-            .map_err(|e| Error::Storage(e.to_string()))?
-            .with_semantics(
-                StorageSemantics::new()
-                    .with_filter_policies(crate::filter_sequence::filter_policies()),
-            );
-        // Route every log record to a SlateDB segment keyed by the 6-byte
-        // routing prefix `[subsystem, version, segment_id]`. No-op for the
-        // in-memory backend; for slatedb-backed storage this installs the
-        // extractor on the underlying `DbBuilder` (see RFC 0024).
-        //
-        // The filter policies are an orthogonal slatedb axis (see RFC 0007):
-        // the `LogKeyPrefixExtractor` bloom hashes the logical `(segment,
-        // user_key)` prefix into per-SST bloom filters to prune SSTs that
-        // cannot contain the key (`whole_key_filtering=false` — the extracted
-        // prefix discriminates everything we probe), and the sequence-range
-        // filter prunes SSTs whose records for the key all sit below a scan's
-        // resume cursor. Writer, compactor, and reader must share the same set.
-        let sb = sb.map_slatedb(|db| {
-            db.with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared())
-        });
+        let sb =
+            StorageBuilder::new(&self.config.storage)
+                .await
+                .map_err(|e| Error::Storage(e.to_string()))?
+                .with_semantics(
+                    // Route every log record to a SlateDB segment keyed by the
+                    // 6-byte routing prefix `[subsystem, version, segment_id]`. No-op
+                    // for the in-memory backend; for slatedb-backed storage this
+                    // installs the extractor on both the writer's `DbBuilder` and any
+                    // standalone `DbReader` (see RFC 0024). SlateDB 0.14 persists the
+                    // extractor name and rejects a reader that doesn't match.
+                    //
+                    // The filter policies are an orthogonal slatedb axis (see RFC
+                    // 0007): the `LogKeyPrefixExtractor` bloom hashes the logical
+                    // `(segment, user_key)` prefix into per-SST bloom filters to
+                    // prune SSTs that cannot contain the key
+                    // (`whole_key_filtering=false` — the extracted prefix
+                    // discriminates everything we probe), and the sequence-range
+                    // filter prunes SSTs whose records for the key all sit below a
+                    // scan's resume cursor. Writer, compactor, and reader must share
+                    // the same set.
+                    StorageSemantics::new()
+                        .with_filter_policies(crate::filter_sequence::filter_policies())
+                        .with_segment_extractor(
+                            crate::segment_extractor::LogSegmentExtractor::shared(),
+                        ),
+                );
         // Install the LogDb compaction scheduler for every SlateDB-backed log.
         let compactor_view_cell: CompactorViewCell =
             Arc::new(ArcSwap::from_pointee(CompactorView {

--- a/log/src/log.rs
+++ b/log/src/log.rs
@@ -572,22 +572,24 @@ impl LogDbBuilder {
                 .await
                 .map_err(|e| Error::Storage(e.to_string()))?
                 .with_semantics(
-                    // Route every log record to a SlateDB segment keyed by the
-                    // 6-byte routing prefix `[subsystem, version, segment_id]`. No-op
-                    // for the in-memory backend; for slatedb-backed storage this
-                    // installs the extractor on both the writer's `DbBuilder` and any
-                    // standalone `DbReader` (see RFC 0024). SlateDB 0.14 persists the
-                    // extractor name and rejects a reader that doesn't match.
+                    // Two orthogonal SlateDB axes, both of which the writer,
+                    // compactor, and reader must configure identically:
                     //
-                    // The filter policies are an orthogonal slatedb axis (see RFC
-                    // 0007): the `LogKeyPrefixExtractor` bloom hashes the logical
-                    // `(segment, user_key)` prefix into per-SST bloom filters to
-                    // prune SSTs that cannot contain the key
-                    // (`whole_key_filtering=false` — the extracted prefix
-                    // discriminates everything we probe), and the sequence-range
-                    // filter prunes SSTs whose records for the key all sit below a
-                    // scan's resume cursor. Writer, compactor, and reader must share
-                    // the same set.
+                    // 1. Segment extractor (RFC 0024): routes every log record to a
+                    //    SlateDB segment keyed by the 6-byte routing prefix
+                    //    `[subsystem, version, segment_id]`. No-op for the in-memory
+                    //    backend; for slatedb-backed storage it installs on both the
+                    //    writer's `DbBuilder` and any standalone `DbReader`. SlateDB
+                    //    0.14 persists the extractor name and rejects a reader whose
+                    //    extractor doesn't match.
+                    //
+                    // 2. Filter policies (RFC 0007): the `LogKeyPrefixExtractor` bloom
+                    //    hashes the logical `(segment, user_key)` prefix into per-SST
+                    //    bloom filters to prune SSTs that cannot contain the key
+                    //    (`whole_key_filtering=false` — the extracted prefix
+                    //    discriminates everything we probe), and the sequence-range
+                    //    filter prunes SSTs whose records for the key all sit below a
+                    //    scan's resume cursor.
                     StorageSemantics::new()
                         .with_filter_policies(crate::filter_sequence::filter_policies())
                         .with_segment_extractor(

--- a/log/src/reader.rs
+++ b/log/src/reader.rs
@@ -718,7 +718,9 @@ impl LogDbReader {
         let storage: Arc<dyn StorageRead> = create_storage_read(
             &config.storage,
             StorageReaderRuntime::new(),
-            StorageSemantics::new().with_filter_policies(crate::filter_sequence::filter_policies()),
+            StorageSemantics::new()
+                .with_filter_policies(crate::filter_sequence::filter_policies())
+                .with_segment_extractor(crate::segment_extractor::LogSegmentExtractor::shared()),
             reader_options,
         )
         .await

--- a/log/src/segment_extractor.rs
+++ b/log/src/segment_extractor.rs
@@ -336,6 +336,7 @@ mod integration_tests {
     use slatedb::DbReader;
     use tempfile::TempDir;
 
+    use super::LogSegmentExtractor;
     use crate::config::{Config, SegmentConfig};
     use crate::log::{LogDb, LogDbBuilder};
     use crate::model::Record;
@@ -371,6 +372,7 @@ mod integration_tests {
     async fn manifest_segment_ids(slate: &SlateDbStorageConfig) -> Vec<u32> {
         let object_store = create_object_store(&slate.object_store).expect("object store");
         let reader = DbReader::builder(slate.path.clone(), object_store)
+            .with_segment_extractor(LogSegmentExtractor::shared())
             .build()
             .await
             .expect("open DbReader");
@@ -419,6 +421,7 @@ mod integration_tests {
         // then — reopen as a DbReader and verify the extractor name is persisted
         let object_store = create_object_store(&slate.object_store).expect("object store");
         let reader = DbReader::builder(slate.path.clone(), object_store)
+            .with_segment_extractor(LogSegmentExtractor::shared())
             .build()
             .await
             .expect("open DbReader");

--- a/log/src/serde.rs
+++ b/log/src/serde.rs
@@ -287,6 +287,31 @@ impl LogEntryKey {
         buf.freeze()
     }
 
+    /// Builds the sequence subrange to pair with [`Self::scan_prefix`].
+    ///
+    /// Every entry under a `(segment, key)` prefix differs only in its trailing
+    /// `var_u64(relative_seq)`, so the suffix range that selects `seq_range`
+    /// (inclusive start, exclusive end) is simply
+    /// `[var_u64(rel_start), var_u64(rel_end))`. `var_u64` is order-preserving,
+    /// so this lexicographic byte range matches the numeric sequence range.
+    /// Passing this alongside `scan_prefix` lets the backend bound the scan
+    /// natively rather than relying solely on client-side filtering.
+    pub fn scan_subrange(segment: &LogSegment, seq_range: Range<u64>) -> BytesRange {
+        BytesRange::new(
+            Bound::Included(Self::relative_seq_suffix(segment, seq_range.start)),
+            Bound::Excluded(Self::relative_seq_suffix(segment, seq_range.end)),
+        )
+    }
+
+    /// Encodes the trailing `var_u64(relative_seq)` suffix for `seq`, i.e. the
+    /// portion of a full entry key after [`Self::scan_prefix`].
+    fn relative_seq_suffix(segment: &LogSegment, seq: u64) -> Bytes {
+        let relative_seq = seq.saturating_sub(segment.meta().start_seq);
+        let mut buf = BytesMut::new();
+        var_u64::serialize(relative_seq, &mut buf);
+        buf.freeze()
+    }
+
     /// Builds a complete scan key with segment prefix and relative sequence.
     fn build_scan_key(segment: &LogSegment, key: &[u8], seq: u64) -> Bytes {
         let relative_seq = seq.saturating_sub(segment.meta().start_seq);

--- a/log/src/storage.rs
+++ b/log/src/storage.rs
@@ -91,11 +91,18 @@ pub(crate) trait LogStorageRead: StorageRead {
         seq_range: Range<u64>,
     ) -> Result<SegmentIterator> {
         let prefix = LogEntryKey::scan_prefix(segment, key);
+        // Bound the scan to the requested sequence window natively: the suffix
+        // subrange restricts the trailing relative-sequence bytes, so the
+        // backend stops at `seq_range.end` instead of leaning entirely on
+        // `SegmentIterator`'s client-side early-exit.
+        let subrange = LogEntryKey::scan_subrange(segment, seq_range.clone());
         let relative_cursor = seq_range.start.saturating_sub(segment.meta().start_seq);
         let filter_context = Some(crate::filter_sequence::sequence_filter_context(
             relative_cursor,
         ));
-        let inner = self.scan_prefix_iter(prefix, filter_context).await?;
+        let inner = self
+            .scan_prefix_iter(prefix, subrange, filter_context)
+            .await?;
         Ok(SegmentIterator::new(
             inner,
             seq_range,

--- a/vector/src/reader.rs
+++ b/vector/src/reader.rs
@@ -57,7 +57,11 @@ impl VectorDbReader {
         let storage = create_storage_read(
             &config.storage,
             runtime,
-            StorageSemantics::new().with_merge_operator(Arc::new(merge_op)),
+            StorageSemantics::new()
+                .with_merge_operator(Arc::new(merge_op))
+                .with_segment_extractor(
+                    crate::storage::segment_extractor::VectorSegmentExtractor::shared(),
+                ),
             slatedb::config::DbReaderOptions::default(),
         )
         .await?;


### PR DESCRIPTION
I think the only notable change is in log. Since `scan_prefix` now accepts a sub-range, we can pass through the explicit sequence range.