### PR TITLE
Common: make snapshot static generic in write coordinator

### DIFF
--- a/common/src/coordinator/handle.rs
+++ b/common/src/coordinator/handle.rs
@@ -3,7 +3,6 @@ use super::{BroadcastedView, WriteCommand};
 use super::{Delta, Durability, WriteError, WriteResult};
 use crate::StorageRead;
 use crate::coordinator::traits::EpochStamped;
-use crate::storage::StorageSnapshot;
 use futures::FutureExt;
 use futures::future::Shared;
 use std::sync::Arc;
@@ -27,7 +26,7 @@ use tokio::sync::{broadcast, mpsc, oneshot, watch};
 pub struct View<D: Delta> {
     pub current: D::DeltaView,
     pub frozen: Vec<EpochStamped<D::FrozenView>>,
-    pub snapshot: Arc<dyn StorageSnapshot>,
+    pub snapshot: D::Snapshot,
     pub last_written_delta: Option<EpochStamped<D::FrozenView>>,
 }
 

--- a/common/src/coordinator/mod.rs
+++ b/common/src/coordinator/mod.rs
@@ -27,7 +27,6 @@ enum FlushEvent<D: Delta> {
 
 // Internal use only
 use crate::StorageRead;
-use crate::storage::StorageSnapshot;
 use async_trait::async_trait;
 pub use handle::EpochWatcher;
 use std::sync::{Arc, Mutex};
@@ -86,7 +85,7 @@ impl<D: Delta, F: Flusher<D>> WriteCoordinator<D, F> {
         config: WriteCoordinatorConfig,
         channels: Vec<impl ToString>,
         initial_context: D::Context,
-        initial_snapshot: Arc<dyn StorageSnapshot>,
+        initial_snapshot: D::Snapshot,
         flusher: F,
     ) -> WriteCoordinator<D, F> {
         let (watermarks, watcher) = EpochWatermarks::new();
@@ -218,7 +217,7 @@ impl<D: Delta> WriteCoordinatorTask<D> {
     pub fn new(
         config: WriteCoordinatorConfig,
         initial_context: D::Context,
-        initial_snapshot: Arc<dyn StorageSnapshot>,
+        initial_snapshot: D::Snapshot,
         write_rxs: Vec<PausableReceiver<D>>,
         flush_tx: mpsc::Sender<FlushEvent<D>>,
         watermarks: Arc<EpochWatermarks>,
@@ -610,7 +609,7 @@ impl<D: Delta> BroadcastedView<D> {
         }
     }
 
-    fn update_flush_finished(&self, snapshot: Arc<dyn StorageSnapshot>, epoch_range: Range<u64>) {
+    fn update_flush_finished(&self, snapshot: D::Snapshot, epoch_range: Range<u64>) {
         self.inner
             .lock()
             .expect("lock poisoned")
@@ -639,11 +638,7 @@ struct BroadcastedViewInner<D: Delta> {
 }
 
 impl<D: Delta> BroadcastedViewInner<D> {
-    fn update_flush_finished(
-        &mut self,
-        snapshot: Arc<dyn StorageSnapshot>,
-        epoch_range: Range<u64>,
-    ) {
+    fn update_flush_finished(&mut self, snapshot: D::Snapshot, epoch_range: Range<u64>) {
         let mut new_frozen = self.view.frozen.clone();
         let last = new_frozen
             .pop()
@@ -800,6 +795,7 @@ mod tests {
         type Frozen = FrozenTestDelta;
         type FrozenView = Arc<HashMap<String, u64>>;
         type ApplyResult = ();
+        type Snapshot = Arc<dyn StorageSnapshot>;
 
         fn init(context: Self::Context) -> Self {
             Self {

--- a/common/src/coordinator/traits.rs
+++ b/common/src/coordinator/traits.rs
@@ -1,6 +1,5 @@
 use crate::StorageRead;
 use crate::coordinator::WriteCommand;
-use crate::storage::StorageSnapshot;
 use async_trait::async_trait;
 use std::ops::Range;
 use std::sync::Arc;
@@ -52,6 +51,12 @@ pub trait Delta: Sized + Send + Sync + 'static {
     /// is up to the delta implementation. It is up to the implementation to provide
     /// the APIs required for a given database, including support for snapshot isolation
     type DeltaView: Clone + Send + Sync + 'static;
+    /// A point-in-time view of flushed storage, produced by the [`Flusher`] and
+    /// broadcast to readers via [`View`](super::View). The coordinator treats it
+    /// as opaque — it only stores, clones, and rebroadcasts it — so the bound is
+    /// deliberately minimal. Each database plugs in its own backend's snapshot
+    /// type (e.g. a trait object over the storage layer, or a concrete handle).
+    type Snapshot: Clone + Send + Sync + 'static;
 
     /// Create a new delta initialized from a snapshot context.
     /// The delta takes ownership of the context while it is mutable.
@@ -101,7 +106,7 @@ pub trait Flusher<D: Delta>: Send + Sync + 'static {
         &mut self,
         frozen: D::Frozen,
         epoch_range: &Range<u64>,
-    ) -> Result<Arc<dyn StorageSnapshot>, String>;
+    ) -> Result<D::Snapshot, String>;
 
     /// Ensure storage durability (e.g. call storage.flush()).
     async fn flush_storage(&self) -> Result<(), String>;

--- a/timeseries/src/delta.rs
+++ b/timeseries/src/delta.rs
@@ -154,6 +154,7 @@ impl Delta for TsdbWriteDelta {
     type FrozenView = ();
     type ApplyResult = ();
     type DeltaView = ();
+    type Snapshot = Arc<dyn common::storage::StorageSnapshot>;
 
     fn init(context: Self::Context) -> Self {
         Self {

--- a/vector/src/write/delta.rs
+++ b/vector/src/write/delta.rs
@@ -63,6 +63,7 @@ impl Delta for VectorDbOpDelta {
     type FrozenView = Arc<VectorDbDeltaView>;
     type ApplyResult = Arc<dyn Any + Send + Sync + 'static>;
     type DeltaView = Arc<std::sync::RwLock<VectorDbDeltaView>>;
+    type Snapshot = Arc<dyn common::storage::StorageSnapshot>;
 
     fn init(_context: Self::Context) -> Self {
         Self {


### PR DESCRIPTION
## Summary

Generalizes the snapshot type in the `WriteCoordinator` to take a static generic type instead of a dynamic trait implementation. 

This change is needed to make `WriteCoordinator` independent of the common storage module. A future commit will make Timeseries use directly SlateDB instead of the common storage module.   
 

## Checklist

- [ ] Tests added/updated
- [x] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
