### PR TITLE
vector: collapse nested if into a match guard (clippy collapsible_match)

### DIFF
--- a/vector/src/storage/compaction_scheduler.rs
+++ b/vector/src/storage/compaction_scheduler.rs
@@ -126,10 +126,10 @@ impl FtsDeleteTracker {
     ) {
         let mut state = self.state.lock().unwrap();
         match &*state {
-            FtsDeleteTrackerState::Compacted { manifest_id, .. } => {
-                if update_manifest_id >= *manifest_id {
-                    *state = FtsDeleteTrackerState::Accumulating(fields);
-                }
+            FtsDeleteTrackerState::Compacted { manifest_id, .. }
+                if update_manifest_id >= *manifest_id =>
+            {
+                *state = FtsDeleteTrackerState::Accumulating(fields);
             }
             FtsDeleteTrackerState::Accumulating(_) => {
                 *state = FtsDeleteTrackerState::Accumulating(fields);


### PR DESCRIPTION
## Summary

Fixes clippy::collapsible_match flagged by clippy 1.95 under -D warnings.

## Checklist

- [x] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
