### PR TITLE
Timeseries: use slatedb-storage 

### DIFF
--- a/bencher/src/config.rs
+++ b/bencher/src/config.rs
@@ -37,6 +37,25 @@ pub struct DataConfig {
     pub storage: StorageConfig,
 }
 
+impl DataConfig {
+    /// The benchmark data storage as a TimeSeries SlateDB config.
+    ///
+    /// TimeSeries is SlateDB-only, so an `InMemory` data config maps to SlateDB
+    /// over an in-memory object store.
+    pub fn to_slatedb_config(&self) -> SlateDbStorageConfig {
+        match &self.storage {
+            StorageConfig::SlateDb(config) => config.clone(),
+            StorageConfig::InMemory => SlateDbStorageConfig {
+                path: "bench-data".to_string(),
+                object_store: ObjectStoreConfig::InMemory,
+                settings_path: None,
+                block_cache: None,
+                meta_cache: None,
+            },
+        }
+    }
+}
+
 /// Configuration for metrics reporting.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ReporterConfig {
@@ -52,14 +71,14 @@ fn default_interval() -> Duration {
 }
 
 impl ReporterConfig {
-    /// Convert to a StorageConfig for TimeSeries.
-    pub fn to_storage_config(&self) -> StorageConfig {
-        StorageConfig::SlateDb(SlateDbStorageConfig {
+    /// Convert to the SlateDB storage config used by the TimeSeries reporter.
+    pub fn to_storage_config(&self) -> SlateDbStorageConfig {
+        SlateDbStorageConfig {
             path: "bench-results".to_string(),
             object_store: self.object_store.clone(),
             settings_path: None,
             block_cache: None,
             meta_cache: None,
-        })
+        }
     }
 }

--- a/timeseries/bench/src/ingest.rs
+++ b/timeseries/bench/src/ingest.rs
@@ -78,7 +78,7 @@ impl Benchmark for IngestBenchmark {
         let bucket_start_ms: i64 = 3_600_000;
 
         let config = Config {
-            storage: bench.spec().data().storage.clone(),
+            storage: bench.spec().data().to_slatedb_config(),
             ..Default::default()
         };
         let timeseries = TimeSeriesDb::open(config).await?;

--- a/timeseries/examples/query_bench.rs
+++ b/timeseries/examples/query_bench.rs
@@ -14,7 +14,7 @@
 use std::time::{Duration, Instant, SystemTime};
 
 use clap::Parser;
-use common::StorageConfig;
+use common::storage::config::SlateDbStorageConfig;
 use serde::{Deserialize, Deserializer};
 use slatedb::config::DbReaderOptions;
 use timeseries::TimeSeriesDbReader;
@@ -83,7 +83,7 @@ struct Args {
 
 #[derive(Deserialize)]
 struct BenchConfig {
-    storage: StorageConfig,
+    storage: SlateDbStorageConfig,
     #[serde(
         default = "default_reader_options",
         deserialize_with = "deserialize_reader_options"

--- a/timeseries/src/config.rs
+++ b/timeseries/src/config.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use common::StorageConfig;
+use common::storage::config::{LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig};
 
 /// Configuration for opening a [`TimeSeriesDb`](crate::timeseries::TimeSeriesDb) database.
 ///
@@ -17,13 +17,13 @@ use common::StorageConfig;
 ///
 /// ```no_run
 /// use timeseries::Config;
-/// use common::StorageConfig;
+/// use common::storage::config::SlateDbStorageConfig;
 /// use std::time::Duration;
 ///
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let config = Config {
-///     storage: StorageConfig::default(),
+///     storage: SlateDbStorageConfig::default(),
 ///     flush_interval: Duration::from_secs(30),
 ///     retention: Some(Duration::from_secs(86400 * 7)), // 7 days
 /// };
@@ -35,9 +35,9 @@ use common::StorageConfig;
 pub struct Config {
     /// Storage backend configuration.
     ///
-    /// Determines where and how time series data is persisted. See [`StorageConfig`]
-    /// for available options including in-memory and SlateDB backends.
-    pub storage: StorageConfig,
+    /// Determines where and how time series data is persisted. See
+    /// [`SlateDbStorageConfig`] for object-store and tuning options.
+    pub storage: SlateDbStorageConfig,
 
     /// How often to flush data to durable storage.
     ///
@@ -55,7 +55,18 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
-            storage: StorageConfig::default(),
+            // Local `.data` directory by default (matches the historical
+            // `StorageConfig::default()`; SlateDbStorageConfig::default() would
+            // use an in-memory object store instead).
+            storage: SlateDbStorageConfig {
+                path: "data".to_string(),
+                object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
+                    path: ".data".to_string(),
+                }),
+                settings_path: None,
+                block_cache: None,
+                meta_cache: None,
+            },
             flush_interval: Duration::from_secs(60),
             retention: None,
         }

--- a/timeseries/src/delta.rs
+++ b/timeseries/src/delta.rs
@@ -154,7 +154,7 @@ impl Delta for TsdbWriteDelta {
     type FrozenView = ();
     type ApplyResult = ();
     type DeltaView = ();
-    type Snapshot = Arc<dyn common::storage::StorageSnapshot>;
+    type Snapshot = crate::storage::StorageSnapshot;
 
     fn init(context: Self::Context) -> Self {
         Self {

--- a/timeseries/src/flusher.rs
+++ b/timeseries/src/flusher.rs
@@ -4,12 +4,15 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common::coordinator::Flusher;
-use common::storage::{RecordOp, Storage, StorageSnapshot, Ttl};
+use common::storage::{RecordOp, Ttl};
 
 use crate::active_series::{ActiveSeriesTracker, current_unix_minute};
 use crate::delta::{FrozenTsdbDelta, TsdbWriteDelta};
 use crate::model::TimeBucket;
-use crate::storage::{OpenTsdbStorageExt, OpenTsdbStorageReadExt};
+use crate::storage::{
+    StorageSnapshot, Store, insert_forward_index, insert_series_id, merge_bucket_list,
+    merge_inverted_index, merge_samples,
+};
 use crate::tsdb_metrics;
 
 /// Sum the wire-equivalent size of an op as `key.len() + value.len()`. This
@@ -28,7 +31,7 @@ fn op_estimated_bytes(op: &RecordOp) -> usize {
 /// Converts a `FrozenTsdbDelta` into storage operations and applies them
 /// atomically, then returns a new snapshot for readers.
 pub(crate) struct TsdbFlusher {
-    pub(crate) storage: Arc<dyn Storage>,
+    pub(crate) storage: Arc<dyn Store>,
     /// Optional retention duration. When set, every record produced by a flush
     /// is stamped with the same `Ttl::ExpireAt(bucket_start_ms + retention_ms)`
     /// so SlateDB can collapse merge operands during compaction. Without a
@@ -58,7 +61,7 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
         &mut self,
         frozen: FrozenTsdbDelta,
         _epoch_range: &Range<u64>,
-    ) -> Result<Arc<dyn StorageSnapshot>, String> {
+    ) -> Result<StorageSnapshot, String> {
         // Advance the active-series ring to the current minute and republish
         // the gauge. Done unconditionally (even on empty deltas) so the window
         // continues to slide for idle workloads.
@@ -102,9 +105,7 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
             push_op(
                 &mut ops,
                 &mut estimated_bytes,
-                self.storage
-                    .merge_bucket_list(frozen.bucket, ttl)
-                    .map_err(|e| e.to_string())?,
+                merge_bucket_list(frozen.bucket, ttl).map_err(|e| e.to_string())?,
             );
         }
 
@@ -112,8 +113,7 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
             push_op(
                 &mut ops,
                 &mut estimated_bytes,
-                self.storage
-                    .insert_series_id(frozen.bucket, *fingerprint, *series_id, ttl)
+                insert_series_id(frozen.bucket, *fingerprint, *series_id, ttl)
                     .map_err(|e| e.to_string())?,
             );
         }
@@ -122,8 +122,7 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
             push_op(
                 &mut ops,
                 &mut estimated_bytes,
-                self.storage
-                    .insert_forward_index(frozen.bucket, *entry.key(), entry.value().clone(), ttl)
+                insert_forward_index(frozen.bucket, *entry.key(), entry.value().clone(), ttl)
                     .map_err(|e| e.to_string())?,
             );
         }
@@ -132,14 +131,13 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
             push_op(
                 &mut ops,
                 &mut estimated_bytes,
-                self.storage
-                    .merge_inverted_index(
-                        frozen.bucket,
-                        entry.key().clone(),
-                        entry.value().clone(),
-                        ttl,
-                    )
-                    .map_err(|e| e.to_string())?,
+                merge_inverted_index(
+                    frozen.bucket,
+                    entry.key().clone(),
+                    entry.value().clone(),
+                    ttl,
+                )
+                .map_err(|e| e.to_string())?,
             );
         }
 
@@ -147,15 +145,14 @@ impl Flusher<TsdbWriteDelta> for TsdbFlusher {
             push_op(
                 &mut ops,
                 &mut estimated_bytes,
-                self.storage
-                    .merge_samples(
-                        frozen.bucket,
-                        series_id,
-                        &series_samples.metric_name,
-                        series_samples.points,
-                        ttl,
-                    )
-                    .map_err(|e| e.to_string())?,
+                merge_samples(
+                    frozen.bucket,
+                    series_id,
+                    &series_samples.metric_name,
+                    series_samples.points,
+                    ttl,
+                )
+                .map_err(|e| e.to_string())?,
             );
         }
         let ops_count = ops.len() as u64;
@@ -210,17 +207,14 @@ mod tests {
     use crate::model::{Label, MetricType, Sample, Series, TimeBucket};
     use crate::serde::bucket_list::BucketListValue;
     use crate::serde::key::BucketListKey;
-    use crate::storage::OpenTsdbStorageReadExt;
-    use crate::storage::merge_operator::OpenTsdbMergeOperator;
+    use crate::storage::{FailingStorage, Storage, StorageRead, in_memory_storage};
     use common::Record;
     use common::coordinator::Delta;
-    use common::storage::in_memory::InMemoryStorage;
+    use common::storage::StorageError;
     use std::collections::HashMap;
 
-    fn create_test_storage() -> Arc<dyn Storage> {
-        Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-            OpenTsdbMergeOperator,
-        )))
+    async fn create_test_storage() -> Arc<Storage> {
+        Arc::new(in_memory_storage().await)
     }
 
     fn create_test_bucket() -> TimeBucket {
@@ -288,7 +282,7 @@ mod tests {
     #[tokio::test]
     async fn should_flush_delta_to_storage() {
         // given
-        let storage = create_test_storage();
+        let storage = create_test_storage().await;
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
             retention: None,
@@ -318,7 +312,7 @@ mod tests {
     #[tokio::test]
     async fn should_skip_empty_delta() {
         // given
-        let storage = create_test_storage();
+        let storage = create_test_storage().await;
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
             retention: None,
@@ -343,11 +337,6 @@ mod tests {
         assert_eq!(buckets.len(), 0);
     }
 
-    fn create_failing_storage() -> Arc<common::storage::in_memory::FailingStorage> {
-        let inner = create_test_storage();
-        common::storage::in_memory::FailingStorage::wrap(inner)
-    }
-
     fn create_non_empty_frozen() -> FrozenTsdbDelta {
         let ctx = TsdbContext {
             bucket: create_test_bucket(),
@@ -363,16 +352,22 @@ mod tests {
         frozen
     }
 
+    // ── storage-fault-injection tests ──────────────────────────────────
+
+    fn flusher_with(storage: Arc<FailingStorage>) -> TsdbFlusher {
+        TsdbFlusher {
+            storage,
+            retention: None,
+            active_series: Arc::new(crate::active_series::ActiveSeriesTracker::new(0)),
+        }
+    }
+
     #[tokio::test]
     async fn should_propagate_apply_error() {
         // given
-        let storage = create_failing_storage();
-        let mut flusher = TsdbFlusher {
-            storage: storage.clone(),
-            retention: None,
-            active_series: ::std::sync::Arc::new(crate::active_series::ActiveSeriesTracker::new(0)),
-        };
-        storage.fail_apply(common::StorageError::Storage("test apply error".into()));
+        let storage = FailingStorage::wrap_in_memory().await;
+        storage.fail_apply(StorageError::Storage("test apply error".into()));
+        let mut flusher = flusher_with(storage);
 
         // when
         let result = flusher
@@ -389,15 +384,11 @@ mod tests {
 
     #[tokio::test]
     async fn should_propagate_snapshot_error_after_apply() {
-        // given
-        let storage = create_failing_storage();
-        let mut flusher = TsdbFlusher {
-            storage: storage.clone(),
-            retention: None,
-            active_series: ::std::sync::Arc::new(crate::active_series::ActiveSeriesTracker::new(0)),
-        };
-        // Apply succeeds, but snapshot after apply fails
-        storage.fail_snapshot(common::StorageError::Storage("test snapshot error".into()));
+        // given: apply succeeds against the real inner storage, but the
+        // snapshot refresh afterwards fails
+        let storage = FailingStorage::wrap_in_memory().await;
+        storage.fail_snapshot(StorageError::Storage("test snapshot error".into()));
+        let mut flusher = flusher_with(storage);
 
         // when
         let result = flusher
@@ -415,29 +406,25 @@ mod tests {
     #[tokio::test]
     async fn should_propagate_flush_storage_error() {
         // given
-        let storage = create_failing_storage();
-        let flusher = TsdbFlusher {
-            storage: storage.clone(),
-            retention: None,
-            active_series: ::std::sync::Arc::new(crate::active_series::ActiveSeriesTracker::new(0)),
-        };
-        storage.fail_flush(common::StorageError::Storage("test flush error".into()));
+        let storage = FailingStorage::wrap_in_memory().await;
+        storage.fail_flush(StorageError::Storage("test flush error".into()));
+        let flusher = flusher_with(storage);
 
         // when
         let result = flusher.flush_storage().await;
 
         // then
-        assert!(result.is_err());
+        let err = result.expect_err("expected flush error");
         assert!(
-            result.unwrap_err().contains("test flush error"),
-            "expected test flush error message"
+            err.contains("test flush error"),
+            "expected test flush error message, got: {err}"
         );
     }
 
     #[tokio::test]
     async fn should_register_bucket_on_first_flush() {
         // given
-        let storage = create_test_storage();
+        let storage = create_test_storage().await;
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
             retention: None,
@@ -470,7 +457,7 @@ mod tests {
     #[tokio::test]
     async fn should_not_duplicate_bucket_across_multiple_flushes() {
         // given: two back-to-back flushes for the same bucket
-        let storage = create_test_storage();
+        let storage = create_test_storage().await;
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
             retention: None,
@@ -511,7 +498,7 @@ mod tests {
     #[tokio::test]
     async fn should_skip_bucket_list_merge_when_bucket_already_present() {
         // given: storage pre-populated with the bucket in the BucketList
-        let storage = create_test_storage();
+        let storage = create_test_storage().await;
         let bucket = create_test_bucket();
         let pre_existing = BucketListValue {
             buckets: vec![(bucket.size, bucket.start)],
@@ -557,7 +544,7 @@ mod tests {
     #[tokio::test]
     async fn should_persist_series_dict_entries() {
         // given
-        let storage = create_test_storage();
+        let storage = create_test_storage().await;
         let mut flusher = TsdbFlusher {
             storage: storage.clone(),
             retention: None,

--- a/timeseries/src/lib.rs
+++ b/timeseries/src/lib.rs
@@ -21,10 +21,10 @@
 //!
 //! ```
 //! # use timeseries::{TimeSeriesDb, Config, Series};
-//! # use common::StorageConfig;
+//! # use common::storage::config::SlateDbStorageConfig;
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-//! let config = Config { storage: StorageConfig::InMemory, ..Default::default() };
+//! let config = Config { storage: SlateDbStorageConfig::default(), ..Default::default() };
 //! let ts = TimeSeriesDb::open(config).await?;
 //!
 //! let series = Series::builder("http_requests_total")

--- a/timeseries/src/main.rs
+++ b/timeseries/src/main.rs
@@ -32,12 +32,11 @@ mod util;
 use std::sync::Arc;
 
 use clap::Parser;
-use common::{StorageBuilder, StorageSemantics};
 
 use promql::config::{CliArgs, PrometheusConfig, load_config};
 use reader::TimeSeriesDbReader;
 use server::{ServerConfig, TimeSeriesHttpServer};
-use storage::merge_operator::OpenTsdbMergeOperator;
+use storage::Storage;
 use tracing_subscriber::EnvFilter;
 use tsdb::{Tsdb, TsdbEngine};
 
@@ -120,22 +119,14 @@ async fn main() {
         engine
     } else {
         // Read-write mode: open full storage + Tsdb
-        let merge_operator = Arc::new(OpenTsdbMergeOperator);
-        let storage = StorageBuilder::new(&prometheus_config.storage)
-            .await
-            .unwrap_or_else(|e| {
-                tracing::error!("Failed to create storage: {}", e);
-                std::process::exit(1);
-            })
-            .with_semantics(StorageSemantics::new().with_merge_operator(merge_operator))
-            .build()
+        let storage = Storage::try_new(&prometheus_config.storage)
             .await
             .unwrap_or_else(|e| {
                 tracing::error!("Failed to create storage: {}", e);
                 std::process::exit(1);
             });
         tracing::info!("Storage created successfully");
-        Arc::new(Arc::new(Tsdb::new(storage)).into())
+        Arc::new(Arc::new(Tsdb::new(Arc::new(storage))).into())
     };
 
     // Create server configuration

--- a/timeseries/src/minitsdb.rs
+++ b/timeseries/src/minitsdb.rs
@@ -4,8 +4,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use common::coordinator::{Durability, WriteCoordinator, WriteCoordinatorConfig, WriteError};
-use common::storage::StorageSnapshot;
-use common::{Storage, StorageRead};
+
+use crate::storage::{Storage, StorageRead, StorageSnapshot};
 
 const WRITE_CHANNEL: &str = "write";
 
@@ -18,16 +18,18 @@ use crate::model::{Label, Sample, Series, SeriesId, TimeBucket};
 use crate::query::BucketQueryReader;
 use crate::serde::key::TimeSeriesKey;
 use crate::serde::timeseries::TimeSeriesIterator;
-use crate::storage::OpenTsdbStorageReadExt;
 use crate::util::Result;
 
-pub(crate) struct MiniQueryReader {
+/// Per-bucket query reader over any storage read handle — a
+/// [`StorageSnapshot`] on the write path, a
+/// [`crate::storage::StorageReader`] on the read-only path.
+pub(crate) struct MiniQueryReader<R: StorageRead> {
     bucket: TimeBucket,
-    snapshot: Arc<dyn StorageRead>,
+    snapshot: R,
 }
 
-impl MiniQueryReader {
-    pub(crate) fn new(bucket: TimeBucket, storage: Arc<dyn StorageRead>) -> Self {
+impl<R: StorageRead> MiniQueryReader<R> {
+    pub(crate) fn new(bucket: TimeBucket, storage: R) -> Self {
         Self {
             bucket,
             snapshot: storage,
@@ -36,7 +38,7 @@ impl MiniQueryReader {
 }
 
 #[async_trait]
-impl BucketQueryReader for MiniQueryReader {
+impl<R: StorageRead> BucketQueryReader for MiniQueryReader<R> {
     async fn forward_index(
         &self,
         series_ids: &[SeriesId],
@@ -125,21 +127,21 @@ impl BucketQueryReader for MiniQueryReader {
             metric_name: metric_name.to_string(),
             series_id,
         };
-        let record = io_trace_async(
+        let value = io_trace_async(
             IoKindLocal::SamplesFetch,
             self.snapshot.get(storage_key.encode()),
         )
         .await?;
 
-        match record {
-            Some(record) => {
+        match value {
+            Some(value) => {
                 crate::promql::trace::record_bytes(
                     crate::promql::trace::IoKind::SamplesFetch,
-                    record.value.len() as u64,
+                    value.len() as u64,
                 );
-                let raw_len = record.value.len() as u64;
+                let raw_len = value.len() as u64;
                 let samples = io_trace_sync(IoKindLocal::Deserialize, || {
-                    let iter = TimeSeriesIterator::new(record.value.as_ref()).ok_or_else(|| {
+                    let iter = TimeSeriesIterator::new(value.as_ref()).ok_or_else(|| {
                         Error::Internal("Invalid timeseries data in storage".into())
                     })?;
                     let samples: Vec<Sample> = iter
@@ -188,7 +190,7 @@ impl MiniTsdb {
     }
 
     /// Create a query reader for read operations.
-    pub(crate) fn query_reader(&self) -> MiniQueryReader {
+    pub(crate) fn query_reader(&self) -> MiniQueryReader<StorageSnapshot> {
         let view = self.write_coordinator.view();
         MiniQueryReader {
             bucket: self.bucket,
@@ -198,7 +200,7 @@ impl MiniTsdb {
 
     pub(crate) async fn load(
         bucket: TimeBucket,
-        storage: Arc<dyn Storage>,
+        storage: Arc<Storage>,
         retention: Option<Duration>,
         active_series: Arc<ActiveSeriesTracker>,
     ) -> Result<Self> {
@@ -224,7 +226,7 @@ impl MiniTsdb {
             active_series,
         };
 
-        let initial_snapshot: Arc<dyn StorageSnapshot> = storage
+        let initial_snapshot: StorageSnapshot = storage
             .snapshot()
             .await
             .map_err(|e| Error::Storage(e.to_string()))?;
@@ -348,11 +350,12 @@ fn map_write_error(e: WriteError) -> Error {
 mod tests {
     use super::*;
     use crate::model::{Label, Sample, Series};
+    use crate::storage::in_memory_storage;
 
     /// Create a MiniTsdb with a custom queue capacity.
     async fn load_with_config(
         bucket: TimeBucket,
-        storage: Arc<dyn Storage>,
+        storage: Arc<Storage>,
         queue_capacity: usize,
     ) -> MiniTsdb {
         let snapshot = storage.snapshot().await.unwrap();
@@ -379,7 +382,7 @@ mod tests {
             active_series,
         };
 
-        let initial_snapshot: Arc<dyn StorageSnapshot> = storage.snapshot().await.unwrap();
+        let initial_snapshot: StorageSnapshot = storage.snapshot().await.unwrap();
 
         let config = WriteCoordinatorConfig {
             queue_capacity,
@@ -409,19 +412,8 @@ mod tests {
         )
     }
 
-    async fn test_storage() -> Arc<dyn Storage> {
-        use crate::storage::merge_operator::OpenTsdbMergeOperator;
-        use common::{StorageBuilder, StorageConfig, StorageSemantics};
-
-        StorageBuilder::new(&StorageConfig::InMemory)
-            .await
-            .unwrap()
-            .with_semantics(
-                StorageSemantics::new().with_merge_operator(Arc::new(OpenTsdbMergeOperator)),
-            )
-            .build()
-            .await
-            .unwrap()
+    async fn test_storage() -> Arc<Storage> {
+        Arc::new(in_memory_storage().await)
     }
 
     #[tokio::test]

--- a/timeseries/src/promql/config.rs
+++ b/timeseries/src/promql/config.rs
@@ -5,9 +5,7 @@ use std::path::Path;
 use std::time::Duration;
 
 use crate::util::Result;
-#[cfg(feature = "otel")]
-use common::ObjectStoreConfig;
-use common::storage::config::StorageConfig;
+use common::storage::config::{LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig};
 use serde::{Deserialize, Deserializer};
 use slatedb::config::DbReaderOptions;
 use uuid::Uuid;
@@ -42,8 +40,8 @@ pub struct PrometheusConfig {
     #[cfg(feature = "otel")]
     #[serde(default)]
     pub buffer_consumer: Option<BufferConsumerConfig>,
-    #[serde(default)]
-    pub storage: StorageConfig,
+    #[serde(default = "default_storage")]
+    pub storage: SlateDbStorageConfig,
     /// Flush interval in seconds for persisting data to storage.
     /// Defaults to 5 seconds.
     #[serde(default = "default_flush_interval_secs")]
@@ -129,6 +127,20 @@ fn default_cache_capacity() -> u64 {
     crate::reader::DEFAULT_CACHE_CAPACITY
 }
 
+/// Default storage: a SlateDB on a local `.data` directory (matches the
+/// historical `StorageConfig::default()`).
+fn default_storage() -> SlateDbStorageConfig {
+    SlateDbStorageConfig {
+        path: "data".to_string(),
+        object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
+            path: ".data".to_string(),
+        }),
+        settings_path: None,
+        block_cache: None,
+        meta_cache: None,
+    }
+}
+
 impl Default for PrometheusConfig {
     fn default() -> Self {
         Self {
@@ -137,7 +149,7 @@ impl Default for PrometheusConfig {
             otel: OtelServerConfig::default(),
             #[cfg(feature = "otel")]
             buffer_consumer: None,
-            storage: StorageConfig::default(),
+            storage: default_storage(),
             flush_interval_secs: default_flush_interval_secs(),
             read_only: false,
             reader: default_reader_options(),
@@ -534,7 +546,9 @@ scrape_configs:
         // given
         let yaml = r#"
 storage:
-  type: InMemory
+  path: data
+  object_store:
+    type: InMemory
 read_only: true
 cache_capacity: 200
 reader:

--- a/timeseries/src/promql/promqltest/runner.rs
+++ b/timeseries/src/promql/promqltest/runner.rs
@@ -2,11 +2,11 @@ use crate::promql::promqltest::assert::assert_results;
 use crate::promql::promqltest::dsl::*;
 use crate::promql::promqltest::evaluator::eval_instant;
 use crate::promql::promqltest::loader::load_series;
-use crate::storage::merge_operator::OpenTsdbMergeOperator;
+use crate::storage::in_memory_storage;
 use crate::tsdb::Tsdb;
-use common::storage::in_memory::InMemoryStorage;
 use std::collections::HashMap;
 use std::fs;
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::UNIX_EPOCH;
@@ -42,9 +42,10 @@ async fn run_builtin_tests() -> Result<(), String> {
 }
 
 /// Run all tests with custom storage factory (matches Prometheus RunBuiltinTestsWithStorage)
-async fn run_builtin_tests_with_storage<F>(storage_factory: F) -> Result<(), String>
+async fn run_builtin_tests_with_storage<F, Fut>(storage_factory: F) -> Result<(), String>
 where
-    F: Fn() -> Tsdb,
+    F: Fn() -> Fut,
+    Fut: Future<Output = Tsdb>,
 {
     let test_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("src")
@@ -76,16 +77,17 @@ pub async fn run_test(name: &str, content: &str) -> Result<(), String> {
 }
 
 /// Run a single test file with custom storage (matches Prometheus RunTestWithStorage)
-async fn run_test_with_storage<F>(
+async fn run_test_with_storage<F, Fut>(
     name: &str,
     content: &str,
     storage_factory: &F,
 ) -> Result<(), String>
 where
-    F: Fn() -> Tsdb,
+    F: Fn() -> Fut,
+    Fut: Future<Output = Tsdb>,
 {
     let commands = parse_test_file(content)?;
-    let mut tsdb = storage_factory();
+    let mut tsdb = storage_factory().await;
     let mut eval_count = 0;
     let mut ignoring = false;
 
@@ -93,7 +95,7 @@ where
         match cmd {
             Command::Clear(_) => {
                 // Create fresh TSDB instance - clears all state including caches and snapshots
-                tsdb = storage_factory();
+                tsdb = storage_factory().await;
             }
 
             Command::Ignore(_) => {
@@ -134,10 +136,8 @@ where
 // Storage Factory
 // ============================================================================
 
-fn new_test_storage() -> Tsdb {
-    let storage = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-        OpenTsdbMergeOperator,
-    )));
+async fn new_test_storage() -> Tsdb {
+    let storage = Arc::new(in_memory_storage().await);
     Tsdb::new(storage)
 }
 
@@ -149,7 +149,7 @@ mod tests {
     #[tokio::test]
     async fn should_load_series_into_storage() {
         // given
-        let tsdb = new_test_storage();
+        let tsdb = new_test_storage().await;
         let series = vec![SeriesLoad {
             labels: HashMap::from([
                 ("__name__".to_string(), "test_metric".to_string()),
@@ -174,7 +174,7 @@ mod tests {
     #[tokio::test]
     async fn should_evaluate_query_at_specific_time() {
         // given
-        let tsdb = new_test_storage();
+        let tsdb = new_test_storage().await;
         let series = vec![SeriesLoad {
             labels: HashMap::from([("__name__".to_string(), "metric".to_string())]),
             values: vec![(0, 10.0), (1, 20.0), (2, 30.0)],
@@ -215,7 +215,7 @@ eval instant at 10m
     #[tokio::test]
     async fn should_reject_negative_step_index() {
         // given
-        let tsdb = new_test_storage();
+        let tsdb = new_test_storage().await;
         let series = vec![SeriesLoad {
             labels: HashMap::from([("__name__".to_string(), "metric".to_string())]),
             values: vec![(-1, 10.0)], // Negative step

--- a/timeseries/src/promql/scraper.rs
+++ b/timeseries/src/promql/scraper.rs
@@ -238,14 +238,10 @@ impl Scraper {
 mod tests {
     use super::*;
 
-    #[test]
-    fn should_create_scraper() {
+    #[tokio::test]
+    async fn should_create_scraper() {
         // given
-        let storage = Arc::new(
-            common::storage::in_memory::InMemoryStorage::with_merge_operator(Arc::new(
-                crate::storage::merge_operator::OpenTsdbMergeOperator,
-            )),
-        );
+        let storage = Arc::new(crate::storage::in_memory_storage().await);
         let tsdb = Arc::new(Tsdb::new(storage));
         let config = PrometheusConfig::default();
 

--- a/timeseries/src/reader.rs
+++ b/timeseries/src/reader.rs
@@ -11,10 +11,7 @@ use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use async_trait::async_trait;
-use common::StorageConfig;
-use common::StorageRead;
-use common::storage::factory::create_storage_read;
-use common::{StorageReaderRuntime, StorageSemantics};
+use common::storage::config::SlateDbStorageConfig;
 use futures::stream::{self, StreamExt};
 use moka::future::Cache;
 use uuid::Uuid;
@@ -26,8 +23,7 @@ use crate::model::{
     Label, Labels, QueryOptions, QueryValue, RangeSample, Sample, SeriesId, TimeBucket,
 };
 use crate::query::{BucketQueryReader, QueryReader};
-use crate::storage::OpenTsdbStorageReadExt;
-use crate::storage::merge_operator::OpenTsdbMergeOperator;
+use crate::storage::{StorageRead, StorageReader};
 use crate::tsdb::{
     TsdbReadEngine, find_label_values_in_range, find_labels_in_range, find_series_in_range,
 };
@@ -41,11 +37,11 @@ pub(crate) const DEFAULT_CACHE_CAPACITY: u64 = 50;
 /// Wraps `Arc<MiniQueryReader>` per bucket (unlike `TsdbQueryReader` which
 /// uses owned `MiniQueryReader`).
 pub(crate) struct ReaderQueryReader {
-    mini_readers: HashMap<TimeBucket, Arc<MiniQueryReader>>,
+    mini_readers: HashMap<TimeBucket, Arc<MiniQueryReader<StorageReader>>>,
 }
 
 impl ReaderQueryReader {
-    fn new(readers: Vec<(TimeBucket, Arc<MiniQueryReader>)>) -> Self {
+    fn new(readers: Vec<(TimeBucket, Arc<MiniQueryReader<StorageReader>>)>) -> Self {
         Self {
             mini_readers: readers.into_iter().collect(),
         }
@@ -166,9 +162,9 @@ impl QueryReader for ReaderQueryReader {
 /// let result = reader.query("rate(http_requests_total[5m])", None).await?;
 /// ```
 pub struct TimeSeriesDbReader {
-    storage: Arc<dyn StorageRead>,
+    storage: StorageReader,
     /// LRU cache for read-only query buckets.
-    query_cache: Cache<TimeBucket, Arc<MiniQueryReader>>,
+    query_cache: Cache<TimeBucket, Arc<MiniQueryReader<StorageReader>>>,
 }
 
 impl TimeSeriesDbReader {
@@ -181,7 +177,7 @@ impl TimeSeriesDbReader {
     ///
     /// Returns an error if the storage backend cannot be initialized.
     pub async fn open(
-        storage_config: StorageConfig,
+        storage_config: SlateDbStorageConfig,
         reader_options: slatedb::config::DbReaderOptions,
         cache_capacity: u64,
     ) -> Result<Self> {
@@ -195,7 +191,7 @@ impl TimeSeriesDbReader {
     /// writes. The checkpoint must already exist (typically created via
     /// `TimeSeriesDb::create_checkpoint`).
     pub async fn open_at_checkpoint(
-        storage_config: StorageConfig,
+        storage_config: SlateDbStorageConfig,
         reader_options: slatedb::config::DbReaderOptions,
         cache_capacity: u64,
         checkpoint_id: Uuid,
@@ -210,31 +206,21 @@ impl TimeSeriesDbReader {
     }
 
     async fn open_inner(
-        storage_config: StorageConfig,
+        storage_config: SlateDbStorageConfig,
         reader_options: slatedb::config::DbReaderOptions,
         cache_capacity: u64,
         checkpoint_id: Option<Uuid>,
     ) -> Result<Self> {
-        let mut runtime = StorageReaderRuntime::new();
-        if let Some(id) = checkpoint_id {
-            runtime = runtime.with_checkpoint_id(id);
-        }
-        let storage = create_storage_read(
-            &storage_config,
-            runtime,
-            StorageSemantics::new().with_merge_operator(Arc::new(OpenTsdbMergeOperator)),
-            reader_options,
-        )
-        .await?;
-        Ok(Self::from_storage_with_capacity(storage, cache_capacity))
+        let reader = StorageReader::try_new(&storage_config, reader_options, checkpoint_id).await?;
+        Ok(Self::from_storage_with_capacity(reader, cache_capacity))
     }
 
     /// Creates a TimeSeriesDbReader from an existing storage implementation.
-    pub(crate) fn from_storage(storage: Arc<dyn StorageRead>) -> Self {
+    pub(crate) fn from_storage(storage: StorageReader) -> Self {
         Self::from_storage_with_capacity(storage, DEFAULT_CACHE_CAPACITY)
     }
 
-    fn from_storage_with_capacity(storage: Arc<dyn StorageRead>, cache_capacity: u64) -> Self {
+    fn from_storage_with_capacity(storage: StorageReader, cache_capacity: u64) -> Self {
         let query_cache = Cache::builder().max_capacity(cache_capacity).build();
         Self {
             storage,
@@ -244,12 +230,12 @@ impl TimeSeriesDbReader {
 
     /// Returns a read handle to the underlying storage, for background tasks
     /// like the cache warmer.
-    pub(crate) fn storage_read(&self) -> Arc<dyn StorageRead> {
+    pub(crate) fn storage_read(&self) -> StorageReader {
         self.storage.clone()
     }
 
     /// Get a cached bucket reader, loading from storage if needed.
-    async fn get_or_load_bucket(&self, bucket: TimeBucket) -> Arc<MiniQueryReader> {
+    async fn get_or_load_bucket(&self, bucket: TimeBucket) -> Arc<MiniQueryReader<StorageReader>> {
         let storage = self.storage.clone();
         self.query_cache
             .get_with(bucket, async move {
@@ -377,21 +363,20 @@ impl TsdbReadEngine for TimeSeriesDbReader {
 mod tests {
     use super::*;
     use crate::model::Series;
-    use crate::storage::merge_operator::OpenTsdbMergeOperator;
-    use common::storage::in_memory::InMemoryStorage;
+    use crate::storage::{SharedInMemoryStorage, in_memory_shared_storage};
 
-    fn create_shared_storage() -> Arc<InMemoryStorage> {
-        Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-            OpenTsdbMergeOperator,
-        )))
+    /// Writer storage plus the shared object store, so the tests can open
+    /// real (non-fencing) `DbReader`-backed readers over the same data.
+    async fn create_shared_storage() -> SharedInMemoryStorage {
+        in_memory_shared_storage().await
     }
 
     #[tokio::test]
     async fn reader_sees_written_data() {
         // Write data through internal Tsdb, then verify reader sees it.
-        let storage = create_shared_storage();
+        let shared = create_shared_storage().await;
 
-        let tsdb = crate::tsdb::Tsdb::new(storage.clone());
+        let tsdb = crate::tsdb::Tsdb::new(shared.storage.clone());
         let series = vec![
             Series::builder("http_requests_total")
                 .label("method", "GET")
@@ -404,7 +389,7 @@ mod tests {
         tsdb.flush().await.unwrap();
 
         // Open reader on the same storage
-        let reader = TimeSeriesDbReader::from_storage(storage);
+        let reader = TimeSeriesDbReader::from_storage(shared.reader().await);
 
         // Query should find the data
         let query_time = SystemTime::UNIX_EPOCH + Duration::from_millis(1700000001000);
@@ -424,9 +409,9 @@ mod tests {
 
     #[tokio::test]
     async fn reader_series_discovery() {
-        let storage = create_shared_storage();
+        let shared = create_shared_storage().await;
 
-        let tsdb = crate::tsdb::Tsdb::new(storage.clone());
+        let tsdb = crate::tsdb::Tsdb::new(shared.storage.clone());
         let series = vec![
             Series::builder("http_requests_total")
                 .label("method", "GET")
@@ -444,7 +429,7 @@ mod tests {
         tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
-        let reader = TimeSeriesDbReader::from_storage(storage);
+        let reader = TimeSeriesDbReader::from_storage(shared.reader().await);
 
         // Series discovery
         let series = reader
@@ -486,11 +471,11 @@ mod tests {
 
     #[tokio::test]
     async fn writer_and_reader_coexist_on_shared_storage() {
-        // Verify that a writer and reader can both operate on the same
-        // InMemoryStorage without interfering with each other.
-        let storage = create_shared_storage();
+        // Verify that a writer and a non-fencing reader can both operate on
+        // the same shared object store without interfering with each other.
+        let shared = create_shared_storage().await;
 
-        let tsdb = crate::tsdb::Tsdb::new(storage.clone());
+        let tsdb = crate::tsdb::Tsdb::new(shared.storage.clone());
 
         // Write initial data
         let series = vec![
@@ -503,7 +488,7 @@ mod tests {
         tsdb.flush().await.unwrap();
 
         // Open reader
-        let reader = TimeSeriesDbReader::from_storage(storage.clone());
+        let reader = TimeSeriesDbReader::from_storage(shared.reader().await);
 
         // Reader sees initial data
         let query_time = SystemTime::UNIX_EPOCH + Duration::from_millis(1700000000000);
@@ -513,7 +498,7 @@ mod tests {
             _ => panic!("expected Vector"),
         }
 
-        // Writer can still write more data (no fencing error)
+        // Writer can still write more data (the DbReader does not fence it)
         let more_series = vec![
             Series::builder("metric_a")
                 .label("env", "prod")
@@ -523,9 +508,15 @@ mod tests {
         tsdb.ingest_samples(more_series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
-        // Reader sees newly written data (InMemory storage shares state)
+        // A reader opened after the new flush sees the new data. (The first
+        // reader's view advances only on manifest polls, so a fresh reader is
+        // used to assert visibility deterministically.)
+        let late_reader = TimeSeriesDbReader::from_storage(shared.reader().await);
         let query_time2 = SystemTime::UNIX_EPOCH + Duration::from_millis(1700000002000);
-        let result2 = reader.query("metric_a", Some(query_time2)).await.unwrap();
+        let result2 = late_reader
+            .query("metric_a", Some(query_time2))
+            .await
+            .unwrap();
         match &result2 {
             QueryValue::Vector(samples) => {
                 assert_eq!(samples.len(), 1);
@@ -533,13 +524,23 @@ mod tests {
             }
             _ => panic!("expected Vector"),
         }
+
+        // The first reader still serves its original view.
+        let result3 = reader.query("metric_a", Some(query_time)).await.unwrap();
+        match &result3 {
+            QueryValue::Vector(samples) => {
+                assert_eq!(samples.len(), 1);
+                assert_eq!(samples[0].value, 1.0);
+            }
+            _ => panic!("expected Vector"),
+        }
     }
 
     #[tokio::test]
     async fn reader_query_range() {
-        let storage = create_shared_storage();
+        let shared = create_shared_storage().await;
 
-        let tsdb = crate::tsdb::Tsdb::new(storage.clone());
+        let tsdb = crate::tsdb::Tsdb::new(shared.storage.clone());
         let series = vec![
             Series::builder("counter")
                 .label("job", "test")
@@ -553,7 +554,7 @@ mod tests {
         tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
-        let reader = TimeSeriesDbReader::from_storage(storage);
+        let reader = TimeSeriesDbReader::from_storage(shared.reader().await);
 
         let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1700000000);
         let end = SystemTime::UNIX_EPOCH + Duration::from_secs(1700000060);
@@ -584,7 +585,7 @@ mod tests {
         };
 
         let tmp_dir = tempfile::tempdir().unwrap();
-        let storage_config = common::StorageConfig::SlateDb(SlateDbStorageConfig {
+        let storage_config = SlateDbStorageConfig {
             path: "data".to_string(),
             object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
                 path: tmp_dir.path().to_str().unwrap().to_string(),
@@ -592,7 +593,7 @@ mod tests {
             settings_path: None,
             block_cache: None,
             meta_cache: None,
-        });
+        };
 
         // 1. Open writer and write data
         let writer = TimeSeriesDb::open(Config {
@@ -699,7 +700,7 @@ mod tests {
 
         // given
         let tmp_dir = tempfile::tempdir().unwrap();
-        let storage_config = common::StorageConfig::SlateDb(SlateDbStorageConfig {
+        let storage_config = SlateDbStorageConfig {
             path: "data".to_string(),
             object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
                 path: tmp_dir.path().to_str().unwrap().to_string(),
@@ -707,7 +708,7 @@ mod tests {
             settings_path: None,
             block_cache: None,
             meta_cache: None,
-        });
+        };
 
         let writer = TimeSeriesDb::open(Config {
             storage: storage_config.clone(),
@@ -760,8 +761,8 @@ mod tests {
     async fn writer_and_reader_query_range_parity_at_boundary() {
         use crate::model::QueryOptions;
 
-        let storage = create_shared_storage();
-        let tsdb = crate::tsdb::Tsdb::new(storage.clone());
+        let shared = create_shared_storage().await;
+        let tsdb = crate::tsdb::Tsdb::new(shared.storage.clone());
 
         // 5 samples at 15s intervals: t+0, t+15, t+30, t+45, t+60
         let series = vec![
@@ -777,10 +778,10 @@ mod tests {
         tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
-        let reader = TimeSeriesDbReader::from_storage(storage.clone());
+        let reader = TimeSeriesDbReader::from_storage(shared.reader().await);
 
         // Use Tsdb directly for the writer side (same data, same storage)
-        let writer_tsdb = crate::tsdb::Tsdb::new(storage);
+        let writer_tsdb = crate::tsdb::Tsdb::new(shared.storage.clone());
 
         let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1700000000);
         let end = SystemTime::UNIX_EPOCH + Duration::from_secs(1700000060);
@@ -826,9 +827,9 @@ mod tests {
 
     #[tokio::test]
     async fn query_range_rejects_zero_step() {
-        let storage = create_shared_storage();
+        let shared = create_shared_storage().await;
 
-        let tsdb = crate::tsdb::Tsdb::new(storage.clone());
+        let tsdb = crate::tsdb::Tsdb::new(shared.storage.clone());
         let series = vec![
             Series::builder("counter")
                 .label("job", "test")
@@ -838,7 +839,7 @@ mod tests {
         tsdb.ingest_samples(series, None).await.unwrap();
         tsdb.flush().await.unwrap();
 
-        let reader = TimeSeriesDbReader::from_storage(storage);
+        let reader = TimeSeriesDbReader::from_storage(shared.reader().await);
 
         let start = SystemTime::UNIX_EPOCH + Duration::from_secs(1700000000);
         let end = SystemTime::UNIX_EPOCH + Duration::from_secs(1700000060);
@@ -869,7 +870,7 @@ mod tests {
 
         // given
         let tmp_dir = tempfile::tempdir().unwrap();
-        let storage_config = common::StorageConfig::SlateDb(SlateDbStorageConfig {
+        let storage_config = SlateDbStorageConfig {
             path: "data".to_string(),
             object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
                 path: tmp_dir.path().to_str().unwrap().to_string(),
@@ -877,7 +878,7 @@ mod tests {
             settings_path: None,
             block_cache: None,
             meta_cache: None,
-        });
+        };
 
         let writer = TimeSeriesDb::open(Config {
             storage: storage_config.clone(),
@@ -964,20 +965,20 @@ mod tests {
         }
     }
 
-    #[test]
-    fn from_storage_uses_default_cache_capacity() {
-        let storage = create_shared_storage();
-        let reader = TimeSeriesDbReader::from_storage(storage);
+    #[tokio::test]
+    async fn from_storage_uses_default_cache_capacity() {
+        let shared = create_shared_storage().await;
+        let reader = TimeSeriesDbReader::from_storage(shared.reader().await);
         assert_eq!(
             reader.query_cache.policy().max_capacity(),
             Some(DEFAULT_CACHE_CAPACITY)
         );
     }
 
-    #[test]
-    fn from_storage_with_capacity_honors_custom_value() {
-        let storage = create_shared_storage();
-        let reader = TimeSeriesDbReader::from_storage_with_capacity(storage, 123);
+    #[tokio::test]
+    async fn from_storage_with_capacity_honors_custom_value() {
+        let shared = create_shared_storage().await;
+        let reader = TimeSeriesDbReader::from_storage_with_capacity(shared.reader().await, 123);
         assert_eq!(reader.query_cache.policy().max_capacity(), Some(123));
     }
 }

--- a/timeseries/src/server/cache_warmer.rs
+++ b/timeseries/src/server/cache_warmer.rs
@@ -1,14 +1,14 @@
 //! Startup cache warmer that pre-populates the block cache by scanning
-//! recent time bucket key ranges through the normal StorageRead API.
+//! recent time bucket key ranges through the normal storage read API.
 //!
 //! This is a temporary workaround until SlateDB's CacheManager
 //! (`set_warm_prefixes()` + `warm_current()`) is available. Delete this
 //! module when that lands.
 
-use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
-use common::{BytesRange, StorageRead};
+use common::BytesRange;
+use common::storage::StorageError;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -17,7 +17,7 @@ use crate::serde::TimeBucketScoped;
 use crate::serde::key::{
     BucketListKey, ForwardIndexKey, InvertedIndexKey, SeriesDictionaryKey, TimeSeriesKey,
 };
-use crate::storage::OpenTsdbStorageReadExt;
+use crate::storage::StorageRead;
 
 const LOG_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -37,7 +37,10 @@ impl CacheWarmerHandle {
 
 /// Spawns a one-off cache warming task. Returns a handle that must be
 /// shut down before closing the database.
-pub(crate) fn start(storage: Arc<dyn StorageRead>, config: CacheWarmerConfig) -> CacheWarmerHandle {
+pub(crate) fn start<R: StorageRead + 'static>(
+    storage: R,
+    config: CacheWarmerConfig,
+) -> CacheWarmerHandle {
     let cancel = CancellationToken::new();
     let join = tokio::spawn({
         let cancel = cancel.clone();
@@ -62,8 +65,8 @@ struct WarmStats {
     elapsed: Duration,
 }
 
-async fn warm(
-    storage: &Arc<dyn StorageRead>,
+async fn warm<R: StorageRead>(
+    storage: &R,
     config: &CacheWarmerConfig,
     cancel: &CancellationToken,
 ) -> crate::util::Result<WarmStats> {
@@ -120,10 +123,15 @@ async fn warm(
 
 /// Scan a key range, consuming all records to populate the block cache.
 /// Returns the number of records touched.
-async fn drain_scan(storage: &Arc<dyn StorageRead>, range: BytesRange) -> crate::util::Result<u64> {
-    let mut iter = storage.scan_iter(range).await?;
+async fn drain_scan<R: StorageRead>(storage: &R, range: BytesRange) -> crate::util::Result<u64> {
+    let mut iter = storage.scan(range).await?;
     let mut count = 0u64;
-    while iter.next().await?.is_some() {
+    while iter
+        .next()
+        .await
+        .map_err(StorageError::from_storage)?
+        .is_some()
+    {
         count += 1;
     }
     Ok(count)
@@ -133,20 +141,18 @@ async fn drain_scan(storage: &Arc<dyn StorageRead>, range: BytesRange) -> crate:
 mod tests {
     use super::*;
     use crate::model::Series;
-    use crate::storage::merge_operator::OpenTsdbMergeOperator;
+    use crate::storage::{Storage, in_memory_storage};
     use crate::tsdb::Tsdb;
-    use common::storage::in_memory::InMemoryStorage;
+    use std::sync::Arc;
 
-    fn create_storage() -> Arc<InMemoryStorage> {
-        Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-            OpenTsdbMergeOperator,
-        )))
+    async fn create_storage() -> Arc<Storage> {
+        Arc::new(in_memory_storage().await)
     }
 
     #[tokio::test]
     async fn should_warm_with_data() {
         // given
-        let storage = create_storage();
+        let storage = create_storage().await;
         let tsdb = Tsdb::new(storage.clone());
         let series = vec![
             Series::builder("http_requests_total")
@@ -170,9 +176,7 @@ mod tests {
 
         // when
         let cancel = CancellationToken::new();
-        let stats = warm(&(storage as Arc<dyn StorageRead>), &config, &cancel)
-            .await
-            .unwrap();
+        let stats = warm(storage.as_ref(), &config, &cancel).await.unwrap();
 
         // then
         assert!(stats.buckets > 0);
@@ -182,7 +186,7 @@ mod tests {
     #[tokio::test]
     async fn should_warm_empty_storage() {
         // given
-        let storage = create_storage();
+        let storage = create_storage().await;
         let config = CacheWarmerConfig {
             warm_range: Duration::from_secs(3600),
             include_samples: true,
@@ -190,9 +194,7 @@ mod tests {
 
         // when
         let cancel = CancellationToken::new();
-        let stats = warm(&(storage as Arc<dyn StorageRead>), &config, &cancel)
-            .await
-            .unwrap();
+        let stats = warm(storage.as_ref(), &config, &cancel).await.unwrap();
 
         // then
         assert_eq!(stats.buckets, 0);
@@ -202,7 +204,7 @@ mod tests {
     #[tokio::test]
     async fn should_stop_on_cancellation() {
         // given
-        let storage = create_storage();
+        let storage = create_storage().await;
         let tsdb = Tsdb::new(storage.clone());
         let series = vec![
             Series::builder("metric_a")
@@ -227,9 +229,7 @@ mod tests {
         // when — cancel before starting
         let cancel = CancellationToken::new();
         cancel.cancel();
-        let stats = warm(&(storage as Arc<dyn StorageRead>), &config, &cancel)
-            .await
-            .unwrap();
+        let stats = warm(storage.as_ref(), &config, &cancel).await.unwrap();
 
         // then — should have found buckets but processed none
         assert_eq!(stats.records, 0);

--- a/timeseries/src/server/http.rs
+++ b/timeseries/src/server/http.rs
@@ -199,13 +199,22 @@ impl TimeSeriesHttpServer {
                 .cache_warmer
                 .as_ref()
                 .map(|warmer_config| {
-                    let storage = self.tsdb.storage_read();
                     tracing::info!(
                         warm_range = ?warmer_config.warm_range,
                         include_samples = warmer_config.include_samples,
                         "Starting cache warmer"
                     );
-                    super::cache_warmer::start(storage, warmer_config.clone())
+                    // The writer and the read-only reader expose different
+                    // SlateDB read handles, so dispatch to the generic warmer
+                    // per engine variant.
+                    match self.tsdb.as_ref() {
+                        TsdbEngine::ReadWrite(tsdb) => {
+                            super::cache_warmer::start(tsdb.storage_read(), warmer_config.clone())
+                        }
+                        TsdbEngine::ReadOnly(reader) => {
+                            super::cache_warmer::start(reader.storage_read(), warmer_config.clone())
+                        }
+                    }
                 });
 
         // Build router with metrics middleware

--- a/timeseries/src/storage/mod.rs
+++ b/timeseries/src/storage/mod.rs
@@ -1,478 +1,46 @@
-use async_trait::async_trait;
-use common::storage::{MergeOptions, MergeRecordOp, PutOptions, PutRecordOp, RecordOp, Ttl};
-use common::{Record, Storage, StorageRead};
-use roaring::RoaringBitmap;
-
-use crate::index::{InvertedIndex, SeriesSpec};
-use crate::model::{Sample, SeriesFingerprint, SeriesId, TimeBucket};
-use crate::serde::key::TimeSeriesKey;
-use crate::serde::timeseries::TimeSeriesValue;
-use crate::{
-    index::ForwardIndex,
-    model::Label,
-    serde::{
-        TimeBucketScoped,
-        bucket_list::BucketListValue,
-        dictionary::SeriesDictionaryValue,
-        forward_index::ForwardIndexValue,
-        inverted_index::InvertedIndexValue,
-        key::{BucketListKey, ForwardIndexKey, InvertedIndexKey, SeriesDictionaryKey},
-    },
-    util::Result,
-};
-
+//! Native SlateDB storage for timeseries.
+//!
+//! This module replaces timeseries' use of the `common::storage` *handles*
+//! (`Storage`/`StorageRead`/`StorageSnapshot`) with a direct SlateDB
+//! integration. Everything reusable — value types (`Record`, `RecordOp`,
+//! `Ttl`, …), the merge-operator trait, the error type, the config types,
+//! the object-store / foyer-cache / metrics-recorder plumbing, and the
+//! `Ttl`/options → SlateDB conversions — is reused from `common::storage`
+//! rather than duplicated.
+//!
+//! - [`slate`] — the concrete [`Storage`] writer plus the [`StorageReader`]
+//!   and [`StorageSnapshot`] read handles; all three serve reads through the
+//!   shared [`StorageRead`] methods.
+//! - [`merge_operator`] — the OpenTSDB merge operator.
+//! - [`factory`] — the in-memory test storage helper.
 pub(crate) mod factory;
 pub(crate) mod merge_operator;
 pub(crate) mod slate;
 
-/// Extension trait for StorageRead that provides OpenTSDB-specific loading methods
-#[async_trait]
-pub(crate) trait OpenTsdbStorageReadExt: StorageRead {
-    /// Given a time range, return all the time buckets that contain data for
-    /// that range sorted by start time.
-    ///
-    /// This method examines the actual list of buckets in storage to determine the
-    /// candidate buckets (as opposed to computing theoretical buckets from the
-    /// start and end times).
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_buckets_in_range(
-        &self,
-        start_secs: Option<i64>,
-        end_secs: Option<i64>,
-    ) -> Result<Vec<TimeBucket>> {
-        if let (Some(start), Some(end)) = (start_secs, end_secs)
-            && end < start
-        {
-            return Err("end must be greater than or equal to start".into());
-        }
+pub(crate) use slate::{
+    Storage, StorageRead, StorageReader, StorageSnapshot, Store, insert_forward_index,
+    insert_series_id, merge_bucket_list, merge_inverted_index, merge_samples,
+};
 
-        // Convert to minutes once before filtering
-        let start_min = start_secs.map(|s| (s / 60) as u32);
-        let end_min = end_secs.map(|e| (e / 60) as u32);
-
-        let key = BucketListKey.encode();
-        let record = self.get(key).await?;
-        let bucket_list = match record {
-            Some(record) => BucketListValue::decode(record.value.as_ref())?,
-            None => BucketListValue {
-                buckets: Vec::new(),
-            },
-        };
-
-        let mut filtered_buckets: Vec<TimeBucket> = bucket_list
-            .buckets
-            .into_iter()
-            .map(|(size, start)| TimeBucket { size, start })
-            .filter(|bucket| match (start_min, end_min) {
-                (None, None) => true,
-                (Some(start), None) => {
-                    let start_bucket_min = start - start % bucket.size_in_mins();
-                    bucket.start >= start_bucket_min
-                }
-                (None, Some(end)) => {
-                    let end_bucket_min = end - end % bucket.size_in_mins();
-                    bucket.start <= end_bucket_min
-                }
-                (Some(start), Some(end)) => {
-                    let start_bucket_min = start - start % bucket.size_in_mins();
-                    let end_bucket_min = end - end % bucket.size_in_mins();
-                    bucket.start >= start_bucket_min && bucket.start <= end_bucket_min
-                }
-            })
-            .collect();
-
-        filtered_buckets.sort_by_key(|bucket| bucket.start);
-        Ok(filtered_buckets)
-    }
-
-    /// Given a set of sorted, non-overlapping time ranges, return all buckets
-    /// that overlap any range. Reads the bucket list once.
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_buckets_for_ranges(&self, ranges: &[(i64, i64)]) -> Result<Vec<TimeBucket>> {
-        if ranges.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let key = BucketListKey.encode();
-        let record = self.get(key).await?;
-        let bucket_list = match record {
-            Some(record) => BucketListValue::decode(record.value.as_ref())?,
-            None => {
-                return Ok(Vec::new());
-            }
-        };
-
-        let mut filtered_buckets: Vec<TimeBucket> = bucket_list
-            .buckets
-            .into_iter()
-            .map(|(size, start)| TimeBucket { size, start })
-            .filter(|bucket| {
-                let bucket_start_min = bucket.start as i64;
-                let bucket_end_min = bucket_start_min + bucket.size_in_mins() as i64;
-                // Convert bucket bounds to seconds for comparison
-                let bucket_start_secs = bucket_start_min * 60;
-                let bucket_end_secs = bucket_end_min * 60;
-                // Bucket is half-open [start, end), range is closed [r_start, r_end].
-                // Overlap iff bucket_end > r_start (strict: end is exclusive) and
-                // bucket_start <= r_end (inclusive: start is inclusive).
-                ranges.iter().any(|&(r_start, r_end)| {
-                    bucket_end_secs > r_start && bucket_start_secs <= r_end
-                })
-            })
-            .collect();
-
-        filtered_buckets.sort_by_key(|bucket| bucket.start);
-        Ok(filtered_buckets)
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_forward_index(&self, bucket: TimeBucket) -> Result<ForwardIndex> {
-        let range = ForwardIndexKey::bucket_range(&bucket);
-        let records = self.scan(range).await?;
-
-        let forward_index = ForwardIndex::default();
-        for record in records {
-            let key = ForwardIndexKey::decode(record.key.as_ref())?;
-            let value = ForwardIndexValue::decode(record.value.as_ref())?;
-            forward_index.series.insert(key.series_id, value.into());
-        }
-
-        Ok(forward_index)
-    }
-
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_inverted_index(&self, bucket: TimeBucket) -> Result<InvertedIndex> {
-        let range = InvertedIndexKey::bucket_range(&bucket);
-        let records = self.scan(range).await?;
-
-        let inverted_index = InvertedIndex::default();
-        for record in records {
-            let key = InvertedIndexKey::decode(record.key.as_ref())?;
-            let value = InvertedIndexValue::decode(record.value.as_ref())?;
-            inverted_index.postings.insert(
-                Label {
-                    name: key.attribute,
-                    value: key.value,
-                },
-                value.postings,
-            );
-        }
-
-        Ok(inverted_index)
-    }
-
-    /// Load only the specified terms from the inverted index. Legacy
-    /// batch path — kept for the v1 evaluator / pipeline which still
-    /// calls it. New callers should use [`Self::get_inverted_index_term`]
-    /// and fan out in parallel themselves so each per-term latency is
-    /// independently traceable.
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_inverted_index_terms(
-        &self,
-        bucket: &TimeBucket,
-        terms: &[Label],
-    ) -> Result<InvertedIndex> {
-        let result = InvertedIndex::default();
-        for term in terms {
-            if let Some(postings) = self.get_inverted_index_term(bucket, term).await? {
-                result.postings.insert(term.clone(), postings);
-            }
-        }
-        Ok(result)
-    }
-
-    /// Load only the specified series from the forward index. Legacy
-    /// batch path — see [`Self::get_inverted_index_terms`] for context.
-    /// New callers should use [`Self::get_forward_index_one`].
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_forward_index_series(
-        &self,
-        bucket: &TimeBucket,
-        series_ids: &[SeriesId],
-    ) -> Result<ForwardIndex> {
-        let result = ForwardIndex::default();
-        for &series_id in series_ids {
-            if let Some(spec) = self.get_forward_index_one(bucket, series_id).await? {
-                result.series.insert(series_id, spec);
-            }
-        }
-        Ok(result)
-    }
-
-    /// Fetch a single inverted-index posting for `(bucket, term)`.
-    /// Returns `None` when the term isn't present in the bucket.
-    ///
-    /// Per-term granularity by design: callers (e.g. the query
-    /// adapter) parallelise at *their* layer so concurrency budget and
-    /// caching can be managed end-to-end. The previous batched variant
-    /// looped sequentially and was a silent bottleneck.
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_inverted_index_term(
-        &self,
-        bucket: &TimeBucket,
-        term: &Label,
-    ) -> Result<Option<RoaringBitmap>> {
-        let key = InvertedIndexKey {
-            time_bucket: bucket.start,
-            bucket_size: bucket.size,
-            attribute: term.name.clone(),
-            value: term.value.clone(),
-        }
-        .encode();
-        let rec = self.get(key).await?;
-        match rec {
-            Some(r) => {
-                crate::promql::trace::record_bytes(
-                    crate::promql::trace::IoKind::InvertedIndexFetch,
-                    r.value.len() as u64,
-                );
-                let value = InvertedIndexValue::decode(r.value.as_ref())?;
-                Ok(Some(value.postings))
-            }
-            None => Ok(None),
-        }
-    }
-
-    /// Fetch a single forward-index entry for `(bucket, series_id)`.
-    /// Returns `None` when the series isn't present in the bucket.
-    /// See [`Self::get_inverted_index_term`] for why this is per-key.
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_forward_index_one(
-        &self,
-        bucket: &TimeBucket,
-        series_id: SeriesId,
-    ) -> Result<Option<SeriesSpec>> {
-        let key = ForwardIndexKey {
-            time_bucket: bucket.start,
-            bucket_size: bucket.size,
-            series_id,
-        }
-        .encode();
-        let rec = self.get(key).await?;
-        match rec {
-            Some(r) => {
-                crate::promql::trace::record_bytes(
-                    crate::promql::trace::IoKind::ForwardIndexFetch,
-                    r.value.len() as u64,
-                );
-                let value = ForwardIndexValue::decode(r.value.as_ref())?;
-                Ok(Some(value.into()))
-            }
-            None => Ok(None),
-        }
-    }
-
-    /// Load the series dictionary using the provided insert function and
-    /// return the maximum series ID found, which can be used to
-    /// initialize counters
-    #[tracing::instrument(level = "trace", skip(self, bucket, insert))]
-    async fn load_series_dictionary<F>(&self, bucket: &TimeBucket, mut insert: F) -> Result<u32>
-    where
-        F: FnMut(SeriesFingerprint, SeriesId) + Send,
-    {
-        let range = SeriesDictionaryKey::bucket_range(bucket);
-        let records = self.scan(range).await?;
-
-        let mut max_series_id = 0;
-        for record in records {
-            let key = SeriesDictionaryKey::decode(record.key.as_ref())?;
-            let value = SeriesDictionaryValue::decode(record.value.as_ref())?;
-            insert(key.series_fingerprint, value.series_id);
-            max_series_id = std::cmp::max(max_series_id, value.series_id);
-        }
-
-        Ok(max_series_id)
-    }
-
-    /// Check whether `bucket` is already present in the stored `BucketList`.
-    ///
-    /// Used by the flush path to suppress redundant single-element merges
-    /// on a bucket that has already been announced. The `BucketListKey` is
-    /// a global singleton that stays hot in SlateDB's block cache (read on
-    /// every query and warmed at startup), so this is a cache hit in the
-    /// common case.
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn bucket_list_contains(&self, bucket: TimeBucket) -> Result<bool> {
-        let key = BucketListKey.encode();
-        let Some(record) = self.get(key).await? else {
-            return Ok(false);
-        };
-        let list = BucketListValue::decode(record.value.as_ref())?;
-        Ok(list.buckets.contains(&(bucket.size, bucket.start)))
-    }
-
-    /// Get all unique values for a specific label name within a bucket.
-    /// This method scans only the inverted index keys for the specified label,
-    /// which is more efficient than loading all inverted index entries.
-    ///
-    /// Note: We don't need to verify that the decoded `key.attribute` matches
-    /// `label_name` after scanning. The `attribute_range` prefix includes a
-    /// 2-byte little-endian length prefix before the attribute string (see
-    /// `encode_utf8`), which guarantees that only exact attribute matches are
-    /// returned. For example, searching for "hostname" (len=8, encoded as
-    /// `[0x08, 0x00, ...]`) can never match a key with attribute "host"
-    /// (len=4, encoded as `[0x04, 0x00, ...]`) because the length bytes differ.
-    /// See `serde::name::tests::should_not_match_shorter_attribute_with_value_that_looks_like_suffix`
-    /// for test coverage of this invariant.
-    #[tracing::instrument(level = "trace", skip_all)]
-    async fn get_label_values(&self, bucket: &TimeBucket, label_name: &str) -> Result<Vec<String>> {
-        let range = InvertedIndexKey::attribute_range(bucket, label_name);
-        let records = self.scan(range).await?;
-
-        let mut values = Vec::new();
-        for record in records {
-            let key = InvertedIndexKey::decode(record.key.as_ref())?;
-            values.push(key.value);
-        }
-
-        Ok(values)
-    }
-}
-
-// Implement the trait for all types that implement StorageRead
-impl<T: ?Sized + StorageRead> OpenTsdbStorageReadExt for T {}
-
-pub(crate) trait OpenTsdbStorageExt: Storage {
-    fn merge_bucket_list(&self, bucket: TimeBucket, ttl: Ttl) -> Result<RecordOp> {
-        let key = BucketListKey.encode();
-        let value = BucketListValue {
-            buckets: vec![(bucket.size, bucket.start)],
-        }
-        .encode();
-
-        Ok(RecordOp::Merge(MergeRecordOp::new_with_ttl(
-            Record { key, value },
-            MergeOptions { ttl },
-        )))
-    }
-
-    fn insert_series_id(
-        &self,
-        bucket: TimeBucket,
-        fingerprint: SeriesFingerprint,
-        id: SeriesId,
-        ttl: Ttl,
-    ) -> Result<RecordOp> {
-        let key = SeriesDictionaryKey {
-            time_bucket: bucket.start,
-            bucket_size: bucket.size,
-            series_fingerprint: fingerprint,
-        }
-        .encode();
-        let value = SeriesDictionaryValue { series_id: id }.encode();
-        Ok(RecordOp::Put(PutRecordOp::new_with_options(
-            Record { key, value },
-            PutOptions { ttl },
-        )))
-    }
-
-    fn insert_forward_index(
-        &self,
-        bucket: TimeBucket,
-        series_id: SeriesId,
-        series_spec: SeriesSpec,
-        ttl: Ttl,
-    ) -> Result<RecordOp> {
-        let key = ForwardIndexKey {
-            time_bucket: bucket.start,
-            bucket_size: bucket.size,
-            series_id,
-        }
-        .encode();
-        let value = ForwardIndexValue {
-            metric_unit: series_spec.unit,
-            metric_meta: series_spec.metric_type.into(),
-            label_count: series_spec.labels.len() as u16,
-            labels: series_spec.labels,
-        }
-        .encode();
-        Ok(RecordOp::Put(PutRecordOp::new_with_options(
-            Record { key, value },
-            PutOptions { ttl },
-        )))
-    }
-
-    fn merge_inverted_index(
-        &self,
-        bucket: TimeBucket,
-        label: Label,
-        postings: RoaringBitmap,
-        ttl: Ttl,
-    ) -> Result<RecordOp> {
-        let key = InvertedIndexKey {
-            time_bucket: bucket.start,
-            bucket_size: bucket.size,
-            attribute: label.name,
-            value: label.value,
-        }
-        .encode();
-        let value = InvertedIndexValue { postings }.encode()?;
-        Ok(RecordOp::Merge(MergeRecordOp::new_with_ttl(
-            Record { key, value },
-            MergeOptions { ttl },
-        )))
-    }
-
-    fn merge_samples(
-        &self,
-        bucket: TimeBucket,
-        series_id: SeriesId,
-        metric_name: &str,
-        samples: Vec<Sample>,
-        ttl: Ttl,
-    ) -> Result<RecordOp> {
-        let key = TimeSeriesKey {
-            time_bucket: bucket.start,
-            bucket_size: bucket.size,
-            metric_name: metric_name.to_string(),
-            series_id,
-        }
-        .encode();
-        let value = TimeSeriesValue { points: samples }.encode()?;
-        Ok(RecordOp::Merge(MergeRecordOp::new_with_ttl(
-            Record { key, value },
-            MergeOptions { ttl },
-        )))
-    }
-}
-
-// Implement the trait for all types that implement Storage
-impl<T: ?Sized + Storage> OpenTsdbStorageExt for T {}
-
-/// Read the current `BucketList` value and rewrite it as a single `Put`,
-/// collapsing the merge chain that accrues across ingestion batches into
-/// one flat record. Intended to run once at startup before ingestion
-/// begins, so later reads don't have to replay operands scattered across
-/// SSTs. Safe only when there are no concurrent writers.
-#[tracing::instrument(level = "info", skip_all)]
-pub(crate) async fn coalesce_bucket_list(storage: &dyn Storage) -> Result<()> {
-    let key = BucketListKey.encode();
-    let Some(record) = storage.get(key.clone()).await? else {
-        return Ok(());
-    };
-    storage
-        .put(vec![PutRecordOp::new(Record {
-            key,
-            value: record.value,
-        })])
-        .await?;
-    Ok(())
-}
+#[cfg(any(test, feature = "testing"))]
+pub(crate) use factory::in_memory_storage;
+#[cfg(test)]
+pub(crate) use factory::{FailingStorage, SharedInMemoryStorage, in_memory_shared_storage};
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::storage::merge_operator::OpenTsdbMergeOperator;
-    use common::storage::PutRecordOp;
-    use common::storage::in_memory::InMemoryStorage;
+    use crate::model::TimeBucket;
+    use crate::serde::bucket_list::BucketListValue;
+    use crate::serde::key::BucketListKey;
+    use crate::storage::{Storage, StorageRead, in_memory_storage, merge_bucket_list};
+    use common::Record;
+    use common::storage::{PutRecordOp, Ttl};
     use std::sync::Arc;
 
-    /// Create an InMemoryStorage with the given hour-buckets pre-populated.
+    /// Create a SlateDb storage with the given hour-buckets pre-populated.
     /// Each entry in `bucket_starts` is the bucket start in minutes.
-    async fn storage_with_buckets(bucket_starts: &[u32]) -> Arc<InMemoryStorage> {
-        let storage = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-            OpenTsdbMergeOperator,
-        )));
+    async fn storage_with_buckets(bucket_starts: &[u32]) -> Arc<Storage> {
+        let storage = Arc::new(in_memory_storage().await);
         let buckets: Vec<(u8, u32)> = bucket_starts.iter().map(|&s| (1u8, s)).collect();
         let key = BucketListKey.encode();
         let value = BucketListValue { buckets }.encode();
@@ -581,9 +149,7 @@ mod tests {
     #[tokio::test]
     async fn should_return_false_when_bucket_list_key_missing() {
         // given
-        let storage = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-            OpenTsdbMergeOperator,
-        )));
+        let storage = Arc::new(in_memory_storage().await);
 
         // when
         let present = storage
@@ -620,30 +186,23 @@ mod tests {
     #[tokio::test]
     async fn should_coalesce_bucket_list_preserving_merged_value() {
         // given: several merge operands have accrued on the BucketList key
-        let storage = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-            OpenTsdbMergeOperator,
-        )));
+        let storage = Arc::new(in_memory_storage().await);
         let ops = vec![
-            storage
-                .merge_bucket_list(TimeBucket { size: 1, start: 0 }, Ttl::Default)
-                .unwrap(),
-            storage
-                .merge_bucket_list(TimeBucket { size: 1, start: 60 }, Ttl::Default)
-                .unwrap(),
-            storage
-                .merge_bucket_list(
-                    TimeBucket {
-                        size: 1,
-                        start: 120,
-                    },
-                    Ttl::Default,
-                )
-                .unwrap(),
+            merge_bucket_list(TimeBucket { size: 1, start: 0 }, Ttl::Default).unwrap(),
+            merge_bucket_list(TimeBucket { size: 1, start: 60 }, Ttl::Default).unwrap(),
+            merge_bucket_list(
+                TimeBucket {
+                    size: 1,
+                    start: 120,
+                },
+                Ttl::Default,
+            )
+            .unwrap(),
         ];
         storage.apply(ops).await.unwrap();
 
         // when
-        coalesce_bucket_list(storage.as_ref()).await.unwrap();
+        storage.coalesce_bucket_list().await.unwrap();
 
         // then: readable value still reflects the full merged list
         let buckets = storage.get_buckets_in_range(None, None).await.unwrap();
@@ -653,15 +212,13 @@ mod tests {
     #[tokio::test]
     async fn should_be_noop_when_bucket_list_absent() {
         // given
-        let storage = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-            OpenTsdbMergeOperator,
-        )));
+        let storage = Arc::new(in_memory_storage().await);
 
         // when
-        coalesce_bucket_list(storage.as_ref()).await.unwrap();
+        storage.coalesce_bucket_list().await.unwrap();
 
         // then: key is still absent
-        let record = storage.get(BucketListKey.encode()).await.unwrap();
-        assert!(record.is_none());
+        let value = storage.get(BucketListKey.encode()).await.unwrap();
+        assert!(value.is_none());
     }
 }

--- a/timeseries/src/testing/columnar_stress.rs
+++ b/timeseries/src/testing/columnar_stress.rs
@@ -2,13 +2,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use common::storage::in_memory::InMemoryStorage;
+use crate::storage::in_memory_storage;
 
 use crate::model::{
     InstantSample, Label, Labels, MetricType, QueryOptions, RangeSample, Sample, Series,
     Temporality,
 };
-use crate::storage::merge_operator::OpenTsdbMergeOperator;
 use crate::tsdb::Tsdb;
 
 const BUCKET_MS: i64 = 60 * 60 * 1000;
@@ -199,9 +198,7 @@ pub(crate) fn build_oracle(scenario: &Scenario) -> Oracle {
 }
 
 pub(crate) async fn create_tsdb_for_scenario(scenario: &Scenario) -> Tsdb {
-    let tsdb = Tsdb::new(Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-        OpenTsdbMergeOperator,
-    ))));
+    let tsdb = Tsdb::new(Arc::new(in_memory_storage().await));
 
     for bucket_idx in 0..scenario.config.bucket_count {
         let bucket_series = build_bucket_series(scenario, bucket_idx);

--- a/timeseries/src/testing/mod.rs
+++ b/timeseries/src/testing/mod.rs
@@ -13,9 +13,8 @@ pub mod http;
 use std::sync::Arc;
 
 use common::storage::config::SlateDbStorageConfig;
-use common::{StorageBuilder, StorageConfig, StorageSemantics};
 
-use common::Storage;
+use crate::storage::Storage;
 
 /// Install a global metrics-rs recorder once for the test process.
 ///
@@ -36,7 +35,6 @@ pub fn ensure_metrics_recorder() -> metrics_exporter_prometheus::PrometheusHandl
 }
 
 use crate::model::Series;
-use crate::storage::merge_operator::OpenTsdbMergeOperator;
 use crate::tsdb::Tsdb;
 
 // Re-export storage config types so benchmarks and integration tests
@@ -61,7 +59,7 @@ pub use crate::promql::response::{query_value_to_response, range_result_to_respo
 /// without the crate needing to expose `Tsdb` as a public type.
 pub struct TestTsdb {
     pub(crate) inner: Arc<Tsdb>,
-    pub(crate) storage: Arc<dyn Storage>,
+    pub(crate) storage: Arc<Storage>,
 }
 
 impl TestTsdb {
@@ -93,22 +91,14 @@ pub async fn create_test_tsdb_with_config(object_store: ObjectStoreConfig) -> Te
     #[cfg(feature = "http-server")]
     ensure_metrics_recorder();
 
-    let config = StorageConfig::SlateDb(SlateDbStorageConfig {
+    let config = SlateDbStorageConfig {
         path: "bench-data".to_string(),
         object_store,
         settings_path: None,
         block_cache: None,
         meta_cache: None,
-    });
-    let storage = StorageBuilder::new(&config)
-        .await
-        .unwrap()
-        .with_semantics(
-            StorageSemantics::new().with_merge_operator(Arc::new(OpenTsdbMergeOperator)),
-        )
-        .build()
-        .await
-        .unwrap();
+    };
+    let storage = Arc::new(Storage::try_new(&config).await.unwrap());
     TestTsdb {
         inner: Arc::new(Tsdb::new(storage.clone())),
         storage,

--- a/timeseries/src/timeseries.rs
+++ b/timeseries/src/timeseries.rs
@@ -8,13 +8,10 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
-use common::{StorageBuilder, StorageSemantics};
-
 use crate::config::Config;
 use crate::error::{QueryError, Result};
 use crate::model::{Labels, MetricMetadata, QueryValue, RangeSample, Series};
-use crate::storage::coalesce_bucket_list;
-use crate::storage::merge_operator::OpenTsdbMergeOperator;
+use crate::storage::Storage;
 use crate::tsdb::{
     Tsdb, TsdbReadEngine, find_label_values_in_range, find_labels_in_range, find_series_in_range,
 };
@@ -29,10 +26,10 @@ use crate::tsdb::{
 ///
 /// ```
 /// # use timeseries::{TimeSeriesDb, Config, Series};
-/// # use common::StorageConfig;
+/// # use common::storage::config::SlateDbStorageConfig;
 /// # #[tokio::main]
 /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let config = Config { storage: StorageConfig::InMemory, ..Default::default() };
+/// let config = Config { storage: SlateDbStorageConfig::default(), ..Default::default() };
 /// let ts = TimeSeriesDb::open(config).await?;
 ///
 /// let series = Series::builder("http_requests_total")
@@ -68,26 +65,16 @@ impl TimeSeriesDb {
     ///
     /// ```
     /// # use timeseries::{TimeSeriesDb, Config};
-    /// # use common::StorageConfig;
+    /// # use common::storage::config::SlateDbStorageConfig;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let config = Config { storage: StorageConfig::InMemory, ..Default::default() };
+    /// let config = Config { storage: SlateDbStorageConfig::default(), ..Default::default() };
     /// let ts = TimeSeriesDb::open(config).await?;
     /// # Ok(())
     /// # }
     /// ```
     pub async fn open(config: Config) -> Result<Self> {
-        let storage = StorageBuilder::new(&config.storage)
-            .await?
-            .with_semantics(
-                StorageSemantics::new().with_merge_operator(Arc::new(OpenTsdbMergeOperator)),
-            )
-            .build()
-            .await?;
-        // Flatten accumulated BucketList merge operands into a single Put so
-        // later reads don't have to replay them across SSTs. Runs before any
-        // writer is started, so no concurrent merges can race the Put.
-        coalesce_bucket_list(storage.as_ref()).await?;
+        let storage = Arc::new(Storage::try_new(&config.storage).await?);
         let tsdb = Tsdb::with_retention(storage, config.retention);
         Ok(Self { tsdb })
     }
@@ -119,10 +106,10 @@ impl TimeSeriesDb {
     ///
     /// ```no_run
     /// # use timeseries::{TimeSeriesDb, Config, Series};
-    /// # use common::StorageConfig;
+    /// # use common::storage::config::SlateDbStorageConfig;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let config = Config { storage: StorageConfig::InMemory, ..Default::default() };
+    /// # let config = Config { storage: SlateDbStorageConfig::default(), ..Default::default() };
     /// # let ts = TimeSeriesDb::open(config).await?;
     /// let series = vec![
     ///     Series::builder("cpu_usage")
@@ -156,11 +143,11 @@ impl TimeSeriesDb {
     ///
     /// ```no_run
     /// # use timeseries::{TimeSeriesDb, Config, Series};
-    /// # use common::StorageConfig;
+    /// # use common::storage::config::SlateDbStorageConfig;
     /// # use std::time::Duration;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let config = Config { storage: StorageConfig::InMemory, ..Default::default() };
+    /// # let config = Config { storage: SlateDbStorageConfig::default(), ..Default::default() };
     /// # let ts = TimeSeriesDb::open(config).await?;
     /// let series = vec![
     ///     Series::builder("cpu_usage")
@@ -284,7 +271,6 @@ impl TimeSeriesDb {
 mod tests {
     use super::*;
     use crate::model::{Label, Sample, Series};
-    use common::StorageConfig;
     use common::storage::config::{
         LocalObjectStoreConfig, ObjectStoreConfig, SlateDbStorageConfig,
     };
@@ -292,7 +278,7 @@ mod tests {
     #[tokio::test]
     async fn close_without_explicit_flush_guarantees_durability() {
         let tmp_dir = tempfile::tempdir().unwrap();
-        let storage = StorageConfig::SlateDb(SlateDbStorageConfig {
+        let storage = SlateDbStorageConfig {
             path: "ts-data".to_string(),
             object_store: ObjectStoreConfig::Local(LocalObjectStoreConfig {
                 path: tmp_dir.path().to_str().unwrap().to_string(),
@@ -300,7 +286,7 @@ mod tests {
             settings_path: None,
             block_cache: None,
             meta_cache: None,
-        });
+        };
 
         // Write a series and close without calling flush()
         {

--- a/timeseries/src/tsdb.rs
+++ b/timeseries/src/tsdb.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use async_trait::async_trait;
-use common::{Storage, StorageRead};
 use futures::stream;
 use futures::{StreamExt, TryStreamExt};
 use moka::future::Cache;
@@ -21,7 +20,7 @@ use crate::model::{
     TimeBucket,
 };
 use crate::query::{BucketQueryReader, QueryReader};
-use crate::storage::OpenTsdbStorageReadExt;
+use crate::storage::{Storage, StorageRead, StorageSnapshot};
 use crate::tsdb_metrics;
 use crate::util::Result;
 
@@ -969,7 +968,7 @@ pub(crate) async fn discover_label_values<R: QueryReader>(
 /// Tsdb manages multiple MiniTsdb instances (one per time bucket) and provides
 /// a unified QueryReader interface that merges results across buckets.
 pub(crate) struct Tsdb {
-    storage: Arc<dyn Storage>,
+    storage: Arc<Storage>,
 
     /// TTI cache (15 min idle) for buckets being actively ingested into.
     /// Also used during queries so that unflushed data is visible.
@@ -989,11 +988,11 @@ pub(crate) struct Tsdb {
 }
 
 impl Tsdb {
-    pub(crate) fn new(storage: Arc<dyn Storage>) -> Self {
+    pub(crate) fn new(storage: Arc<Storage>) -> Self {
         Self::with_retention(storage, None)
     }
 
-    pub(crate) fn with_retention(storage: Arc<dyn Storage>, retention: Option<Duration>) -> Self {
+    pub(crate) fn with_retention(storage: Arc<Storage>, retention: Option<Duration>) -> Self {
         // TTI cache: 15 minute idle timeout for ingest buckets
         let ingest_cache = Cache::builder()
             .time_to_idle(Duration::from_secs(15 * 60))
@@ -1012,8 +1011,8 @@ impl Tsdb {
 
     /// Returns a read handle to the underlying storage, for background tasks
     /// like the cache warmer.
-    pub(crate) fn storage_read(&self) -> Arc<dyn StorageRead> {
-        self.storage.clone() as Arc<dyn StorageRead>
+    pub(crate) fn storage_read(&self) -> Storage {
+        (*self.storage).clone()
     }
 
     /// Get or create a MiniTsdb for ingestion into a specific bucket.
@@ -1084,15 +1083,15 @@ impl Tsdb {
     /// available, otherwise constructs a reader directly from the snapshot.
     async fn build_readers(
         &self,
-        snapshot: &Arc<dyn common::storage::StorageSnapshot>,
+        snapshot: &StorageSnapshot,
         buckets: Vec<TimeBucket>,
-    ) -> Vec<(TimeBucket, MiniQueryReader)> {
+    ) -> Vec<(TimeBucket, MiniQueryReader<StorageSnapshot>)> {
         let mut readers = Vec::with_capacity(buckets.len());
         for bucket in buckets {
             let reader = if let Some(mini) = self.ingest_cache.get(&bucket).await {
                 mini.query_reader()
             } else {
-                MiniQueryReader::new(bucket, snapshot.clone() as Arc<dyn StorageRead>)
+                MiniQueryReader::new(bucket, snapshot.clone())
             };
             readers.push((bucket, reader));
         }
@@ -1299,15 +1298,6 @@ impl TsdbEngine {
     /// Returns `true` when the engine is read-only.
     pub(crate) fn is_read_only(&self) -> bool {
         matches!(self, Self::ReadOnly(_))
-    }
-
-    /// Returns a read handle to the underlying storage, for background tasks
-    /// like the cache warmer.
-    pub(crate) fn storage_read(&self) -> Arc<dyn StorageRead> {
-        match self {
-            Self::ReadWrite(tsdb) => tsdb.storage_read(),
-            Self::ReadOnly(reader) => reader.storage_read(),
-        }
     }
 
     /// Returns a clone of the inner `Arc<Tsdb>` if this is a read-write engine.
@@ -1553,11 +1543,11 @@ impl From<Arc<crate::reader::TimeSeriesDbReader>> for TsdbEngine {
 /// QueryReader implementation that properly handles bucket-scoped series IDs.
 pub(crate) struct TsdbQueryReader {
     /// Map from bucket to MiniTsdb for efficient bucket queries
-    mini_readers: HashMap<TimeBucket, MiniQueryReader>,
+    mini_readers: HashMap<TimeBucket, MiniQueryReader<StorageSnapshot>>,
 }
 
 impl TsdbQueryReader {
-    pub fn new(mini_tsdbs: Vec<(TimeBucket, MiniQueryReader)>) -> Self {
+    pub fn new(mini_tsdbs: Vec<(TimeBucket, MiniQueryReader<StorageSnapshot>)>) -> Self {
         let bucket_minis = mini_tsdbs.into_iter().collect();
         Self {
             mini_readers: bucket_minis,
@@ -1652,9 +1642,7 @@ impl QueryReader for TsdbQueryReader {
 mod tests {
     use super::*;
     use crate::model::MetricType;
-    use crate::storage::merge_operator::OpenTsdbMergeOperator;
-    use common::storage::in_memory::InMemoryStorage;
-    use opendata_macros::storage_test;
+    use crate::storage::in_memory_storage;
 
     fn create_sample(
         metric_name: &str,
@@ -1684,8 +1672,9 @@ mod tests {
         }
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn should_create_tsdb_with_caches(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn should_create_tsdb_with_caches() {
+        let storage = Arc::new(in_memory_storage().await);
         // when
         let tsdb = Tsdb::new(storage);
 
@@ -1694,8 +1683,9 @@ mod tests {
         assert_eq!(tsdb.ingest_cache.entry_count(), 0);
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn should_get_or_create_bucket_for_ingest(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn should_get_or_create_bucket_for_ingest() {
+        let storage = Arc::new(in_memory_storage().await);
         // given
         let tsdb = Tsdb::new(storage);
         let bucket = TimeBucket::hour(1000);
@@ -1710,8 +1700,9 @@ mod tests {
         assert_eq!(tsdb.ingest_cache.entry_count(), 1);
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn should_use_ingest_cache_during_queries(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn should_use_ingest_cache_during_queries() {
+        let storage = Arc::new(in_memory_storage().await);
         // given: a bucket in the ingest cache with ingested data
         let tsdb = Tsdb::new(storage);
         let bucket = TimeBucket::hour(60);
@@ -1729,8 +1720,9 @@ mod tests {
         assert_eq!(buckets.len(), 1);
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn should_ingest_and_query_single_bucket(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn should_ingest_and_query_single_bucket() {
+        let storage = Arc::new(in_memory_storage().await);
         // given
         let tsdb = Tsdb::new(storage);
 
@@ -1761,8 +1753,9 @@ mod tests {
         assert_eq!(series_ids.len(), 1);
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn should_query_across_multiple_buckets(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn should_query_across_multiple_buckets() {
+        let storage = Arc::new(in_memory_storage().await);
         use crate::test_utils::assertions::assert_approx_eq;
         use std::time::{Duration, UNIX_EPOCH};
 
@@ -1932,13 +1925,12 @@ mod tests {
         }
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn should_query_across_multiple_buckets_with_different_series_id_mappings(
-        storage: Arc<dyn Storage>,
-    ) {
+    #[tokio::test]
+    async fn should_query_across_multiple_buckets_with_different_series_id_mappings() {
         use std::time::{Duration, UNIX_EPOCH};
 
         // given: Two time buckets with overlapping series but different series IDs
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
         // Bucket 1: hour 60 (covers 3,600,000-7,199,999 ms)
         let bucket1 = TimeBucket::hour(60);
@@ -2012,9 +2004,7 @@ mod tests {
     // ── Native read method tests ─────────────────────────────────────
 
     async fn create_tsdb_with_data() -> Tsdb {
-        let tsdb = Tsdb::new(Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-            OpenTsdbMergeOperator,
-        ))));
+        let tsdb = Tsdb::new(Arc::new(in_memory_storage().await));
 
         // Ingest two series into bucket at minute 60 (covers 3,600,000–7,199,999 ms)
         let series = vec![
@@ -2114,8 +2104,9 @@ mod tests {
         );
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn eval_query_should_return_scalar(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn eval_query_should_return_scalar() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
         let query_time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(100);
 
@@ -2143,8 +2134,9 @@ mod tests {
         }
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn eval_query_should_return_error_for_invalid_query(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn eval_query_should_return_error_for_invalid_query() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
 
         let opts = QueryOptions::default();
@@ -2177,8 +2169,9 @@ mod tests {
         assert_eq!(results[1].labels.get("env"), Some("staging"));
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn eval_query_range_should_return_scalar(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn eval_query_range_should_return_scalar() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
         let start = std::time::UNIX_EPOCH + std::time::Duration::from_secs(100);
         let end = std::time::UNIX_EPOCH + std::time::Duration::from_secs(160);
@@ -2197,8 +2190,9 @@ mod tests {
         assert_eq!(results[0].samples[1].1, 2.0);
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn eval_query_range_should_return_error_for_invalid_query(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn eval_query_range_should_return_error_for_invalid_query() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
         let start = std::time::UNIX_EPOCH + std::time::Duration::from_secs(100);
         let end = std::time::UNIX_EPOCH + std::time::Duration::from_secs(200);
@@ -2236,8 +2230,9 @@ mod tests {
         assert_eq!(results[1].get("env"), Some("staging"));
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn find_series_should_error_on_empty_matchers(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn find_series_should_error_on_empty_matchers() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
 
         let result = tsdb.find_series(&[], 0, i64::MAX).await;
@@ -2249,8 +2244,9 @@ mod tests {
         ));
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn find_series_should_dedup_across_buckets(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn find_series_should_dedup_across_buckets() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
 
         // Same series in two different buckets
@@ -2292,8 +2288,9 @@ mod tests {
         assert!(results.contains(&"env".to_string()));
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn find_labels_should_return_empty_for_no_data(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn find_labels_should_return_empty_for_no_data() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
 
         let results = tsdb.find_labels(None, 0, 100).await.unwrap();
@@ -2325,16 +2322,18 @@ mod tests {
         assert_eq!(results, vec!["prod"]);
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn find_label_values_should_return_empty_for_no_data(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn find_label_values_should_return_empty_for_no_data() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
 
         let results = tsdb.find_label_values("env", None, 0, 100).await.unwrap();
         assert!(results.is_empty());
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn find_metadata_should_return_all(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn find_metadata_should_return_all() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
 
         let mut series = create_sample("cpu", vec![("host", "a")], 4_000_000, 1.0);
@@ -2390,8 +2389,9 @@ mod tests {
         }
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn eval_query_with_offset_before_epoch_should_not_error(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn eval_query_with_offset_before_epoch_should_not_error() {
+        let storage = Arc::new(in_memory_storage().await);
         // Query at 100s with offset 1h → effective time = -3500s (before epoch).
         let tsdb = Tsdb::new(storage);
         let query_time = std::time::UNIX_EPOCH + std::time::Duration::from_secs(100);
@@ -2408,8 +2408,9 @@ mod tests {
         );
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn eval_query_range_with_at_before_epoch_should_not_error(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn eval_query_range_with_at_before_epoch_should_not_error() {
+        let storage = Arc::new(in_memory_storage().await);
         // `@ 0 offset 1h` pins evaluation to t=0, then offset pushes to -3600.
         let tsdb = Tsdb::new(storage);
         let start = std::time::UNIX_EPOCH + std::time::Duration::from_secs(1000);
@@ -2457,8 +2458,9 @@ mod tests {
     // Multi-bucket dedup for labels and label_values
     // -----------------------------------------------------------------------
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn find_labels_should_dedup_across_buckets(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn find_labels_should_dedup_across_buckets() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
 
         // Same series in two different buckets
@@ -2484,8 +2486,9 @@ mod tests {
         assert!(results.contains(&"host".to_string()));
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn find_label_values_should_dedup_across_buckets(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn find_label_values_should_dedup_across_buckets() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
 
         // Same series in two different buckets
@@ -2508,8 +2511,9 @@ mod tests {
         );
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn find_metadata_should_filter_by_metric(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn find_metadata_should_filter_by_metric() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
 
         tsdb.ingest_samples(
@@ -2530,8 +2534,9 @@ mod tests {
         assert!(results.is_empty());
     }
 
-    #[storage_test(merge_operator = OpenTsdbMergeOperator)]
-    async fn eval_query_range_rejects_zero_step(storage: Arc<dyn Storage>) {
+    #[tokio::test]
+    async fn eval_query_range_rejects_zero_step() {
+        let storage = Arc::new(in_memory_storage().await);
         let tsdb = Tsdb::new(storage);
 
         tsdb.ingest_samples(vec![create_sample("cpu", vec![], 1_000_000, 1.0)], None)
@@ -2647,9 +2652,7 @@ mod tests {
         producer.close().await.unwrap();
 
         // Start the real BufferConsumer against the shared object store
-        let tsdb = Arc::new(Tsdb::new(Arc::new(InMemoryStorage::with_merge_operator(
-            Arc::new(OpenTsdbMergeOperator),
-        ))));
+        let tsdb = Arc::new(Tsdb::new(Arc::new(in_memory_storage().await)));
         let converter = Arc::new(crate::otel::OtelConverter::new(
             crate::otel::OtelConfig::default(),
         ));
@@ -2707,9 +2710,7 @@ mod tests {
         };
 
         async fn create_tsdb_with_counter() -> Tsdb {
-            let tsdb = Tsdb::new(Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-                OpenTsdbMergeOperator,
-            ))));
+            let tsdb = Tsdb::new(Arc::new(in_memory_storage().await));
             // Counter over bucket at minute 60 (covers 3.6M-7.2M ms).
             // Samples every 10s at 4_000_000, 4_010_000, 4_020_000.
             let series = vec![
@@ -3038,9 +3039,7 @@ mod tests {
         /// base_ts + step)` — two samples per series so `sum_over_time`
         /// has real values to aggregate inside the 10s sub-window.
         async fn create_tsdb_with_large_roster(metric: &str, n_series: usize) -> Tsdb {
-            let tsdb = Tsdb::new(Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-                OpenTsdbMergeOperator,
-            ))));
+            let tsdb = Tsdb::new(Arc::new(in_memory_storage().await));
             let mut samples = Vec::with_capacity(n_series * 2);
             for i in 0..n_series {
                 samples.push(create_sample(
@@ -3113,9 +3112,7 @@ mod tests {
             const N_SERIES: usize = 1500;
             const GROUPS: usize = 3;
             let tsdb = {
-                let tsdb = Tsdb::new(Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-                    OpenTsdbMergeOperator,
-                ))));
+                let tsdb = Tsdb::new(Arc::new(in_memory_storage().await));
                 let mut samples = Vec::with_capacity(N_SERIES);
                 for i in 0..N_SERIES {
                     samples.push(create_sample(
@@ -3355,10 +3352,8 @@ mod tests {
         /// counter spanning 3 samples, flush, and return both handles.
         async fn create_writer_and_reader_with_counter() -> (Tsdb, crate::reader::TimeSeriesDbReader)
         {
-            let storage = Arc::new(InMemoryStorage::with_merge_operator(Arc::new(
-                OpenTsdbMergeOperator,
-            )));
-            let tsdb = Tsdb::new(storage.clone());
+            let shared = crate::storage::in_memory_shared_storage().await;
+            let tsdb = Tsdb::new(shared.storage.clone());
             let series = vec![
                 create_sample("req_total", vec![("env", "prod")], 4_000_000, 10.0),
                 create_sample("req_total", vec![("env", "prod")], 4_010_000, 20.0),
@@ -3366,7 +3361,8 @@ mod tests {
             ];
             tsdb.ingest_samples(series, None).await.unwrap();
             tsdb.flush().await.unwrap();
-            let reader = crate::reader::TimeSeriesDbReader::from_storage(storage);
+            // Open the reader only after the flush so its view includes the data.
+            let reader = crate::reader::TimeSeriesDbReader::from_storage(shared.reader().await);
             (tsdb, reader)
         }
 


### PR DESCRIPTION
## Summary

Replaces usages of common storage with usages of SlateDB-native storage introduce in https://github.com/opendata-oss/opendata/pull/504.

This PR is stacked on https://github.com/opendata-oss/opendata/pull/504.
For review, look at c6461e6 and above.  

## Test Plan

unit tests

## Checklist

- [ ] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
