### PR TITLE
Timeseries: switch key to v2 layout

### DIFF
--- a/timeseries/src/minitsdb.rs
+++ b/timeseries/src/minitsdb.rs
@@ -122,8 +122,7 @@ impl<R: StorageRead> BucketQueryReader for MiniQueryReader<R> {
         end_ms: i64,
     ) -> Result<Vec<Sample>> {
         let storage_key = TimeSeriesKey {
-            time_bucket: self.bucket.start,
-            bucket_size: self.bucket.size,
+            bucket: self.bucket,
             metric_name: metric_name.to_string(),
             series_id,
         };

--- a/timeseries/src/model.rs
+++ b/timeseries/src/model.rs
@@ -21,9 +21,6 @@ pub(crate) type BucketStart = u32;
 /// Time bucket size (1-15, exponential: 1=1h, 2=2h, 3=4h, 4=8h, etc. = 2^(n-1) hours)
 pub(crate) type BucketSize = u8;
 
-// Re-export common RecordTag for internal use
-pub(crate) use common::serde::record_tag::RecordTag;
-
 /// NormalNaN is a quiet NaN (same as f64::NAN)
 pub const NORMAL_NAN: u64 = 0x7ff8000000000001;
 

--- a/timeseries/src/serde/key.rs
+++ b/timeseries/src/serde/key.rs
@@ -1,17 +1,14 @@
 // Key structures with big-endian encoding
 
 use super::*;
-use crate::model::{BucketSize, BucketStart, SeriesFingerprint, SeriesId};
+use crate::model::{SeriesFingerprint, SeriesId, TimeBucket};
 use bytes::{Bytes, BytesMut};
 use common::BytesRange;
-use common::serde::key_prefix::KEY_PREFIX_LEN;
+use common::serde::key_prefix::{KEY_PREFIX_LEN, KeyPrefix};
 use common::serde::terminated_bytes;
 
-/// Offset of the first subsystem-defined field after the 2-byte common prefix
-/// plus the 1-byte timeseries tag.
-const PREFIX_AND_TAG_LEN: usize = KEY_PREFIX_LEN + 1;
-
-/// BucketList key (global-scoped)
+/// BucketList key (global-scoped, 3-byte prefix). Slated for removal in a
+/// follow-up commit alongside the rest of the bucket-list bookkeeping.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BucketListKey;
 
@@ -21,20 +18,19 @@ impl BucketListKey {
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        let tag = parse_record_tag(buf)?;
-        let record_type = RecordType::from_id(tag.record_type())?;
+        KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
+        if buf.len() < KEY_PREFIX_LEN + 1 {
+            return Err(EncodingError {
+                message: "Buffer too short for BucketListKey".to_string(),
+            });
+        }
+        let record_type = RecordType::from_id(buf[KEY_PREFIX_LEN])?;
         if record_type != RecordType::BucketList {
             return Err(EncodingError {
                 message: format!(
                     "invalid record type: expected BucketList, got {:?}",
                     record_type
                 ),
-            });
-        }
-        if bucket_size_from_tag(tag).is_some() {
-            return Err(EncodingError {
-                message: "BucketListKey should be global-scoped (bucket_size should be None)"
-                    .to_string(),
             });
         }
         Ok(BucketListKey)
@@ -44,28 +40,25 @@ impl BucketListKey {
 /// SeriesDictionary key
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SeriesDictionaryKey {
-    pub time_bucket: BucketStart,
-    pub bucket_size: BucketSize,
+    pub bucket: TimeBucket,
     pub series_fingerprint: SeriesFingerprint,
 }
 
 impl SeriesDictionaryKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        RecordType::SeriesDictionary.write_prefix_with_bucket_size(&mut buf, self.bucket_size);
-        buf.extend_from_slice(&self.time_bucket.to_be_bytes());
+        write_record_prefix(&mut buf, &self.bucket, RecordType::SeriesDictionary);
         buf.extend_from_slice(&self.series_fingerprint.to_be_bytes());
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < PREFIX_AND_TAG_LEN + 4 + 16 {
+        if buf.len() < PREFIX_AND_RECORD_TYPE_LEN + 16 {
             return Err(EncodingError {
                 message: "Buffer too short for SeriesDictionaryKey".to_string(),
             });
         }
-        let tag = parse_record_tag(buf)?;
-        let record_type = RecordType::from_id(tag.record_type())?;
+        let (bucket, record_type) = parse_bucket_record_type(buf)?;
         if record_type != RecordType::SeriesDictionary {
             return Err(EncodingError {
                 message: format!(
@@ -74,22 +67,12 @@ impl SeriesDictionaryKey {
                 ),
             });
         }
-        let bucket_size = bucket_size_from_tag(tag).ok_or_else(|| EncodingError {
-            message: "SeriesDictionaryKey should be bucket-scoped".to_string(),
-        })?;
-
-        let suffix = &buf[PREFIX_AND_TAG_LEN..];
-        let time_bucket = u32::from_be_bytes([suffix[0], suffix[1], suffix[2], suffix[3]]);
-        let series_fingerprint = u128::from_be_bytes([
-            suffix[4], suffix[5], suffix[6], suffix[7], suffix[8], suffix[9], suffix[10],
-            suffix[11], suffix[12], suffix[13], suffix[14], suffix[15], suffix[16], suffix[17],
-            suffix[18], suffix[19],
-        ]);
+        let suffix = &buf[PREFIX_AND_RECORD_TYPE_LEN..];
+        let series_fingerprint = u128::from_be_bytes(suffix[..16].try_into().unwrap());
 
         Ok(SeriesDictionaryKey {
-            time_bucket,
+            bucket,
             series_fingerprint,
-            bucket_size,
         })
     }
 }
@@ -99,39 +82,33 @@ impl RecordKey for SeriesDictionaryKey {
 }
 
 impl TimeBucketScoped for SeriesDictionaryKey {
-    fn bucket(&self) -> crate::model::TimeBucket {
-        crate::model::TimeBucket {
-            start: self.time_bucket,
-            size: self.bucket_size,
-        }
+    fn bucket(&self) -> TimeBucket {
+        self.bucket
     }
 }
 
 /// ForwardIndex key
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ForwardIndexKey {
-    pub time_bucket: BucketStart,
-    pub bucket_size: BucketSize,
+    pub bucket: TimeBucket,
     pub series_id: SeriesId,
 }
 
 impl ForwardIndexKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        RecordType::ForwardIndex.write_prefix_with_bucket_size(&mut buf, self.bucket_size);
-        buf.extend_from_slice(&self.time_bucket.to_be_bytes());
+        write_record_prefix(&mut buf, &self.bucket, RecordType::ForwardIndex);
         buf.extend_from_slice(&self.series_id.to_be_bytes());
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < PREFIX_AND_TAG_LEN + 4 + 4 {
+        if buf.len() < PREFIX_AND_RECORD_TYPE_LEN + 4 {
             return Err(EncodingError {
                 message: "Buffer too short for ForwardIndexKey".to_string(),
             });
         }
-        let tag = parse_record_tag(buf)?;
-        let record_type = RecordType::from_id(tag.record_type())?;
+        let (bucket, record_type) = parse_bucket_record_type(buf)?;
         if record_type != RecordType::ForwardIndex {
             return Err(EncodingError {
                 message: format!(
@@ -140,19 +117,10 @@ impl ForwardIndexKey {
                 ),
             });
         }
-        let bucket_size = bucket_size_from_tag(tag).ok_or_else(|| EncodingError {
-            message: "ForwardIndexKey should be bucket-scoped".to_string(),
-        })?;
+        let suffix = &buf[PREFIX_AND_RECORD_TYPE_LEN..];
+        let series_id = u32::from_be_bytes(suffix[..4].try_into().unwrap());
 
-        let suffix = &buf[PREFIX_AND_TAG_LEN..];
-        let time_bucket = u32::from_be_bytes([suffix[0], suffix[1], suffix[2], suffix[3]]);
-        let series_id = u32::from_be_bytes([suffix[4], suffix[5], suffix[6], suffix[7]]);
-
-        Ok(ForwardIndexKey {
-            time_bucket,
-            series_id,
-            bucket_size,
-        })
+        Ok(ForwardIndexKey { bucket, series_id })
     }
 }
 
@@ -161,19 +129,15 @@ impl RecordKey for ForwardIndexKey {
 }
 
 impl TimeBucketScoped for ForwardIndexKey {
-    fn bucket(&self) -> crate::model::TimeBucket {
-        crate::model::TimeBucket {
-            start: self.time_bucket,
-            size: self.bucket_size,
-        }
+    fn bucket(&self) -> TimeBucket {
+        self.bucket
     }
 }
 
 /// InvertedIndex key
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvertedIndexKey {
-    pub time_bucket: BucketStart,
-    pub bucket_size: BucketSize,
+    pub bucket: TimeBucket,
     pub attribute: String,
     pub value: String,
 }
@@ -181,8 +145,7 @@ pub struct InvertedIndexKey {
 impl InvertedIndexKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        RecordType::InvertedIndex.write_prefix_with_bucket_size(&mut buf, self.bucket_size);
-        buf.extend_from_slice(&self.time_bucket.to_be_bytes());
+        write_record_prefix(&mut buf, &self.bucket, RecordType::InvertedIndex);
         // Attribute uses terminated encoding to delimit from value
         terminated_bytes::serialize(self.attribute.as_bytes(), &mut buf);
         // Value is raw UTF-8 (no terminator needed - end of key acts as delimiter)
@@ -192,22 +155,20 @@ impl InvertedIndexKey {
 
     /// Create a BytesRange that covers all entries for a specific attribute (label name)
     /// within a given bucket. This allows efficient scanning for all values of a label.
-    pub fn attribute_range(bucket: &crate::model::TimeBucket, attribute: &str) -> BytesRange {
+    pub fn attribute_range(bucket: &TimeBucket, attribute: &str) -> BytesRange {
         let mut buf = BytesMut::new();
-        RecordType::InvertedIndex.write_prefix_with_bucket_size(&mut buf, bucket.size);
-        buf.extend_from_slice(&bucket.start.to_be_bytes());
+        write_record_prefix(&mut buf, bucket, RecordType::InvertedIndex);
         terminated_bytes::serialize(attribute.as_bytes(), &mut buf);
         BytesRange::prefix(buf.freeze())
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        if buf.len() < PREFIX_AND_TAG_LEN + 4 {
+        if buf.len() < PREFIX_AND_RECORD_TYPE_LEN {
             return Err(EncodingError {
                 message: "Buffer too short for InvertedIndexKey".to_string(),
             });
         }
-        let tag = parse_record_tag(buf)?;
-        let record_type = RecordType::from_id(tag.record_type())?;
+        let (bucket, record_type) = parse_bucket_record_type(buf)?;
         if record_type != RecordType::InvertedIndex {
             return Err(EncodingError {
                 message: format!(
@@ -216,13 +177,7 @@ impl InvertedIndexKey {
                 ),
             });
         }
-        let bucket_size = bucket_size_from_tag(tag).ok_or_else(|| EncodingError {
-            message: "InvertedIndexKey should be bucket-scoped".to_string(),
-        })?;
-
-        let mut slice = &buf[PREFIX_AND_TAG_LEN..];
-        let time_bucket = u32::from_be_bytes([slice[0], slice[1], slice[2], slice[3]]);
-        slice = &slice[4..];
+        let mut slice = &buf[PREFIX_AND_RECORD_TYPE_LEN..];
 
         // Attribute uses terminated encoding
         let attribute_bytes = terminated_bytes::deserialize(&mut slice)?;
@@ -236,10 +191,9 @@ impl InvertedIndexKey {
         })?;
 
         Ok(InvertedIndexKey {
-            time_bucket,
+            bucket,
             attribute,
             value,
-            bucket_size,
         })
     }
 }
@@ -249,11 +203,8 @@ impl RecordKey for InvertedIndexKey {
 }
 
 impl TimeBucketScoped for InvertedIndexKey {
-    fn bucket(&self) -> crate::model::TimeBucket {
-        crate::model::TimeBucket {
-            start: self.time_bucket,
-            size: self.bucket_size,
-        }
+    fn bucket(&self) -> TimeBucket {
+        self.bucket
     }
 }
 
@@ -267,8 +218,7 @@ impl TimeBucketScoped for InvertedIndexKey {
 /// PromQL range queries on the cold path.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TimeSeriesKey {
-    pub time_bucket: BucketStart,
-    pub bucket_size: BucketSize,
+    pub bucket: TimeBucket,
     pub metric_name: String,
     pub series_id: SeriesId,
 }
@@ -276,22 +226,20 @@ pub struct TimeSeriesKey {
 impl TimeSeriesKey {
     pub fn encode(&self) -> Bytes {
         let mut buf = BytesMut::new();
-        RecordType::TimeSeries.write_prefix_with_bucket_size(&mut buf, self.bucket_size);
-        buf.extend_from_slice(&self.time_bucket.to_be_bytes());
+        write_record_prefix(&mut buf, &self.bucket, RecordType::TimeSeries);
         terminated_bytes::serialize(self.metric_name.as_bytes(), &mut buf);
         buf.extend_from_slice(&self.series_id.to_be_bytes());
         buf.freeze()
     }
 
     pub fn decode(buf: &[u8]) -> Result<Self, EncodingError> {
-        // Minimum: prefix+tag + 4 (bucket) + 1 (terminated empty metric_name = just 0x00) + 4 (series_id)
-        if buf.len() < PREFIX_AND_TAG_LEN + 4 + 1 + 4 {
+        // Minimum: header + 1 (terminated empty metric_name = just 0x00) + 4 (series_id)
+        if buf.len() < PREFIX_AND_RECORD_TYPE_LEN + 1 + 4 {
             return Err(EncodingError {
                 message: "Buffer too short for TimeSeriesKey".to_string(),
             });
         }
-        let tag = parse_record_tag(buf)?;
-        let record_type = RecordType::from_id(tag.record_type())?;
+        let (bucket, record_type) = parse_bucket_record_type(buf)?;
         if record_type != RecordType::TimeSeries {
             return Err(EncodingError {
                 message: format!(
@@ -300,19 +248,8 @@ impl TimeSeriesKey {
                 ),
             });
         }
-        let bucket_size = bucket_size_from_tag(tag).ok_or_else(|| EncodingError {
-            message: "TimeSeriesKey should be bucket-scoped".to_string(),
-        })?;
 
-        let bucket_offset = PREFIX_AND_TAG_LEN;
-        let time_bucket = u32::from_be_bytes([
-            buf[bucket_offset],
-            buf[bucket_offset + 1],
-            buf[bucket_offset + 2],
-            buf[bucket_offset + 3],
-        ]);
-
-        let mut slice = &buf[bucket_offset + 4..];
+        let mut slice = &buf[PREFIX_AND_RECORD_TYPE_LEN..];
         let metric_name_bytes = terminated_bytes::deserialize(&mut slice)?;
         let metric_name =
             String::from_utf8(metric_name_bytes.to_vec()).map_err(|e| EncodingError {
@@ -327,10 +264,9 @@ impl TimeSeriesKey {
         let series_id = u32::from_be_bytes([slice[0], slice[1], slice[2], slice[3]]);
 
         Ok(TimeSeriesKey {
-            time_bucket,
+            bucket,
             metric_name,
             series_id,
-            bucket_size,
         })
     }
 }
@@ -340,11 +276,8 @@ impl RecordKey for TimeSeriesKey {
 }
 
 impl TimeBucketScoped for TimeSeriesKey {
-    fn bucket(&self) -> crate::model::TimeBucket {
-        crate::model::TimeBucket {
-            start: self.time_bucket,
-            size: self.bucket_size,
-        }
+    fn bucket(&self) -> TimeBucket {
+        self.bucket
     }
 }
 
@@ -369,9 +302,11 @@ mod tests {
     fn should_encode_and_decode_series_dictionary_key() {
         // given
         let key = SeriesDictionaryKey {
-            time_bucket: 12345,
+            bucket: TimeBucket {
+                start: 12345,
+                size: 2,
+            },
             series_fingerprint: 67890,
-            bucket_size: 2,
         };
 
         // when
@@ -386,9 +321,11 @@ mod tests {
     fn should_encode_and_decode_forward_index_key() {
         // given
         let key = ForwardIndexKey {
-            time_bucket: 12345,
+            bucket: TimeBucket {
+                start: 12345,
+                size: 3,
+            },
             series_id: 42,
-            bucket_size: 3,
         };
 
         // when
@@ -403,10 +340,12 @@ mod tests {
     fn should_encode_and_decode_inverted_index_key() {
         // given
         let key = InvertedIndexKey {
-            time_bucket: 12345,
+            bucket: TimeBucket {
+                start: 12345,
+                size: 1,
+            },
             attribute: "host".to_string(),
             value: "server1".to_string(),
-            bucket_size: 1,
         };
 
         // when
@@ -421,10 +360,12 @@ mod tests {
     fn should_encode_and_decode_time_series_key() {
         // given
         let key = TimeSeriesKey {
-            time_bucket: 12345,
+            bucket: TimeBucket {
+                start: 12345,
+                size: 4,
+            },
             metric_name: "http_requests_total".to_string(),
             series_id: 99,
-            bucket_size: 4,
         };
 
         // when
@@ -438,10 +379,12 @@ mod tests {
     #[test]
     fn should_encode_and_decode_time_series_key_with_empty_metric_name() {
         let key = TimeSeriesKey {
-            time_bucket: 12345,
+            bucket: TimeBucket {
+                start: 12345,
+                size: 1,
+            },
             metric_name: "".to_string(),
             series_id: 7,
-            bucket_size: 1,
         };
 
         let encoded = key.encode();
@@ -453,29 +396,33 @@ mod tests {
     #[test]
     fn should_sort_time_series_keys_by_bucket_then_metric_then_series() {
         // Keys with the same bucket should sort by metric name, then series id
+        let bucket_a = TimeBucket {
+            start: 100,
+            size: 1,
+        };
+        let bucket_d = TimeBucket {
+            start: 200,
+            size: 1,
+        };
         let key_a = TimeSeriesKey {
-            time_bucket: 100,
+            bucket: bucket_a,
             metric_name: "cpu_usage".to_string(),
             series_id: 2,
-            bucket_size: 1,
         };
         let key_b = TimeSeriesKey {
-            time_bucket: 100,
+            bucket: bucket_a,
             metric_name: "cpu_usage".to_string(),
             series_id: 10,
-            bucket_size: 1,
         };
         let key_c = TimeSeriesKey {
-            time_bucket: 100,
+            bucket: bucket_a,
             metric_name: "memory_usage".to_string(),
             series_id: 1,
-            bucket_size: 1,
         };
         let key_d = TimeSeriesKey {
-            time_bucket: 200,
+            bucket: bucket_d,
             metric_name: "cpu_usage".to_string(),
             series_id: 1,
-            bucket_size: 1,
         };
 
         let enc_a = key_a.encode();
@@ -494,27 +441,24 @@ mod tests {
     #[test]
     fn should_create_attribute_range_that_matches_same_attribute_keys() {
         // given
-        let bucket = crate::model::TimeBucket {
+        let bucket = TimeBucket {
             start: 12345,
             size: 1,
         };
         let key1 = InvertedIndexKey {
-            time_bucket: 12345,
+            bucket,
             attribute: "host".to_string(),
             value: "server1".to_string(),
-            bucket_size: 1,
         };
         let key2 = InvertedIndexKey {
-            time_bucket: 12345,
+            bucket,
             attribute: "host".to_string(),
             value: "server2".to_string(),
-            bucket_size: 1,
         };
         let key3 = InvertedIndexKey {
-            time_bucket: 12345,
+            bucket,
             attribute: "env".to_string(),
             value: "prod".to_string(),
-            bucket_size: 1,
         };
 
         // when
@@ -531,15 +475,14 @@ mod tests {
         // given - searching for "hostname" should NOT match a key with
         // attribute "host" and value "name" even though "host" + "name" = "hostname"
         // The tuple-style delimiter encoding should prevent this collision.
-        let bucket = crate::model::TimeBucket {
+        let bucket = TimeBucket {
             start: 12345,
             size: 1,
         };
         let host_name_key = InvertedIndexKey {
-            time_bucket: 12345,
+            bucket,
             attribute: "host".to_string(),
             value: "name".to_string(),
-            bucket_size: 1,
         };
 
         // when - search for "hostname"
@@ -557,17 +500,16 @@ mod tests {
     fn should_not_match_when_value_bytes_could_mimic_attribute_continuation() {
         // given - test a more contrived case where naive concatenation
         // might produce a collision
-        let bucket = crate::model::TimeBucket {
+        let bucket = TimeBucket {
             start: 12345,
             size: 1,
         };
 
         // Key with short attribute and value that concatenates to a different attribute
         let short_attr_key = InvertedIndexKey {
-            time_bucket: 12345,
+            bucket,
             attribute: "ab".to_string(),
             value: "cdef".to_string(),
-            bucket_size: 1,
         };
 
         // Search for "abcdef"
@@ -594,10 +536,12 @@ mod tests {
         // from value, and the value extends to the end of the key.
 
         let key = InvertedIndexKey {
-            time_bucket: 12345,
+            bucket: TimeBucket {
+                start: 12345,
+                size: 1,
+            },
             attribute: "host".to_string(),
             value: "server1".to_string(),
-            bucket_size: 1,
         };
 
         let encoded = key.encode();

--- a/timeseries/src/serde/mod.rs
+++ b/timeseries/src/serde/mod.rs
@@ -5,7 +5,7 @@ pub mod inverted_index;
 pub mod key;
 pub mod timeseries;
 
-use crate::model::{BucketSize, RecordTag, TimeBucket};
+use crate::model::{BucketSize, BucketStart, TimeBucket};
 use bytes::{BufMut, Bytes, BytesMut};
 use common::BytesRange;
 use common::serde::key_prefix::{KEY_PREFIX_LEN, KeyPrefix};
@@ -93,17 +93,21 @@ pub fn decode_fixed_element_array<T: Decode>(
     Ok(items)
 }
 
-/// Key format version (currently 0x01)
-pub const KEY_VERSION: u8 = 0x01;
+/// Key format version (currently 0x02).
+pub const KEY_VERSION: u8 = 0x02;
 
 /// Subsystem byte for timeseries storage (see [`common::serde::subsystem`]).
 pub const SUBSYSTEM: u8 = common::serde::subsystem::TIMESERIES;
 
+/// Length of the bucket-scoped header: `[subsystem(1), version(1),
+/// time_bucket(4 BE), bucket_size(1), record_type(1)]`.
+pub const PREFIX_AND_RECORD_TYPE_LEN: usize = KEY_PREFIX_LEN + 4 + 1 + 1;
+
 /// Record type enumeration for timeseries storage.
 ///
-/// Record types are encoded in the high 4 bits of the record tag byte,
-/// following RFC 0001: Record Key Prefix. The low 4 bits are used for
-/// bucket size in bucket-scoped records.
+/// Encoded as a single byte at position 7 of every bucket-scoped key. The
+/// `BucketList` global record is the lone exception and lives at position 2
+/// of a 3-byte global-scoped key — it's removed in a follow-up commit.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RecordType {
     BucketList = 0x01,
@@ -114,7 +118,7 @@ pub enum RecordType {
 }
 
 impl RecordType {
-    /// Returns the record type ID (1-15).
+    /// Returns the record type ID.
     pub fn id(&self) -> u8 {
         *self as u8
     }
@@ -133,69 +137,57 @@ impl RecordType {
         }
     }
 
-    /// Decodes the record type from the tag byte that follows the 2-byte key
-    /// prefix in a timeseries key.
-    pub fn from_tag_byte(byte: u8) -> Result<Self, EncodingError> {
-        let tag = RecordTag::from_byte(byte)?;
-        RecordType::from_id(tag.record_type())
-    }
-
-    /// Creates a global-scoped RecordTag (reserved bits = 0).
-    pub fn tag(&self) -> RecordTag {
-        RecordTag::new(self.id(), 0)
-    }
-
-    /// Creates a bucket-scoped RecordTag with the given bucket size.
-    pub fn tag_with_bucket_size(&self, bucket_size: BucketSize) -> RecordTag {
-        RecordTag::new(self.id(), bucket_size)
-    }
-
-    /// Writes the 3-byte timeseries record prefix `[subsystem, version, tag]`
-    /// for a global-scoped record.
-    pub fn write_prefix(&self, buf: &mut BytesMut) {
-        write_record_prefix(buf, self.tag());
-    }
-
-    /// Writes the 3-byte timeseries record prefix for a bucket-scoped record,
-    /// packing `bucket_size` into the low 4 bits of the tag byte.
-    pub fn write_prefix_with_bucket_size(&self, buf: &mut BytesMut, bucket_size: BucketSize) {
-        write_record_prefix(buf, self.tag_with_bucket_size(bucket_size));
-    }
-
-    /// Encodes the 3-byte timeseries record prefix for a global-scoped record
-    /// into a fresh `Bytes`.
+    /// Encodes the 3-byte global-scoped prefix `[subsystem, version,
+    /// record_type]`. Only valid for `BucketList`; bucket-scoped records use
+    /// [`write_record_prefix`].
     pub fn encode_prefix(&self) -> Bytes {
         let mut buf = BytesMut::with_capacity(KEY_PREFIX_LEN + 1);
-        self.write_prefix(&mut buf);
+        KeyPrefix::new(SUBSYSTEM, KEY_VERSION).write_to(&mut buf);
+        buf.put_u8(self.id());
         buf.freeze()
     }
 }
 
-/// Writes `[subsystem, version, tag]` to `buf`, where `tag` packs the record
-/// type and any subsystem-specific reserved bits (e.g. bucket size).
-fn write_record_prefix(buf: &mut BytesMut, tag: RecordTag) {
+/// Writes the 8-byte bucket-scoped header `[subsystem, version,
+/// time_bucket(4 BE), bucket_size, record_type]` to `buf`.
+///
+/// `bucket.size == 0` is reserved and panics.
+pub fn write_record_prefix(buf: &mut BytesMut, bucket: &TimeBucket, record_type: RecordType) {
+    assert!(bucket.size != 0, "bucket_size 0 is reserved");
     KeyPrefix::new(SUBSYSTEM, KEY_VERSION).write_to(buf);
-    buf.put_u8(tag.as_byte());
+    buf.put_u32(bucket.start);
+    buf.put_u8(bucket.size);
+    buf.put_u8(record_type.id());
 }
 
-/// Reads the tag byte that follows the 2-byte key prefix, validating that the
-/// preceding 2 bytes are the timeseries subsystem and current key version.
-pub fn parse_record_tag(buf: &[u8]) -> Result<RecordTag, EncodingError> {
+/// Reads the bucket-scoped header from `buf`, validating subsystem, version,
+/// `bucket_size`, and the record type ID. Returns the parsed `TimeBucket` and
+/// `RecordType`.
+pub fn parse_bucket_record_type(buf: &[u8]) -> Result<(TimeBucket, RecordType), EncodingError> {
     KeyPrefix::from_bytes_with_validation(buf, SUBSYSTEM, KEY_VERSION)?;
-    if buf.len() < KEY_PREFIX_LEN + 1 {
+    if buf.len() < PREFIX_AND_RECORD_TYPE_LEN {
         return Err(EncodingError {
-            message: "Buffer too short for record tag".to_string(),
+            message: format!(
+                "Buffer too short for bucket-scoped header: need {} bytes, got {}",
+                PREFIX_AND_RECORD_TYPE_LEN,
+                buf.len()
+            ),
         });
     }
-    Ok(RecordTag::from_byte(buf[KEY_PREFIX_LEN])?)
-}
-
-/// Extracts the bucket size from the reserved bits of a record tag.
-///
-/// Returns None if the reserved bits are 0 (global-scoped record).
-pub fn bucket_size_from_tag(tag: RecordTag) -> Option<BucketSize> {
-    let size = tag.reserved();
-    if size == 0 { None } else { Some(size) }
+    let start = BucketStart::from_be_bytes([
+        buf[KEY_PREFIX_LEN],
+        buf[KEY_PREFIX_LEN + 1],
+        buf[KEY_PREFIX_LEN + 2],
+        buf[KEY_PREFIX_LEN + 3],
+    ]);
+    let size: BucketSize = buf[KEY_PREFIX_LEN + 4];
+    if size == 0 {
+        return Err(EncodingError {
+            message: "bucket_size 0 is reserved".to_string(),
+        });
+    }
+    let record_type = RecordType::from_id(buf[KEY_PREFIX_LEN + 5])?;
+    Ok((TimeBucket { start, size }, record_type))
 }
 
 /// Trait for record keys that have a record type
@@ -209,12 +201,11 @@ pub trait TimeBucketScoped: RecordKey {
     /// Returns the time bucket for this record
     fn bucket(&self) -> TimeBucket;
 
-    /// Decodes and validates the bucket-scoped prefix of a key.
-    /// Returns the TimeBucket if the record type matches the expected type.
+    /// Decodes and validates the bucket-scoped header of a key.
+    /// Returns the `TimeBucket` when the encoded record type matches
+    /// `Self::RECORD_TYPE`.
     fn decode_bucket_prefix(bytes: &[u8]) -> Result<TimeBucket, EncodingError> {
-        let tag = parse_record_tag(bytes)?;
-        let record_type = RecordType::from_id(tag.record_type())?;
-
+        let (bucket, record_type) = parse_bucket_record_type(bytes)?;
         if record_type != Self::RECORD_TYPE {
             return Err(EncodingError {
                 message: format!(
@@ -224,46 +215,21 @@ pub trait TimeBucketScoped: RecordKey {
                 ),
             });
         }
-
-        let bucket_size = bucket_size_from_tag(tag).ok_or_else(|| EncodingError {
-            message: "record should be bucket-scoped".to_string(),
-        })?;
-
-        let bucket_offset = KEY_PREFIX_LEN + 1;
-        if bytes.len() < bucket_offset + 4 {
-            return Err(EncodingError {
-                message: "buffer too short for bucket prefix".to_string(),
-            });
-        }
-
-        let start_epoch_min = u32::from_be_bytes([
-            bytes[bucket_offset],
-            bytes[bucket_offset + 1],
-            bytes[bucket_offset + 2],
-            bytes[bucket_offset + 3],
-        ]);
-
-        Ok(TimeBucket {
-            start: start_epoch_min,
-            size: bucket_size,
-        })
+        Ok(bucket)
     }
 
     /// Create a BytesRange that covers all records of this type
     /// for the given time bucket.
     fn bucket_range(bucket: &TimeBucket) -> BytesRange {
         let mut buf = BytesMut::new();
-        Self::RECORD_TYPE.write_prefix_with_bucket_size(&mut buf, bucket.size);
-        buf.put_u32(bucket.start);
+        write_record_prefix(&mut buf, bucket, Self::RECORD_TYPE);
         BytesRange::prefix(buf.freeze())
     }
 }
 
-/// Helper function to write the bucket-scoped prefix to a buffer
+/// Helper function to write the bucket-scoped header to a buffer.
 pub fn write_bucket_scoped_prefix<T: TimeBucketScoped>(buf: &mut BytesMut, record: &T) {
-    let bucket = record.bucket();
-    T::RECORD_TYPE.write_prefix_with_bucket_size(buf, bucket.size);
-    buf.put_u32(bucket.start);
+    write_record_prefix(buf, &record.bucket(), T::RECORD_TYPE);
 }
 
 #[cfg(test)]
@@ -271,38 +237,64 @@ mod tests {
     use super::*;
 
     #[test]
-    fn should_encode_and_decode_record_tag_global_scoped() {
+    fn should_round_trip_global_scoped_prefix() {
         // given
-        let record_tag = RecordType::BucketList.tag();
-
-        // when
-        let encoded = record_tag.as_byte();
-        let decoded = RecordTag::from_byte(encoded).unwrap();
+        let encoded = RecordType::BucketList.encode_prefix();
 
         // then
-        assert_eq!(decoded.as_byte(), record_tag.as_byte());
-        assert_eq!(
-            RecordType::from_id(decoded.record_type()).unwrap(),
-            RecordType::BucketList
-        );
-        assert_eq!(bucket_size_from_tag(decoded), None);
+        assert_eq!(encoded.len(), KEY_PREFIX_LEN + 1);
+        assert_eq!(encoded[0], SUBSYSTEM);
+        assert_eq!(encoded[1], KEY_VERSION);
+        assert_eq!(encoded[2], RecordType::BucketList.id());
     }
 
     #[test]
-    fn should_encode_and_decode_record_tag_bucket_scoped() {
+    fn should_round_trip_bucket_scoped_header() {
         // given
-        let record_tag = RecordType::TimeSeries.tag_with_bucket_size(3);
+        let bucket = TimeBucket {
+            start: 12345,
+            size: 1,
+        };
+        let mut buf = BytesMut::new();
 
         // when
-        let encoded = record_tag.as_byte();
-        let decoded = RecordTag::from_byte(encoded).unwrap();
+        write_record_prefix(&mut buf, &bucket, RecordType::TimeSeries);
+        let (decoded_bucket, decoded_type) = parse_bucket_record_type(&buf).unwrap();
 
         // then
-        assert_eq!(decoded.as_byte(), record_tag.as_byte());
-        assert_eq!(
-            RecordType::from_id(decoded.record_type()).unwrap(),
-            RecordType::TimeSeries
+        assert_eq!(buf.len(), PREFIX_AND_RECORD_TYPE_LEN);
+        assert_eq!(decoded_bucket, bucket);
+        assert_eq!(decoded_type, RecordType::TimeSeries);
+    }
+
+    #[test]
+    #[should_panic(expected = "bucket_size 0 is reserved")]
+    fn should_panic_when_writing_zero_bucket_size() {
+        let mut buf = BytesMut::new();
+        write_record_prefix(
+            &mut buf,
+            &TimeBucket { start: 0, size: 0 },
+            RecordType::TimeSeries,
         );
-        assert_eq!(bucket_size_from_tag(decoded), Some(3));
+    }
+
+    #[test]
+    fn parse_bucket_record_type_rejects_zero_bucket_size() {
+        let mut buf = BytesMut::new();
+        KeyPrefix::new(SUBSYSTEM, KEY_VERSION).write_to(&mut buf);
+        buf.put_u32(0);
+        buf.put_u8(0);
+        buf.put_u8(RecordType::TimeSeries.id());
+
+        let err = parse_bucket_record_type(&buf).unwrap_err();
+
+        assert!(err.message.contains("bucket_size 0 is reserved"));
+    }
+
+    #[test]
+    fn parse_bucket_record_type_rejects_short_buffer() {
+        let buf = [SUBSYSTEM, KEY_VERSION, 0, 0, 0, 0, 1];
+        let err = parse_bucket_record_type(&buf).unwrap_err();
+        assert!(err.message.contains("Buffer too short"));
     }
 }

--- a/timeseries/src/storage/merge_operator.rs
+++ b/timeseries/src/storage/merge_operator.rs
@@ -1,8 +1,9 @@
 use crate::serde::bucket_list::BucketListValue;
 use crate::serde::inverted_index::InvertedIndexValue;
 use crate::serde::timeseries::merge_batch_time_series;
-use crate::serde::{EncodingError, RecordType, parse_record_tag};
+use crate::serde::{EncodingError, RecordType, parse_bucket_record_type};
 use bytes::Bytes;
+use common::serde::key_prefix::KEY_PREFIX_LEN;
 use common::storage::default_merge_batch;
 
 /// Merge operator for OpenTSDB that handles merging of different record types.
@@ -13,10 +14,7 @@ pub(crate) struct OpenTsdbMergeOperator;
 
 impl common::storage::MergeOperator for OpenTsdbMergeOperator {
     fn merge_batch(&self, key: &Bytes, existing_value: Option<Bytes>, operands: &[Bytes]) -> Bytes {
-        // Decode record type from key
-        let tag = parse_record_tag(key.as_ref()).expect("Failed to parse key prefix");
-        let record_type =
-            RecordType::from_id(tag.record_type()).expect("Failed to decode record type");
+        let record_type = decode_record_type(key.as_ref()).expect("Failed to decode record type");
 
         match record_type {
             RecordType::InvertedIndex => merge_batch_inverted_index(existing_value, operands)
@@ -31,6 +29,19 @@ impl common::storage::MergeOperator for OpenTsdbMergeOperator {
                 default_merge_batch(key, existing_value, operands, |_k, _e, v| v)
             }
         }
+    }
+}
+
+/// Returns the record type encoded in `key`, supporting both the 3-byte
+/// `BucketList` global-scoped layout and the 8-byte bucket-scoped header.
+/// Dispatch is by key length — `BucketList` is exactly the prefix, every
+/// other record starts with the full bucket-scoped header.
+fn decode_record_type(key: &[u8]) -> Result<RecordType, EncodingError> {
+    if key.len() == KEY_PREFIX_LEN + 1 {
+        RecordType::from_id(key[KEY_PREFIX_LEN])
+    } else {
+        let (_, record_type) = parse_bucket_record_type(key)?;
+        Ok(record_type)
     }
 }
 
@@ -96,11 +107,17 @@ mod tests {
     use roaring::RoaringBitmap;
     use rstest::rstest;
 
+    fn test_bucket() -> crate::model::TimeBucket {
+        crate::model::TimeBucket {
+            start: 1000,
+            size: 1,
+        }
+    }
+
     /// Helper to create a test key for InvertedIndex
     fn create_inverted_index_key() -> Bytes {
         InvertedIndexKey {
-            time_bucket: 1000,
-            bucket_size: 1,
+            bucket: test_bucket(),
             attribute: "env".to_string(),
             value: "prod".to_string(),
         }
@@ -110,8 +127,7 @@ mod tests {
     /// Helper to create a test key for TimeSeries
     fn create_time_series_key() -> Bytes {
         TimeSeriesKey {
-            time_bucket: 1000,
-            bucket_size: 1,
+            bucket: test_bucket(),
             metric_name: "test_metric".to_string(),
             series_id: 42,
         }
@@ -127,8 +143,7 @@ mod tests {
     fn create_other_record_type_key() -> Bytes {
         use crate::serde::key::SeriesDictionaryKey;
         SeriesDictionaryKey {
-            time_bucket: 1000,
-            bucket_size: 1,
+            bucket: test_bucket(),
             series_fingerprint: 123,
         }
         .encode()

--- a/timeseries/src/storage/segment_extractor.rs
+++ b/timeseries/src/storage/segment_extractor.rs
@@ -26,10 +26,10 @@
 
 use std::sync::Arc;
 
-use common::serde::subsystem::TIMESERIES;
 use slatedb::{PrefixExtractor, PrefixTarget};
 
 use crate::model::{BucketSize, BucketStart, TimeBucket};
+use crate::serde::{KEY_VERSION, SUBSYSTEM};
 
 /// Routing prefix length: `[subsystem(1), version(1), time_bucket(4 BE),
 /// bucket_size(1)]`.
@@ -39,13 +39,6 @@ const ROUTING_PREFIX_LEN: usize = 7;
 /// whenever the routing logic changes in a way that would re-route existing
 /// keys (e.g. a new `KEY_VERSION` with a different prefix shape).
 const EXTRACTOR_NAME: &str = "opendata-timeseries/v2";
-
-/// Version byte the extractor expects in the routing prefix.
-///
-/// This is kept local to the extractor module until the timeseries serde
-/// module bumps its own `KEY_VERSION` to `0x02`. Once aligned, the two
-/// constants will collapse into a single import.
-const KEY_VERSION_V2: u8 = 0x02;
 
 /// Prefix extractor routing timeseries records to per-bucket SlateDB segments.
 ///
@@ -89,8 +82,8 @@ impl PrefixExtractor for TimeseriesSegmentExtractor {
                 let bytes = b.as_ref();
                 assert!(
                     bytes.len() >= ROUTING_PREFIX_LEN
-                        && bytes[0] == TIMESERIES
-                        && bytes[1] == KEY_VERSION_V2,
+                        && bytes[0] == SUBSYSTEM
+                        && bytes[1] == KEY_VERSION,
                     "TimeseriesSegmentExtractor: malformed timeseries key (subsystem/version \
                      mismatch or under {} bytes): {:02x?}",
                     ROUTING_PREFIX_LEN,
@@ -104,8 +97,8 @@ impl PrefixExtractor for TimeseriesSegmentExtractor {
             PrefixTarget::Prefix(b) => {
                 let bytes = b.as_ref();
                 if bytes.len() < ROUTING_PREFIX_LEN
-                    || bytes[0] != TIMESERIES
-                    || bytes[1] != KEY_VERSION_V2
+                    || bytes[0] != SUBSYSTEM
+                    || bytes[1] != KEY_VERSION
                 {
                     None
                 } else {
@@ -121,18 +114,14 @@ impl PrefixExtractor for TimeseriesSegmentExtractor {
 /// Used by the bucket-discovery path to project the segments list returned by
 /// `StorageRead::list_segments` into the set of buckets visible to a query.
 /// Returns `None` for any prefix that isn't a well-formed timeseries routing
-/// prefix.
-///
-/// While the timeseries database is restricted to 1-hour buckets, a routing
-/// prefix with `bucket_size != 1` is rejected as malformed; relax this when
-/// multi-size buckets land.
+/// prefix, including the reserved `bucket_size == 0`.
 pub(crate) fn parse_bucket(prefix: &[u8]) -> Option<TimeBucket> {
-    if prefix.len() < ROUTING_PREFIX_LEN || prefix[0] != TIMESERIES || prefix[1] != KEY_VERSION_V2 {
+    if prefix.len() < ROUTING_PREFIX_LEN || prefix[0] != SUBSYSTEM || prefix[1] != KEY_VERSION {
         return None;
     }
     let start = BucketStart::from_be_bytes([prefix[2], prefix[3], prefix[4], prefix[5]]);
     let size: BucketSize = prefix[6];
-    if size != 1 {
+    if size == 0 {
         return None;
     }
     Some(TimeBucket { start, size })
@@ -145,8 +134,8 @@ mod tests {
 
     fn make_key(bucket_start: u32, bucket_size: u8, record_type: u8, tail: &[u8]) -> Bytes {
         let mut buf = BytesMut::with_capacity(ROUTING_PREFIX_LEN + 1 + tail.len());
-        buf.put_u8(TIMESERIES);
-        buf.put_u8(KEY_VERSION_V2);
+        buf.put_u8(SUBSYSTEM);
+        buf.put_u8(KEY_VERSION);
         buf.put_u32(bucket_start);
         buf.put_u8(bucket_size);
         buf.put_u8(record_type);
@@ -183,8 +172,8 @@ mod tests {
         // then
         assert_eq!(n, Some(ROUTING_PREFIX_LEN));
         let extracted = &key[..n.unwrap()];
-        assert_eq!(extracted[0], TIMESERIES);
-        assert_eq!(extracted[1], KEY_VERSION_V2);
+        assert_eq!(extracted[0], SUBSYSTEM);
+        assert_eq!(extracted[1], KEY_VERSION);
         assert_eq!(&extracted[2..6], &12345u32.to_be_bytes());
         assert_eq!(extracted[6], 1);
     }
@@ -240,7 +229,7 @@ mod tests {
     fn should_return_none_for_prefix_shorter_than_routing_prefix() {
         // given
         let extractor = TimeseriesSegmentExtractor;
-        let short = [TIMESERIES, KEY_VERSION_V2, 0, 0, 0, 0];
+        let short = [SUBSYSTEM, KEY_VERSION, 0, 0, 0, 0];
 
         // when / then
         assert_eq!(extractor.prefix_len(&prefix(&short)), None);
@@ -250,7 +239,7 @@ mod tests {
     fn should_return_none_for_prefix_with_wrong_subsystem() {
         // given
         let extractor = TimeseriesSegmentExtractor;
-        let bad = [0xFF, KEY_VERSION_V2, 0, 0, 0, 0, 1];
+        let bad = [0xFF, KEY_VERSION, 0, 0, 0, 0, 1];
 
         // when / then
         assert_eq!(extractor.prefix_len(&prefix(&bad)), None);
@@ -260,7 +249,7 @@ mod tests {
     fn should_return_none_for_prefix_with_wrong_version() {
         // given
         let extractor = TimeseriesSegmentExtractor;
-        let bad = [TIMESERIES, 0xFF, 0, 0, 0, 0, 1];
+        let bad = [SUBSYSTEM, 0xFF, 0, 0, 0, 0, 1];
 
         // when / then
         assert_eq!(extractor.prefix_len(&prefix(&bad)), None);
@@ -280,7 +269,7 @@ mod tests {
     fn should_panic_on_point_shorter_than_routing_prefix() {
         // given
         let extractor = TimeseriesSegmentExtractor;
-        let short = [TIMESERIES, KEY_VERSION_V2, 0, 0, 0, 0];
+        let short = [SUBSYSTEM, KEY_VERSION, 0, 0, 0, 0];
 
         // when / then
         let _ = extractor.prefix_len(&point(&short));
@@ -291,7 +280,7 @@ mod tests {
     fn should_panic_on_point_with_wrong_subsystem() {
         // given
         let extractor = TimeseriesSegmentExtractor;
-        let bad = [0xFF, KEY_VERSION_V2, 0, 0, 0, 0, 1];
+        let bad = [0xFF, KEY_VERSION, 0, 0, 0, 0, 1];
 
         // when / then
         let _ = extractor.prefix_len(&point(&bad));
@@ -302,7 +291,7 @@ mod tests {
     fn should_panic_on_point_with_wrong_version() {
         // given
         let extractor = TimeseriesSegmentExtractor;
-        let bad = [TIMESERIES, 0xFF, 0, 0, 0, 0, 1];
+        let bad = [SUBSYSTEM, 0xFF, 0, 0, 0, 0, 1];
 
         // when / then
         let _ = extractor.prefix_len(&point(&bad));
@@ -322,7 +311,7 @@ mod tests {
     fn should_satisfy_prefix_extension_invariant_for_well_formed_prefix() {
         // given — a 7-byte scan prefix that targets bucket (start=42, size=1)
         let extractor = TimeseriesSegmentExtractor;
-        let mut scan_prefix = vec![TIMESERIES, KEY_VERSION_V2];
+        let mut scan_prefix = vec![SUBSYSTEM, KEY_VERSION];
         scan_prefix.extend_from_slice(&42u32.to_be_bytes());
         scan_prefix.push(1);
         assert_eq!(scan_prefix.len(), ROUTING_PREFIX_LEN);
@@ -362,15 +351,21 @@ mod tests {
     }
 
     #[test]
-    fn parse_bucket_rejects_non_one_bucket_size() {
-        // given — bucket_size 2 is not yet supported
+    fn parse_bucket_accepts_non_one_bucket_size() {
+        // given
         let p = make_key(7777, 2, 0x05, b"");
 
         // when
         let bucket = parse_bucket(&p[..ROUTING_PREFIX_LEN]);
 
         // then
-        assert_eq!(bucket, None);
+        assert_eq!(
+            bucket,
+            Some(TimeBucket {
+                start: 7777,
+                size: 2
+            })
+        );
     }
 
     #[test]
@@ -388,7 +383,7 @@ mod tests {
     #[test]
     fn parse_bucket_rejects_short_prefix() {
         // given — 6 bytes, one short of the routing prefix
-        let p = [TIMESERIES, KEY_VERSION_V2, 0, 0, 0, 0];
+        let p = [SUBSYSTEM, KEY_VERSION, 0, 0, 0, 0];
 
         // when / then
         assert_eq!(parse_bucket(&p), None);
@@ -397,7 +392,7 @@ mod tests {
     #[test]
     fn parse_bucket_rejects_wrong_subsystem() {
         // given
-        let p = [0xFF, KEY_VERSION_V2, 0, 0, 0, 0, 1];
+        let p = [0xFF, KEY_VERSION, 0, 0, 0, 0, 1];
 
         // when / then
         assert_eq!(parse_bucket(&p), None);
@@ -406,7 +401,7 @@ mod tests {
     #[test]
     fn parse_bucket_rejects_wrong_version() {
         // given
-        let p = [TIMESERIES, 0xFF, 0, 0, 0, 0, 1];
+        let p = [SUBSYSTEM, 0xFF, 0, 0, 0, 0, 1];
 
         // when / then
         assert_eq!(parse_bucket(&p), None);

--- a/timeseries/src/storage/slate.rs
+++ b/timeseries/src/storage/slate.rs
@@ -470,8 +470,7 @@ impl<T: DbReadOps + Send + Sync> StorageReaderInner<T> {
         term: &Label,
     ) -> crate::util::Result<Option<RoaringBitmap>> {
         let key = InvertedIndexKey {
-            time_bucket: bucket.start,
-            bucket_size: bucket.size,
+            bucket: *bucket,
             attribute: term.name.clone(),
             value: term.value.clone(),
         }
@@ -518,8 +517,7 @@ impl<T: DbReadOps + Send + Sync> StorageReaderInner<T> {
         series_id: SeriesId,
     ) -> crate::util::Result<Option<SeriesSpec>> {
         let key = ForwardIndexKey {
-            time_bucket: bucket.start,
-            bucket_size: bucket.size,
+            bucket: *bucket,
             series_id,
         }
         .encode();
@@ -945,8 +943,7 @@ pub(crate) fn insert_series_id(
     ttl: Ttl,
 ) -> crate::util::Result<RecordOp> {
     let key = SeriesDictionaryKey {
-        time_bucket: bucket.start,
-        bucket_size: bucket.size,
+        bucket,
         series_fingerprint: fingerprint,
     }
     .encode();
@@ -963,12 +960,7 @@ pub(crate) fn insert_forward_index(
     series_spec: SeriesSpec,
     ttl: Ttl,
 ) -> crate::util::Result<RecordOp> {
-    let key = ForwardIndexKey {
-        time_bucket: bucket.start,
-        bucket_size: bucket.size,
-        series_id,
-    }
-    .encode();
+    let key = ForwardIndexKey { bucket, series_id }.encode();
     let value = ForwardIndexValue {
         metric_unit: series_spec.unit,
         metric_meta: series_spec.metric_type.into(),
@@ -989,8 +981,7 @@ pub(crate) fn merge_inverted_index(
     ttl: Ttl,
 ) -> crate::util::Result<RecordOp> {
     let key = InvertedIndexKey {
-        time_bucket: bucket.start,
-        bucket_size: bucket.size,
+        bucket,
         attribute: label.name,
         value: label.value,
     }
@@ -1010,8 +1001,7 @@ pub(crate) fn merge_samples(
     ttl: Ttl,
 ) -> crate::util::Result<RecordOp> {
     let key = TimeSeriesKey {
-        time_bucket: bucket.start,
-        bucket_size: bucket.size,
+        bucket,
         metric_name: metric_name.to_string(),
         series_id,
     }


### PR DESCRIPTION
## Summary

Introduces a new key layout that does not split the third byte into high and low, i.e., record type and bucket size. Instead the third byte is the record type, followed by the timestamp of the bucket, followed by the size of the bucket.
In other words, key layout v1:

| subsystem (1 byte) | key version (1 byte) | record tag (high 4 bit: record type, low 4 bit: bucket size ) | timestamp of bucket (4 bytes) | <suffix of the key>

is replaced by key layout v2:

| subsystem (1 byte) | key version (1 byte) | record type (1 byte) | timestamp of bucket (4 bytes) | bucket size in hours |  <suffix of the key>

This change is needed to map Timeseries' time buckets to SlateDB segments.

## Test Plan

unit tests

## Checklist

- [ ] Tests added/updated
- [ ] `cargo fmt` and `cargo clippy` pass
- [ ] Documentation updated (if applicable)
